### PR TITLE
docs(starlight): create Starlight documentation pages for all 13 components

### DIFF
--- a/apps/docs/src/content/docs/component-library/hx-alert.mdx
+++ b/apps/docs/src/content/docs/component-library/hx-alert.mdx
@@ -57,3 +57,181 @@ Use the `actions` slot to add action buttons inside the alert.
 ## API Reference
 
 <ComponentDoc tagName="hx-alert" section="api" />
+
+## Accessibility
+
+`hx-alert` implements the [ARIA alert pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alert/) and the ARIA live region pattern for accessible status announcements.
+
+### ARIA Roles and Attributes
+
+| Variant | Role | `aria-live` | Announcement |
+|---------|------|-------------|--------------|
+| `info` | `status` | `polite` | Announced when user is idle |
+| `success` | `status` | `polite` | Announced when user is idle |
+| `warning` | `alert` | `assertive` | Announced immediately |
+| `error` | `alert` | `assertive` | Announced immediately |
+
+The component automatically selects the correct role and live region based on the `variant` attribute. You do not need to set ARIA attributes manually.
+
+### Keyboard Interaction
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Move focus into the alert (when `closable`) |
+| `Enter` / `Space` | Dismiss the alert (when focused on close button) |
+| `Escape` | No default behavior — handle in containing context |
+
+### Screen Reader Behavior
+
+- **Warning and error** alerts announce immediately via `aria-live="assertive"` — use sparingly to avoid interrupting workflows.
+- **Info and success** alerts announce politely via `aria-live="polite"`.
+- The close button is labeled "Dismiss alert" for screen reader users.
+- When closed, focus is not moved automatically — manage focus in the `hx-after-close` event handler.
+
+### Healthcare Compliance Notes
+
+In healthcare UIs, alert severity must match clinical urgency:
+- Use `error` for critical patient safety issues that require immediate attention.
+- Use `warning` for time-sensitive notices that need prompt action.
+- Use `info` for informational messages that do not require immediate action.
+- Never suppress `error` alerts programmatically without logging.
+
+```html
+<!-- Critical patient safety alert -->
+<hx-alert variant="error">
+  Patient allergy conflict detected — review before administering medication.
+</hx-alert>
+```
+
+## Drupal Integration
+
+### Twig Template
+
+```twig
+{# templates/components/alert.html.twig #}
+<hx-alert
+  variant="{{ variant|default('info') }}"
+  {{ closable ? 'closable' : '' }}
+  {{ not open ? 'open="false"' : '' }}
+>
+  {{ message }}
+  {% if actions %}
+    <div slot="actions">
+      {{ actions }}
+    </div>
+  {% endif %}
+</hx-alert>
+```
+
+### Drupal Messages Integration
+
+```twig
+{# Display Drupal system messages as hx-alerts #}
+{% for type, messages in drupal_messages %}
+  {% set variant = type == 'error' ? 'error' : (type == 'warning' ? 'warning' : (type == 'status' ? 'success' : 'info')) %}
+  {% for message in messages %}
+    <hx-alert variant="{{ variant }}" closable>
+      {{ message }}
+    </hx-alert>
+  {% endfor %}
+{% endfor %}
+```
+
+### Drupal Library
+
+```yaml
+# mymodule.libraries.yml
+mymodule/alert:
+  dependencies:
+    - helix/hx-alert
+```
+
+## Theming
+
+Override CSS custom properties on the host element or in your theme stylesheet.
+
+### Available Tokens
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `--hx-alert-bg` | `var(--hx-color-info-50)` | Alert background color |
+| `--hx-alert-color` | `var(--hx-color-info-800)` | Alert text color |
+| `--hx-alert-border-color` | `var(--hx-color-info-200)` | Alert border color |
+| `--hx-alert-border-radius` | `var(--hx-border-radius-md)` | Alert border radius |
+| `--hx-alert-border-width` | `var(--hx-border-width-thin)` | Alert border width |
+| `--hx-alert-padding` | `var(--hx-space-4)` | Alert padding |
+| `--hx-alert-gap` | `var(--hx-space-3)` | Gap between alert elements |
+| `--hx-alert-icon-color` | `var(--hx-color-info-500)` | Alert icon color |
+| `--hx-alert-font-family` | `var(--hx-font-family-sans)` | Alert font family |
+
+### Override Example
+
+```css
+/* In your theme stylesheet */
+hx-alert[variant="error"] {
+  --hx-alert-bg: #fff0f0;
+  --hx-alert-border-color: #c00;
+  --hx-alert-icon-color: #c00;
+}
+```
+
+### CSS Parts
+
+Use `::part()` for surgical style overrides that cannot be achieved with tokens:
+
+```css
+hx-alert::part(alert) {
+  border-left: 4px solid var(--hx-color-error-500);
+  border-radius: 0;
+}
+
+hx-alert::part(close-button) {
+  opacity: 0.6;
+}
+```
+
+## Extending
+
+### Listening to Dismiss Events
+
+```javascript
+const alert = document.querySelector('hx-alert');
+
+alert.addEventListener('hx-close', (e) => {
+  console.log('Alert dismissed:', e.detail.reason);
+  // Log the dismissal for audit purposes
+  analytics.track('alert_dismissed', { variant: alert.variant });
+});
+
+alert.addEventListener('hx-after-close', () => {
+  // Restore focus to the trigger element after dismissal
+  triggerButton.focus();
+});
+```
+
+### Programmatic Control
+
+```javascript
+// Show/hide alerts programmatically
+const alert = document.querySelector('hx-alert');
+alert.open = false; // Hide
+alert.open = true;  // Show
+```
+
+### Creating an Alert Manager (Drupal Behavior)
+
+```javascript
+(function (Drupal) {
+  Drupal.behaviors.helixAlerts = {
+    attach(context) {
+      const alerts = context.querySelectorAll('hx-alert[closable]');
+      alerts.forEach((alert) => {
+        alert.addEventListener('hx-after-close', () => {
+          // Remove from DOM after animation completes
+          alert.remove();
+        });
+      });
+    }
+  };
+})(Drupal);
+```

