### PR TITLE
feat(tokens): migrate to W3C DTCG format with Style Dictionary 4.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -955,6 +955,212 @@
         "node": ">=18"
       }
     },
+    "node_modules/@bundled-es-modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-Rk453EklPUPC3NRWc3VUNI/SSUjdBaFoaQvFRmNBNtMHVtOFD5AntiWg5kEE1hqcPqedYFDzxE3ZcMYPcA195w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "deepmerge": "^4.3.1"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob": {
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-740y5ofkzydsFao5EXJrGilcIL6EFEw/cmPf2uhTw9J6G1YOhiIFjNFCHdpgEiiH5VlU3G0SARSjlFlimRRSMA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "glob": "^10.4.2",
+        "patch-package": "^8.0.0",
+        "path": "^0.12.7",
+        "stream": "^0.0.3",
+        "string_decoder": "^1.3.0",
+        "url": "^0.11.3"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@bundled-es-modules/glob/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@bundled-es-modules/memfs": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/memfs/-/memfs-4.17.0.tgz",
+      "integrity": "sha512-ykdrkEmQr9BV804yd37ikXfNnvxrwYfY9Z2/EtMHFEFadEjsQXJ1zL9bVZrKNLDtm91UdUOEHso6Aweg93K6xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "assert": "^2.1.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "memfs": "^4.17.0",
+        "path": "^0.12.7",
+        "stream": "^0.0.3",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/@capsizecss/unpack": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.0.tgz",
@@ -3120,6 +3326,436 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@jsonjoy.com/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/buffers": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-17.67.0.tgz",
+      "integrity": "sha512-tfExRpYxBvi32vPs9ZHaTjSP4fHAfzSmcahOfNxtvGHcyJel+aibkPlGeBB+7AoC6hL7lXIE++8okecBxx7lcw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/codegen": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-1.0.0.tgz",
+      "integrity": "sha512-E8Oy+08cmCf0EK/NMxpaJZmOxPqM+6iSe2S4nlSBrPZOORoDJILxtbSUEDKQyTamm/BVAhIGllOBNU79/dwf0g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-core": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-core/-/fs-core-4.56.10.tgz",
+      "integrity": "sha512-PyAEA/3cnHhsGcdY+AmIU+ZPqTuZkDhCXQ2wkXypdLitSpd6d5Ivxhnq4wa2ETRWFVJGabYynBWxIijOswSmOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-fsa": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-fsa/-/fs-fsa-4.56.10.tgz",
+      "integrity": "sha512-/FVK63ysNzTPOnCCcPoPHt77TOmachdMS422txM4KhxddLdbW1fIbFMYH0AM0ow/YchCyS5gqEjKLNyv71j/5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.56.10",
+        "@jsonjoy.com/fs-node-builtins": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node/-/fs-node-4.56.10.tgz",
+      "integrity": "sha512-7R4Gv3tkUdW3dXfXiOkqxkElxKNVdd8BDOWC0/dbERd0pXpPY+s2s1Mino+aTvkGrFPiY+mmVxA7zhskm4Ue4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.56.10",
+        "@jsonjoy.com/fs-node-builtins": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-print": "4.56.10",
+        "@jsonjoy.com/fs-snapshot": "4.56.10",
+        "glob-to-regex.js": "^1.0.0",
+        "thingies": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-builtins": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-builtins/-/fs-node-builtins-4.56.10.tgz",
+      "integrity": "sha512-uUnKz8R0YJyKq5jXpZtkGV9U0pJDt8hmYcLRrPjROheIfjMXsz82kXMgAA/qNg0wrZ1Kv+hrg7azqEZx6XZCVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-to-fsa": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-to-fsa/-/fs-node-to-fsa-4.56.10.tgz",
+      "integrity": "sha512-oH+O6Y4lhn9NyG6aEoFwIBNKZeYy66toP5LJcDOMBgL99BKQMUf/zWJspdRhMdn/3hbzQsZ8EHHsuekbFLGUWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-fsa": "4.56.10",
+        "@jsonjoy.com/fs-node-builtins": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.56.10"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-node-utils": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-node-utils/-/fs-node-utils-4.56.10.tgz",
+      "integrity": "sha512-8EuPBgVI2aDPwFdaNQeNpHsyqPi3rr+85tMNG/lHvQLiVjzoZsvxA//Xd8aB567LUhy4QS03ptT+unkD/DIsNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-builtins": "4.56.10"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-print": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-print/-/fs-print-4.56.10.tgz",
+      "integrity": "sha512-JW4fp5mAYepzFsSGrQ48ep8FXxpg4niFWHdF78wDrFGof7F3tKDJln72QFDEn/27M1yHd4v7sKHHVPh78aWcEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/fs-snapshot/-/fs-snapshot-4.56.10.tgz",
+      "integrity": "sha512-DkR6l5fj7+qj0+fVKm/OOXMGfDFCGXLfyHkORH3DF8hxkpDgIHbhf/DwncBMs2igu/ST7OEkexn1gIqoU6Y+9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^17.65.0",
+        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/json-pack": "^17.65.0",
+        "@jsonjoy.com/util": "^17.65.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/base64": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-17.67.0.tgz",
+      "integrity": "sha512-5SEsJGsm15aP8TQGkDfJvz9axgPwAEm98S5DxOuYe8e1EbfajcDmgeXXzccEjh+mLnjqEKrkBdjHWS5vFNwDdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/codegen": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/codegen/-/codegen-17.67.0.tgz",
+      "integrity": "sha512-idnkUplROpdBOV0HMcwhsCUS5TRUi9poagdGs70A6S4ux9+/aPuKbh8+UYRTLYQHtXvAdNfQWXDqZEx5k4Dj2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pack": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-17.67.0.tgz",
+      "integrity": "sha512-t0ejURcGaZsn1ClbJ/3kFqSOjlryd92eQY465IYrezsXmPcfHPE/av4twRSxf6WE+TkZgLY+71vCZbiIiFKA/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "17.67.0",
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0",
+        "@jsonjoy.com/json-pointer": "17.67.0",
+        "@jsonjoy.com/util": "17.67.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/json-pointer": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-17.67.0.tgz",
+      "integrity": "sha512-+iqOFInH+QZGmSuaybBUNdh7yvNrXvqR+h3wjXm0N/3JK1EyyFAeGJvqnmQL61d1ARLlk/wJdFKSL+LHJ1eaUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/util": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/fs-snapshot/node_modules/@jsonjoy.com/util": {
+      "version": "17.67.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-17.67.0.tgz",
+      "integrity": "sha512-6+8xBaz1rLSohlGh68D1pdw3AwDi9xydm8QNlAFkvnavCJYSze+pxoW2VKP8p308jtlMRLs5NTHfPlZLd4w7ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "17.67.0",
+        "@jsonjoy.com/codegen": "17.67.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.21.0.tgz",
+      "integrity": "sha512-+AKG+R2cfZMShzrF2uQw34v3zbeDYUqnQ+jg7ORic3BGtfw9p/+N6RJbq/kkV8JmYZaINknaEQ2m0/f693ZPpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/base64": "^1.1.2",
+        "@jsonjoy.com/buffers": "^1.2.0",
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/json-pointer": "^1.0.2",
+        "@jsonjoy.com/util": "^1.9.0",
+        "hyperdyperid": "^1.2.0",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pack/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/json-pointer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pointer/-/json-pointer-1.0.2.tgz",
+      "integrity": "sha512-Fsn6wM2zlDzY1U+v4Nc8bo3bVqgfNTGcn6dMgs6FjrEnt4ZCe60o6ByKRjOGlI2gow0aE/Q41QOigdTqkyK5fg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/codegen": "^1.0.0",
+        "@jsonjoy.com/util": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.9.0.tgz",
+      "integrity": "sha512-pLuQo+VPRnN8hfPqUTLTHk126wuYdXVxE6aDmjSeV4NCAgyxWbiOIeNJVtID3h1Vzpoi9m4jXezf73I6LgabgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/buffers": "^1.0.0",
+        "@jsonjoy.com/codegen": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@jsonjoy.com/util/node_modules/@jsonjoy.com/buffers": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jsonjoy.com/buffers/-/buffers-1.2.1.tgz",
+      "integrity": "sha512-12cdlDwX4RUM3QxmUbVJWqZ/mrK6dFQH4Zxq6+r1YXKXYBNgZXndx2qbCJwh3+WWkCSn67IjnlG3XYTvmvYtgA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
@@ -7041,6 +7677,25 @@
         "node": ">=14"
       }
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@zip.js/zip.js": {
+      "version": "2.8.21",
+      "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.21.tgz",
+      "integrity": "sha512-fkyzXISE3IMrstDO1AgPkJCx14MYHP/suIGiAovEYEuBjq3mffsuL6aMV7ohOSjW4rXtuACuUfpA3GtITgdtYg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "bun": ">=0.7.0",
+        "deno": ">=1.0.0",
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -7318,6 +7973,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/assert": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-2.1.0.tgz",
+      "integrity": "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "is-nan": "^1.3.2",
+        "object-is": "^1.1.5",
+        "object.assign": "^4.1.4",
+        "util": "^0.12.5"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -7488,6 +8157,22 @@
         "when-exit": "^2.1.4"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/axe-core": {
       "version": "4.11.1",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
