### PR TITLE
ci: add npm security audit step to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Security audit
+        run: npm audit --audit-level=high
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium firefox webkit
 


### PR DESCRIPTION
## Summary
- Adds `npm audit --audit-level=high` step to GitHub Actions CI workflow
- Builds fail on high/critical dependency vulnerabilities
- Runs on every PR and push to main

## Test plan
- [ ] CI workflow triggers on PR creation
- [ ] Audit step runs after `npm ci`
- [ ] High/critical vulnerabilities fail the build

🤖 Generated with [Claude Code](https://claude.com/claude-code)