### PR TITLE
Set up changesets for semantic versioning

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,0 +1,96 @@
+# ============================================================================
+# Changeset Check — wc-2026 Enterprise Healthcare Web Component Library
+# ============================================================================
+# Enforces that pull requests modifying public package APIs include a
+# changeset entry for semantic versioning and changelog generation.
+#
+# Triggers on: PRs targeting main that touch packages/ or apps/
+# Skips on:    PRs that only touch docs, tests, config, or non-package files
+# ============================================================================
+
+name: Changeset Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'packages/**'
+      - 'apps/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changeset-required:
+    name: Require Changeset
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changeset entry
+        id: check
+        run: |
+          # Get list of files changed in this PR vs main
+          CHANGED_FILES=$(git diff --name-only origin/main...HEAD)
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+          echo ""
+
+          # Check if any public package source files were modified
+          PUBLIC_API_CHANGED=false
+          while IFS= read -r file; do
+            # Public API: component source, token files, index exports
+            if echo "$file" | grep -qE '^packages/.+\.(ts|js)$'; then
+              # Exclude test files, stories, and type-only files
+              if ! echo "$file" | grep -qE '\.(test|spec|stories)\.(ts|js)$'; then
+                echo "Public API file changed: $file"
+                PUBLIC_API_CHANGED=true
+              fi
+            fi
+          done <<< "$CHANGED_FILES"
+
+          echo "public_api_changed=$PUBLIC_API_CHANGED" >> "$GITHUB_OUTPUT"
+
+          if [ "$PUBLIC_API_CHANGED" = "false" ]; then
+            echo ""
+            echo "No public API changes detected — changeset not required."
+            exit 0
+          fi
+
+          echo ""
+          echo "Public API changes detected — checking for changeset entry..."
+
+          # Count changeset files added in this PR (excluding README.md)
+          CHANGESET_FILES=$(git diff --name-only --diff-filter=A origin/main...HEAD | grep -E '^\.changeset/.+\.md$' | grep -v 'README\.md' || true)
+
+          if [ -z "$CHANGESET_FILES" ]; then
+            echo ""
+            echo "ERROR: No changeset entry found."
+            echo ""
+            echo "This PR modifies public package APIs and requires a changeset entry."
+            echo "Run the following command and commit the generated file:"
+            echo ""
+            echo "  pnpm changeset"
+            echo ""
+            echo "Select the changed packages, specify the version bump type (patch/minor/major),"
+            echo "and provide a summary of the changes."
+            echo ""
+            echo "See .changeset/README.md for more details."
+            exit 1
+          fi
+
+          echo ""
+          echo "Changeset entries found:"
+          echo "$CHANGESET_FILES"
+          echo ""
+          echo "Changeset check passed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+# ============================================================================
+# Release — wc-2026 Enterprise Healthcare Web Component Library
+# ============================================================================
+# Automated release pipeline powered by Changesets.
+#
+# Workflow:
+#   1. On push to main, create/update a "Version Packages" PR that:
+#      - Bumps package versions based on changeset entries
+#      - Generates CHANGELOG.md for each changed package
+#      - Removes consumed changeset files
+#   2. When the "Version Packages" PR is merged, publish to npm registry
+#
+# Version bump documentation:
+#   - patch: Bug fixes, non-breaking changes (0.0.x)
+#   - minor: New features, backwards-compatible additions (0.x.0)
+#   - major: Breaking changes that require consumer updates (x.0.0)
+#
+# Usage:
+#   1. Make changes to packages
+#   2. Run `pnpm changeset` and select affected packages + bump type
+#   3. Commit the generated .changeset/*.md file with your changes
+#   4. On merge to main, this workflow creates the "Version Packages" PR
+#   5. Review and merge the "Version Packages" PR to publish
+# ============================================================================
+
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Release Packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Create or update release PR / publish
+        uses: changesets/action@v1
+        with:
+          # When changesets exist: create/update the "Version Packages" PR
+          # When the "Version Packages" PR is merged: publish to npm
+          publish: pnpm run changeset:publish
+          version: pnpm run changeset:version
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

**Milestone:** Phase 1: Production-Grade Foundation

Configure changesets for automated semantic versioning and changelog generation. Integrate with CI to require changeset entries for PRs that modify public API.

**Files to Modify:**
- .changeset/config.json
- .github/workflows/

**Acceptance Criteria:**
- [ ] @changesets/cli configured in monorepo
- [ ] CI check requires changeset for public API changes
- [ ] Changelog auto-generated from changeset entries
- [ ] Version bump workflow documente...

---
*Recovered automatically by Automaker post-agent hook*