@@ -7641,6 +8326,27 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
       "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==",
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
@@ -7802,6 +8508,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -7845,6 +8576,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -7961,6 +8711,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
@@ -8364,6 +9121,19 @@
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/component-emitter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-2.0.0.tgz",
+      "integrity": "sha512-4m5s3Me2xxlVKG9PkZpQqHQR7bgpnN7joDMJ4yvVkVXngjoITG76IaZmzmywSeRTeTpc6N6r3H3+KyUurV8OYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -8822,6 +9592,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-browser": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
@@ -8852,6 +9632,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -8863,6 +9661,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/defu": {
@@ -9826,6 +10642,16 @@
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -10247,6 +11073,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/find-yarn-workspace-root": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -10296,6 +11132,22 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -10376,6 +11228,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-caller-file": {
@@ -10521,6 +11383,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/glob-to-regex.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/glob-to-regex.js/-/glob-to-regex.js-1.2.0.tgz",
+      "integrity": "sha512-QMwlOQKU/IzqMUOAZWubUOT8Qft+Y0KQWnX9nK3ch0CJg0tTp4TvGZsTfudYKv2NzoQSyPcnA6TYeIQ3jGichQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -10601,11 +11480,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -11136,6 +12044,16 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/hyperdyperid": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+      "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      }
+    },
     "node_modules/i18next": {
       "version": "23.16.8",
       "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
@@ -11174,6 +12092,27 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -11348,6 +12287,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -11359,6 +12315,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-core-module": {
@@ -11421,6 +12390,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -11462,6 +12451,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-nan": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.3.2.tgz",
+      "integrity": "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -11497,6 +12503,25 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -11521,6 +12546,22 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-unicode-supported": {
@@ -11569,6 +12610,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -11740,12 +12788,45 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonc-parser": {
       "version": "2.3.1",
@@ -11766,6 +12847,16 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -11774,6 +12865,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
       }
     },
     "node_modules/kleur": {
@@ -12937,6 +14038,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/memfs": {
+      "version": "4.56.10",
+      "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.56.10.tgz",
+      "integrity": "sha512-eLvzyrwqLHnLYalJP7YZ3wBe79MXktMdfQbvMrVD80K+NhrIukCVBvgP30zTJYEEDh9hZ/ep9z0KOdD7FSHo7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jsonjoy.com/fs-core": "4.56.10",
+        "@jsonjoy.com/fs-fsa": "4.56.10",
+        "@jsonjoy.com/fs-node": "4.56.10",
+        "@jsonjoy.com/fs-node-builtins": "4.56.10",
+        "@jsonjoy.com/fs-node-to-fsa": "4.56.10",
+        "@jsonjoy.com/fs-node-utils": "4.56.10",
+        "@jsonjoy.com/fs-print": "4.56.10",
+        "@jsonjoy.com/fs-snapshot": "4.56.10",
+        "@jsonjoy.com/json-pack": "^1.11.0",
+        "@jsonjoy.com/util": "^1.9.0",
+        "glob-to-regex.js": "^1.0.1",
+        "thingies": "^2.5.0",
+        "tree-dump": "^1.0.3",
+        "tslib": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
@@ -13812,6 +14943,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
@@ -14121,6 +15262,54 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -14572,6 +15761,134 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/patch-package": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.1.tgz",
+      "integrity": "sha512-VsKRIA8f5uqHQ7NGhwIna6Bx6D9s/1iXlA1hthBVBEbkq+t4kXD0HHt+rJhf/Z+Ci0F/HCB2hvn0qLdLG+Qxlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^10.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.2.4",
+        "yaml": "^2.2.2"
+      },
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      }
+    },
+    "node_modules/patch-package/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/patch-package/node_modules/open": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/patch-package/node_modules/slash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -14639,6 +15956,30 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-unified": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/path-unified/-/path-unified-0.2.0.tgz",
+      "integrity": "sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path/node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path/node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "2.0.3"
       }
     },
     "node_modules/pathe": {
@@ -14813,6 +16154,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -15001,6 +16352,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/progress": {
@@ -16074,6 +17435,45 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -16150,6 +17550,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {
@@ -16610,6 +18028,16 @@
         }
       }
     },
+    "node_modules/stream": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.3.tgz",
+      "integrity": "sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^2.0.0"
+      }
+    },
     "node_modules/stream-replace-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
@@ -16626,6 +18054,16 @@
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-argv": {
@@ -16831,6 +18269,58 @@
       "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/style-dictionary": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-4.4.0.tgz",
+      "integrity": "sha512-+xU0IA1StzqAqFs/QtXkK+XJa7wpS4X5H+JQccRKsRCElgeLGocFU1U/UMvMUylKFw6vwGV+Y/a2wb2pm5rFFQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bundled-es-modules/deepmerge": "^4.3.1",
+        "@bundled-es-modules/glob": "^10.4.2",
+        "@bundled-es-modules/memfs": "^4.9.4",
+        "@zip.js/zip.js": "^2.7.44",
+        "chalk": "^5.3.0",
+        "change-case": "^5.3.0",
+        "commander": "^12.1.0",
+        "is-plain-obj": "^4.1.0",
+        "json5": "^2.2.2",
+        "patch-package": "^8.0.0",
+        "path-unified": "^0.2.0",
+        "prettier": "^3.3.3",
+        "tinycolor2": "^1.6.0"
+      },
+      "bin": {
+        "style-dictionary": "bin/style-dictionary.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/style-dictionary/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/style-dictionary/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",
@@ -17193,6 +18683,23 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/thingies": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/thingies/-/thingies-2.5.0.tgz",
+      "integrity": "sha512-s+2Bwztg6PhWUD7XMfeYm5qliDdSiZm7M7n8KjTkIsm3l/2lgVRc2/Gx/v+ZX8lT4FMA+i8aQvhcWylldc+ZNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "^2"
+      }
+    },
     "node_modules/third-party-web": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.27.0.tgz",
@@ -17216,6 +18723,13 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -17291,6 +18805,16 @@
         "tldts-core": "^7.0.23"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -17321,6 +18845,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tree-dump": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.1.0.tgz",
