### PR TITLE
feat(library): add comprehensive JSDoc annotations to all 14 components

### DIFF
--- a/packages/hx-library/custom-elements.json
+++ b/packages/hx-library/custom-elements.json
@@ -212,13 +212,6 @@
                 "text": "CustomEvent"
               },
               "description": "Dispatched after the alert is dismissed."
-            },
-            {
-              "type": {
-                "text": "CustomEvent"
-              },
-              "description": "Dispatched after the alert is dismissed.",
-              "name": "wc-after-close"
             }
           ],
           "attributes": [
@@ -298,130 +291,226 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/hx-badge/hx-badge.ts",
+      "path": "src/components/hx-checkbox/hx-checkbox.ts",
       "declarations": [
         {
           "kind": "class",
-          "description": "A small status indicator for notifications, counts, and labels.",
-          "name": "HelixBadge",
+          "description": "A checkbox component with label, validation, and form association.",
+          "name": "HelixCheckbox",
           "cssProperties": [
             {
-              "description": "Badge background color.",
-              "name": "--hx-badge-bg",
-              "default": "var(--hx-color-primary-500)"
+              "description": "Checkbox dimensions.",
+              "name": "--hx-checkbox-size",
+              "default": "var(--hx-size-5, 1.25rem)"
             },
             {
-              "description": "Badge text color.",
-              "name": "--hx-badge-color",
-              "default": "var(--hx-color-neutral-0)"
+              "description": "Checkbox border color.",
+              "name": "--hx-checkbox-border-color",
+              "default": "var(--hx-color-neutral-300, #ced4da)"
             },
             {
-              "description": "Badge font size (set per size variant).",
-              "name": "--hx-badge-font-size"
+              "description": "Checkbox border radius.",
+              "name": "--hx-checkbox-border-radius",
+              "default": "var(--hx-border-radius-sm, 0.25rem)"
             },
             {
-              "description": "Badge font weight.",
-              "name": "--hx-badge-font-weight",
-              "default": "var(--hx-font-weight-semibold)"
+              "description": "Checked background color.",
+              "name": "--hx-checkbox-checked-bg",
+              "default": "var(--hx-color-primary-500, #2563EB)"
             },
             {
-              "description": "Badge font family.",
-              "name": "--hx-badge-font-family",
-              "default": "var(--hx-font-family-sans)"
+              "description": "Checked border color.",
+              "name": "--hx-checkbox-checked-border-color",
+              "default": "var(--hx-color-primary-500, #2563EB)"
             },
             {
-              "description": "Badge border radius.",
-              "name": "--hx-badge-border-radius",
-              "default": "var(--hx-border-radius-md)"
+              "description": "Checkmark color.",
+              "name": "--hx-checkbox-checkmark-color",
+              "default": "var(--hx-color-neutral-0, #ffffff)"
             },
             {
-              "description": "Badge horizontal padding (set per size variant).",
-              "name": "--hx-badge-padding-x"
+              "description": "Focus ring color.",
+              "name": "--hx-checkbox-focus-ring-color",
+              "default": "var(--hx-focus-ring-color, #2563EB)"
             },
             {
-              "description": "Badge vertical padding (set per size variant).",
-              "name": "--hx-badge-padding-y"
+              "description": "Label text color.",
+              "name": "--hx-checkbox-label-color",
+              "default": "var(--hx-color-neutral-700, #343a40)"
             },
             {
-              "description": "Pulse color matching variant background with reduced opacity.",
-              "name": "--hx-badge-pulse-color"
-            },
-            {
-              "description": "Dot indicator size when rendered without content.",
-              "name": "--hx-badge-dot-size",
-              "default": "var(--hx-size-2)"
+              "description": "Error state color.",
+              "name": "--hx-checkbox-error-color",
+              "default": "var(--hx-color-error-500, #dc3545)"
             }
           ],
           "cssParts": [
             {
-              "description": "The badge element.",
-              "name": "badge"
+              "description": "The visual checkbox element.",
+              "name": "checkbox"
+            },
+            {
+              "description": "The label element.",
+              "name": "label"
+            },
+            {
+              "description": "The help text container.",
+              "name": "help-text"
+            },
+            {
+              "description": "The error message container.",
+              "name": "error"
+            },
+            {
+              "description": "The wrapper around checkbox and label.",
+              "name": "control"
             }
           ],
           "slots": [
             {
-              "description": "Default slot for badge content (text, number). When empty with pulse enabled, renders as a dot indicator.",
+              "description": "Custom label content (overrides the label property).",
               "name": ""
+            },
+            {
+              "description": "Custom error content (overrides the error property).",
+              "name": "error"
+            },
+            {
+              "description": "Custom help text content (overrides the helpText property).",
+              "name": "help-text"
             }
           ],
           "members": [
             {
               "kind": "field",
-              "name": "variant",
+              "name": "formAssociated",
               "type": {
-                "text": "'primary' | 'success' | 'warning' | 'error' | 'neutral'"
+                "text": "boolean"
               },
-              "default": "'primary'",
-              "description": "Visual style variant of the badge.",
-              "attribute": "variant",
-              "reflects": true
+              "static": true,
+              "default": "true"
             },
             {
               "kind": "field",
-              "name": "size",
+              "name": "_internals",
               "type": {
-                "text": "'sm' | 'md' | 'lg'"
+                "text": "ElementInternals"
               },
-              "default": "'md'",
-              "description": "Size of the badge.",
-              "attribute": "hx-size",
-              "reflects": true
+              "privacy": "private"
             },
             {
               "kind": "field",
-              "name": "pill",
+              "name": "checked",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Whether the badge uses fully rounded (pill) styling.",
-              "attribute": "pill",
+              "description": "Whether the checkbox is checked.",
+              "attribute": "checked",
               "reflects": true
             },
             {
               "kind": "field",
-              "name": "pulse",
+              "name": "indeterminate",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Whether the badge displays an animated pulse for attention.",
-              "attribute": "pulse",
+              "description": "Whether the checkbox is in an indeterminate state (e.g., for \"select all\" patterns).",
+              "attribute": "indeterminate"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the checkbox is disabled.",
+              "attribute": "disabled",
               "reflects": true
             },
             {
               "kind": "field",
-              "name": "_hasSlotContent",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the checkbox is required for form submission.",
+              "attribute": "required",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The name of the checkbox, used for form submission.",
+              "attribute": "name"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "'on'",
+              "description": "The value submitted when the checkbox is checked.",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The visible label text for the checkbox.",
+              "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "error",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Error message to display. When set, the checkbox enters an error state.",
+              "attribute": "error"
+            },
+            {
+              "kind": "field",
+              "name": "helpText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Help text displayed below the checkbox for guidance.",
+              "attribute": "help-text"
+            },
+            {
+              "kind": "field",
+              "name": "_inputEl",
+              "type": {
+                "text": "HTMLInputElement"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_hasErrorSlot",
               "type": {
                 "text": "boolean"
               },
               "privacy": "private",
-              "default": "false",
-              "description": "Tracks whether the default slot has assigned content."
+              "default": "false"
             },
             {
               "kind": "method",
-              "name": "_handleSlotChange",
+              "name": "_handleErrorSlotChange",
               "privacy": "private",
               "return": {
                 "type": {
@@ -436,240 +525,77 @@
                   }
                 }
               ]
-            }
-          ],
-          "attributes": [
-            {
-              "name": "variant",
-              "type": {
-                "text": "'primary' | 'success' | 'warning' | 'error' | 'neutral'"
-              },
-              "default": "'primary'",
-              "description": "Visual style variant of the badge.",
-              "fieldName": "variant",
-              "attribute": "variant"
-            },
-            {
-              "name": "hx-size",
-              "type": {
-                "text": "'sm' | 'md' | 'lg'"
-              },
-              "default": "'md'",
-              "description": "Size of the badge.",
-              "fieldName": "size",
-              "attribute": "hx-size"
-            },
-            {
-              "name": "pill",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the badge uses fully rounded (pill) styling.",
-              "fieldName": "pill",
-              "attribute": "pill"
-            },
-            {
-              "name": "pulse",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the badge displays an animated pulse for attention.",
-              "fieldName": "pulse",
-              "attribute": "pulse"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "hx-badge",
-          "customElement": true,
-          "summary": "Presentational badge for status indicators, notification counts, and labels."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixBadge",
-          "declaration": {
-            "name": "HelixBadge",
-            "module": "src/components/hx-badge/hx-badge.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "hx-badge",
-          "declaration": {
-            "name": "HelixBadge",
-            "module": "src/components/hx-badge/hx-badge.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-badge/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixBadge",
-          "declaration": {
-            "name": "HelixBadge",
-            "module": "./hx-badge.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-card/hx-card.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "A flexible card component for displaying grouped content.",
-          "name": "HelixCard",
-          "cssProperties": [
-            {
-              "description": "Card background color.",
-              "name": "--hx-card-bg",
-              "default": "var(--hx-color-neutral-0)"
-            },
-            {
-              "description": "Card text color.",
-              "name": "--hx-card-color",
-              "default": "var(--hx-color-neutral-800)"
-            },
-            {
-              "description": "Card border color.",
-              "name": "--hx-card-border-color",
-              "default": "var(--hx-color-neutral-200)"
-            },
-            {
-              "description": "Card border radius.",
-              "name": "--hx-card-border-radius",
-              "default": "var(--hx-border-radius-lg)"
-            },
-            {
-              "description": "Internal padding for card sections.",
-              "name": "--hx-card-padding",
-              "default": "var(--hx-space-6)"
-            },
-            {
-              "description": "Gap between card sections.",
-              "name": "--hx-card-gap",
-              "default": "var(--hx-space-4)"
-            }
-          ],
-          "cssParts": [
-            {
-              "description": "The outer card container element.",
-              "name": "card"
-            },
-            {
-              "description": "The image slot container.",
-              "name": "image"
-            },
-            {
-              "description": "The heading slot container.",
-              "name": "heading"
-            },
-            {
-              "description": "The body slot container.",
-              "name": "body"
-            },
-            {
-              "description": "The footer slot container.",
-              "name": "footer"
-            },
-            {
-              "description": "The actions slot container.",
-              "name": "actions"
-            }
-          ],
-          "slots": [
-            {
-              "description": "Optional image or media content at the top of the card.",
-              "name": "image"
-            },
-            {
-              "description": "The card heading/title content.",
-              "name": "heading"
-            },
-            {
-              "description": "Default slot for the card body content.",
-              "name": ""
-            },
-            {
-              "description": "Optional footer content below the body.",
-              "name": "footer"
-            },
-            {
-              "description": "Optional action buttons, rendered with a top border separator.",
-              "name": "actions"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "variant",
-              "type": {
-                "text": "'default' | 'featured' | 'compact'"
-              },
-              "default": "'default'",
-              "description": "Visual style variant of the card.",
-              "attribute": "variant",
-              "reflects": true
             },
             {
               "kind": "field",
-              "name": "elevation",
+              "name": "form",
               "type": {
-                "text": "'flat' | 'raised' | 'floating'"
+                "text": "HTMLFormElement | null"
               },
-              "default": "'flat'",
-              "description": "Elevation (shadow depth) of the card.",
-              "attribute": "elevation",
-              "reflects": true
+              "description": "Returns the associated form element, if any.",
+              "readonly": true
             },
             {
               "kind": "field",
-              "name": "wcHref",
+              "name": "validationMessage",
               "type": {
                 "text": "string"
               },
-              "default": "''",
-              "description": "Optional URL. When set, the card becomes interactive (clickable)\nand navigates to this URL on click.\nUses wc-href to avoid conflicting with the native HTML href attribute.",
-              "attribute": "hx-href"
+              "description": "Returns the validation message.",
+              "readonly": true
             },
             {
               "kind": "field",
-              "name": "_hasSlotContent",
+              "name": "validity",
               "type": {
-                "text": "Record<string, boolean>"
+                "text": "ValidityState"
               },
-              "privacy": "private",
-              "default": "{ image: false, heading: false, footer: false, actions: false, }"
+              "description": "Returns the ValidityState object.",
+              "readonly": true
             },
             {
               "kind": "method",
-              "name": "_handleSlotChange",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "slotName",
-                  "type": {
-                    "text": "string"
-                  }
+              "name": "checkValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
                 }
-              ]
+              },
+              "description": "Checks whether the checkbox satisfies its constraints."
             },
             {
               "kind": "method",
-              "name": "_handleClick",
+              "name": "reportValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "description": "Reports validity and shows the browser's constraint validation UI."
+            },
+            {
+              "kind": "method",
+              "name": "_updateValidity",
               "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formResetCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "Called by the form when it resets."
+            },
+            {
+              "kind": "method",
+              "name": "formStateRestoreCallback",
               "return": {
                 "type": {
                   "text": "void"
@@ -677,12 +603,23 @@
               },
               "parameters": [
                 {
-                  "name": "e",
+                  "name": "state",
                   "type": {
-                    "text": "MouseEvent"
+                    "text": "string"
                   }
                 }
-              ]
+              ],
+              "description": "Called when the form restores state (e.g., back/forward navigation)."
+            },
+            {
+              "kind": "method",
+              "name": "_handleChange",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
             },
             {
               "kind": "method",
@@ -701,95 +638,341 @@
                   }
                 }
               ]
+            },
+            {
+              "kind": "method",
+              "name": "focus",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "options",
+                  "optional": true,
+                  "type": {
+                    "text": "FocusOptions"
+                  }
+                }
+              ],
+              "description": "Moves focus to the checkbox input element."
+            },
+            {
+              "kind": "field",
+              "name": "_id",
+              "privacy": "private",
+              "default": "`hx-checkbox-${Math.random().toString(36).slice(2, 9)}`"
+            },
+            {
+              "kind": "field",
+              "name": "_helpTextId",
+              "privacy": "private",
+              "default": "`${this._id}-help`"
+            },
+            {
+              "kind": "field",
+              "name": "_errorId",
+              "privacy": "private",
+              "default": "`${this._id}-error`"
+            },
+            {
+              "kind": "field",
+              "name": "_labelId",
+              "privacy": "private",
+              "default": "`${this._id}-label`"
             }
           ],
           "events": [
             {
-              "name": "hx-card-click",
+              "name": "hx-change",
               "type": {
-                "text": "CustomEvent"
+                "text": "CustomEvent<{checked: boolean, value: string}>"
               },
-              "description": "Dispatched when an interactive card is clicked.\nIncludes the target href in the detail."
-            },
-            {
-              "type": {
-                "text": "CustomEvent<{url: string, originalEvent: MouseEvent}>"
-              },
-              "description": "Dispatched when an interactive card (with wc-href) is clicked.",
-              "name": "wc-card-click"
+              "description": "Dispatched when the checkbox is toggled."
             }
           ],
           "attributes": [
             {
-              "name": "variant",
+              "name": "checked",
               "type": {
-                "text": "'default' | 'featured' | 'compact'"
+                "text": "boolean"
               },
-              "default": "'default'",
-              "description": "Visual style variant of the card.",
-              "fieldName": "variant",
-              "attribute": "variant"
+              "default": "false",
+              "description": "Whether the checkbox is checked.",
+              "fieldName": "checked",
+              "attribute": "checked"
             },
             {
-              "name": "elevation",
+              "name": "indeterminate",
               "type": {
-                "text": "'flat' | 'raised' | 'floating'"
+                "text": "boolean"
               },
-              "default": "'flat'",
-              "description": "Elevation (shadow depth) of the card.",
-              "fieldName": "elevation",
-              "attribute": "elevation"
+              "default": "false",
+              "description": "Whether the checkbox is in an indeterminate state (e.g., for \"select all\" patterns).",
+              "fieldName": "indeterminate",
+              "attribute": "indeterminate"
             },
             {
-              "name": "hx-href",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the checkbox is disabled.",
+              "fieldName": "disabled",
+              "attribute": "disabled"
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the checkbox is required for form submission.",
+              "fieldName": "required",
+              "attribute": "required"
+            },
+            {
+              "name": "name",
               "type": {
                 "text": "string"
               },
               "default": "''",
-              "description": "Optional URL. When set, the card becomes interactive (clickable)\nand navigates to this URL on click.\nUses wc-href to avoid conflicting with the native HTML href attribute.",
-              "fieldName": "wcHref",
-              "attribute": "hx-href"
+              "description": "The name of the checkbox, used for form submission.",
+              "fieldName": "name",
+              "attribute": "name"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "'on'",
+              "description": "The value submitted when the checkbox is checked.",
+              "fieldName": "value",
+              "attribute": "value"
+            },
+            {
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The visible label text for the checkbox.",
+              "fieldName": "label",
+              "attribute": "label"
+            },
+            {
+              "name": "error",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Error message to display. When set, the checkbox enters an error state.",
+              "fieldName": "error",
+              "attribute": "error"
+            },
+            {
+              "name": "help-text",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Help text displayed below the checkbox for guidance.",
+              "fieldName": "helpText",
+              "attribute": "help-text"
             }
           ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"
           },
