### PR TITLE
feat(storybook): add ThemeComparison stories to all 14 components

### DIFF
--- a/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
@@ -1218,3 +1218,41 @@ export const PatientSafetyStack: Story = {
     }
   },
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-alert variant="info">Patient vitals recorded successfully.</hx-alert>
+        <hx-alert variant="success">Lab results are within normal range.</hx-alert>
+        <hx-alert variant="warning">Medication dosage requires physician review.</hx-alert>
+        <hx-alert variant="error" closable>Critical: Allergy conflict detected in prescription.</hx-alert>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-alert variant="info">Patient vitals recorded successfully.</hx-alert>
+        <hx-alert variant="success">Lab results are within normal range.</hx-alert>
+        <hx-alert variant="warning">Medication dosage requires physician review.</hx-alert>
+        <hx-alert variant="error" closable>Critical: Allergy conflict detected in prescription.</hx-alert>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-badge/hx-badge.stories.ts
+++ b/packages/hx-library/src/components/hx-badge/hx-badge.stories.ts
@@ -1154,3 +1154,57 @@ export const LabResultStatus: Story = {
     await expect(inProgressSpan?.classList.contains('badge--pulse')).toBe(true);
   },
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+          <hx-badge variant="primary">Active</hx-badge>
+          <hx-badge variant="success">Stable</hx-badge>
+          <hx-badge variant="warning">Monitoring</hx-badge>
+          <hx-badge variant="error" pulse>Critical</hx-badge>
+          <hx-badge variant="neutral">Discharged</hx-badge>
+        </div>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+          <hx-badge variant="primary" pill hx-size="sm">ICU</hx-badge>
+          <hx-badge variant="success" pill hx-size="md">Surgery</hx-badge>
+          <hx-badge variant="warning" pill hx-size="lg">Oncology</hx-badge>
+        </div>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+          <hx-badge variant="primary">Active</hx-badge>
+          <hx-badge variant="success">Stable</hx-badge>
+          <hx-badge variant="warning">Monitoring</hx-badge>
+          <hx-badge variant="error" pulse>Critical</hx-badge>
+          <hx-badge variant="neutral">Discharged</hx-badge>
+        </div>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+          <hx-badge variant="primary" pill hx-size="sm">ICU</hx-badge>
+          <hx-badge variant="success" pill hx-size="md">Surgery</hx-badge>
+          <hx-badge variant="warning" pill hx-size="lg">Oncology</hx-badge>
+        </div>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-button/hx-button.stories.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.stories.ts
@@ -834,3 +834,55 @@ export const EmergencyAction: Story = {
     </hx-button>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center;">
+          <hx-button variant="primary">Admit Patient</hx-button>
+          <hx-button variant="secondary">View Records</hx-button>
+          <hx-button variant="ghost">Cancel</hx-button>
+          <hx-button variant="primary" disabled>Processing...</hx-button>
+        </div>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center;">
+          <hx-button variant="primary" hx-size="sm">Small</hx-button>
+          <hx-button variant="primary" hx-size="md">Medium</hx-button>
+          <hx-button variant="primary" hx-size="lg">Large</hx-button>
+        </div>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center;">
+          <hx-button variant="primary">Admit Patient</hx-button>
+          <hx-button variant="secondary">View Records</hx-button>
+          <hx-button variant="ghost">Cancel</hx-button>
+          <hx-button variant="primary" disabled>Processing...</hx-button>
+        </div>
+        <div style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center;">
+          <hx-button variant="primary" hx-size="sm">Small</hx-button>
+          <hx-button variant="primary" hx-size="md">Medium</hx-button>
+          <hx-button variant="primary" hx-size="lg">Large</hx-button>
+        </div>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-card/hx-card.stories.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.stories.ts
@@ -1174,3 +1174,51 @@ export const PatientDashboard: Story = {
     </div>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 300px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-card variant="default">
+          <span slot="header">Patient Overview</span>
+          <p>Jane Smith · DOB: 1975-03-12 · MRN: 4829301</p>
+          <span slot="actions"><hx-button hx-size="sm">View Chart</hx-button></span>
+        </hx-card>
+        <hx-card variant="elevated">
+          <span slot="header">Lab Results</span>
+          <p>CBC Panel — All values within normal range.</p>
+        </hx-card>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-card variant="default">
+          <span slot="header">Patient Overview</span>
+          <p>Jane Smith · DOB: 1975-03-12 · MRN: 4829301</p>
+          <span slot="actions"><hx-button hx-size="sm">View Chart</hx-button></span>
+        </hx-card>
+        <hx-card variant="elevated">
+          <span slot="header">Lab Results</span>
+          <p>CBC Panel — All values within normal range.</p>
+        </hx-card>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.stories.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.stories.ts
@@ -1256,3 +1256,41 @@ export const MedicationAcknowledgement: Story = {
     await expect(checkbox.checkValidity()).toBe(true);
   },
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-checkbox label="Patient consents to treatment" name="consent" checked></hx-checkbox>
+        <hx-checkbox label="HIPAA authorization acknowledged" name="hipaa"></hx-checkbox>
+        <hx-checkbox label="No known allergies" name="allergies" disabled checked></hx-checkbox>
+        <hx-checkbox label="Required field" name="required" required help-text="This field is required."></hx-checkbox>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-checkbox label="Patient consents to treatment" name="consent2" checked></hx-checkbox>
+        <hx-checkbox label="HIPAA authorization acknowledged" name="hipaa2"></hx-checkbox>
+        <hx-checkbox label="No known allergies" name="allergies2" disabled checked></hx-checkbox>
+        <hx-checkbox label="Required field" name="required2" required help-text="This field is required."></hx-checkbox>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-container/hx-container.stories.ts
+++ b/packages/hx-library/src/components/hx-container/hx-container.stories.ts
@@ -1568,3 +1568,45 @@ export const DashboardLayout: Story = {
     expect(contentContainer.getAttribute('width')).toBe('xl');
   },
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-container width="sm" style="background: var(--hx-color-surface-secondary, #f3f4f6); padding: 1rem;">
+          Patient Summary (sm)
+        </hx-container>
+        <hx-container width="md" style="background: var(--hx-color-surface-secondary, #f3f4f6); padding: 1rem;">
+          Clinical Notes (md)
+        </hx-container>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-container width="sm" style="background: var(--hx-color-surface-secondary, #1e2030); padding: 1rem;">
+          Patient Summary (sm)
+        </hx-container>
+        <hx-container width="md" style="background: var(--hx-color-surface-secondary, #1e2030); padding: 1rem;">
+          Clinical Notes (md)
+        </hx-container>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-form/hx-form.stories.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.stories.ts
@@ -1795,3 +1795,59 @@ export const ClinicalWebform: Story = {
     </hx-form>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 300px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-form>
+          <form>
+            <hx-text-input label="Patient Name" name="name" placeholder="Full legal name" required></hx-text-input>
+            <hx-select label="Department" name="dept">
+              <option value="">Select department</option>
+              <option value="cardiology">Cardiology</option>
+              <option value="oncology">Oncology</option>
+            </hx-select>
+            <div style="margin-top: 1rem;">
+              <hx-button type="submit">Submit</hx-button>
+            </div>
+          </form>
+        </hx-form>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-form>
+          <form>
+            <hx-text-input label="Patient Name" name="name2" placeholder="Full legal name" required></hx-text-input>
+            <hx-select label="Department" name="dept2">
+              <option value="">Select department</option>
+              <option value="cardiology">Cardiology</option>
+              <option value="oncology">Oncology</option>
+            </hx-select>
+            <div style="margin-top: 1rem;">
+              <hx-button type="submit">Submit</hx-button>
+            </div>
+          </form>
+        </hx-form>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-prose/hx-prose.stories.ts
+++ b/packages/hx-library/src/components/hx-prose/hx-prose.stories.ts
@@ -2288,3 +2288,51 @@ export const PolicyDocument: Story = {
     </hx-prose>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-prose>
+          <h2>Patient Care Guidelines</h2>
+          <p>Follow evidence-based protocols for all clinical decisions. Document all interventions in the patient record.</p>
+          <ul>
+            <li>Assess patient every 4 hours</li>
+            <li>Update care plan daily</li>
+            <li>Communicate changes to the care team</li>
+          </ul>
+        </hx-prose>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-prose>
+          <h2>Patient Care Guidelines</h2>
+          <p>Follow evidence-based protocols for all clinical decisions. Document all interventions in the patient record.</p>
+          <ul>
+            <li>Assess patient every 4 hours</li>
+            <li>Update care plan daily</li>
+            <li>Communicate changes to the care team</li>
+          </ul>
+        </hx-prose>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio-group.stories.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio-group.stories.ts
@@ -1308,3 +1308,51 @@ export const TreatmentPreference: Story = {
     expect(group!.value).toBe('undecided');
   },
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1.5rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-radio-group label="Appointment Type" name="appt-light">
+          <hx-radio value="in-person" label="In-Person Visit" checked></hx-radio>
+          <hx-radio value="telehealth" label="Telehealth"></hx-radio>
+          <hx-radio value="phone" label="Phone Consultation"></hx-radio>
+        </hx-radio-group>
+        <hx-radio-group label="Discharge Status" name="discharge-light" disabled>
+          <hx-radio value="ready" label="Ready for Discharge"></hx-radio>
+          <hx-radio value="pending" label="Pending Clearance" checked></hx-radio>
+        </hx-radio-group>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1.5rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-radio-group label="Appointment Type" name="appt-dark">
+          <hx-radio value="in-person" label="In-Person Visit" checked></hx-radio>
+          <hx-radio value="telehealth" label="Telehealth"></hx-radio>
+          <hx-radio value="phone" label="Phone Consultation"></hx-radio>
+        </hx-radio-group>
+        <hx-radio-group label="Discharge Status" name="discharge-dark" disabled>
+          <hx-radio value="ready" label="Ready for Discharge"></hx-radio>
+          <hx-radio value="pending" label="Pending Clearance" checked></hx-radio>
+        </hx-radio-group>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio.stories.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio.stories.ts
@@ -390,3 +390,43 @@ export const InARadioGroup: Story = {
     </div>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-radio-group label="Appointment Type" name="appt-radio-light">
+          <hx-radio value="in-person" label="In-Person Visit" checked></hx-radio>
+          <hx-radio value="telehealth" label="Telehealth"></hx-radio>
+          <hx-radio value="phone" label="Phone Consultation" disabled></hx-radio>
+        </hx-radio-group>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-radio-group label="Appointment Type" name="appt-radio-dark">
+          <hx-radio value="in-person" label="In-Person Visit" checked></hx-radio>
+          <hx-radio value="telehealth" label="Telehealth"></hx-radio>
+          <hx-radio value="phone" label="Phone Consultation" disabled></hx-radio>
+        </hx-radio-group>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-select/hx-select.stories.ts
+++ b/packages/hx-library/src/components/hx-select/hx-select.stories.ts
@@ -1320,3 +1320,59 @@ export const PriorityLevel: Story = {
     </div>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-select label="Department" name="dept-light" placeholder="Select department">
+          <option value="cardiology">Cardiology</option>
+          <option value="oncology">Oncology</option>
+          <option value="neurology">Neurology</option>
+        </hx-select>
+        <hx-select label="Priority" name="priority-light" disabled value="routine">
+          <option value="stat">STAT</option>
+          <option value="urgent">Urgent</option>
+          <option value="routine">Routine</option>
+        </hx-select>
+        <hx-select label="Unit" name="unit-light" error help-text="Please select a unit.">
+          <option value="">Select unit</option>
+        </hx-select>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-select label="Department" name="dept-dark" placeholder="Select department">
+          <option value="cardiology">Cardiology</option>
+          <option value="oncology">Oncology</option>
+          <option value="neurology">Neurology</option>
+        </hx-select>
+        <hx-select label="Priority" name="priority-dark" disabled value="routine">
+          <option value="stat">STAT</option>
+          <option value="urgent">Urgent</option>
+          <option value="routine">Routine</option>
+        </hx-select>
+        <hx-select label="Unit" name="unit-dark" error help-text="Please select a unit.">
+          <option value="">Select unit</option>
+        </hx-select>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-switch/hx-switch.stories.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.stories.ts
@@ -1009,3 +1009,39 @@ export const ClinicalAlerts: Story = {
     </div>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 200px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-switch label="Enable fall risk alerts" name="fall-light" checked help-text="Notify staff when patient is at risk."></hx-switch>
+        <hx-switch label="Do Not Resuscitate" name="dnr-light"></hx-switch>
+        <hx-switch label="Isolation precautions" name="iso-light" disabled checked help-text="Set by infection control."></hx-switch>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-switch label="Enable fall risk alerts" name="fall-dark" checked help-text="Notify staff when patient is at risk."></hx-switch>
+        <hx-switch label="Do Not Resuscitate" name="dnr-dark"></hx-switch>
+        <hx-switch label="Isolation precautions" name="iso-dark" disabled checked help-text="Set by infection control."></hx-switch>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.stories.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.stories.ts
@@ -1219,3 +1219,41 @@ export const SSNMasked: Story = {
     await expect(input.type).toBe('password');
   },
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 300px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-text-input label="Patient Name" name="name-light" placeholder="Full legal name" required></hx-text-input>
+        <hx-text-input label="Date of Birth" name="dob-light" type="date"></hx-text-input>
+        <hx-text-input label="MRN" name="mrn-light" value="4829301" disabled help-text="Assigned by registration."></hx-text-input>
+        <hx-text-input label="Diagnosis Code" name="dx-light" error help-text="Invalid ICD-10 code entered."></hx-text-input>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-text-input label="Patient Name" name="name-dark" placeholder="Full legal name" required></hx-text-input>
+        <hx-text-input label="Date of Birth" name="dob-dark" type="date"></hx-text-input>
+        <hx-text-input label="MRN" name="mrn-dark" value="4829301" disabled help-text="Assigned by registration."></hx-text-input>
+        <hx-text-input label="Diagnosis Code" name="dx-dark" error help-text="Invalid ICD-10 code entered."></hx-text-input>
+      </div>
+    </div>
+  `,
+};

--- a/packages/hx-library/src/components/hx-textarea/hx-textarea.stories.ts
+++ b/packages/hx-library/src/components/hx-textarea/hx-textarea.stories.ts
@@ -1273,3 +1273,75 @@ ALLERGIES:
     </div>
   `,
 };
+
+// ─────────────────────────────────────────────────
+// THEME COMPARISON — Light and Dark side by side
+// ─────────────────────────────────────────────────
+
+export const ThemeComparison: Story = {
+  parameters: {
+    backgrounds: { disable: true },
+  },
+  render: () => html`
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 300px;">
+      <div
+        data-theme="light"
+        style="padding: 2rem; background: #ffffff; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #6b7280;">
+          Light Theme
+        </p>
+        <hx-textarea
+          label="Clinical Notes"
+          name="notes-light"
+          placeholder="Document patient observations..."
+          rows="4"
+          help-text="Include time, date, and your credentials."
+        ></hx-textarea>
+        <hx-textarea
+          label="Discharge Summary"
+          name="discharge-light"
+          disabled
+          value="Patient discharged in stable condition."
+          rows="3"
+        ></hx-textarea>
+        <hx-textarea
+          label="Allergy Notes"
+          name="allergy-light"
+          error
+          help-text="This field cannot be left blank."
+          rows="2"
+        ></hx-textarea>
+      </div>
+      <div
+        data-theme="dark"
+        style="padding: 2rem; background: #1a1a2e; display: flex; flex-direction: column; gap: 1rem;"
+      >
+        <p style="margin: 0 0 1rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #9ca3af;">
+          Dark Theme
+        </p>
+        <hx-textarea
+          label="Clinical Notes"
+          name="notes-dark"
+          placeholder="Document patient observations..."
+          rows="4"
+          help-text="Include time, date, and your credentials."
+        ></hx-textarea>
+        <hx-textarea
+          label="Discharge Summary"
+          name="discharge-dark"
+          disabled
+          value="Patient discharged in stable condition."
+          rows="3"
+        ></hx-textarea>
+        <hx-textarea
+          label="Allergy Notes"
+          name="allergy-dark"
+          error
+          help-text="This field cannot be left blank."
+          rows="2"
+        ></hx-textarea>
+      </div>
+    </div>
+  `,
+};


### PR DESCRIPTION
## Summary

- Adds `ThemeComparison` stories to all 14 components demonstrating dark/light theme variants
- ThemeComparison story shows each component rendered side-by-side in both themes
- All existing stories preserved; 666 lines added across 14 files

## Verification

- [x] TypeScript type-check passes
- [x] Storybook builds successfully
- [x] Playwright verification complete
- [x] All variant/state/composition stories already present
- [x] Controls for all public properties configured via CEM autodocs

## Acceptance Criteria

- [x] Every component has stories for all visual variants
- [x] State stories: default, hover, focus, active, disabled, error
- [x] Theme stories: ThemeComparison added to all 14 components ✅ (this PR)
- [x] Composition stories: common component combinations
- [x] Controls for all public properties
- [x] CEM-driven autodocs configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)