### PR TITLE
feat(admin): add Umami analytics with conditional script loading

### DIFF
--- a/apps/admin/.env.local.example
+++ b/apps/admin/.env.local.example
@@ -1,0 +1,10 @@
+# Umami Analytics (privacy-friendly, self-hosted)
+# Register your website at umami.proto-labs.ai to obtain these values.
+#
+# NEXT_PUBLIC_UMAMI_URL: Full URL to the Umami tracking script
+# Example: https://umami.proto-labs.ai/script.js
+NEXT_PUBLIC_UMAMI_URL=
+
+# NEXT_PUBLIC_UMAMI_WEBSITE_ID: The website ID assigned by Umami
+# Example: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=

--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -14,6 +14,7 @@ import {
   GitBranch,
 } from 'lucide-react';
 import { DOCS_URL, STORYBOOK_URL } from '@/lib/env';
+import { Analytics } from '@/components/Analytics';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -50,6 +51,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="dark">
       <body className="antialiased">
+        <Analytics />
         <div className="flex min-h-screen">
           {/* Sidebar */}
           <aside className="sticky top-0 h-screen w-64 border-r border-border bg-sidebar p-4 flex flex-col gap-6 shrink-0 overflow-y-auto">

--- a/apps/admin/src/components/Analytics.tsx
+++ b/apps/admin/src/components/Analytics.tsx
@@ -1,0 +1,18 @@
+import Script from 'next/script';
+
+const UMAMI_URL = process.env.NEXT_PUBLIC_UMAMI_URL;
+const UMAMI_WEBSITE_ID = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+
+export function Analytics() {
+  if (!UMAMI_URL || !UMAMI_WEBSITE_ID) {
+    return null;
+  }
+
+  return (
+    <Script
+      src={UMAMI_URL}
+      data-website-id={UMAMI_WEBSITE_ID}
+      strategy="afterInteractive"
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `Analytics` component that conditionally loads Umami script based on env vars
- Integrates into root layout of apps/admin (Next.js)
- Zero-config when env vars are absent — no script injected
- Documents `NEXT_PUBLIC_UMAMI_URL` and `NEXT_PUBLIC_UMAMI_WEBSITE_ID` in `.env.local.example`

## Test plan
- [x] TypeScript: component compiles cleanly
- [x] Build: admin app builds successfully
- [x] Playwright: page loads without errors when env vars absent, no Umami script injected
- [ ] Manual: set env vars and verify Umami script loads with correct website ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)