+      "integrity": "sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/streamich"
+      },
+      "peerDependencies": {
+        "tslib": "2"
       }
     },
     "node_modules/trim-lines": {
@@ -17400,7 +18941,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -17989,6 +19531,27 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/url/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -17997,6 +19560,20 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
       }
     },
     "node_modules/util-deprecate": {
@@ -19052,6 +20629,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -19486,6 +21085,7 @@
         "lit": "^3.3.2"
       },
       "devDependencies": {
+        "style-dictionary": "^4.0.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.2"
       }

--- a/packages/hx-library/tokens/component/button.json
+++ b/packages/hx-library/tokens/component/button.json
@@ -1,0 +1,11 @@
+{
+  "button": {
+    "bg":           { "$value": "{color.primary.500}",    "$type": "color",      "$description": "Button background color" },
+    "color":        { "$value": "{color.neutral.0}",      "$type": "color",      "$description": "Button text color" },
+    "border-color": { "$value": "transparent",            "$type": "color",      "$description": "Button border color" },
+    "border-radius":{ "$value": "{border.radius.md}",     "$type": "dimension",  "$description": "Button border radius" },
+    "font-family":  { "$value": "{font.family.sans}",     "$type": "fontFamily", "$description": "Button font family" },
+    "font-weight":  { "$value": "{font.weight.semibold}",  "$type": "fontWeight", "$description": "Button font weight" },
+    "focus-ring-color": { "$value": "{color.primary.400}", "$type": "color",    "$description": "Button focus ring color" }
+  }
+}

--- a/packages/hx-library/tokens/component/card.json
+++ b/packages/hx-library/tokens/component/card.json
@@ -1,0 +1,9 @@
+{
+  "card": {
+    "bg":           { "$value": "{color.surface.default}", "$type": "color",     "$description": "Card background color" },
+    "border-color": { "$value": "{color.border.default}",  "$type": "color",     "$description": "Card border color" },
+    "border-radius":{ "$value": "{border.radius.lg}",      "$type": "dimension", "$description": "Card border radius" },
+    "shadow":       { "$value": "{shadow.sm}",             "$type": "shadow",    "$description": "Card box shadow" },
+    "padding":      { "$value": "{space.6}",               "$type": "dimension", "$description": "Card internal padding" }
+  }
+}

--- a/packages/hx-library/tokens/component/form.json
+++ b/packages/hx-library/tokens/component/form.json
@@ -1,0 +1,13 @@
+{
+  "input": {
+    "bg":              { "$value": "{color.surface.default}",  "$type": "color",      "$description": "Input background color" },
+    "border-color":    { "$value": "{color.border.default}",   "$type": "color",      "$description": "Input border color" },
+    "border-radius":   { "$value": "{border.radius.md}",       "$type": "dimension",  "$description": "Input border radius" },
+    "color":           { "$value": "{color.text.primary}",     "$type": "color",      "$description": "Input text color" },
+    "placeholder-color":{ "$value": "{color.text.muted}",      "$type": "color",      "$description": "Input placeholder text color" },
+    "label-color":     { "$value": "{color.neutral.700}",      "$type": "color",      "$description": "Input label text color" },
+    "error-color":     { "$value": "{color.error.500}",        "$type": "color",      "$description": "Input error state color" },
+    "font-family":     { "$value": "{font.family.sans}",       "$type": "fontFamily", "$description": "Input font family" },
+    "focus-ring-color":{ "$value": "{color.primary.500}",      "$type": "color",      "$description": "Input focus ring color" }
+  }
+}

--- a/packages/hx-tokens/package.json
+++ b/packages/hx-tokens/package.json
@@ -35,7 +35,8 @@
     "src/tokens.json"
   ],
   "scripts": {
-    "build": "tsc && npx tsx scripts/generate-css.ts",
+    "build": "tsc && node sd.config.mjs",
+    "build:sd": "node sd.config.mjs",
     "type-check": "tsc --noEmit",
     "clean": "rm -rf dist"
   },
@@ -43,6 +44,7 @@
     "lit": "^3.3.2"
   },
   "devDependencies": {
+    "style-dictionary": "^4.0.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.2"
   }

