### PR TITLE
build: enable composite TypeScript config

### DIFF
--- a/apps/mcp-servers/cem-analyzer/tsconfig.json
+++ b/apps/mcp-servers/cem-analyzer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "module": "Node16",
     "moduleResolution": "Node16",
     "outDir": "./build",

--- a/apps/mcp-servers/health-scorer/tsconfig.json
+++ b/apps/mcp-servers/health-scorer/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "module": "Node16",
     "moduleResolution": "Node16",
     "outDir": "./build",

--- a/apps/mcp-servers/shared/tsconfig.json
+++ b/apps/mcp-servers/shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "module": "Node16",
     "moduleResolution": "Node16",
     "outDir": "./build",

--- a/apps/mcp-servers/typescript-diagnostics/tsconfig.json
+++ b/apps/mcp-servers/typescript-diagnostics/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "module": "Node16",
     "moduleResolution": "Node16",
     "outDir": "./build",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,9 +13,18 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
+    "composite": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true
   },
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist"],
+  "references": [
+    { "path": "./packages/hx-tokens" },
+    { "path": "./packages/hx-library" },
+    { "path": "./apps/mcp-servers/shared" },
+    { "path": "./apps/mcp-servers/cem-analyzer" },
+    { "path": "./apps/mcp-servers/health-scorer" },
+    { "path": "./apps/mcp-servers/typescript-diagnostics" }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add `composite: true` to `tsconfig.base.json` and all 4 MCP server tsconfigs
- Set up project `references` in root config pointing to all 6 packages (hx-tokens, hx-library, + 4 MCP servers)
- Enables incremental TypeScript builds and proper cross-package dependency tracking

## Test plan
- [x] `npm run type-check` passes with zero errors (all 11 tasks cached, full turbo)
- [ ] Verify incremental builds work correctly after changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)