### PR TITLE
Add axe-core accessibility tests to all components

### DIFF
--- a/packages/hx-library/.cache/coverage/coverage-summary.json
+++ b/packages/hx-library/.cache/coverage/coverage-summary.json
@@ -1,16 +1,93 @@
-{"total": {"lines":{"total":1653,"covered":1568,"skipped":0,"pct":94.85},"statements":{"total":1653,"covered":1568,"skipped":0,"pct":94.85},"functions":{"total":153,"covered":142,"skipped":0,"pct":92.81},"branches":{"total":397,"covered":375,"skipped":0,"pct":94.45},"branchesTrue":{"total":0,"covered":0,"skipped":0,"pct":100}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-alert/hx-alert.ts": {"lines":{"total":82,"covered":82,"skipped":0,"pct":100},"functions":{"total":12,"covered":12,"skipped":0,"pct":100},"statements":{"total":82,"covered":82,"skipped":0,"pct":100},"branches":{"total":24,"covered":24,"skipped":0,"pct":100}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-badge/hx-badge.ts": {"lines":{"total":44,"covered":43,"skipped":0,"pct":97.72},"functions":{"total":3,"covered":3,"skipped":0,"pct":100},"statements":{"total":44,"covered":43,"skipped":0,"pct":97.72},"branches":{"total":9,"covered":7,"skipped":0,"pct":77.77}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-button/hx-button.ts": {"lines":{"total":57,"covered":53,"skipped":0,"pct":92.98},"functions":{"total":4,"covered":4,"skipped":0,"pct":100},"statements":{"total":57,"covered":53,"skipped":0,"pct":92.98},"branches":{"total":12,"covered":11,"skipped":0,"pct":91.66}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-card/hx-card.ts": {"lines":{"total":69,"covered":69,"skipped":0,"pct":100},"functions":{"total":5,"covered":5,"skipped":0,"pct":100},"statements":{"total":69,"covered":69,"skipped":0,"pct":100},"branches":{"total":18,"covered":18,"skipped":0,"pct":100}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts": {"lines":{"total":162,"covered":159,"skipped":0,"pct":98.14},"functions":{"total":15,"covered":14,"skipped":0,"pct":93.33},"statements":{"total":162,"covered":159,"skipped":0,"pct":98.14},"branches":{"total":46,"covered":45,"skipped":0,"pct":97.82}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-container/hx-container.ts": {"lines":{"total":21,"covered":21,"skipped":0,"pct":100},"functions":{"total":2,"covered":2,"skipped":0,"pct":100},"statements":{"total":21,"covered":21,"skipped":0,"pct":100},"branches":{"total":2,"covered":2,"skipped":0,"pct":100}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-form/hx-form.ts": {"lines":{"total":161,"covered":138,"skipped":0,"pct":85.71},"functions":{"total":13,"covered":13,"skipped":0,"pct":100},"statements":{"total":161,"covered":138,"skipped":0,"pct":85.71},"branches":{"total":23,"covered":19,"skipped":0,"pct":82.6}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-prose/hx-prose.ts": {"lines":{"total":52,"covered":52,"skipped":0,"pct":100},"functions":{"total":6,"covered":6,"skipped":0,"pct":100},"statements":{"total":52,"covered":52,"skipped":0,"pct":100},"branches":{"total":10,"covered":10,"skipped":0,"pct":100}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts": {"lines":{"total":216,"covered":205,"skipped":0,"pct":94.9},"functions":{"total":21,"covered":18,"skipped":0,"pct":85.71},"statements":{"total":216,"covered":205,"skipped":0,"pct":94.9},"branches":{"total":57,"covered":53,"skipped":0,"pct":92.98}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-radio-group/hx-radio.ts": {"lines":{"total":55,"covered":55,"skipped":0,"pct":100},"functions":{"total":4,"covered":4,"skipped":0,"pct":100},"statements":{"total":55,"covered":55,"skipped":0,"pct":100},"branches":{"total":8,"covered":8,"skipped":0,"pct":100}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-select/hx-select.ts": {"lines":{"total":188,"covered":181,"skipped":0,"pct":96.27},"functions":{"total":17,"covered":15,"skipped":0,"pct":88.23},"statements":{"total":188,"covered":181,"skipped":0,"pct":96.27},"branches":{"total":47,"covered":44,"skipped":0,"pct":93.61}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-switch/hx-switch.ts": {"lines":{"total":160,"covered":157,"skipped":0,"pct":98.12},"functions":{"total":16,"covered":15,"skipped":0,"pct":93.75},"statements":{"total":160,"covered":157,"skipped":0,"pct":98.12},"branches":{"total":51,"covered":47,"skipped":0,"pct":92.15}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-text-input/hx-text-input.ts": {"lines":{"total":181,"covered":167,"skipped":0,"pct":92.26},"functions":{"total":17,"covered":15,"skipped":0,"pct":88.23},"statements":{"total":181,"covered":167,"skipped":0,"pct":92.26},"branches":{"total":41,"covered":40,"skipped":0,"pct":97.56}}
-,"/Volumes/Development/wc-2026/packages/hx-library/src/components/hx-textarea/hx-textarea.ts": {"lines":{"total":205,"covered":186,"skipped":0,"pct":90.73},"functions":{"total":18,"covered":16,"skipped":0,"pct":88.88},"statements":{"total":205,"covered":186,"skipped":0,"pct":90.73},"branches":{"total":49,"covered":47,"skipped":0,"pct":95.91}}
+{
+  "total": {
+    "lines": { "total": 1653, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 1653, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 14, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 14, "covered": 0, "skipped": 0, "pct": 0 },
+    "branchesTrue": { "total": 0, "covered": 0, "skipped": 0, "pct": 100 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-alert/hx-alert.ts": {
+    "lines": { "total": 82, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 82, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-badge/hx-badge.ts": {
+    "lines": { "total": 44, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 44, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-button/hx-button.ts": {
+    "lines": { "total": 57, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 57, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-card/hx-card.ts": {
+    "lines": { "total": 69, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 69, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts": {
+    "lines": { "total": 162, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 162, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-container/hx-container.ts": {
+    "lines": { "total": 21, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 21, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-form/hx-form.ts": {
+    "lines": { "total": 161, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 161, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-prose/hx-prose.ts": {
+    "lines": { "total": 52, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 52, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts": {
+    "lines": { "total": 216, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 216, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-radio-group/hx-radio.ts": {
+    "lines": { "total": 55, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 55, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-select/hx-select.ts": {
+    "lines": { "total": 188, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 188, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-switch/hx-switch.ts": {
+    "lines": { "total": 160, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 160, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-text-input/hx-text-input.ts": {
+    "lines": { "total": 181, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 181, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  },
+  "/Volumes/Development/helix/.worktrees/feature-phase-1-production-add-axe-core/packages/hx-library/src/components/hx-textarea/hx-textarea.ts": {
+    "lines": { "total": 205, "covered": 0, "skipped": 0, "pct": 0 },
+    "functions": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 },
+    "statements": { "total": 205, "covered": 0, "skipped": 0, "pct": 0 },
+    "branches": { "total": 1, "covered": 0, "skipped": 0, "pct": 0 }
+  }
 }


### PR DESCRIPTION
## Summary

**Milestone:** Phase 1: Production-Grade Foundation

Add automated accessibility tests using axe-core to every component test file. Use the existing test-utils checkA11y helper. Test in multiple states: default, disabled, error, focused, with content, empty.

**Files to Modify:**
- packages/hx-library/src/components/*/hx-*.test.ts

**Acceptance Criteria:**
- [ ] Every component test file includes axe-core checks
- [ ] Tests cover default, disabled, error, and focused states
- [ ] Zero axe-core v...

---
*Created automatically by Automaker*