--- a/packages/hx-tokens/sd.config.mjs
+++ b/packages/hx-tokens/sd.config.mjs
@@ -1,0 +1,271 @@
+/**
+ * Style Dictionary 4.x configuration for @helix/tokens
+ *
+ * DTCG (W3C Design Token Community Group) format source files.
+ * Outputs:
+ *   dist/tokens.css           — :root light-mode variables
+ *   dist/tokens-dark-auto.css — @media prefers-color-scheme: dark auto override
+ *   dist/tokens-dark-manual.css — [data-theme="dark"] manual override
+ *   dist/tokens-lit.js        — Lit CSS tagged template (tokenStyles export)
+ *
+ * Three-tier token cascade:
+ *   Primitive → Semantic → Component
+ *
+ * Dark-mode tokens live under the `dark.*` namespace in semantic/dark.json.
+ * When outputting dark CSS the `dark.` prefix is stripped from property names
+ * so `dark.color.text.primary` becomes `--hx-color-text-primary`.
+ */
+
+import StyleDictionary from 'style-dictionary';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Custom name transform: strips leading "dark." segment and joins with dashes
+// StyleDictionary 4 name transforms receive (token, options)
+// ---------------------------------------------------------------------------
+StyleDictionary.registerTransform({
+  name: 'name/hx/kebab',
+  type: 'name',
+  transform(token) {
+    // token.path is the full path array, e.g. ['color', 'primary', '500']
+    // or ['dark', 'color', 'text', 'primary'] for dark-mode overrides.
+    // We always strip the leading 'dark' segment for name generation so that
+    // dark-mode tokens share the same CSS custom property name as their
+    // light-mode counterparts (they are overrides in different selectors).
+    // The 'hx-' prefix is embedded here so css/variables format produces --hx-* variables.
+    const path = token.path[0] === 'dark' ? token.path.slice(1) : token.path;
+    return `hx-${path.join('-')}`;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Custom formatter: produces the dark-mode @media block
+// ---------------------------------------------------------------------------
+StyleDictionary.registerFormat({
+  name: 'css/dark-media',
+  format({ dictionary, options }) {
+    const selector = options?.selector ?? ':root';
+    const props = dictionary.allTokens
+      .map((token) => {
+        const value = token.$value ?? token.value;
+        return `  --${token.name}: ${value};`;
+      })
+      .join('\n');
+
+    return `@media (prefers-color-scheme: dark) {\n  ${selector} {\n${props}\n  }\n}\n`;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Custom formatter: produces a Lit css`` tagged template export
+// ---------------------------------------------------------------------------
+StyleDictionary.registerFormat({
+  name: 'js/lit-css',
+  format({ dictionary }) {
+    const lightTokens = dictionary.allTokens.filter((t) => t.path[0] !== 'dark');
+    const darkTokens = dictionary.allTokens.filter((t) => t.path[0] === 'dark');
+
+    const lightProps = lightTokens
+      .map((token) => {
+        const value = token.$value ?? token.value;
+        return `  --${token.name}: ${value};`;
+      })
+      .join('\n');
+
+    const darkProps = darkTokens
+      .map((token) => {
+        const value = token.$value ?? token.value;
+        return `  --${token.name}: ${value};`;
+      })
+      .join('\n');
+
+    const darkBlock =
+      darkProps.length > 0
+        ? `\n\n/** Dark-mode overrides applied to :host when data-theme="dark" */\nexport const darkTokenStyles = css\`\n:host([data-theme="dark"]) {\n${darkProps}\n}\n@media (prefers-color-scheme: dark) {\n  :host(:not([data-theme="light"])) {\n${darkProps}\n  }\n}\n\`;\n`
+        : `\nexport const darkTokenStyles = css\`\`;\n`;
+
+    return `import { css } from 'lit';\n\n/** Light-mode design tokens as Lit :host custom properties */\nexport const tokenStyles = css\`\n:host {\n${lightProps}\n}\n\`;${darkBlock}`;
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Helper: build a StyleDictionary instance filtered to a token subset
+// ---------------------------------------------------------------------------
+function buildFilteredSD(filter, additionalConfig = {}) {
+  return new StyleDictionary(
+    {
+      usesDtcg: true,
+      source: [
+        `${__dirname}/tokens/primitive/**/*.json`,
+        `${__dirname}/tokens/semantic/**/*.json`,
+      ],
+      log: { warnings: 'warn', verbosity: 'default' },
+      ...additionalConfig,
+    },
+    { verbosity: 'default' },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Build 1: Light-mode tokens (:root)
+// Excludes dark.* tokens, uses outputReferences so semantic tokens reference
+// primitive var() names instead of emitting resolved hex values.
+// ---------------------------------------------------------------------------
+async function buildLight() {
+  const sd = new StyleDictionary(
+    {
+      usesDtcg: true,
+      source: [
+        `${__dirname}/tokens/primitive/**/*.json`,
+        `${__dirname}/tokens/semantic/**/*.json`,
+      ],
+      log: { warnings: 'warn', verbosity: 'default' },
+      platforms: {
+        css: {
+          transforms: ['name/hx/kebab'],
+          buildPath: `${__dirname}/dist/`,
+          files: [
+            {
+              destination: 'tokens.css',
+              format: 'css/variables',
+              filter: (token) => token.path[0] !== 'dark',
+              options: {
+                outputReferences: true,
+                selector: ':root',
+              },
+            },
+          ],
+        },
+      },
+    },
+    { verbosity: 'default' },
+  );
+
+  await sd.buildAllPlatforms();
+}
+
+// ---------------------------------------------------------------------------
+// Build 2: Dark auto-mode (@media prefers-color-scheme: dark)
+// ---------------------------------------------------------------------------
+async function buildDarkAuto() {
+  const sd = new StyleDictionary(
+    {
+      usesDtcg: true,
+      source: [
+        `${__dirname}/tokens/primitive/**/*.json`,
+        `${__dirname}/tokens/semantic/**/*.json`,
+      ],
+      log: { warnings: 'warn', verbosity: 'default' },
+      platforms: {
+        css: {
+          transforms: ['name/hx/kebab'],
+          buildPath: `${__dirname}/dist/`,
+          files: [
+            {
+              destination: 'tokens-dark-auto.css',
+              format: 'css/dark-media',
+              filter: (token) => token.path[0] === 'dark',
+              options: {
+                outputReferences: false,
+                selector: ':root:not([data-theme="light"])',
+              },
+            },
+          ],
+        },
+      },
+    },
+    { verbosity: 'default' },
+  );
+
+  await sd.buildAllPlatforms();
+}
+
+// ---------------------------------------------------------------------------
+// Build 3: Dark manual override ([data-theme="dark"])
+// ---------------------------------------------------------------------------
+async function buildDarkManual() {
+  const sd = new StyleDictionary(
+    {
+      usesDtcg: true,
+      source: [
+        `${__dirname}/tokens/primitive/**/*.json`,
+        `${__dirname}/tokens/semantic/**/*.json`,
+      ],
+      log: { warnings: 'warn', verbosity: 'default' },
+      platforms: {
+        css: {
+          transforms: ['name/hx/kebab'],
+          buildPath: `${__dirname}/dist/`,
+          files: [
+            {
+              destination: 'tokens-dark-manual.css',
+              format: 'css/variables',
+              filter: (token) => token.path[0] === 'dark',
+              options: {
+                outputReferences: false,
+                selector: ':root[data-theme="dark"]',
+              },
+            },
+          ],
+        },
+      },
+    },
+    { verbosity: 'default' },
+  );
+
+  await sd.buildAllPlatforms();
+}
+
+// ---------------------------------------------------------------------------
+// Build 4: Lit CSS tagged template
+// ---------------------------------------------------------------------------
+async function buildLit() {
+  const sd = new StyleDictionary(
+    {
+      usesDtcg: true,
+      source: [
+        `${__dirname}/tokens/primitive/**/*.json`,
+        `${__dirname}/tokens/semantic/**/*.json`,
+      ],
+      log: { warnings: 'warn', verbosity: 'default' },
+      platforms: {
+        js: {
+          transforms: ['name/hx/kebab'],
+          buildPath: `${__dirname}/dist/`,
+          files: [
+            {
+              destination: 'tokens-lit.js',
+              format: 'js/lit-css',
+            },
+          ],
+        },
+      },
+    },
+    { verbosity: 'default' },
+  );
+
+  await sd.buildAllPlatforms();
+}
+
+// ---------------------------------------------------------------------------
+// Main: ensure dist exists then run all builds sequentially
+// ---------------------------------------------------------------------------
+export async function buildTokens() {
+  mkdirSync(resolve(__dirname, 'dist'), { recursive: true });
+  await buildLight();
+  await buildDarkAuto();
+  await buildDarkManual();
+  await buildLit();
+}
+
+// When invoked directly (node sd.config.mjs) run the build immediately
+if (import.meta.url === `file://${process.argv[1]}`) {
+  buildTokens().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/hx-tokens/tokens/README.md
+++ b/packages/hx-tokens/tokens/README.md
@@ -1,0 +1,115 @@
+# Design Token Architecture — @helix/tokens
+
+Three-tier cascade processed by [Style Dictionary 4.x](https://styledictionary.com/).
+
+```
+Primitive  →  Semantic  →  Component
+```
+
+---
+
+## Tier 1 — Primitive (`tokens/primitive/`)
+
+Raw values: the palette. Never consumed directly by components.
+
+| File              | Contents                                         |
+| ----------------- | ------------------------------------------------ |
+| `color.json`      | Color scales (primary, secondary, neutral, etc.) |
+| `spacing.json`    | Spacing scale (`space.0` … `space.64`)           |
+| `typography.json` | Font families, sizes, weights, line-heights      |
+| `effects.json`    | Border radius, widths, shadows                   |
+| `motion.json`     | Duration and easing values                       |
+
+All tokens use W3C DTCG format:
+```json
+{ "$value": "#2563EB", "$type": "color" }
+```
+
+## Tier 2 — Semantic (`tokens/semantic/`)
+
+Intent-based aliases of primitives. Consumed by Tier 3 and directly by layout styles.
+
+| File         | Contents                                                       |
+| ------------ | -------------------------------------------------------------- |
+| `color.json` | `color.text.*`, `color.surface.*`, `color.border.*`, focus, state |
+| `dark.json`  | Dark-mode overrides under the `dark.*` namespace               |
+
+Semantic tokens reference primitives via DTCG alias syntax:
+```json
+{ "$value": "{color.neutral.900}", "$type": "color" }
+```
+
+## Tier 3 — Component (`packages/hx-library/tokens/component/`)
+
+Per-component token files consumed by Lit component styles. These sit in `hx-library` to keep component-specific decisions co-located with the component package.
+
+| File          | Contents                          |
+| ------------- | --------------------------------- |
+| `button.json` | `button.bg`, `button.color`, etc. |
+| `card.json`   | `card.bg`, `card.shadow`, etc.    |
+| `form.json`   | `input.*` tokens                  |
+
+---
+
+## Build Pipeline
+
+```bash
+# From repo root:
+npm run build:sd --workspace=packages/hx-tokens
+
+# Or directly:
+node packages/hx-tokens/sd.config.mjs
+```
+
+### Outputs (`packages/hx-tokens/dist/`)
+
+| File                   | Description                                         |
+| ---------------------- | --------------------------------------------------- |
+| `tokens.css`           | `:root` CSS custom properties (light mode)          |
+| `tokens-dark-auto.css` | `@media (prefers-color-scheme: dark)` overrides     |
+| `tokens-dark-manual.css` | `[data-theme="dark"]` selector overrides          |
+| `tokens-lit.js`        | Lit `css\`\`` tagged template exports               |
+
+---
+
+## CSS Custom Property Convention
+
+All generated CSS custom properties use the `--hx-` prefix:
+
+```css
+/* Primitive */
+--hx-color-primary-500: #2563EB;
+--hx-color-neutral-900: #0F172A;
+
+/* Semantic (references primitives) */
+--hx-color-text-primary: var(--hx-color-neutral-900);
+--hx-color-border-focus:  var(--hx-color-primary-500);
+
+/* Component (in Lit shadow host, references semantic) */
+:host {
+  --_bg: var(--hx-button-bg, var(--hx-color-primary-500));
+}
+```
+
+Consumers override at the **semantic level** via `--hx-color-*`.
+Components consume at the **component level** with semantic fallbacks.
+
+---
+
+## Token Format Reference (W3C DTCG)
+
+```json
+{
+  "color": {
+    "primary": {
+      "500": {
+        "$value": "#2563EB",
+        "$type": "color",
+        "$description": "Primary brand blue"
+      }
+    }
+  }
+}
+```
+
+Supported `$type` values: `color`, `dimension`, `fontFamily`, `fontWeight`, `number`, `shadow`, `string`.

--- a/packages/hx-tokens/tokens/primitive/color.json
+++ b/packages/hx-tokens/tokens/primitive/color.json
@@ -1,0 +1,109 @@
+{
+  "color": {
+    "primary": {
+      "50":  { "$value": "#EFF6FF", "$type": "color" },
+      "100": { "$value": "#DBEAFE", "$type": "color" },
+      "200": { "$value": "#BFDBFE", "$type": "color" },
+      "300": { "$value": "#93C5FD", "$type": "color" },
+      "400": { "$value": "#60A5FA", "$type": "color" },
+      "500": { "$value": "#2563EB", "$type": "color" },
+      "600": { "$value": "#1D4ED8", "$type": "color" },
+      "700": { "$value": "#1E40AF", "$type": "color" },
+      "800": { "$value": "#1E3A8A", "$type": "color" },
+      "900": { "$value": "#1E3050", "$type": "color" },
+      "950": { "$value": "#172554", "$type": "color" }
+    },
+    "secondary": {
+      "50":  { "$value": "#ECFEFF", "$type": "color" },
+      "100": { "$value": "#CFFAFE", "$type": "color" },
+      "200": { "$value": "#A5F3FC", "$type": "color" },
+      "300": { "$value": "#67E8F9", "$type": "color" },
+      "400": { "$value": "#22D3EE", "$type": "color" },
+      "500": { "$value": "#0891B2", "$type": "color" },
+      "600": { "$value": "#0E7490", "$type": "color" },
+      "700": { "$value": "#155E75", "$type": "color" },
+      "800": { "$value": "#164E63", "$type": "color" },
+      "900": { "$value": "#134152", "$type": "color" },
+      "950": { "$value": "#083344", "$type": "color" }
+    },
+    "accent": {
+      "50":  { "$value": "#FFFBEB", "$type": "color" },
+      "100": { "$value": "#FEF3C7", "$type": "color" },
+      "200": { "$value": "#FDE68A", "$type": "color" },
+      "300": { "$value": "#FCD34D", "$type": "color" },
+      "400": { "$value": "#FBBF24", "$type": "color" },
+      "500": { "$value": "#D97706", "$type": "color" },
+      "600": { "$value": "#B45309", "$type": "color" },
+      "700": { "$value": "#92400E", "$type": "color" },
+      "800": { "$value": "#78350F", "$type": "color" },
+      "900": { "$value": "#633112", "$type": "color" },
+      "950": { "$value": "#451A03", "$type": "color" }
+    },
+    "neutral": {
+      "0":   { "$value": "#FFFFFF", "$type": "color" },
+      "50":  { "$value": "#F8FAFC", "$type": "color" },
+      "100": { "$value": "#F1F5F9", "$type": "color" },
+      "200": { "$value": "#E2E8F0", "$type": "color" },
+      "300": { "$value": "#CBD5E1", "$type": "color" },
+      "400": { "$value": "#94A3B8", "$type": "color" },
+      "500": { "$value": "#64748B", "$type": "color" },
+      "600": { "$value": "#475569", "$type": "color" },
+      "700": { "$value": "#334155", "$type": "color" },
+      "800": { "$value": "#1E293B", "$type": "color" },
+      "900": { "$value": "#0F172A", "$type": "color" },
+      "950": { "$value": "#020617", "$type": "color" }
+    },
+    "success": {
+      "50":  { "$value": "#F0FDF4", "$type": "color" },
+      "100": { "$value": "#DCFCE7", "$type": "color" },
+      "200": { "$value": "#BBF7D0", "$type": "color" },
+      "300": { "$value": "#86EFAC", "$type": "color" },
+      "400": { "$value": "#4ADE80", "$type": "color" },
+      "500": { "$value": "#16A34A", "$type": "color" },
+      "600": { "$value": "#15803D", "$type": "color" },
+      "700": { "$value": "#166534", "$type": "color" },
+      "800": { "$value": "#14532D", "$type": "color" },
+      "900": { "$value": "#0D3B21", "$type": "color" },
+      "950": { "$value": "#052E16", "$type": "color" }
+    },
+    "warning": {
+      "50":  { "$value": "#FFFBEB", "$type": "color" },
+      "100": { "$value": "#FEF3C7", "$type": "color" },
+      "200": { "$value": "#FDE68A", "$type": "color" },
+      "300": { "$value": "#FCD34D", "$type": "color" },
+      "400": { "$value": "#FBBF24", "$type": "color" },
+      "500": { "$value": "#D97706", "$type": "color" },
+      "600": { "$value": "#B45309", "$type": "color" },
+      "700": { "$value": "#92400E", "$type": "color" },
+      "800": { "$value": "#78350F", "$type": "color" },
+      "900": { "$value": "#633112", "$type": "color" },
+      "950": { "$value": "#451A03", "$type": "color" }
+    },
+    "error": {
+      "50":  { "$value": "#FEF2F2", "$type": "color" },
+      "100": { "$value": "#FEE2E2", "$type": "color" },
+      "200": { "$value": "#FECACA", "$type": "color" },
+      "300": { "$value": "#FCA5A5", "$type": "color" },
+      "400": { "$value": "#F87171", "$type": "color" },
+      "500": { "$value": "#DC2626", "$type": "color" },
+      "600": { "$value": "#B91C1C", "$type": "color" },
+      "700": { "$value": "#991B1B", "$type": "color" },
+      "800": { "$value": "#7F1D1D", "$type": "color" },
+      "900": { "$value": "#651A1A", "$type": "color" },
+      "950": { "$value": "#450A0A", "$type": "color" }
+    },
+    "info": {
+      "50":  { "$value": "#F0F9FF", "$type": "color" },
+      "100": { "$value": "#E0F2FE", "$type": "color" },
+      "200": { "$value": "#BAE6FD", "$type": "color" },
+      "300": { "$value": "#7DD3FC", "$type": "color" },
+      "400": { "$value": "#38BDF8", "$type": "color" },
+      "500": { "$value": "#0284C7", "$type": "color" },
+      "600": { "$value": "#0369A1", "$type": "color" },
+      "700": { "$value": "#075985", "$type": "color" },
+      "800": { "$value": "#0C4A6E", "$type": "color" },
+      "900": { "$value": "#0A3553", "$type": "color" },
+      "950": { "$value": "#082F49", "$type": "color" }
+    }
+  }
+}

--- a/packages/hx-tokens/tokens/primitive/effects.json
+++ b/packages/hx-tokens/tokens/primitive/effects.json
@@ -1,0 +1,84 @@
+{
+  "shadow": {
+    "none":  { "$value": "none",                                                                                              "$type": "shadow" },
+    "sm":    { "$value": "0 1px 2px 0 rgb(0 0 0 / 0.05)",                                                                    "$type": "shadow" },
+    "md":    { "$value": "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",                                "$type": "shadow" },
+    "lg":    { "$value": "0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)",                              "$type": "shadow" },
+    "xl":    { "$value": "0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)",                             "$type": "shadow" },
+    "2xl":   { "$value": "0 25px 50px -12px rgb(0 0 0 / 0.25)",                                                              "$type": "shadow" },
+    "inner": { "$value": "inset 0 2px 4px 0 rgb(0 0 0 / 0.05)",                                                              "$type": "shadow" }
+  },
+  "border": {
+    "radius": {
+      "none": { "$value": "0",       "$type": "dimension" },
+      "sm":   { "$value": "0.25rem", "$type": "dimension" },
+      "md":   { "$value": "0.375rem","$type": "dimension" },
+      "lg":   { "$value": "0.5rem",  "$type": "dimension" },
+      "xl":   { "$value": "0.75rem", "$type": "dimension" },
+      "2xl":  { "$value": "1rem",    "$type": "dimension" },
+      "full": { "$value": "9999px",  "$type": "dimension" }
+    },
+    "width": {
+      "thin":   { "$value": "1px", "$type": "dimension" },
+      "medium": { "$value": "2px", "$type": "dimension" },
+      "thick":  { "$value": "3px", "$type": "dimension" }
+    }
+  },
+  "opacity": {
+    "0":        { "$value": "0",    "$type": "number" },
+    "5":        { "$value": "0.05", "$type": "number" },
+    "10":       { "$value": "0.1",  "$type": "number" },
+    "25":       { "$value": "0.25", "$type": "number" },
+    "50":       { "$value": "0.5",  "$type": "number" },
+    "75":       { "$value": "0.75", "$type": "number" },
+    "90":       { "$value": "0.9",  "$type": "number" },
+    "100":      { "$value": "1",    "$type": "number" },
+    "disabled": { "$value": "0.5",  "$type": "number" },
+    "overlay":  { "$value": "0.75", "$type": "number" }
+  },
+  "z-index": {
+    "base":     { "$value": "0",    "$type": "number" },
+    "dropdown": { "$value": "1000", "$type": "number" },
+    "sticky":   { "$value": "1100", "$type": "number" },
+    "fixed":    { "$value": "1200", "$type": "number" },
+    "backdrop": { "$value": "1300", "$type": "number" },
+    "modal":    { "$value": "1400", "$type": "number" },
+    "popover":  { "$value": "1500", "$type": "number" },
+    "tooltip":  { "$value": "1600", "$type": "number" },
+    "toast":    { "$value": "1700", "$type": "number" }
+  },
+  "size": {
+    "4":           { "$value": "1rem",    "$type": "dimension" },
+    "5":           { "$value": "1.25rem", "$type": "dimension" },
+    "6":           { "$value": "1.5rem",  "$type": "dimension" },
+    "8":           { "$value": "2rem",    "$type": "dimension" },
+    "10":          { "$value": "2.5rem",  "$type": "dimension" },
+    "12":          { "$value": "3rem",    "$type": "dimension" },
+    "16":          { "$value": "4rem",    "$type": "dimension" },
+    "20":          { "$value": "5rem",    "$type": "dimension" },
+    "icon-sm":     { "$value": "1rem",    "$type": "dimension" },
+    "icon-md":     { "$value": "1.25rem", "$type": "dimension" },
+    "icon-lg":     { "$value": "1.5rem",  "$type": "dimension" },
+    "touch-target":{ "$value": "2.75rem", "$type": "dimension" }
+  },
+  "container": {
+    "sm":      { "$value": "640px",  "$type": "dimension" },
+    "md":      { "$value": "768px",  "$type": "dimension" },
+    "lg":      { "$value": "1024px", "$type": "dimension" },
+    "xl":      { "$value": "1280px", "$type": "dimension" },
+    "content": { "$value": "72rem",  "$type": "dimension" }
+  },
+  "breakpoint": {
+    "sm":  { "$value": "640px",  "$type": "dimension" },
+    "md":  { "$value": "768px",  "$type": "dimension" },
+    "lg":  { "$value": "1024px", "$type": "dimension" },
+    "xl":  { "$value": "1280px", "$type": "dimension" },
+    "2xl": { "$value": "1536px", "$type": "dimension" }
+  },
+  "aspect-ratio": {
+    "auto":     { "$value": "auto",  "$type": "string" },
+    "square":   { "$value": "1 / 1", "$type": "string" },
+    "video":    { "$value": "16 / 9","$type": "string" },
+    "portrait": { "$value": "3 / 4", "$type": "string" }
+  }
+}

--- a/packages/hx-tokens/tokens/primitive/motion.json
+++ b/packages/hx-tokens/tokens/primitive/motion.json
@@ -1,0 +1,22 @@
+{
+  "duration": {
+    "instant": { "$value": "0ms",   "$type": "duration" },
+    "fast":    { "$value": "100ms", "$type": "duration" },
+    "normal":  { "$value": "200ms", "$type": "duration" },
+    "slow":    { "$value": "300ms", "$type": "duration" },
+    "slower":  { "$value": "500ms", "$type": "duration" },
+    "reduced": { "$value": "0ms",   "$type": "duration" }
+  },
+  "easing": {
+    "default": { "$value": "cubic-bezier(0.4, 0, 0.2, 1)",   "$type": "cubicBezier" },
+    "in":      { "$value": "cubic-bezier(0.4, 0, 1, 1)",     "$type": "cubicBezier" },
+    "out":     { "$value": "cubic-bezier(0, 0, 0.2, 1)",     "$type": "cubicBezier" },
+    "in-out":  { "$value": "cubic-bezier(0.4, 0, 0.2, 1)",   "$type": "cubicBezier" },
+    "spring":  { "$value": "cubic-bezier(0.175, 0.885, 0.32, 1.275)", "$type": "cubicBezier" }
+  },
+  "transition": {
+    "fast":   { "$value": "150ms ease", "$type": "string" },
+    "normal": { "$value": "250ms ease", "$type": "string" },
+    "slow":   { "$value": "350ms ease", "$type": "string" }
+  }
+}

--- a/packages/hx-tokens/tokens/primitive/spacing.json
+++ b/packages/hx-tokens/tokens/primitive/spacing.json
@@ -1,0 +1,24 @@
+{
+  "space": {
+    "0":  { "$value": "0",       "$type": "dimension" },
+    "px": { "$value": "1px",     "$type": "dimension" },
+    "1":  { "$value": "0.25rem", "$type": "dimension" },
+    "2":  { "$value": "0.5rem",  "$type": "dimension" },
+    "3":  { "$value": "0.75rem", "$type": "dimension" },
+    "4":  { "$value": "1rem",    "$type": "dimension" },
+    "5":  { "$value": "1.25rem", "$type": "dimension" },
+    "6":  { "$value": "1.5rem",  "$type": "dimension" },
+    "7":  { "$value": "1.75rem", "$type": "dimension" },
+    "8":  { "$value": "2rem",    "$type": "dimension" },
+    "10": { "$value": "2.5rem",  "$type": "dimension" },
+    "12": { "$value": "3rem",    "$type": "dimension" },
+    "14": { "$value": "3.5rem",  "$type": "dimension" },
+    "16": { "$value": "4rem",    "$type": "dimension" },
+    "20": { "$value": "5rem",    "$type": "dimension" },
+    "24": { "$value": "6rem",    "$type": "dimension" },
+    "32": { "$value": "8rem",    "$type": "dimension" },
+    "40": { "$value": "10rem",   "$type": "dimension" },
+    "48": { "$value": "12rem",   "$type": "dimension" },
+    "64": { "$value": "16rem",   "$type": "dimension" }
+  }
+}

--- a/packages/hx-tokens/tokens/primitive/typography.json
+++ b/packages/hx-tokens/tokens/primitive/typography.json
@@ -1,0 +1,44 @@
+{
+  "font": {
+    "family": {
+      "sans":  { "$value": "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif", "$type": "fontFamily" },
+      "serif": { "$value": "'Georgia', 'Times New Roman', serif",                                         "$type": "fontFamily" },
+      "mono":  { "$value": "'JetBrains Mono', ui-monospace, 'Cascadia Code', monospace",                 "$type": "fontFamily" }
+    },
+    "size": {
+      "2xs": { "$value": "0.625rem",  "$type": "dimension" },
+      "xs":  { "$value": "0.75rem",   "$type": "dimension" },
+      "sm":  { "$value": "0.875rem",  "$type": "dimension" },
+      "md":  { "$value": "1rem",      "$type": "dimension" },
+      "lg":  { "$value": "1.125rem",  "$type": "dimension" },
+      "xl":  { "$value": "1.25rem",   "$type": "dimension" },
+      "2xl": { "$value": "1.5rem",    "$type": "dimension" },
+      "3xl": { "$value": "1.875rem",  "$type": "dimension" },
+      "4xl": { "$value": "2.25rem",   "$type": "dimension" },
+      "5xl": { "$value": "3rem",      "$type": "dimension" }
+    },
+    "weight": {
+      "light":     { "$value": "300", "$type": "fontWeight" },
+      "normal":    { "$value": "400", "$type": "fontWeight" },
+      "medium":    { "$value": "500", "$type": "fontWeight" },
+      "semibold":  { "$value": "600", "$type": "fontWeight" },
+      "bold":      { "$value": "700", "$type": "fontWeight" },
+      "extrabold": { "$value": "800", "$type": "fontWeight" }
+    }
+  },
+  "line-height": {
+    "tighter": { "$value": "1.125", "$type": "number" },
+    "tight":   { "$value": "1.25",  "$type": "number" },
+    "normal":  { "$value": "1.5",   "$type": "number" },
+    "relaxed": { "$value": "1.75",  "$type": "number" },
+    "loose":   { "$value": "2",     "$type": "number" }
+  },
+  "letter-spacing": {
+    "tighter": { "$value": "-0.05em", "$type": "dimension" },
+    "tight":   { "$value": "-0.025em","$type": "dimension" },
+    "normal":  { "$value": "0",       "$type": "dimension" },
+    "wide":    { "$value": "0.025em", "$type": "dimension" },
+    "wider":   { "$value": "0.05em",  "$type": "dimension" },
+    "widest":  { "$value": "0.1em",   "$type": "dimension" }
+  }
+}

--- a/packages/hx-tokens/tokens/semantic/color.json
+++ b/packages/hx-tokens/tokens/semantic/color.json
@@ -1,0 +1,87 @@
+{
+  "color": {
+    "text": {
+      "primary":      { "$value": "{color.neutral.900}", "$type": "color", "$description": "Default body text color" },
+      "secondary":    { "$value": "{color.neutral.600}", "$type": "color", "$description": "Secondary text, less emphasis" },
+      "muted":        { "$value": "{color.neutral.500}", "$type": "color", "$description": "Muted or placeholder text" },
+      "disabled":     { "$value": "{color.neutral.400}", "$type": "color", "$description": "Text on disabled elements" },
+      "inverse":      { "$value": "{color.neutral.0}",   "$type": "color", "$description": "Text on dark/inverted backgrounds" },
+      "on-primary":   { "$value": "{color.neutral.0}",   "$type": "color", "$description": "Text placed on primary color surfaces" },
+      "on-secondary": { "$value": "{color.neutral.0}",   "$type": "color", "$description": "Text placed on secondary color surfaces" },
+      "on-error":     { "$value": "{color.neutral.0}",   "$type": "color", "$description": "Text placed on error color surfaces" },
+      "on-success":   { "$value": "{color.neutral.0}",   "$type": "color", "$description": "Text placed on success color surfaces" },
+      "on-warning":   { "$value": "{color.neutral.900}", "$type": "color", "$description": "Text placed on warning color surfaces" },
+      "on-info":      { "$value": "{color.neutral.0}",   "$type": "color", "$description": "Text placed on info color surfaces" },
+      "link":         { "$value": "{color.primary.600}", "$type": "color", "$description": "Hyperlink text color" },
+      "link-hover":   { "$value": "{color.primary.700}", "$type": "color", "$description": "Hyperlink hover state" },
+      "link-visited": { "$value": "{color.secondary.600}", "$type": "color", "$description": "Visited hyperlink color" },
+      "link-active":  { "$value": "{color.primary.800}", "$type": "color", "$description": "Hyperlink active/pressed state" }
+    },
+    "surface": {
+      "default": { "$value": "{color.neutral.0}",   "$type": "color", "$description": "Default page/card background" },
+      "raised":  { "$value": "{color.neutral.50}",  "$type": "color", "$description": "Slightly elevated surface (cards, dropdowns)" },
+      "sunken":  { "$value": "{color.neutral.100}", "$type": "color", "$description": "Recessed surface (inputs, wells)" },
+      "overlay": { "$value": "rgba(0, 0, 0, 0.75)", "$type": "color", "$description": "Modal/dialog backdrop overlay" }
+    },
+    "border": {
+      "default": { "$value": "{color.neutral.200}", "$type": "color", "$description": "Default border color" },
+      "subtle":  { "$value": "{color.neutral.100}", "$type": "color", "$description": "Subtle/lightweight border" },
+      "strong":  { "$value": "{color.neutral.400}", "$type": "color", "$description": "High-emphasis border" },
+      "focus":   { "$value": "{color.primary.500}", "$type": "color", "$description": "Focus-state border color" }
+    },
+    "focus-ring": { "$value": "{color.primary.400}", "$type": "color", "$description": "Focus ring / outline color" },
+    "selection": {
+      "bg":    { "$value": "{color.primary.200}", "$type": "color", "$description": "Text selection background" },
+      "color": { "$value": "{color.neutral.900}", "$type": "color", "$description": "Text selection foreground" }
+    }
+  },
+  "body": {
+    "bg":          { "$value": "{color.surface.default}",  "$type": "color",      "$description": "Body background color" },
+    "color":       { "$value": "{color.text.primary}",     "$type": "color",      "$description": "Body text color" },
+    "font-family": { "$value": "{font.family.sans}",       "$type": "fontFamily", "$description": "Body font family" },
+    "font-size":   { "$value": "{font.size.md}",           "$type": "dimension",  "$description": "Body base font size" },
+    "line-height": { "$value": "{line-height.normal}",     "$type": "number",     "$description": "Body line height" }
+  },
+  "heading": {
+    "font-family":    { "$value": "{font.family.sans}",      "$type": "fontFamily", "$description": "Heading font family" },
+    "font-weight":    { "$value": "{font.weight.bold}",      "$type": "fontWeight", "$description": "Heading font weight" },
+    "line-height":    { "$value": "{line-height.tight}",     "$type": "number",     "$description": "Heading line height" },
+    "letter-spacing": { "$value": "{letter-spacing.tight}",  "$type": "dimension",  "$description": "Heading letter spacing" }
+  },
+  "focus": {
+    "ring-color":   { "$value": "{color.primary.400}", "$type": "color",     "$description": "Focus ring color" },
+    "ring-width":   { "$value": "2px",                 "$type": "dimension", "$description": "Focus ring width" },
+    "ring-offset":  { "$value": "2px",                 "$type": "dimension", "$description": "Focus ring offset from element" },
+    "ring-style":   { "$value": "solid",               "$type": "string",    "$description": "Focus ring border style" },
+    "ring-opacity": { "$value": "0.25",                "$type": "number",    "$description": "Focus ring opacity" }
+  },
+  "state": {
+    "hover-opacity":   { "$value": "0.08", "$type": "number", "$description": "Hover state overlay opacity" },
+    "pressed-opacity": { "$value": "0.12", "$type": "number", "$description": "Pressed/active state overlay opacity" },
+    "dragged-opacity": { "$value": "0.16", "$type": "number", "$description": "Dragged state overlay opacity" },
+    "focus-opacity":   { "$value": "0.12", "$type": "number", "$description": "Focus state overlay opacity" }
+  },
+  "filter": {
+    "brightness-hover":    { "$value": "0.9",  "$type": "number",    "$description": "Brightness filter on hover" },
+    "brightness-active":   { "$value": "0.8",  "$type": "number",    "$description": "Brightness filter on active/pressed" },
+    "brightness-disabled": { "$value": "0.6",  "$type": "number",    "$description": "Brightness filter for disabled state" },
+    "blur-sm":             { "$value": "4px",  "$type": "dimension", "$description": "Small blur filter value" },
+    "blur-md":             { "$value": "8px",  "$type": "dimension", "$description": "Medium blur filter value" },
+    "blur-lg":             { "$value": "16px", "$type": "dimension", "$description": "Large blur filter value" }
+  },
+  "transform": {
+    "lift-sm": { "$value": "-1px", "$type": "dimension", "$description": "Small translateY lift on interaction" },
+    "lift-md": { "$value": "-2px", "$type": "dimension", "$description": "Medium translateY lift on interaction" },
+    "lift-lg": { "$value": "-4px", "$type": "dimension", "$description": "Large translateY lift on interaction" }
+  },
+  "divider": {
+    "color":   { "$value": "{color.border.default}", "$type": "color",     "$description": "Divider/separator line color" },
+    "width":   { "$value": "{border.width.thin}",    "$type": "dimension", "$description": "Divider/separator line width" },
+    "spacing": { "$value": "{space.4}",              "$type": "dimension", "$description": "Space around dividers" }
+  },
+  "input": {
+    "height-sm": { "$value": "{size.8}",  "$type": "dimension", "$description": "Small input height" },
+    "height-md": { "$value": "{size.10}", "$type": "dimension", "$description": "Medium input height" },
+    "height-lg": { "$value": "{size.12}", "$type": "dimension", "$description": "Large input height" }
+  }
+}

--- a/packages/hx-tokens/tokens/semantic/dark.json
+++ b/packages/hx-tokens/tokens/semantic/dark.json
@@ -1,0 +1,45 @@
+{
+  "dark": {
+    "color": {
+      "text": {
+        "primary":      { "$value": "{color.neutral.100}",   "$type": "color", "$description": "Dark mode default body text" },
+        "secondary":    { "$value": "{color.neutral.300}",   "$type": "color", "$description": "Dark mode secondary text" },
+        "muted":        { "$value": "{color.neutral.400}",   "$type": "color", "$description": "Dark mode muted text" },
+        "disabled":     { "$value": "{color.neutral.600}",   "$type": "color", "$description": "Dark mode disabled text" },
+        "inverse":      { "$value": "{color.neutral.900}",   "$type": "color", "$description": "Dark mode inverted text" },
+        "link":         { "$value": "{color.primary.400}",   "$type": "color", "$description": "Dark mode link text" },
+        "link-hover":   { "$value": "{color.primary.300}",   "$type": "color", "$description": "Dark mode link hover" },
+        "link-visited": { "$value": "{color.secondary.400}", "$type": "color", "$description": "Dark mode visited link" },
+        "link-active":  { "$value": "{color.primary.200}",   "$type": "color", "$description": "Dark mode active link" }
+      },
+      "surface": {
+        "default": { "$value": "{color.neutral.900}", "$type": "color", "$description": "Dark mode page/card background" },
+        "raised":  { "$value": "{color.neutral.800}", "$type": "color", "$description": "Dark mode elevated surface" },
+        "sunken":  { "$value": "{color.neutral.950}", "$type": "color", "$description": "Dark mode recessed surface" },
+        "overlay": { "$value": "rgba(0, 0, 0, 0.85)", "$type": "color", "$description": "Dark mode backdrop overlay" }
+      },
+      "border": {
+        "default": { "$value": "{color.neutral.700}", "$type": "color", "$description": "Dark mode default border" },
+        "subtle":  { "$value": "{color.neutral.800}", "$type": "color", "$description": "Dark mode subtle border" },
+        "strong":  { "$value": "{color.neutral.500}", "$type": "color", "$description": "Dark mode strong border" },
+        "focus":   { "$value": "{color.primary.400}", "$type": "color", "$description": "Dark mode focus border" }
+      },
+      "focus-ring": { "$value": "{color.primary.400}", "$type": "color", "$description": "Dark mode focus ring color" },
+      "selection": {
+        "bg":    { "$value": "{color.primary.800}", "$type": "color", "$description": "Dark mode text selection background" },
+        "color": { "$value": "{color.neutral.100}", "$type": "color", "$description": "Dark mode text selection foreground" }
+      }
+    },
+    "body": {
+      "bg":    { "$value": "{color.neutral.900}", "$type": "color", "$description": "Dark mode body background" },
+      "color": { "$value": "{color.neutral.100}", "$type": "color", "$description": "Dark mode body text" }
+    },
+    "shadow": {
+      "sm":  { "$value": "0 1px 2px 0 rgb(0 0 0 / 0.3)",                                                 "$type": "shadow", "$description": "Dark mode small shadow" },
+      "md":  { "$value": "0 4px 6px -1px rgb(0 0 0 / 0.4), 0 2px 4px -2px rgb(0 0 0 / 0.3)",            "$type": "shadow", "$description": "Dark mode medium shadow" },
+      "lg":  { "$value": "0 10px 15px -3px rgb(0 0 0 / 0.4), 0 4px 6px -4px rgb(0 0 0 / 0.3)",          "$type": "shadow", "$description": "Dark mode large shadow" },
+      "xl":  { "$value": "0 20px 25px -5px rgb(0 0 0 / 0.4), 0 8px 10px -6px rgb(0 0 0 / 0.3)",         "$type": "shadow", "$description": "Dark mode extra-large shadow" },
+      "2xl": { "$value": "0 25px 50px -12px rgb(0 0 0 / 0.5)",                                           "$type": "shadow", "$description": "Dark mode 2xl shadow" }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Convert token source from flat JSON to **W3C Design Token Community Group** format
- Set up **Style Dictionary 4.x** pipeline with custom `--hx-` prefix transform
- Three-tier cascade: **primitive** (raw values) → **semantic** (intent aliases) → **component** (per-component overrides)
- Generates 4 outputs: `tokens.css`, `tokens-dark-auto.css`, `tokens-dark-manual.css`, `tokens-lit.js`
- Dark mode support via `@media prefers-color-scheme` and `[data-theme="dark"]`
- All existing `--hx-*` tokens preserved — zero breaking changes

### Files Added/Modified
- `packages/hx-tokens/sd.config.mjs` — Style Dictionary 4.x config with custom transforms/formats
- `packages/hx-tokens/tokens/primitive/` — 5 DTCG source files (color, spacing, typography, effects, motion)
- `packages/hx-tokens/tokens/semantic/` — 2 DTCG source files (color aliases, dark mode)
- `packages/hx-library/tokens/component/` — 3 Tier 3 token files (button, card, form)
- `packages/hx-tokens/tokens/README.md` — Architecture documentation

## Test plan
- [x] `node packages/hx-tokens/sd.config.mjs` generates all 4 output files
- [x] All CSS variables use `--hx-` prefix correctly
- [x] Semantic tokens reference primitives via `var()` (outputReferences: true)
- [x] Dark mode tokens generate correct `@media` and `[data-theme]` selectors
- [ ] Full test suite passes (563 tests)
- [ ] Type-check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)