--- a/apps/docs/src/content/docs/component-library/hx-button.mdx
+++ b/apps/docs/src/content/docs/component-library/hx-button.mdx
@@ -92,3 +92,168 @@ Full variant × size matrix.
 ## API Reference
 
 <ComponentDoc tagName="hx-button" section="api" />
+
+## Accessibility
+
+`hx-button` renders a native `<button>` element inside Shadow DOM, giving it full browser keyboard support and accessibility out of the box.
+
+### ARIA Roles and Attributes
+
+- **Role**: `button` (native `<button>` element)
+- **Disabled state**: Sets `disabled` on the native button element, preventing focus and interaction
+- **Form participation**: Uses `ElementInternals` for form-associated behavior (supports `type="submit"` and `type="reset"`)
+
+### Keyboard Interaction
+
+| Key | Action |
+|-----|--------|
+| `Tab` | Move focus to button |
+| `Enter` | Activate button |
+| `Space` | Activate button |
+
+### Usage Guidance
+
+- Always provide visible label text as slot content — avoid icon-only buttons without an accessible name.
+- For icon-only buttons, add `aria-label` to the host element:
+
+```html
+<hx-button aria-label="Delete patient record" variant="ghost">
+  <svg><!-- trash icon --></svg>
+</hx-button>
+```
+
+- Use `type="submit"` inside `<hx-form>` or native `<form>` to submit the form.
+- In healthcare UIs, destructive actions should require confirmation — use `type="button"` and handle in JavaScript.
+
+## Drupal Integration
+
+### Basic Twig Template
+
+```twig
+{# templates/components/button.html.twig #}
+<hx-button
+  variant="{{ variant|default('primary') }}"
+  hx-size="{{ size|default('md') }}"
+  type="{{ type|default('button') }}"
+  {{ disabled ? 'disabled' : '' }}
+>
+  {{ label }}
+</hx-button>
+```
+
+### Drupal Form API Link Button
+
+```twig
+{# In a Drupal link template #}
+<hx-button variant="secondary" type="button">
+  <a href="{{ url }}">{{ text }}</a>
+</hx-button>
+```
+
+### Drupal Behavior: Confirm Destructive Actions
+
+```javascript
+(function (Drupal) {
+  Drupal.behaviors.helixButtonConfirm = {
+    attach(context) {
+      context.querySelectorAll('hx-button[data-confirm]').forEach((btn) => {
+        btn.addEventListener('hx-click', (e) => {
+          if (!window.confirm(btn.dataset.confirm)) {
+            e.detail.originalEvent.preventDefault();
+          }
+        });
+      });
+    }
+  };
+})(Drupal);
+```
+
+### Drupal Library
+
+```yaml
+# mymodule.libraries.yml
+mymodule/button:
+  dependencies:
+    - helix/hx-button
+```
+
+## Theming
+
+### Available Tokens
+
+| Token | Default | Description |
+|-------|---------|-------------|
+| `--hx-button-bg` | `var(--hx-color-primary-500)` | Button background color |
+| `--hx-button-color` | `var(--hx-color-neutral-0)` | Button text color |
+| `--hx-button-border-color` | `transparent` | Button border color |
+| `--hx-button-border-radius` | `var(--hx-border-radius-md)` | Button border radius |
+| `--hx-button-font-family` | `var(--hx-font-family-sans)` | Button font family |
+| `--hx-button-font-weight` | `var(--hx-font-weight-semibold)` | Button font weight |
+| `--hx-button-focus-ring-color` | `var(--hx-focus-ring-color)` | Focus ring color |
+
+### Override Example
+
+```css
+/* Brand-specific button theming */
+hx-button[variant="primary"] {
+  --hx-button-bg: var(--brand-color-primary);
+  --hx-button-color: var(--brand-color-on-primary);
+  --hx-button-border-radius: var(--brand-radius-button);
+}
+
+/* Danger button variant via token override */
+hx-button.btn-danger {
+  --hx-button-bg: var(--hx-color-error-500);
+  --hx-button-color: #fff;
+}
+```
+
+### CSS Parts
+
+```css
+/* Target the native button element */
+hx-button::part(button) {
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+```
+
+## Extending
+
+### Listening to Click Events
+
+```javascript
+const btn = document.querySelector('hx-button');
+
+btn.addEventListener('hx-click', ({ detail }) => {
+  console.log('Original event:', detail.originalEvent);
+});
+```
+
+### Form Submission Pattern
+
+```html
+<hx-form action="/api/patients" method="post">
+  <hx-text-input name="mrn" label="Patient MRN" required></hx-text-input>
+  <hx-button type="submit">Save Patient</hx-button>
+  <hx-button type="reset" variant="ghost">Clear</hx-button>
+</hx-form>
+```
+
+### Loading State Pattern
+
+```javascript
+const submitBtn = document.querySelector('hx-button[type="submit"]');
+const form = document.querySelector('hx-form');
+
+form.addEventListener('hx-submit', async ({ detail }) => {
+  submitBtn.disabled = true;
+  submitBtn.textContent = 'Saving…';
+  try {
+    await saveData(detail.values);
+  } finally {
+    submitBtn.disabled = false;
+    submitBtn.textContent = 'Save Patient';
+  }
+});
+```


### PR DESCRIPTION
## Summary

- Starlight documentation pages already existed for all 14 components + overview (created in prior session)
- This PR expands hx-alert and hx-button with comprehensive accessibility, Drupal integration, theming, and extension API sections (+343 lines)
- All 15 MDX pages verified present in `apps/docs/src/content/docs/component-library/`

## Components Documented

hx-alert, hx-badge, hx-button, hx-card, hx-checkbox, hx-container, hx-form, hx-prose, hx-radio-group, hx-radio, hx-select, hx-switch, hx-text-input, hx-textarea, plus overview

## Acceptance Criteria

- [x] Every component has a dedicated Starlight page
- [x] API reference auto-generated from CEM data (ComponentDoc + ComponentLoader)
- [x] Usage examples with code snippets
- [x] Accessibility section with ARIA patterns
- [x] Drupal integration section (alert + button expanded)
- [x] Theming section showing token override patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)