-          "tagName": "hx-card",
+          "tagName": "hx-checkbox",
           "customElement": true,
-          "summary": "Content container with image, heading, body, footer, and action slots."
+          "summary": "Form-associated checkbox with built-in label, error, and help text."
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "HelixCard",
+          "name": "HelixCheckbox",
           "declaration": {
-            "name": "HelixCard",
-            "module": "src/components/hx-card/hx-card.ts"
+            "name": "HelixCheckbox",
+            "module": "src/components/hx-checkbox/hx-checkbox.ts"
           }
         },
         {
           "kind": "custom-element-definition",
-          "name": "hx-card",
+          "name": "hx-checkbox",
           "declaration": {
-            "name": "HelixCard",
-            "module": "src/components/hx-card/hx-card.ts"
+            "name": "HelixCheckbox",
+            "module": "src/components/hx-checkbox/hx-checkbox.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/hx-card/index.ts",
+      "path": "src/components/hx-checkbox/index.ts",
       "declarations": [],
       "exports": [
         {
           "kind": "js",
-          "name": "HelixCard",
+          "name": "HelixCheckbox",
           "declaration": {
-            "name": "HelixCard",
-            "module": "./hx-card.js"
+            "name": "HelixCheckbox",
+            "module": "./hx-checkbox.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-container/hx-container.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A layout container that constrains content width and provides\nconsistent vertical spacing and horizontal gutters.\n\nUses a two-layer model: the outer host spans full width (background,\nvertical padding), while the inner wrapper constrains max-width,\ncenters content, and applies horizontal gutters.",
+          "name": "HelixContainer",
+          "cssProperties": [
+            {
+              "description": "Background color on the outer wrapper.",
+              "name": "--hx-container-bg",
+              "default": "transparent"
+            },
+            {
+              "description": "Horizontal padding on the inner box.",
+              "name": "--hx-container-gutter",
+              "default": "var(--hx-space-6)"
+            },
+            {
+              "description": "Override the max-width set by the width property.",
+              "name": "--hx-container-max-width"
+            },
+            {
+              "description": "Max-width for the content width preset.",
+              "name": "--hx-container-content",
+              "default": "72rem"
+            },
+            {
+              "description": "Max-width for the sm width preset.",
+              "name": "--hx-container-sm",
+              "default": "640px"
+            },
+            {
+              "description": "Max-width for the md width preset.",
+              "name": "--hx-container-md",
+              "default": "768px"
+            },
+            {
+              "description": "Max-width for the lg width preset.",
+              "name": "--hx-container-lg",
+              "default": "1024px"
+            },
+            {
+              "description": "Max-width for the xl width preset.",
+              "name": "--hx-container-xl",
+              "default": "1280px"
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "The inner wrapper that constrains max-width and applies gutters.",
+              "name": "inner"
+            }
+          ],
+          "slots": [
+            {
+              "description": "Default slot for container content.",
+              "name": ""
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "width",
+              "type": {
+                "text": "'full' | 'content' | 'narrow' | 'sm' | 'md' | 'lg' | 'xl'"
+              },
+              "default": "'content'",
+              "description": "Controls the max-width of the inner content wrapper.",
+              "attribute": "width",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "padding",
+              "type": {
+                "text": "'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'"
+              },
+              "default": "'none'",
+              "description": "Vertical padding applied to the outer wrapper.",
+              "attribute": "padding",
+              "reflects": true
+            }
+          ],
+          "attributes": [
+            {
+              "name": "width",
+              "type": {
+                "text": "'full' | 'content' | 'narrow' | 'sm' | 'md' | 'lg' | 'xl'"
+              },
+              "default": "'content'",
+              "description": "Controls the max-width of the inner content wrapper.",
+              "fieldName": "width",
+              "attribute": "width"
+            },
+            {
+              "name": "padding",
+              "type": {
+                "text": "'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'"
+              },
+              "default": "'none'",
+              "description": "Vertical padding applied to the outer wrapper.",
+              "fieldName": "padding",
+              "attribute": "padding"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "hx-container",
+          "customElement": true,
+          "summary": "Layout primitive for constraining content width with consistent spacing."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixContainer",
+          "declaration": {
+            "name": "HelixContainer",
+            "module": "src/components/hx-container/hx-container.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "hx-container",
+          "declaration": {
+            "name": "HelixContainer",
+            "module": "src/components/hx-container/hx-container.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-container/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixContainer",
+          "declaration": {
+            "name": "HelixContainer",
+            "module": "./hx-container.js"
           }
         }
       ]
@@ -1079,7 +1262,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The URL to submit the form to. When empty, the form handles\nsubmission client-side only and dispatches `wc-submit`.",
+              "description": "The URL to submit the form to. When empty, the form handles\nsubmission client-side only and dispatches `hx-submit`.",
               "attribute": "action"
             },
             {
@@ -1200,21 +1383,21 @@
                 "text": "CustomEvent<{valid: boolean, values: Record<string, FormDataEntryValue>}>"
               },
               "description": "Dispatched on valid client-side submit when no action is set.",
-              "name": "wc-submit"
+              "name": "hx-submit"
             },
             {
               "type": {
                 "text": "CustomEvent<{errors: Array<{name: string, message: string}>}>"
               },
               "description": "Dispatched when validation fails on submit.",
-              "name": "wc-invalid"
+              "name": "hx-invalid"
             },
             {
               "type": {
                 "text": "CustomEvent"
               },
               "description": "Dispatched when the form is reset.",
-              "name": "wc-reset"
+              "name": "hx-reset"
             }
           ],
           "attributes": [
@@ -1224,7 +1407,7 @@
                 "text": "string"
               },
               "default": "''",
-              "description": "The URL to submit the form to. When empty, the form handles\nsubmission client-side only and dispatches `wc-submit`.",
+              "description": "The URL to submit the form to. When empty, the form handles\nsubmission client-side only and dispatches `hx-submit`.",
               "fieldName": "action",
               "attribute": "action"
             },
@@ -1304,150 +1487,491 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/hx-container/hx-container.ts",
+      "path": "src/components/hx-card/hx-card.ts",
       "declarations": [
         {
           "kind": "class",
-          "description": "A layout container that constrains content width and provides\nconsistent vertical spacing and horizontal gutters.\n\nUses a two-layer model: the outer host spans full width (background,\nvertical padding), while the inner wrapper constrains max-width,\ncenters content, and applies horizontal gutters.",
-          "name": "HelixContainer",
+          "description": "A flexible card component for displaying grouped content.",
+          "name": "HelixCard",
           "cssProperties": [
             {
-              "description": "Background color on the outer wrapper.",
-              "name": "--hx-container-bg",
-              "default": "transparent"
+              "description": "Card background color.",
+              "name": "--hx-card-bg",
+              "default": "var(--hx-color-neutral-0)"
             },
             {
-              "description": "Horizontal padding on the inner box.",
-              "name": "--hx-container-gutter",
+              "description": "Card text color.",
+              "name": "--hx-card-color",
+              "default": "var(--hx-color-neutral-800)"
+            },
+            {
+              "description": "Card border color.",
+              "name": "--hx-card-border-color",
+              "default": "var(--hx-color-neutral-200)"
+            },
+            {
+              "description": "Card border radius.",
+              "name": "--hx-card-border-radius",
+              "default": "var(--hx-border-radius-lg)"
+            },
+            {
+              "description": "Internal padding for card sections.",
+              "name": "--hx-card-padding",
               "default": "var(--hx-space-6)"
             },
             {
-              "description": "Override the max-width set by the width property.",
-              "name": "--hx-container-max-width"
-            },
-            {
-              "description": "Max-width for the content width preset.",
-              "name": "--hx-container-content",
-              "default": "72rem"
-            },
-            {
-              "description": "Max-width for the sm width preset.",
-              "name": "--hx-container-sm",
-              "default": "640px"
-            },
-            {
-              "description": "Max-width for the md width preset.",
-              "name": "--hx-container-md",
-              "default": "768px"
-            },
-            {
-              "description": "Max-width for the lg width preset.",
-              "name": "--hx-container-lg",
-              "default": "1024px"
-            },
-            {
-              "description": "Max-width for the xl width preset.",
-              "name": "--hx-container-xl",
-              "default": "1280px"
+              "description": "Gap between card sections.",
+              "name": "--hx-card-gap",
+              "default": "var(--hx-space-4)"
             }
           ],
           "cssParts": [
             {
-              "description": "The inner wrapper that constrains max-width and applies gutters.",
-              "name": "inner"
+              "description": "The outer card container element.",
+              "name": "card"
+            },
+            {
+              "description": "The image slot container.",
+              "name": "image"
+            },
+            {
+              "description": "The heading slot container.",
+              "name": "heading"
+            },
+            {
+              "description": "The body slot container.",
+              "name": "body"
+            },
+            {
+              "description": "The footer slot container.",
+              "name": "footer"
+            },
+            {
+              "description": "The actions slot container.",
+              "name": "actions"
             }
           ],
           "slots": [
             {
-              "description": "Default slot for container content.",
+              "description": "Optional image or media content at the top of the card.",
+              "name": "image"
+            },
+            {
+              "description": "The card heading/title content.",
+              "name": "heading"
+            },
+            {
+              "description": "Default slot for the card body content.",
               "name": ""
+            },
+            {
+              "description": "Optional footer content below the body.",
+              "name": "footer"
+            },
+            {
+              "description": "Optional action buttons, rendered with a top border separator.",
+              "name": "actions"
             }
           ],
           "members": [
             {
               "kind": "field",
-              "name": "width",
+              "name": "variant",
               "type": {
-                "text": "'full' | 'content' | 'narrow' | 'sm' | 'md' | 'lg' | 'xl'"
+                "text": "'default' | 'featured' | 'compact'"
               },
-              "default": "'content'",
-              "description": "Controls the max-width of the inner content wrapper.",
-              "attribute": "width",
+              "default": "'default'",
+              "description": "Visual style variant of the card.",
+              "attribute": "variant",
               "reflects": true
             },
             {
               "kind": "field",
-              "name": "padding",
+              "name": "elevation",
               "type": {
-                "text": "'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'"
+                "text": "'flat' | 'raised' | 'floating'"
               },
-              "default": "'none'",
-              "description": "Vertical padding applied to the outer wrapper.",
-              "attribute": "padding",
+              "default": "'flat'",
+              "description": "Elevation (shadow depth) of the card.",
+              "attribute": "elevation",
               "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "wcHref",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Optional URL. When set, the card becomes interactive (clickable)\nand navigates to this URL on click.\nUses hx-href to avoid conflicting with the native HTML href attribute.",
+              "attribute": "hx-href"
+            },
+            {
+              "kind": "field",
+              "name": "_hasSlotContent",
+              "type": {
+                "text": "Record<string, boolean>"
+              },
+              "privacy": "private",
+              "default": "{ image: false, heading: false, footer: false, actions: false, }"
+            },
+            {
+              "kind": "method",
+              "name": "_handleSlotChange",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "slotName",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleClick",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "MouseEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleKeyDown",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ]
+            }
+          ],
+          "events": [
+            {
+              "name": "hx-card-click",
+              "type": {
+                "text": "CustomEvent<{url: string, originalEvent: MouseEvent}>"
+              },
+              "description": "Dispatched when an interactive card (with hx-href) is clicked."
             }
           ],
           "attributes": [
             {
-              "name": "width",
+              "name": "variant",
               "type": {
-                "text": "'full' | 'content' | 'narrow' | 'sm' | 'md' | 'lg' | 'xl'"
+                "text": "'default' | 'featured' | 'compact'"
               },
-              "default": "'content'",
-              "description": "Controls the max-width of the inner content wrapper.",
-              "fieldName": "width",
-              "attribute": "width"
+              "default": "'default'",
+              "description": "Visual style variant of the card.",
+              "fieldName": "variant",
+              "attribute": "variant"
             },
             {
-              "name": "padding",
+              "name": "elevation",
               "type": {
-                "text": "'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'"
+                "text": "'flat' | 'raised' | 'floating'"
               },
-              "default": "'none'",
-              "description": "Vertical padding applied to the outer wrapper.",
-              "fieldName": "padding",
-              "attribute": "padding"
+              "default": "'flat'",
+              "description": "Elevation (shadow depth) of the card.",
+              "fieldName": "elevation",
+              "attribute": "elevation"
+            },
+            {
+              "name": "hx-href",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Optional URL. When set, the card becomes interactive (clickable)\nand navigates to this URL on click.\nUses hx-href to avoid conflicting with the native HTML href attribute.",
+              "fieldName": "wcHref",
+              "attribute": "hx-href"
             }
           ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"
           },
-          "tagName": "hx-container",
+          "tagName": "hx-card",
           "customElement": true,
-          "summary": "Layout primitive for constraining content width with consistent spacing."
+          "summary": "Content container with image, heading, body, footer, and action slots."
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "HelixContainer",
+          "name": "HelixCard",
           "declaration": {
-            "name": "HelixContainer",
-            "module": "src/components/hx-container/hx-container.ts"
+            "name": "HelixCard",
+            "module": "src/components/hx-card/hx-card.ts"
           }
         },
         {
           "kind": "custom-element-definition",
-          "name": "hx-container",
+          "name": "hx-card",
           "declaration": {
-            "name": "HelixContainer",
-            "module": "src/components/hx-container/hx-container.ts"
+            "name": "HelixCard",
+            "module": "src/components/hx-card/hx-card.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/hx-container/index.ts",
+      "path": "src/components/hx-card/index.ts",
       "declarations": [],
       "exports": [
         {
           "kind": "js",
-          "name": "HelixContainer",
+          "name": "HelixCard",
           "declaration": {
-            "name": "HelixContainer",
-            "module": "./hx-container.js"
+            "name": "HelixCard",
+            "module": "./hx-card.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-badge/hx-badge.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A small status indicator for notifications, counts, and labels.",
+          "name": "HelixBadge",
+          "cssProperties": [
+            {
+              "description": "Badge background color.",
+              "name": "--hx-badge-bg",
+              "default": "var(--hx-color-primary-500)"
+            },
+            {
+              "description": "Badge text color.",
+              "name": "--hx-badge-color",
+              "default": "var(--hx-color-neutral-0)"
+            },
+            {
+              "description": "Badge font size (set per size variant).",
+              "name": "--hx-badge-font-size"
+            },
+            {
+              "description": "Badge font weight.",
+              "name": "--hx-badge-font-weight",
+              "default": "var(--hx-font-weight-semibold)"
+            },
+            {
+              "description": "Badge font family.",
+              "name": "--hx-badge-font-family",
+              "default": "var(--hx-font-family-sans)"
+            },
+            {
+              "description": "Badge border radius.",
+              "name": "--hx-badge-border-radius",
+              "default": "var(--hx-border-radius-md)"
+            },
+            {
+              "description": "Badge horizontal padding (set per size variant).",
+              "name": "--hx-badge-padding-x"
+            },
+            {
+              "description": "Badge vertical padding (set per size variant).",
+              "name": "--hx-badge-padding-y"
+            },
+            {
+              "description": "Pulse color matching variant background with reduced opacity.",
+              "name": "--hx-badge-pulse-color"
+            },
+            {
+              "description": "Dot indicator size when rendered without content.",
+              "name": "--hx-badge-dot-size",
+              "default": "var(--hx-size-2)"
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "The badge element.",
+              "name": "badge"
+            }
+          ],
+          "slots": [
+            {
+              "description": "Default slot for badge content (text, number). When empty with pulse enabled, renders as a dot indicator.",
+              "name": ""
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "variant",
+              "type": {
+                "text": "'primary' | 'success' | 'warning' | 'error' | 'neutral'"
+              },
+              "default": "'primary'",
+              "description": "Visual style variant of the badge.",
+              "attribute": "variant",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "'sm' | 'md' | 'lg'"
+              },
+              "default": "'md'",
+              "description": "Size of the badge.",
+              "attribute": "hx-size",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "pill",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the badge uses fully rounded (pill) styling.",
+              "attribute": "pill",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "pulse",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the badge displays an animated pulse for attention.",
+              "attribute": "pulse",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "_hasSlotContent",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false",
+              "description": "Tracks whether the default slot has assigned content."
+            },
+            {
+              "kind": "method",
+              "name": "_handleSlotChange",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            }
+          ],
+          "attributes": [
+            {
+              "name": "variant",
+              "type": {
+                "text": "'primary' | 'success' | 'warning' | 'error' | 'neutral'"
+              },
+              "default": "'primary'",
+              "description": "Visual style variant of the badge.",
+              "fieldName": "variant",
+              "attribute": "variant"
+            },
+            {
+              "name": "hx-size",
+              "type": {
+                "text": "'sm' | 'md' | 'lg'"
+              },
+              "default": "'md'",
+              "description": "Size of the badge.",
+              "fieldName": "size",
+              "attribute": "hx-size"
+            },
+            {
+              "name": "pill",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the badge uses fully rounded (pill) styling.",
+              "fieldName": "pill",
+              "attribute": "pill"
+            },
+            {
+              "name": "pulse",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the badge displays an animated pulse for attention.",
+              "fieldName": "pulse",
+              "attribute": "pulse"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "hx-badge",
+          "customElement": true,
+          "summary": "Presentational badge for status indicators, notification counts, and labels."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixBadge",
+          "declaration": {
+            "name": "HelixBadge",
+            "module": "src/components/hx-badge/hx-badge.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "hx-badge",
+          "declaration": {
+            "name": "HelixBadge",
+            "module": "src/components/hx-badge/hx-badge.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-badge/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixBadge",
+          "declaration": {
+            "name": "HelixBadge",
+            "module": "./hx-badge.js"
           }
         }
       ]
@@ -1609,6 +2133,1298 @@
           "declaration": {
             "name": "HelixProse",
             "module": "./hx-prose.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-radio-group/hx-radio-group.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A form-associated radio group that manages a set of `<hx-radio>` children.",
+          "name": "HelixRadioGroup",
+          "cssProperties": [
+            {
+              "description": "Gap between radio items.",
+              "name": "--hx-radio-group-gap",
+              "default": "var(--hx-space-3, 0.75rem)"
+            },
+            {
+              "description": "Label text color.",
+              "name": "--hx-radio-group-label-color",
+              "default": "var(--hx-color-neutral-700, #343a40)"
+            },
+            {
+              "description": "Error message color.",
+              "name": "--hx-radio-group-error-color",
+              "default": "var(--hx-color-error-500, #dc3545)"
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "The fieldset wrapper.",
+              "name": "fieldset"
+            },
+            {
+              "description": "The legend/label.",
+              "name": "legend"
+            },
+            {
+              "description": "The container for radio items.",
+              "name": "group"
+            },
+            {
+              "description": "The error message.",
+              "name": "error"
+            },
+            {
+              "description": "The help text.",
+              "name": "help-text"
+            }
+          ],
+          "slots": [
+            {
+              "description": "`<hx-radio>` elements.",
+              "name": ""
+            },
+            {
+              "description": "Custom error content (overrides the error property).",
+              "name": "error"
+            },
+            {
+              "description": "Custom help text content (overrides the helpText property).",
+              "name": "help-text"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "_internals",
+              "type": {
+                "text": "ElementInternals"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The selected radio's value.",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The name used for form submission.",
+              "attribute": "name"
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The fieldset legend/label text.",
+              "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether a selection is required for form submission.",
+              "attribute": "required",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the entire group is disabled.",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "error",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Error message to display. When set, the group enters an error state.",
+              "attribute": "error"
+            },
+            {
+              "kind": "field",
+              "name": "helpText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Help text displayed below the group for guidance.",
+              "attribute": "help-text"
+            },
+            {
+              "kind": "field",
+              "name": "orientation",
+              "type": {
+                "text": "'vertical' | 'horizontal'"
+              },
+              "default": "'vertical'",
+              "description": "Layout orientation of the radio items.",
+              "attribute": "orientation",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "_groupEl",
+              "type": {
+                "text": "HTMLElement"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_hasErrorSlot",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "_groupId",
+              "privacy": "private",
+              "default": "`hx-radio-group-${Math.random().toString(36).slice(2, 9)}`"
+            },
+            {
+              "kind": "field",
+              "name": "_helpTextId",
+              "privacy": "private",
+              "default": "`${this._groupId}-help`"
+            },
+            {
+              "kind": "field",
+              "name": "_errorId",
+              "privacy": "private",
+              "default": "`${this._groupId}-error`"
+            },
+            {
+              "kind": "method",
+              "name": "_handleErrorSlotChange",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_getRadios",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "HelixRadio[]"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_getEnabledRadios",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "HelixRadio[]"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "_syncRadios",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "_handleRadioSelect",
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_handleKeydown",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_handleSlotChange",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "field",
+              "name": "form",
+              "type": {
+                "text": "HTMLFormElement | null"
+              },
+              "description": "Returns the associated form element, if any.",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "validationMessage",
+              "type": {
+                "text": "string"
+              },
+              "description": "Returns the validation message.",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "validity",
+              "type": {
+                "text": "ValidityState"
+              },
+              "description": "Returns the ValidityState object.",
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "checkValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "description": "Checks whether the group satisfies its constraints."
+            },
+            {
+              "kind": "method",
+              "name": "reportValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "description": "Reports validity and shows the browser's constraint validation UI."
+            },
+            {
+              "kind": "method",
+              "name": "_updateValidity",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formResetCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "Called by the form when it resets."
+            },
+            {
+              "kind": "method",
+              "name": "formStateRestoreCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ],
+              "description": "Called when the form restores state (e.g., back/forward navigation)."
+            }
+          ],
+          "events": [
+            {
+              "type": {
+                "text": "CustomEvent<{value: string}>"
+              },
+              "description": "Dispatched when the selected radio changes.",
+              "name": "hx-change"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The selected radio's value.",
+              "fieldName": "value",
+              "attribute": "value"
+            },
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The name used for form submission.",
+              "fieldName": "name",
+              "attribute": "name"
+            },
+            {
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The fieldset legend/label text.",
+              "fieldName": "label",
+              "attribute": "label"
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether a selection is required for form submission.",
+              "fieldName": "required",
+              "attribute": "required"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the entire group is disabled.",
+              "fieldName": "disabled",
+              "attribute": "disabled"
+            },
+            {
+              "name": "error",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Error message to display. When set, the group enters an error state.",
+              "fieldName": "error",
+              "attribute": "error"
+            },
+            {
+              "name": "help-text",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Help text displayed below the group for guidance.",
+              "fieldName": "helpText",
+              "attribute": "help-text"
+            },
+            {
+              "name": "orientation",
+              "type": {
+                "text": "'vertical' | 'horizontal'"
+              },
+              "default": "'vertical'",
+              "description": "Layout orientation of the radio items.",
+              "fieldName": "orientation",
+              "attribute": "orientation"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "hx-radio-group",
+          "customElement": true,
+          "summary": "Form-associated radio group with label, validation, help text, and keyboard navigation."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixRadioGroup",
+          "declaration": {
+            "name": "HelixRadioGroup",
+            "module": "src/components/hx-radio-group/hx-radio-group.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "hx-radio-group",
+          "declaration": {
+            "name": "HelixRadioGroup",
+            "module": "src/components/hx-radio-group/hx-radio-group.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-radio-group/hx-radio.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "An individual radio button, designed to be used inside a `<hx-radio-group>`.",
+          "name": "HelixRadio",
+          "cssProperties": [
+            {
+              "description": "Radio circle size.",
+              "name": "--hx-radio-size",
+              "default": "var(--hx-size-5, 1.25rem)"
+            },
+            {
+              "description": "Radio border color.",
+              "name": "--hx-radio-border-color",
+              "default": "var(--hx-color-neutral-300, #ced4da)"
+            },
+            {
+              "description": "Checked background color.",
+              "name": "--hx-radio-checked-bg",
+              "default": "var(--hx-color-primary-500, #2563EB)"
+            },
+            {
+              "description": "Checked border color.",
+              "name": "--hx-radio-checked-border-color",
+              "default": "var(--hx-color-primary-500, #2563EB)"
+            },
+            {
+              "description": "Inner dot color when checked.",
+              "name": "--hx-radio-dot-color",
+              "default": "var(--hx-color-neutral-0, #ffffff)"
+            },
+            {
+              "description": "Focus ring color.",
+              "name": "--hx-radio-focus-ring-color",
+              "default": "var(--hx-focus-ring-color, #2563EB)"
+            },
+            {
+              "description": "Label text color.",
+              "name": "--hx-radio-label-color",
+              "default": "var(--hx-color-neutral-700, #343a40)"
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "The visual radio circle.",
+              "name": "radio"
+            },
+            {
+              "description": "The label text.",
+              "name": "label"
+            }
+          ],
+          "slots": [
+            {
+              "description": "Custom label content (overrides the label property).",
+              "name": ""
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The value this radio represents.",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Visible label text for the radio.",
+              "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether this radio is disabled.",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "checked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether this radio is checked. Managed by the parent group.",
+              "attribute": "checked",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "_inputId",
+              "privacy": "private",
+              "default": "`wc-radio-${Math.random().toString(36).slice(2, 9)}`"
+            },
+            {
+              "kind": "method",
+              "name": "_handleClick",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            }
+          ],
+          "attributes": [
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The value this radio represents.",
+              "fieldName": "value",
+              "attribute": "value"
+            },
+            {
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Visible label text for the radio.",
+              "fieldName": "label",
+              "attribute": "label"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether this radio is disabled.",
+              "fieldName": "disabled",
+              "attribute": "disabled"
+            },
+            {
+              "name": "checked",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether this radio is checked. Managed by the parent group.",
+              "fieldName": "checked",
+              "attribute": "checked"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "hx-radio",
+          "customElement": true,
+          "summary": "Presentational radio button managed by its parent radio group."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixRadio",
+          "declaration": {
+            "name": "HelixRadio",
+            "module": "src/components/hx-radio-group/hx-radio.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "hx-radio",
+          "declaration": {
+            "name": "HelixRadio",
+            "module": "src/components/hx-radio-group/hx-radio.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-radio-group/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixRadioGroup",
+          "declaration": {
+            "name": "HelixRadioGroup",
+            "module": "./hx-radio-group.js"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "HelixRadio",
+          "declaration": {
+            "name": "HelixRadio",
+            "module": "./hx-radio.js"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-text-input/hx-text-input.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "A text input component with label, validation, and form association.",
+          "name": "HelixTextInput",
+          "cssProperties": [
+            {
+              "description": "Input background color.",
+              "name": "--hx-input-bg",
+              "default": "var(--hx-color-neutral-0)"
+            },
+            {
+              "description": "Input text color.",
+              "name": "--hx-input-color",
+              "default": "var(--hx-color-neutral-800)"
+            },
+            {
+              "description": "Input border color.",
+              "name": "--hx-input-border-color",
+              "default": "var(--hx-color-neutral-300)"
+            },
+            {
+              "description": "Input border radius.",
+              "name": "--hx-input-border-radius",
+              "default": "var(--hx-border-radius-md)"
+            },
+            {
+              "description": "Input font family.",
+              "name": "--hx-input-font-family",
+              "default": "var(--hx-font-family-sans)"
+            },
+            {
+              "description": "Focus ring color.",
+              "name": "--hx-input-focus-ring-color",
+              "default": "var(--hx-focus-ring-color)"
+            },
+            {
+              "description": "Error state color.",
+              "name": "--hx-input-error-color",
+              "default": "var(--hx-color-error-500)"
+            },
+            {
+              "description": "Label text color.",
+              "name": "--hx-input-label-color",
+              "default": "var(--hx-color-neutral-700)"
+            }
+          ],
+          "cssParts": [
+            {
+              "description": "The outer field container.",
+              "name": "field"
+            },
+            {
+              "description": "The label element.",
+              "name": "label"
+            },
+            {
+              "description": "The wrapper around prefix, input, and suffix.",
+              "name": "input-wrapper"
+            },
+            {
+              "description": "The native input element.",
+              "name": "input"
+            },
+            {
+              "description": "The help text container.",
+              "name": "help-text"
+            },
+            {
+              "description": "The error message container.",
+              "name": "error"
+            }
+          ],
+          "slots": [
+            {
+              "description": "Custom label content (overrides the label property). Use for Drupal Form API rendered labels.",
+              "name": "label"
+            },
+            {
+              "description": "Content rendered before the input (e.g., icon).",
+              "name": "prefix"
+            },
+            {
+              "description": "Content rendered after the input (e.g., icon or button).",
+              "name": "suffix"
+            },
+            {
+              "description": "Custom help text content (overrides the helpText property).",
+              "name": "help-text"
+            },
+            {
+              "description": "Custom error content (overrides the error property). Use for Drupal Form API rendered errors.",
+              "name": "error"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "formAssociated",
+              "type": {
+                "text": "boolean"
+              },
+              "static": true,
+              "default": "true"
+            },
+            {
+              "kind": "field",
+              "name": "_internals",
+              "type": {
+                "text": "ElementInternals"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The visible label text for the input.",
+              "attribute": "label"
+            },
+            {
+              "kind": "field",
+              "name": "placeholder",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Placeholder text shown when the input is empty.",
+              "attribute": "placeholder"
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The current value of the input.",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "'text' | 'email' | 'password' | 'tel' | 'url' | 'search' | 'number'"
+              },
+              "default": "'text'",
+              "description": "The type of the native input element.",
+              "attribute": "type"
+            },
+            {
+              "kind": "field",
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the input is required for form submission.",
+              "attribute": "required",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the input is disabled.",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "error",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Error message to display. When set, the input enters an error state.",
+              "attribute": "error"
+            },
+            {
+              "kind": "field",
+              "name": "helpText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Help text displayed below the input for guidance.",
+              "attribute": "help-text"
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The name of the input, used for form submission.",
+              "attribute": "name"
+            },
+            {
+              "kind": "field",
+              "name": "ariaLabel",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "description": "Accessible name for screen readers, if different from the visible label.",
+              "attribute": "aria-label"
+            },
+            {
+              "kind": "field",
+              "name": "_input",
+              "type": {
+                "text": "HTMLInputElement"
+              },
+              "privacy": "private"
+            },
+            {
+              "kind": "field",
+              "name": "_hasLabelSlot",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "field",
+              "name": "_hasErrorSlot",
+              "type": {
+                "text": "boolean"
+              },
+              "privacy": "private",
+              "default": "false"
+            },
+            {
+              "kind": "method",
+              "name": "_handleLabelSlotChange",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleErrorSlotChange",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "field",
+              "name": "form",
+              "type": {
+                "text": "HTMLFormElement | null"
+              },
+              "description": "Returns the associated form element, if any.",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "validationMessage",
+              "type": {
+                "text": "string"
+              },
+              "description": "Returns the validation message.",
+              "readonly": true
+            },
+            {
+              "kind": "field",
+              "name": "validity",
+              "type": {
+                "text": "ValidityState"
+              },
+              "description": "Returns the ValidityState object.",
+              "readonly": true
+            },
+            {
+              "kind": "method",
+              "name": "checkValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "description": "Checks whether the input satisfies its constraints."
+            },
+            {
+              "kind": "method",
+              "name": "reportValidity",
+              "return": {
+                "type": {
+                  "text": "boolean"
+                }
+              },
+              "description": "Reports validity and shows the browser's constraint validation UI."
+            },
+            {
+              "kind": "method",
+              "name": "_updateValidity",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formResetCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              }
+            },
+            {
+              "kind": "method",
+              "name": "formStateRestoreCallback",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "state",
+                  "type": {
+                    "text": "string"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleInput",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleChange",
+              "privacy": "private",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "focus",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "parameters": [
+                {
+                  "name": "options",
+                  "optional": true,
+                  "type": {
+                    "text": "FocusOptions"
+                  }
+                }
+              ],
+              "description": "Moves focus to the input element."
+            },
+            {
+              "kind": "method",
+              "name": "select",
+              "return": {
+                "type": {
+                  "text": "void"
+                }
+              },
+              "description": "Selects all text in the input."
+            },
+            {
+              "kind": "field",
+              "name": "_inputId",
+              "privacy": "private",
+              "default": "`hx-text-input-${Math.random().toString(36).slice(2, 9)}`"
+            },
+            {
+              "kind": "field",
+              "name": "_helpTextId",
+              "privacy": "private",
+              "default": "`${this._inputId}-help`"
+            },
+            {
+              "kind": "field",
+              "name": "_errorId",
+              "privacy": "private",
+              "default": "`${this._inputId}-error`"
+            }
+          ],
+          "events": [
+            {
+              "name": "hx-input",
+              "type": {
+                "text": "CustomEvent<{value: string}>"
+              },
+              "description": "Dispatched on every keystroke as the user types."
+            },
+            {
+              "name": "hx-change",
+              "type": {
+                "text": "CustomEvent<{value: string}>"
+              },
+              "description": "Dispatched when the input loses focus after its value changed."
+            }
+          ],
+          "attributes": [
+            {
+              "name": "label",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The visible label text for the input.",
+              "fieldName": "label",
+              "attribute": "label"
+            },
+            {
+              "name": "placeholder",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Placeholder text shown when the input is empty.",
+              "fieldName": "placeholder",
+              "attribute": "placeholder"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The current value of the input.",
+              "fieldName": "value",
+              "attribute": "value"
+            },
+            {
+              "name": "type",
+              "type": {
+                "text": "'text' | 'email' | 'password' | 'tel' | 'url' | 'search' | 'number'"
+              },
+              "default": "'text'",
+              "description": "The type of the native input element.",
+              "fieldName": "type",
+              "attribute": "type"
+            },
+            {
+              "name": "required",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the input is required for form submission.",
+              "fieldName": "required",
+              "attribute": "required"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether the input is disabled.",
+              "fieldName": "disabled",
+              "attribute": "disabled"
+            },
+            {
+              "name": "error",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Error message to display. When set, the input enters an error state.",
+              "fieldName": "error",
+              "attribute": "error"
+            },
+            {
+              "name": "help-text",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Help text displayed below the input for guidance.",
+              "fieldName": "helpText",
+              "attribute": "help-text"
+            },
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "The name of the input, used for form submission.",
+              "fieldName": "name",
+              "attribute": "name"
+            },
+            {
+              "name": "aria-label",
+              "type": {
+                "text": "string | null"
+              },
+              "default": "null",
+              "description": "Accessible name for screen readers, if different from the visible label.",
+              "fieldName": "ariaLabel",
+              "attribute": "aria-label"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "hx-text-input",
+          "customElement": true,
+          "summary": "Form-associated text input with built-in label, error, and help text."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixTextInput",
+          "declaration": {
+            "name": "HelixTextInput",
+            "module": "src/components/hx-text-input/hx-text-input.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "hx-text-input",
+          "declaration": {
+            "name": "HelixTextInput",
+            "module": "src/components/hx-text-input/hx-text-input.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/hx-text-input/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "HelixTextInput",
+          "declaration": {
+            "name": "HelixTextInput",
+            "module": "./hx-text-input.js"
           }
         }
       ]
@@ -2754,1836 +4570,6 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/hx-radio-group/hx-radio-group.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "A form-associated radio group that manages a set of `<wc-radio>` children.",
-          "name": "HelixRadioGroup",
-          "cssProperties": [
-            {
-              "description": "Gap between radio items.",
-              "name": "--hx-radio-group-gap",
-              "default": "var(--hx-space-3, 0.75rem)"
-            },
-            {
-              "description": "Label text color.",
-              "name": "--hx-radio-group-label-color",
-              "default": "var(--hx-color-neutral-700, #343a40)"
-            },
-            {
-              "description": "Error message color.",
-              "name": "--hx-radio-group-error-color",
-              "default": "var(--hx-color-error-500, #dc3545)"
-            }
-          ],
-          "cssParts": [
-            {
-              "description": "The fieldset wrapper.",
-              "name": "fieldset"
-            },
-            {
-              "description": "The legend/label.",
-              "name": "legend"
-            },
-            {
-              "description": "The container for radio items.",
-              "name": "group"
-            },
-            {
-              "description": "The error message.",
-              "name": "error"
-            },
-            {
-              "description": "The help text.",
-              "name": "help-text"
-            }
-          ],
-          "slots": [
-            {
-              "description": "`<wc-radio>` elements.",
-              "name": ""
-            },
-            {
-              "description": "Custom error content (overrides the error property).",
-              "name": "error"
-            },
-            {
-              "description": "Custom help text content (overrides the helpText property).",
-              "name": "help-text"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "formAssociated",
-              "type": {
-                "text": "boolean"
-              },
-              "static": true,
-              "default": "true"
-            },
-            {
-              "kind": "field",
-              "name": "_internals",
-              "type": {
-                "text": "ElementInternals"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The selected radio's value.",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The name used for form submission.",
-              "attribute": "name"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The fieldset legend/label text.",
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether a selection is required for form submission.",
-              "attribute": "required",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the entire group is disabled.",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "error",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Error message to display. When set, the group enters an error state.",
-              "attribute": "error"
-            },
-            {
-              "kind": "field",
-              "name": "helpText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Help text displayed below the group for guidance.",
-              "attribute": "help-text"
-            },
-            {
-              "kind": "field",
-              "name": "orientation",
-              "type": {
-                "text": "'vertical' | 'horizontal'"
-              },
-              "default": "'vertical'",
-              "description": "Layout orientation of the radio items.",
-              "attribute": "orientation",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "_groupEl",
-              "type": {
-                "text": "HTMLElement"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "_hasErrorSlot",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "private",
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "_groupId",
-              "privacy": "private",
-              "default": "`hx-radio-group-${Math.random().toString(36).slice(2, 9)}`"
-            },
-            {
-              "kind": "field",
-              "name": "_helpTextId",
-              "privacy": "private",
-              "default": "`${this._groupId}-help`"
-            },
-            {
-              "kind": "field",
-              "name": "_errorId",
-              "privacy": "private",
-              "default": "`${this._groupId}-error`"
-            },
-            {
-              "kind": "method",
-              "name": "_handleErrorSlotChange",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_getRadios",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "HelixRadio[]"
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_getEnabledRadios",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "HelixRadio[]"
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_syncRadios",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            },
-            {
-              "kind": "field",
-              "name": "_handleRadioSelect",
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "_handleKeydown",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "_handleSlotChange",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            },
-            {
-              "kind": "field",
-              "name": "form",
-              "type": {
-                "text": "HTMLFormElement | null"
-              },
-              "description": "Returns the associated form element, if any.",
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "validationMessage",
-              "type": {
-                "text": "string"
-              },
-              "description": "Returns the validation message.",
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "validity",
-              "type": {
-                "text": "ValidityState"
-              },
-              "description": "Returns the ValidityState object.",
-              "readonly": true
-            },
-            {
-              "kind": "method",
-              "name": "checkValidity",
-              "return": {
-                "type": {
-                  "text": "boolean"
-                }
-              },
-              "description": "Checks whether the group satisfies its constraints."
-            },
-            {
-              "kind": "method",
-              "name": "reportValidity",
-              "return": {
-                "type": {
-                  "text": "boolean"
-                }
-              },
-              "description": "Reports validity and shows the browser's constraint validation UI."
-            },
-            {
-              "kind": "method",
-              "name": "_updateValidity",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "formResetCallback",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "description": "Called by the form when it resets."
-            },
-            {
-              "kind": "method",
-              "name": "formStateRestoreCallback",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "state",
-                  "type": {
-                    "text": "string"
-                  }
-                }
-              ],
-              "description": "Called when the form restores state (e.g., back/forward navigation)."
-            }
-          ],
-          "events": [
-            {
-              "type": {
-                "text": "CustomEvent<{value: string}>"
-              },
-              "description": "Dispatched when the selected radio changes.",
-              "name": "hx-change"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The selected radio's value.",
-              "fieldName": "value",
-              "attribute": "value"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The name used for form submission.",
-              "fieldName": "name",
-              "attribute": "name"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The fieldset legend/label text.",
-              "fieldName": "label",
-              "attribute": "label"
-            },
-            {
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether a selection is required for form submission.",
-              "fieldName": "required",
-              "attribute": "required"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the entire group is disabled.",
-              "fieldName": "disabled",
-              "attribute": "disabled"
-            },
-            {
-              "name": "error",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Error message to display. When set, the group enters an error state.",
-              "fieldName": "error",
-              "attribute": "error"
-            },
-            {
-              "name": "help-text",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Help text displayed below the group for guidance.",
-              "fieldName": "helpText",
-              "attribute": "help-text"
-            },
-            {
-              "name": "orientation",
-              "type": {
-                "text": "'vertical' | 'horizontal'"
-              },
-              "default": "'vertical'",
-              "description": "Layout orientation of the radio items.",
-              "fieldName": "orientation",
-              "attribute": "orientation"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "hx-radio-group",
-          "customElement": true,
-          "summary": "Form-associated radio group with label, validation, help text, and keyboard navigation."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixRadioGroup",
-          "declaration": {
-            "name": "HelixRadioGroup",
-            "module": "src/components/hx-radio-group/hx-radio-group.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "hx-radio-group",
-          "declaration": {
-            "name": "HelixRadioGroup",
-            "module": "src/components/hx-radio-group/hx-radio-group.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-radio-group/hx-radio.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "An individual radio button, designed to be used inside a `<wc-radio-group>`.",
-          "name": "HelixRadio",
-          "cssProperties": [
-            {
-              "description": "Radio circle size.",
-              "name": "--hx-radio-size",
-              "default": "var(--hx-size-5, 1.25rem)"
-            },
-            {
-              "description": "Radio border color.",
-              "name": "--hx-radio-border-color",
-              "default": "var(--hx-color-neutral-300, #ced4da)"
-            },
-            {
-              "description": "Checked background color.",
-              "name": "--hx-radio-checked-bg",
-              "default": "var(--hx-color-primary-500, #2563EB)"
-            },
-            {
-              "description": "Checked border color.",
-              "name": "--hx-radio-checked-border-color",
-              "default": "var(--hx-color-primary-500, #2563EB)"
-            },
-            {
-              "description": "Inner dot color when checked.",
-              "name": "--hx-radio-dot-color",
-              "default": "var(--hx-color-neutral-0, #ffffff)"
-            },
-            {
-              "description": "Focus ring color.",
-              "name": "--hx-radio-focus-ring-color",
-              "default": "var(--hx-focus-ring-color, #2563EB)"
-            },
-            {
-              "description": "Label text color.",
-              "name": "--hx-radio-label-color",
-              "default": "var(--hx-color-neutral-700, #343a40)"
-            }
-          ],
-          "cssParts": [
-            {
-              "description": "The visual radio circle.",
-              "name": "radio"
-            },
-            {
-              "description": "The label text.",
-              "name": "label"
-            }
-          ],
-          "slots": [
-            {
-              "description": "Custom label content (overrides the label property).",
-              "name": ""
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The value this radio represents.",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Visible label text for the radio.",
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether this radio is disabled.",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether this radio is checked. Managed by the parent group.",
-              "attribute": "checked",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "_inputId",
-              "privacy": "private",
-              "default": "`wc-radio-${Math.random().toString(36).slice(2, 9)}`"
-            },
-            {
-              "kind": "method",
-              "name": "_handleClick",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            }
-          ],
-          "attributes": [
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The value this radio represents.",
-              "fieldName": "value",
-              "attribute": "value"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Visible label text for the radio.",
-              "fieldName": "label",
-              "attribute": "label"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether this radio is disabled.",
-              "fieldName": "disabled",
-              "attribute": "disabled"
-            },
-            {
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether this radio is checked. Managed by the parent group.",
-              "fieldName": "checked",
-              "attribute": "checked"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "hx-radio",
-          "customElement": true,
-          "summary": "Presentational radio button managed by its parent radio group."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixRadio",
-          "declaration": {
-            "name": "HelixRadio",
-            "module": "src/components/hx-radio-group/hx-radio.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "hx-radio",
-          "declaration": {
-            "name": "HelixRadio",
-            "module": "src/components/hx-radio-group/hx-radio.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-radio-group/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixRadioGroup",
-          "declaration": {
-            "name": "HelixRadioGroup",
-            "module": "./hx-radio-group.js"
-          }
-        },
-        {
-          "kind": "js",
-          "name": "HelixRadio",
-          "declaration": {
-            "name": "HelixRadio",
-            "module": "./hx-radio.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-checkbox/hx-checkbox.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "A checkbox component with label, validation, and form association.",
-          "name": "HelixCheckbox",
-          "cssProperties": [
-            {
-              "description": "Checkbox dimensions.",
-              "name": "--hx-checkbox-size",
-              "default": "var(--hx-size-5, 1.25rem)"
-            },
-            {
-              "description": "Checkbox border color.",
-              "name": "--hx-checkbox-border-color",
-              "default": "var(--hx-color-neutral-300, #ced4da)"
-            },
-            {
-              "description": "Checkbox border radius.",
-              "name": "--hx-checkbox-border-radius",
-              "default": "var(--hx-border-radius-sm, 0.25rem)"
-            },
-            {
-              "description": "Checked background color.",
-              "name": "--hx-checkbox-checked-bg",
-              "default": "var(--hx-color-primary-500, #2563EB)"
-            },
-            {
-              "description": "Checked border color.",
-              "name": "--hx-checkbox-checked-border-color",
-              "default": "var(--hx-color-primary-500, #2563EB)"
-            },
-            {
-              "description": "Checkmark color.",
-              "name": "--hx-checkbox-checkmark-color",
-              "default": "var(--hx-color-neutral-0, #ffffff)"
-            },
-            {
-              "description": "Focus ring color.",
-              "name": "--hx-checkbox-focus-ring-color",
-              "default": "var(--hx-focus-ring-color, #2563EB)"
-            },
-            {
-              "description": "Label text color.",
-              "name": "--hx-checkbox-label-color",
-              "default": "var(--hx-color-neutral-700, #343a40)"
-            },
-            {
-              "description": "Error state color.",
-              "name": "--hx-checkbox-error-color",
-              "default": "var(--hx-color-error-500, #dc3545)"
-            }
-          ],
-          "cssParts": [
-            {
-              "description": "The visual checkbox element.",
-              "name": "checkbox"
-            },
-            {
-              "description": "The label element.",
-              "name": "label"
-            },
-            {
-              "description": "The help text container.",
-              "name": "help-text"
-            },
-            {
-              "description": "The error message container.",
-              "name": "error"
-            },
-            {
-              "description": "The wrapper around checkbox and label.",
-              "name": "control"
-            }
-          ],
-          "slots": [
-            {
-              "description": "Custom label content (overrides the label property).",
-              "name": ""
-            },
-            {
-              "description": "Custom error content (overrides the error property).",
-              "name": "error"
-            },
-            {
-              "description": "Custom help text content (overrides the helpText property).",
-              "name": "help-text"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "formAssociated",
-              "type": {
-                "text": "boolean"
-              },
-              "static": true,
-              "default": "true"
-            },
-            {
-              "kind": "field",
-              "name": "_internals",
-              "type": {
-                "text": "ElementInternals"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is checked.",
-              "attribute": "checked",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "indeterminate",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is in an indeterminate state (e.g., for \"select all\" patterns).",
-              "attribute": "indeterminate"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is disabled.",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is required for form submission.",
-              "attribute": "required",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The name of the checkbox, used for form submission.",
-              "attribute": "name"
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "'on'",
-              "description": "The value submitted when the checkbox is checked.",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The visible label text for the checkbox.",
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
-              "name": "error",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Error message to display. When set, the checkbox enters an error state.",
-              "attribute": "error"
-            },
-            {
-              "kind": "field",
-              "name": "helpText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Help text displayed below the checkbox for guidance.",
-              "attribute": "help-text"
-            },
-            {
-              "kind": "field",
-              "name": "_inputEl",
-              "type": {
-                "text": "HTMLInputElement"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "_hasErrorSlot",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "private",
-              "default": "false"
-            },
-            {
-              "kind": "method",
-              "name": "_handleErrorSlotChange",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "field",
-              "name": "form",
-              "type": {
-                "text": "HTMLFormElement | null"
-              },
-              "description": "Returns the associated form element, if any.",
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "validationMessage",
-              "type": {
-                "text": "string"
-              },
-              "description": "Returns the validation message.",
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "validity",
-              "type": {
-                "text": "ValidityState"
-              },
-              "description": "Returns the ValidityState object.",
-              "readonly": true
-            },
-            {
-              "kind": "method",
-              "name": "checkValidity",
-              "return": {
-                "type": {
-                  "text": "boolean"
-                }
-              },
-              "description": "Checks whether the checkbox satisfies its constraints."
-            },
-            {
-              "kind": "method",
-              "name": "reportValidity",
-              "return": {
-                "type": {
-                  "text": "boolean"
-                }
-              },
-              "description": "Reports validity and shows the browser's constraint validation UI."
-            },
-            {
-              "kind": "method",
-              "name": "_updateValidity",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "formResetCallback",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "description": "Called by the form when it resets."
-            },
-            {
-              "kind": "method",
-              "name": "formStateRestoreCallback",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "state",
-                  "type": {
-                    "text": "string"
-                  }
-                }
-              ],
-              "description": "Called when the form restores state (e.g., back/forward navigation)."
-            },
-            {
-              "kind": "method",
-              "name": "_handleChange",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "_handleKeyDown",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "KeyboardEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "focus",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "options",
-                  "optional": true,
-                  "type": {
-                    "text": "FocusOptions"
-                  }
-                }
-              ],
-              "description": "Moves focus to the checkbox input element."
-            },
-            {
-              "kind": "field",
-              "name": "_id",
-              "privacy": "private",
-              "default": "`hx-checkbox-${Math.random().toString(36).slice(2, 9)}`"
-            },
-            {
-              "kind": "field",
-              "name": "_helpTextId",
-              "privacy": "private",
-              "default": "`${this._id}-help`"
-            },
-            {
-              "kind": "field",
-              "name": "_errorId",
-              "privacy": "private",
-              "default": "`${this._id}-error`"
-            },
-            {
-              "kind": "field",
-              "name": "_labelId",
-              "privacy": "private",
-              "default": "`${this._id}-label`"
-            }
-          ],
-          "events": [
-            {
-              "name": "hx-change",
-              "type": {
-                "text": "CustomEvent<{checked: boolean, value: string}>"
-              },
-              "description": "Dispatched when the checkbox is toggled."
-            }
-          ],
-          "attributes": [
-            {
-              "name": "checked",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is checked.",
-              "fieldName": "checked",
-              "attribute": "checked"
-            },
-            {
-              "name": "indeterminate",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is in an indeterminate state (e.g., for \"select all\" patterns).",
-              "fieldName": "indeterminate",
-              "attribute": "indeterminate"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is disabled.",
-              "fieldName": "disabled",
-              "attribute": "disabled"
-            },
-            {
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the checkbox is required for form submission.",
-              "fieldName": "required",
-              "attribute": "required"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The name of the checkbox, used for form submission.",
-              "fieldName": "name",
-              "attribute": "name"
-            },
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "'on'",
-              "description": "The value submitted when the checkbox is checked.",
-              "fieldName": "value",
-              "attribute": "value"
-            },
-            {
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The visible label text for the checkbox.",
-              "fieldName": "label",
-              "attribute": "label"
-            },
-            {
-              "name": "error",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Error message to display. When set, the checkbox enters an error state.",
-              "fieldName": "error",
-              "attribute": "error"
-            },
-            {
-              "name": "help-text",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Help text displayed below the checkbox for guidance.",
-              "fieldName": "helpText",
-              "attribute": "help-text"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "hx-checkbox",
-          "customElement": true,
-          "summary": "Form-associated checkbox with built-in label, error, and help text."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixCheckbox",
-          "declaration": {
-            "name": "HelixCheckbox",
-            "module": "src/components/hx-checkbox/hx-checkbox.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "hx-checkbox",
-          "declaration": {
-            "name": "HelixCheckbox",
-            "module": "src/components/hx-checkbox/hx-checkbox.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-checkbox/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixCheckbox",
-          "declaration": {
-            "name": "HelixCheckbox",
-            "module": "./hx-checkbox.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-text-input/hx-text-input.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "A text input component with label, validation, and form association.",
-          "name": "HelixTextInput",
-          "cssProperties": [
-            {
-              "description": "Input background color.",
-              "name": "--hx-input-bg",
-              "default": "var(--hx-color-neutral-0)"
-            },
-            {
-              "description": "Input text color.",
-              "name": "--hx-input-color",
-              "default": "var(--hx-color-neutral-800)"
-            },
-            {
-              "description": "Input border color.",
-              "name": "--hx-input-border-color",
-              "default": "var(--hx-color-neutral-300)"
-            },
-            {
-              "description": "Input border radius.",
-              "name": "--hx-input-border-radius",
-              "default": "var(--hx-border-radius-md)"
-            },
-            {
-              "description": "Input font family.",
-              "name": "--hx-input-font-family",
-              "default": "var(--hx-font-family-sans)"
-            },
-            {
-              "description": "Focus ring color.",
-              "name": "--hx-input-focus-ring-color",
-              "default": "var(--hx-focus-ring-color)"
-            },
-            {
-              "description": "Error state color.",
-              "name": "--hx-input-error-color",
-              "default": "var(--hx-color-error-500)"
-            },
-            {
-              "description": "Label text color.",
-              "name": "--hx-input-label-color",
-              "default": "var(--hx-color-neutral-700)"
-            }
-          ],
-          "cssParts": [
-            {
-              "description": "The outer field container.",
-              "name": "field"
-            },
-            {
-              "description": "The label element.",
-              "name": "label"
-            },
-            {
-              "description": "The wrapper around prefix, input, and suffix.",
-              "name": "input-wrapper"
-            },
-            {
-              "description": "The native input element.",
-              "name": "input"
-            },
-            {
-              "description": "The help text container.",
-              "name": "help-text"
-            },
-            {
-              "description": "The error message container.",
-              "name": "error"
-            }
-          ],
-          "slots": [
-            {
-              "description": "Custom label content (overrides the label property). Use for Drupal Form API rendered labels.",
-              "name": "label"
-            },
-            {
-              "description": "Content rendered before the input (e.g., icon).",
-              "name": "prefix"
-            },
-            {
-              "description": "Content rendered after the input (e.g., icon or button).",
-              "name": "suffix"
-            },
-            {
-              "description": "Custom help text content (overrides the helpText property).",
-              "name": "help-text"
-            },
-            {
-              "description": "Custom error content (overrides the error property). Use for Drupal Form API rendered errors.",
-              "name": "error"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "formAssociated",
-              "type": {
-                "text": "boolean"
-              },
-              "static": true,
-              "default": "true"
-            },
-            {
-              "kind": "field",
-              "name": "_internals",
-              "type": {
-                "text": "ElementInternals"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The visible label text for the input.",
-              "attribute": "label"
-            },
-            {
-              "kind": "field",
-              "name": "placeholder",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Placeholder text shown when the input is empty.",
-              "attribute": "placeholder"
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The current value of the input.",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
-              "name": "type",
-              "type": {
-                "text": "'text' | 'email' | 'password' | 'tel' | 'url' | 'search' | 'number'"
-              },
-              "default": "'text'",
-              "description": "The type of the native input element.",
-              "attribute": "type"
-            },
-            {
-              "kind": "field",
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the input is required for form submission.",
-              "attribute": "required",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the input is disabled.",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "error",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Error message to display. When set, the input enters an error state.",
-              "attribute": "error"
-            },
-            {
-              "kind": "field",
-              "name": "helpText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Help text displayed below the input for guidance.",
-              "attribute": "help-text"
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The name of the input, used for form submission.",
-              "attribute": "name"
-            },
-            {
-              "kind": "field",
-              "name": "ariaLabel",
-              "type": {
-                "text": "string | null"
-              },
-              "default": "null",
-              "description": "Accessible name for screen readers, if different from the visible label.",
-              "attribute": "aria-label"
-            },
-            {
-              "kind": "field",
-              "name": "_input",
-              "type": {
-                "text": "HTMLInputElement"
-              },
-              "privacy": "private"
-            },
-            {
-              "kind": "field",
-              "name": "_hasLabelSlot",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "private",
-              "default": "false"
-            },
-            {
-              "kind": "field",
-              "name": "_hasErrorSlot",
-              "type": {
-                "text": "boolean"
-              },
-              "privacy": "private",
-              "default": "false"
-            },
-            {
-              "kind": "method",
-              "name": "_handleLabelSlotChange",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_handleErrorSlotChange",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "field",
-              "name": "form",
-              "type": {
-                "text": "HTMLFormElement | null"
-              },
-              "description": "Returns the associated form element, if any.",
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "validationMessage",
-              "type": {
-                "text": "string"
-              },
-              "description": "Returns the validation message.",
-              "readonly": true
-            },
-            {
-              "kind": "field",
-              "name": "validity",
-              "type": {
-                "text": "ValidityState"
-              },
-              "description": "Returns the ValidityState object.",
-              "readonly": true
-            },
-            {
-              "kind": "method",
-              "name": "checkValidity",
-              "return": {
-                "type": {
-                  "text": "boolean"
-                }
-              },
-              "description": "Checks whether the input satisfies its constraints."
-            },
-            {
-              "kind": "method",
-              "name": "reportValidity",
-              "return": {
-                "type": {
-                  "text": "boolean"
-                }
-              },
-              "description": "Reports validity and shows the browser's constraint validation UI."
-            },
-            {
-              "kind": "method",
-              "name": "_updateValidity",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "formResetCallback",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              }
-            },
-            {
-              "kind": "method",
-              "name": "formStateRestoreCallback",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "state",
-                  "type": {
-                    "text": "string"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_handleInput",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_handleChange",
-              "privacy": "private",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "focus",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "parameters": [
-                {
-                  "name": "options",
-                  "optional": true,
-                  "type": {
-                    "text": "FocusOptions"
-                  }
-                }
-              ],
-              "description": "Moves focus to the input element."
-            },
-            {
-              "kind": "method",
-              "name": "select",
-              "return": {
-                "type": {
-                  "text": "void"
-                }
-              },
-              "description": "Selects all text in the input."
-            },
-            {
-              "kind": "field",
-              "name": "_inputId",
-              "privacy": "private",
-              "default": "`hx-text-input-${Math.random().toString(36).slice(2, 9)}`"
-            },
-            {
-              "kind": "field",
-              "name": "_helpTextId",
-              "privacy": "private",
-              "default": "`${this._inputId}-help`"
-            },
-            {
-              "kind": "field",
-              "name": "_errorId",
-              "privacy": "private",
-              "default": "`${this._inputId}-error`"
-            }
-          ],
-          "events": [
-            {
-              "name": "hx-input",
-              "type": {
-                "text": "CustomEvent<{value: string}>"
-              },
-              "description": "Dispatched on every keystroke as the user types."
-            },
-            {
-              "name": "hx-change",
-              "type": {
-                "text": "CustomEvent<{value: string}>"
-              },
-              "description": "Dispatched when the input loses focus after its value changed."
-            }
-          ],
-          "attributes": [
-            {
-              "name": "label",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The visible label text for the input.",
-              "fieldName": "label",
-              "attribute": "label"
-            },
-            {
-              "name": "placeholder",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Placeholder text shown when the input is empty.",
-              "fieldName": "placeholder",
-              "attribute": "placeholder"
-            },
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The current value of the input.",
-              "fieldName": "value",
-              "attribute": "value"
-            },
-            {
-              "name": "type",
-              "type": {
-                "text": "'text' | 'email' | 'password' | 'tel' | 'url' | 'search' | 'number'"
-              },
-              "default": "'text'",
-              "description": "The type of the native input element.",
-              "fieldName": "type",
-              "attribute": "type"
-            },
-            {
-              "name": "required",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the input is required for form submission.",
-              "fieldName": "required",
-              "attribute": "required"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether the input is disabled.",
-              "fieldName": "disabled",
-              "attribute": "disabled"
-            },
-            {
-              "name": "error",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Error message to display. When set, the input enters an error state.",
-              "fieldName": "error",
-              "attribute": "error"
-            },
-            {
-              "name": "help-text",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Help text displayed below the input for guidance.",
-              "fieldName": "helpText",
-              "attribute": "help-text"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "The name of the input, used for form submission.",
-              "fieldName": "name",
-              "attribute": "name"
-            },
-            {
-              "name": "aria-label",
-              "type": {
-                "text": "string | null"
-              },
-              "default": "null",
-              "description": "Accessible name for screen readers, if different from the visible label.",
-              "fieldName": "ariaLabel",
-              "attribute": "aria-label"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "hx-text-input",
-          "customElement": true,
-          "summary": "Form-associated text input with built-in label, error, and help text."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixTextInput",
-          "declaration": {
-            "name": "HelixTextInput",
-            "module": "src/components/hx-text-input/hx-text-input.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "hx-text-input",
-          "declaration": {
-            "name": "HelixTextInput",
-            "module": "src/components/hx-text-input/hx-text-input.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/hx-text-input/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "HelixTextInput",
-          "declaration": {
-            "name": "HelixTextInput",
-            "module": "./hx-text-input.js"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
       "path": "src/components/hx-textarea/hx-textarea.ts",
       "declarations": [
         {
@@ -4798,6 +4784,7 @@
                 "text": "number | undefined"
               },
               "description": "Maximum number of characters allowed.",
+              "default": "undefined",
               "attribute": "maxlength"
             },
             {
@@ -5178,6 +5165,7 @@
                 "text": "number | undefined"
               },
               "description": "Maximum number of characters allowed.",
+              "default": "undefined",
               "fieldName": "maxlength",
               "attribute": "maxlength"
             },

--- a/packages/hx-library/src/components/hx-alert/hx-alert.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.ts
@@ -20,7 +20,7 @@ type AlertVariant = 'info' | 'success' | 'warning' | 'error';
  * @slot actions - Action buttons rendered within the alert.
  *
  * @fires {CustomEvent<{reason: string}>} hx-close - Dispatched when the user dismisses the alert.
- * @fires {CustomEvent} wc-after-close - Dispatched after the alert is dismissed.
+ * @fires {CustomEvent} hx-after-close - Dispatched after the alert is dismissed.
  *
  * @csspart alert - The outer alert container.
  * @csspart icon - The icon container.
@@ -47,6 +47,7 @@ export class HelixAlert extends LitElement {
   /**
    * Visual variant of the alert that determines colors and ARIA semantics.
    * @attr variant
+   * @default 'info'
    */
   @property({ type: String, reflect: true })
   variant: AlertVariant = 'info';
@@ -54,6 +55,7 @@ export class HelixAlert extends LitElement {
   /**
    * Whether the alert can be dismissed by the user.
    * @attr closable
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   closable = false;
@@ -61,6 +63,7 @@ export class HelixAlert extends LitElement {
   /**
    * Whether the alert is visible. Set to false to hide the alert.
    * @attr open
+   * @default true
    */
   @property({ type: Boolean, reflect: true })
   open = true;

--- a/packages/hx-library/src/components/hx-badge/hx-badge.ts
+++ b/packages/hx-library/src/components/hx-badge/hx-badge.ts
@@ -33,6 +33,7 @@ export class HelixBadge extends LitElement {
   /**
    * Visual style variant of the badge.
    * @attr variant
+   * @default 'primary'
    */
   @property({ type: String, reflect: true })
   variant: 'primary' | 'success' | 'warning' | 'error' | 'neutral' = 'primary';
@@ -40,6 +41,7 @@ export class HelixBadge extends LitElement {
   /**
    * Size of the badge.
    * @attr hx-size
+   * @default 'md'
    */
   @property({ type: String, reflect: true, attribute: 'hx-size' })
   size: 'sm' | 'md' | 'lg' = 'md';
@@ -47,6 +49,7 @@ export class HelixBadge extends LitElement {
   /**
    * Whether the badge uses fully rounded (pill) styling.
    * @attr pill
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   pill = false;
@@ -54,6 +57,7 @@ export class HelixBadge extends LitElement {
   /**
    * Whether the badge displays an animated pulse for attention.
    * @attr pulse
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   pulse = false;

--- a/packages/hx-library/src/components/hx-button/hx-button.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.ts
@@ -32,6 +32,7 @@ export class HelixButton extends LitElement {
   /**
    * Visual style variant of the button.
    * @attr variant
+   * @default 'primary'
    */
   @property({ type: String, reflect: true })
   variant: 'primary' | 'secondary' | 'ghost' = 'primary';
@@ -39,6 +40,7 @@ export class HelixButton extends LitElement {
   /**
    * Size of the button.
    * @attr hx-size
+   * @default 'md'
    */
   @property({ type: String, reflect: true, attribute: 'hx-size' })
   size: 'sm' | 'md' | 'lg' = 'md';
@@ -46,6 +48,7 @@ export class HelixButton extends LitElement {
   /**
    * Whether the button is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -53,6 +56,7 @@ export class HelixButton extends LitElement {
   /**
    * The type attribute for the underlying button element.
    * @attr type
+   * @default 'button'
    */
   @property({ type: String })
   type: 'button' | 'submit' | 'reset' = 'button';

--- a/packages/hx-library/src/components/hx-card/hx-card.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.ts
@@ -17,7 +17,7 @@ import { helixCardStyles } from './hx-card.styles.js';
  * @slot footer - Optional footer content below the body.
  * @slot actions - Optional action buttons, rendered with a top border separator.
  *
- * @fires {CustomEvent<{url: string, originalEvent: MouseEvent}>} wc-card-click - Dispatched when an interactive card (with wc-href) is clicked.
+ * @fires {CustomEvent<{url: string, originalEvent: MouseEvent}>} hx-card-click - Dispatched when an interactive card (with hx-href) is clicked.
  *
  * @csspart card - The outer card container element.
  * @csspart image - The image slot container.
@@ -40,6 +40,7 @@ export class HelixCard extends LitElement {
   /**
    * Visual style variant of the card.
    * @attr variant
+   * @default 'default'
    */
   @property({ type: String, reflect: true })
   variant: 'default' | 'featured' | 'compact' = 'default';
@@ -47,6 +48,7 @@ export class HelixCard extends LitElement {
   /**
    * Elevation (shadow depth) of the card.
    * @attr elevation
+   * @default 'flat'
    */
   @property({ type: String, reflect: true })
   elevation: 'flat' | 'raised' | 'floating' = 'flat';
@@ -54,8 +56,9 @@ export class HelixCard extends LitElement {
   /**
    * Optional URL. When set, the card becomes interactive (clickable)
    * and navigates to this URL on click.
-   * Uses wc-href to avoid conflicting with the native HTML href attribute.
+   * Uses hx-href to avoid conflicting with the native HTML href attribute.
    * @attr hx-href
+   * @default ''
    */
   @property({ type: String, attribute: 'hx-href' })
   wcHref = '';

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
@@ -55,6 +55,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * Whether the checkbox is checked.
    * @attr checked
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   checked = false;
@@ -62,6 +63,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * Whether the checkbox is in an indeterminate state (e.g., for "select all" patterns).
    * @attr indeterminate
+   * @default false
    */
   @property({ type: Boolean })
   indeterminate = false;
@@ -69,6 +71,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * Whether the checkbox is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -76,6 +79,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * Whether the checkbox is required for form submission.
    * @attr required
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   required = false;
@@ -83,6 +87,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * The name of the checkbox, used for form submission.
    * @attr name
+   * @default ''
    */
   @property({ type: String })
   name = '';
@@ -90,6 +95,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * The value submitted when the checkbox is checked.
    * @attr value
+   * @default 'on'
    */
   @property({ type: String })
   value = 'on';
@@ -97,6 +103,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * The visible label text for the checkbox.
    * @attr label
+   * @default ''
    */
   @property({ type: String })
   label = '';
@@ -104,6 +111,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * Error message to display. When set, the checkbox enters an error state.
    * @attr error
+   * @default ''
    */
   @property({ type: String })
   error = '';
@@ -111,6 +119,7 @@ export class HelixCheckbox extends LitElement {
   /**
    * Help text displayed below the checkbox for guidance.
    * @attr help-text
+   * @default ''
    */
   @property({ type: String, attribute: 'help-text' })
   helpText = '';

--- a/packages/hx-library/src/components/hx-container/hx-container.ts
+++ b/packages/hx-library/src/components/hx-container/hx-container.ts
@@ -36,6 +36,7 @@ export class HelixContainer extends LitElement {
   /**
    * Controls the max-width of the inner content wrapper.
    * @attr width
+   * @default 'content'
    */
   @property({ type: String, reflect: true })
   width: 'full' | 'content' | 'narrow' | 'sm' | 'md' | 'lg' | 'xl' = 'content';
@@ -43,6 +44,7 @@ export class HelixContainer extends LitElement {
   /**
    * Vertical padding applied to the outer wrapper.
    * @attr padding
+   * @default 'none'
    */
   @property({ type: String, reflect: true })
   padding: 'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl' = 'none';

--- a/packages/hx-library/src/components/hx-form/hx-form.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.ts
@@ -21,9 +21,9 @@ import { helixFormScopedCss } from './hx-form.styles.js';
  *
  * @slot - Default slot for form fields and controls.
  *
- * @fires {CustomEvent<{valid: boolean, values: Record<string, FormDataEntryValue>}>} wc-submit - Dispatched on valid client-side submit when no action is set.
- * @fires {CustomEvent<{errors: Array<{name: string, message: string}>}>} wc-invalid - Dispatched when validation fails on submit.
- * @fires {CustomEvent} wc-reset - Dispatched when the form is reset.
+ * @fires {CustomEvent<{valid: boolean, values: Record<string, FormDataEntryValue>}>} hx-submit - Dispatched on valid client-side submit when no action is set.
+ * @fires {CustomEvent<{errors: Array<{name: string, message: string}>}>} hx-invalid - Dispatched when validation fails on submit.
+ * @fires {CustomEvent} hx-reset - Dispatched when the form is reset.
  *
  * @cssprop [--hx-form-gap=var(--hx-space-4)] - Gap between form fields.
  * @cssprop [--hx-form-max-width=none] - Maximum width of the form.
@@ -59,8 +59,9 @@ export class HelixForm extends LitElement {
 
   /**
    * The URL to submit the form to. When empty, the form handles
-   * submission client-side only and dispatches `wc-submit`.
+   * submission client-side only and dispatches `hx-submit`.
    * @attr action
+   * @default ''
    */
   @property({ type: String })
   action = '';
@@ -68,6 +69,7 @@ export class HelixForm extends LitElement {
   /**
    * The HTTP method used when submitting the form.
    * @attr method
+   * @default 'post'
    */
   @property({ type: String })
   method: 'get' | 'post' = 'post';
@@ -76,6 +78,7 @@ export class HelixForm extends LitElement {
    * When true, disables the browser's built-in constraint validation
    * on form submission.
    * @attr novalidate
+   * @default false
    */
   @property({ type: Boolean })
   novalidate = false;
@@ -83,6 +86,7 @@ export class HelixForm extends LitElement {
   /**
    * Identifies the form for scripting and form discovery.
    * @attr name
+   * @default ''
    */
   @property({ type: String })
   name = '';

--- a/packages/hx-library/src/components/hx-prose/hx-prose.ts
+++ b/packages/hx-library/src/components/hx-prose/hx-prose.ts
@@ -42,6 +42,7 @@ export class HelixProse extends LitElement {
   /**
    * Typography scale for the prose content.
    * @attr size
+   * @default 'base'
    */
   @property({ type: String, reflect: true })
   size: 'sm' | 'base' | 'lg' = 'base';
@@ -50,6 +51,7 @@ export class HelixProse extends LitElement {
    * Maximum content width. When set, overrides the --hx-prose-max-width token.
    * Accepts any valid CSS width value (e.g., '640px', '80ch', '100%').
    * @attr max-width
+   * @default ''
    */
   @property({ type: String, reflect: true, attribute: 'max-width' })
   maxWidth = '';

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
@@ -6,13 +6,13 @@ import { helixRadioGroupStyles } from './hx-radio-group.styles.js';
 import type { HelixRadio } from './hx-radio.js';
 
 /**
- * A form-associated radio group that manages a set of `<wc-radio>` children.
+ * A form-associated radio group that manages a set of `<hx-radio>` children.
  *
  * @summary Form-associated radio group with label, validation, help text, and keyboard navigation.
  *
  * @tag hx-radio-group
  *
- * @slot - `<wc-radio>` elements.
+ * @slot - `<hx-radio>` elements.
  * @slot error - Custom error content (overrides the error property).
  * @slot help-text - Custom help text content (overrides the helpText property).
  *
@@ -48,6 +48,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * The selected radio's value.
    * @attr value
+   * @default ''
    */
   @property({ type: String })
   value = '';
@@ -55,6 +56,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * The name used for form submission.
    * @attr name
+   * @default ''
    */
   @property({ type: String })
   name = '';
@@ -62,6 +64,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * The fieldset legend/label text.
    * @attr label
+   * @default ''
    */
   @property({ type: String })
   label = '';
@@ -69,6 +72,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * Whether a selection is required for form submission.
    * @attr required
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   required = false;
@@ -76,6 +80,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * Whether the entire group is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -83,6 +88,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * Error message to display. When set, the group enters an error state.
    * @attr error
+   * @default ''
    */
   @property({ type: String })
   error = '';
@@ -90,6 +96,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * Help text displayed below the group for guidance.
    * @attr help-text
+   * @default ''
    */
   @property({ type: String, attribute: 'help-text' })
   helpText = '';
@@ -97,6 +104,7 @@ export class HelixRadioGroup extends LitElement {
   /**
    * Layout orientation of the radio items.
    * @attr orientation
+   * @default 'vertical'
    */
   @property({ type: String, reflect: true })
   orientation: 'vertical' | 'horizontal' = 'vertical';

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio.ts
@@ -5,7 +5,7 @@ import { tokenStyles } from '@helix/tokens/lit';
 import { helixRadioStyles } from './hx-radio.styles.js';
 
 /**
- * An individual radio button, designed to be used inside a `<wc-radio-group>`.
+ * An individual radio button, designed to be used inside a `<hx-radio-group>`.
  *
  * @summary Presentational radio button managed by its parent radio group.
  *
@@ -33,6 +33,7 @@ export class HelixRadio extends LitElement {
   /**
    * The value this radio represents.
    * @attr value
+   * @default ''
    */
   @property({ type: String })
   value = '';
@@ -40,6 +41,7 @@ export class HelixRadio extends LitElement {
   /**
    * Visible label text for the radio.
    * @attr label
+   * @default ''
    */
   @property({ type: String })
   label = '';
@@ -47,6 +49,7 @@ export class HelixRadio extends LitElement {
   /**
    * Whether this radio is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -54,6 +57,7 @@ export class HelixRadio extends LitElement {
   /**
    * Whether this radio is checked. Managed by the parent group.
    * @attr checked
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   checked = false;

--- a/packages/hx-library/src/components/hx-select/hx-select.ts
+++ b/packages/hx-library/src/components/hx-select/hx-select.ts
@@ -61,6 +61,7 @@ export class HelixSelect extends LitElement {
   /**
    * The visible label text for the select.
    * @attr label
+   * @default ''
    */
   @property({ type: String })
   label = '';
@@ -68,6 +69,7 @@ export class HelixSelect extends LitElement {
   /**
    * Placeholder option text shown as the first disabled option.
    * @attr placeholder
+   * @default ''
    */
   @property({ type: String })
   placeholder = '';
@@ -75,6 +77,7 @@ export class HelixSelect extends LitElement {
   /**
    * The current value of the select.
    * @attr value
+   * @default ''
    */
   @property({ type: String, reflect: true })
   value = '';
@@ -82,6 +85,7 @@ export class HelixSelect extends LitElement {
   /**
    * Whether the select is required for form submission.
    * @attr required
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   required = false;
@@ -89,6 +93,7 @@ export class HelixSelect extends LitElement {
   /**
    * Whether the select is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -96,6 +101,7 @@ export class HelixSelect extends LitElement {
   /**
    * The name of the select, used for form submission.
    * @attr name
+   * @default ''
    */
   @property({ type: String })
   name = '';
@@ -103,6 +109,7 @@ export class HelixSelect extends LitElement {
   /**
    * Error message to display. When set, the select enters an error state.
    * @attr error
+   * @default ''
    */
   @property({ type: String })
   error = '';
@@ -110,6 +117,7 @@ export class HelixSelect extends LitElement {
   /**
    * Help text displayed below the select for guidance.
    * @attr help-text
+   * @default ''
    */
   @property({ type: String, attribute: 'help-text' })
   helpText = '';
@@ -117,6 +125,7 @@ export class HelixSelect extends LitElement {
   /**
    * Size variant of the select.
    * @attr hx-size
+   * @default 'md'
    */
   @property({ type: String, attribute: 'hx-size', reflect: true })
   size: 'sm' | 'md' | 'lg' = 'md';
@@ -124,6 +133,7 @@ export class HelixSelect extends LitElement {
   /**
    * Accessible name for screen readers, if different from the visible label.
    * @attr aria-label
+   * @default null
    */
   @property({ type: String, attribute: 'aria-label' })
   override ariaLabel: string | null = null;

--- a/packages/hx-library/src/components/hx-switch/hx-switch.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.ts
@@ -53,6 +53,7 @@ export class HelixSwitch extends LitElement {
   /**
    * Whether the switch is toggled on.
    * @attr checked
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   checked = false;
@@ -60,6 +61,7 @@ export class HelixSwitch extends LitElement {
   /**
    * Whether the switch is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -67,6 +69,7 @@ export class HelixSwitch extends LitElement {
   /**
    * Whether the switch is required for form submission.
    * @attr required
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   required = false;
@@ -74,6 +77,7 @@ export class HelixSwitch extends LitElement {
   /**
    * The name of the switch, used for form submission.
    * @attr name
+   * @default ''
    */
   @property({ type: String })
   name = '';
@@ -81,6 +85,7 @@ export class HelixSwitch extends LitElement {
   /**
    * The value submitted when the switch is checked.
    * @attr value
+   * @default 'on'
    */
   @property({ type: String })
   value = 'on';
@@ -88,6 +93,7 @@ export class HelixSwitch extends LitElement {
   /**
    * The visible label text for the switch.
    * @attr label
+   * @default ''
    */
   @property({ type: String })
   label = '';
@@ -95,6 +101,7 @@ export class HelixSwitch extends LitElement {
   /**
    * Size variant of the switch.
    * @attr hx-size
+   * @default 'md'
    */
   @property({ type: String, reflect: true, attribute: 'hx-size' })
   size: 'sm' | 'md' | 'lg' = 'md';
@@ -102,6 +109,7 @@ export class HelixSwitch extends LitElement {
   /**
    * Error message to display. When set, the switch enters an error state.
    * @attr error
+   * @default ''
    */
   @property({ type: String })
   error = '';
@@ -109,6 +117,7 @@ export class HelixSwitch extends LitElement {
   /**
    * Help text displayed below the switch for guidance.
    * @attr help-text
+   * @default ''
    */
   @property({ type: String, attribute: 'help-text' })
   helpText = '';

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
@@ -58,6 +58,7 @@ export class HelixTextInput extends LitElement {
   /**
    * The visible label text for the input.
    * @attr label
+   * @default ''
    */
   @property({ type: String })
   label = '';
@@ -65,6 +66,7 @@ export class HelixTextInput extends LitElement {
   /**
    * Placeholder text shown when the input is empty.
    * @attr placeholder
+   * @default ''
    */
   @property({ type: String })
   placeholder = '';
@@ -72,6 +74,7 @@ export class HelixTextInput extends LitElement {
   /**
    * The current value of the input.
    * @attr value
+   * @default ''
    */
   @property({ type: String })
   value = '';
@@ -79,6 +82,7 @@ export class HelixTextInput extends LitElement {
   /**
    * The type of the native input element.
    * @attr type
+   * @default 'text'
    */
   @property({ type: String })
   type: 'text' | 'email' | 'password' | 'tel' | 'url' | 'search' | 'number' = 'text';
@@ -86,6 +90,7 @@ export class HelixTextInput extends LitElement {
   /**
    * Whether the input is required for form submission.
    * @attr required
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   required = false;
@@ -93,6 +98,7 @@ export class HelixTextInput extends LitElement {
   /**
    * Whether the input is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -100,6 +106,7 @@ export class HelixTextInput extends LitElement {
   /**
    * Error message to display. When set, the input enters an error state.
    * @attr error
+   * @default ''
    */
   @property({ type: String })
   error = '';
@@ -107,6 +114,7 @@ export class HelixTextInput extends LitElement {
   /**
    * Help text displayed below the input for guidance.
    * @attr help-text
+   * @default ''
    */
   @property({ type: String, attribute: 'help-text' })
   helpText = '';
@@ -114,6 +122,7 @@ export class HelixTextInput extends LitElement {
   /**
    * The name of the input, used for form submission.
    * @attr name
+   * @default ''
    */
   @property({ type: String })
   name = '';
@@ -121,6 +130,7 @@ export class HelixTextInput extends LitElement {
   /**
    * Accessible name for screen readers, if different from the visible label.
    * @attr aria-label
+   * @default null
    */
   @property({ type: String, attribute: 'aria-label' })
   override ariaLabel: string | null = null;

--- a/packages/hx-library/src/components/hx-textarea/hx-textarea.ts
+++ b/packages/hx-library/src/components/hx-textarea/hx-textarea.ts
@@ -58,6 +58,7 @@ export class HelixTextarea extends LitElement {
   /**
    * The visible label text for the textarea.
    * @attr label
+   * @default ''
    */
   @property({ type: String })
   label = '';
@@ -65,6 +66,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Placeholder text shown when the textarea is empty.
    * @attr placeholder
+   * @default ''
    */
   @property({ type: String })
   placeholder = '';
@@ -72,6 +74,7 @@ export class HelixTextarea extends LitElement {
   /**
    * The current value of the textarea.
    * @attr value
+   * @default ''
    */
   @property({ type: String })
   value = '';
@@ -79,6 +82,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Whether the textarea is required for form submission.
    * @attr required
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   required = false;
@@ -86,6 +90,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Whether the textarea is disabled.
    * @attr disabled
+   * @default false
    */
   @property({ type: Boolean, reflect: true })
   disabled = false;
@@ -93,6 +98,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Error message to display. When set, the textarea enters an error state.
    * @attr error
+   * @default ''
    */
   @property({ type: String })
   error = '';
@@ -100,6 +106,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Help text displayed below the textarea for guidance.
    * @attr help-text
+   * @default ''
    */
   @property({ type: String, attribute: 'help-text' })
   helpText = '';
@@ -107,6 +114,7 @@ export class HelixTextarea extends LitElement {
   /**
    * The name of the textarea, used for form submission.
    * @attr name
+   * @default ''
    */
   @property({ type: String })
   name = '';
@@ -114,6 +122,7 @@ export class HelixTextarea extends LitElement {
   /**
    * The number of visible text rows.
    * @attr rows
+   * @default 4
    */
   @property({ type: Number })
   rows = 4;
@@ -121,6 +130,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Maximum number of characters allowed.
    * @attr maxlength
+   * @default undefined
    */
   @property({ type: Number, attribute: 'maxlength' })
   maxlength: number | undefined;
@@ -128,6 +138,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Controls how the textarea can be resized. Use 'auto' for auto-grow behavior.
    * @attr resize
+   * @default 'vertical'
    */
   @property({ type: String, reflect: true })
   resize: 'none' | 'vertical' | 'both' | 'auto' = 'vertical';
@@ -135,6 +146,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Whether to show a character count below the textarea.
    * @attr show-count
+   * @default false
    */
   @property({ type: Boolean, attribute: 'show-count' })
   showCount = false;
@@ -142,6 +154,7 @@ export class HelixTextarea extends LitElement {
   /**
    * Accessible name for screen readers, if different from the visible label.
    * @attr aria-label
+   * @default null
    */
   @property({ type: String, attribute: 'aria-label' })
   override ariaLabel: string | null = null;


### PR DESCRIPTION
## Summary

- Complete JSDoc coverage on all 14 hx-* web components
- 85 @property fields now have @default tags
- 35 slots, 51 CSS parts, 101 CSS custom properties documented with JSDoc
- Corrected 9 stale wc-* event names to hx-* (hx-form submit/invalid/reset, hx-card click, etc.)
- CEM manifest regenerated — 29/29 verification checks pass

## Verification

- TypeScript: ✅ zero errors
- Tests: ✅ 553/553 pass
- CEM: ✅ manifest generated cleanly, all 14 components documented
- Build: ✅ built in 876ms

## Test plan

- [x] `npm run type-check` — zero errors
- [x] `npm run test` — 553 tests pass
- [x] `npm run cem` — manifest regenerated with complete API surface
- [x] `npm run build` — library builds cleanly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)