### PR TITLE
M2: Library Registry REST API Routes

### DIFF
--- a/apps/admin/src/app/api/libraries/[id]/resolve/route.ts
+++ b/apps/admin/src/app/api/libraries/[id]/resolve/route.ts
@@ -1,0 +1,112 @@
+import { NextResponse } from 'next/server';
+import { getLibrary, updateLibrary } from '@/lib/library-registry';
+import { createMcpSession } from '@/lib/mcp-client';
+import { existsSync } from 'node:fs';
+import { WC_TOOLS_BINARY } from '@/lib/mcp-constants';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+interface ResolvedCemResult {
+  componentCount?: number;
+  declarations?: unknown[];
+  [key: string]: unknown;
+}
+
+/**
+ * POST /api/libraries/[id]/resolve
+ * Triggers CEM resolution for CDN/npm libraries via wc-tools resolve_cdn_cem.
+ * Updates componentCount and lastScored on the registry entry.
+ *
+ * Returns 404 if the library is not found.
+ * Returns 400 if the library is a local source (resolution not applicable).
+ * Returns 503 if the wc-tools binary is not found.
+ */
+export async function POST(_request: Request, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { id } = await params;
+    const library = getLibrary(id);
+
+    if (!library) {
+      return NextResponse.json({ error: `Library "${id}" not found.` }, { status: 404 });
+    }
+
+    if (library.source === 'local') {
+      return NextResponse.json(
+        { error: 'CEM resolution is only applicable to cdn and npm libraries.' },
+        { status: 400 },
+      );
+    }
+
+    if (!existsSync(WC_TOOLS_BINARY)) {
+      return NextResponse.json(
+        { error: 'wc-tools binary not found. Cannot perform CEM resolution.' },
+        { status: 503 },
+      );
+    }
+
+    if (!library.packageName) {
+      return NextResponse.json(
+        { error: 'packageName is required for CEM resolution.' },
+        { status: 400 },
+      );
+    }
+
+    const session = await createMcpSession();
+    if (!session) {
+      return NextResponse.json(
+        { error: 'Failed to start wc-tools MCP session.' },
+        { status: 503 },
+      );
+    }
+
+    let resolvedData: ResolvedCemResult | null = null;
+    try {
+      const args: Record<string, unknown> = { package: library.packageName };
+      if (library.version) {
+        args.version = library.version;
+      }
+
+      const result = await session.callTool<ResolvedCemResult>('resolve_cdn_cem', args);
+      if (result.error) {
+        return NextResponse.json(
+          { error: 'CEM resolution failed', detail: result.error },
+          { status: 502 },
+        );
+      }
+      resolvedData = result.data;
+    } finally {
+      session.close();
+    }
+
+    // Derive componentCount from resolved CEM declarations
+    let componentCount = 0;
+    if (resolvedData) {
+      if (typeof resolvedData.componentCount === 'number') {
+        componentCount = resolvedData.componentCount;
+      } else if (Array.isArray(resolvedData.declarations)) {
+        componentCount = resolvedData.declarations.length;
+      }
+    }
+
+    const now = new Date().toISOString();
+    const updated = updateLibrary(id, {
+      componentCount,
+      lastScored: now,
+    });
+
+    return NextResponse.json({
+      library: updated,
+      resolved: resolvedData,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    return NextResponse.json(
+      { error: 'Failed to resolve library CEM', detail: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/src/app/api/libraries/[id]/route.ts
+++ b/apps/admin/src/app/api/libraries/[id]/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from 'next/server';
+import { getLibrary, updateLibrary, removeLibrary } from '@/lib/library-registry';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * GET /api/libraries/[id]
+ * Returns a single library entry by ID.
+ * Returns 404 if not found.
+ */
+export async function GET(_request: Request, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { id } = await params;
+    const library = getLibrary(id);
+
+    if (!library) {
+      return NextResponse.json({ error: `Library "${id}" not found.` }, { status: 404 });
+    }
+
+    return NextResponse.json(library);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    return NextResponse.json({ error: 'Failed to load library', detail: message }, { status: 500 });
+  }
+}
+
+interface PatchLibraryBody {
+  name?: string;
+  prefix?: string;
+  cemPath?: string;
+  packageName?: string;
+  version?: string;
+  isDefault?: boolean;
+  lastScored?: string | null;
+  componentCount?: number;
+}
+
+/**
+ * PATCH /api/libraries/[id]
+ * Partially updates an existing library entry.
+ *
+ * Body (JSON): any subset of library fields (except id)
+ */
+export async function PATCH(request: Request, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { id } = await params;
+    const body = (await request.json()) as PatchLibraryBody;
+
+    const updated = updateLibrary(id, body);
+    return NextResponse.json(updated);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    if (message.includes('not found')) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+    return NextResponse.json({ error: 'Failed to update library', detail: message }, { status: 500 });
+  }
+}
+
+/**
+ * DELETE /api/libraries/[id]
+ * Removes a library entry by ID.
+ * Returns 400 if the library is the default.
+ * Returns 404 if not found.
+ */
+export async function DELETE(_request: Request, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { id } = await params;
+    removeLibrary(id);
+    return NextResponse.json({ success: true, id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    if (message.includes('Cannot remove the default library')) {
+      return NextResponse.json({ error: message }, { status: 400 });
+    }
+    if (message.includes('not found')) {
+      return NextResponse.json({ error: message }, { status: 404 });
+    }
+    return NextResponse.json({ error: 'Failed to delete library', detail: message }, { status: 500 });
+  }
+}

--- a/apps/admin/src/app/api/libraries/[id]/score/route.ts
+++ b/apps/admin/src/app/api/libraries/[id]/score/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { getLibrary, updateLibrary } from '@/lib/library-registry';
+import { scoreAllComponents } from '@/lib/health-scorer';
+import { mcpScoreAllComponents } from '@/lib/mcp-client';
+import { existsSync } from 'node:fs';
+import { WC_TOOLS_BINARY } from '@/lib/mcp-constants';
+
+export const dynamic = 'force-dynamic';
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+/**
+ * POST /api/libraries/[id]/score
+ * Triggers health scoring for the library.
+ *
+ * For local libraries: runs the admin 17-dimension scorer.
+ * For CDN/npm libraries: calls wc-tools score_all_components with cached CEM.
+ *
+ * Returns a scoring tier indicator: "full" (local) or "cem-only" (cdn/npm).
+ */
+export async function POST(_request: Request, { params }: RouteParams): Promise<NextResponse> {
+  try {
+    const { id } = await params;
+    const library = getLibrary(id);
+
+    if (!library) {
+      return NextResponse.json({ error: `Library "${id}" not found.` }, { status: 404 });
+    }
+
+    const now = new Date().toISOString();
+
+    if (library.source === 'local') {
+      // Full 17-dimension local scorer
+      const results = await scoreAllComponents();
+      const componentCount = results.length;
+
+      const updated = updateLibrary(id, {
+        componentCount,
+        lastScored: now,
+      });
+
+      return NextResponse.json({
+        library: updated,
+        tier: 'full',
+        componentCount,
+        scores: results,
+      });
+    }
+
+    // CDN/npm: use wc-tools MCP score_all_components
+    if (!existsSync(WC_TOOLS_BINARY)) {
+      return NextResponse.json(
+        { error: 'wc-tools binary not found. Cannot perform CEM-based scoring.' },
+        { status: 503 },
+      );
+    }
+
+    const scores = await mcpScoreAllComponents();
+    if (!scores) {
+      return NextResponse.json(
+        { error: 'Failed to retrieve scores from wc-tools.' },
+        { status: 502 },
+      );
+    }
+
+    const componentCount = scores.length;
+    const updated = updateLibrary(id, {
+      componentCount,
+      lastScored: now,
+    });
+
+    return NextResponse.json({
+      library: updated,
+      tier: 'cem-only',
+      componentCount,
+      scores,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    return NextResponse.json(
+      { error: 'Failed to score library', detail: message },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/src/app/api/libraries/route.ts
+++ b/apps/admin/src/app/api/libraries/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { getRegistry, addLibrary } from '@/lib/library-registry';
+import type { LibrarySource } from '@/lib/library-registry';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/libraries
+ * Returns all library entries from the registry.
+ */
+export async function GET(): Promise<NextResponse> {
+  try {
+    const libraries = getRegistry();
+    return NextResponse.json({ libraries });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    return NextResponse.json({ error: 'Failed to load libraries', detail: message }, { status: 500 });
+  }
+}
+
+interface CreateLibraryBody {
+  name: string;
+  source: LibrarySource;
+  prefix: string;
+  cemPath?: string;
+  packageName?: string;
+  version?: string;
+  isDefault?: boolean;
+}
+
+/**
+ * POST /api/libraries
+ * Adds a new library entry to the registry.
+ *
+ * Body (JSON):
+ *  - name (required)
+ *  - source (required): "local" | "cdn" | "npm"
+ *  - prefix (required): tag prefix, e.g. "hx-"
+ *  - cemPath (required when source is "local")
+ *  - packageName (required when source is "cdn" or "npm")
+ *  - version (optional)
+ *  - isDefault (optional, defaults to false)
+ */
+export async function POST(request: Request): Promise<NextResponse> {
+  try {
+    const body = (await request.json()) as CreateLibraryBody;
+
+    if (!body.name || !body.source || !body.prefix) {
+      return NextResponse.json(
+        {
+          error: 'Missing required fields',
+          required: ['name', 'source', 'prefix'],
+        },
+        { status: 400 },
+      );
+    }
+
+    if (body.source === 'local' && !body.cemPath) {
+      return NextResponse.json(
+        { error: 'cemPath is required for local libraries' },
+        { status: 400 },
+      );
+    }
+
+    if ((body.source === 'cdn' || body.source === 'npm') && !body.packageName) {
+      return NextResponse.json(
+        { error: 'packageName is required for cdn and npm libraries' },
+        { status: 400 },
+      );
+    }
+
+    const newEntry = addLibrary({
+      name: body.name,
+      source: body.source,
+      prefix: body.prefix,
+      cemPath: body.cemPath,
+      packageName: body.packageName,
+      version: body.version,
+      isDefault: body.isDefault ?? false,
+      lastScored: null,
+      componentCount: 0,
+    });
+
+    return NextResponse.json(newEntry, { status: 201 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    return NextResponse.json({ error: 'Failed to add library', detail: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

## What

REST API routes for the library registry, enabling the UI (M3) to manage libraries.

## Deliverables

1. **route.ts** at apps/admin/src/app/api/libraries — GET (list all) and POST (add library)
2. **route.ts** at apps/admin/src/app/api/libraries/[id] — GET (single), PATCH (update), DELETE (remove)
3. **resolve route** at apps/admin/src/app/api/libraries/[id]/resolve — POST triggers CEM resolution via wc-tools resolve_cdn_cem for CDN/npm libraries. Updates componentCount and lastScored o...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added library management API with full CRUD operations (create, read, update, delete)
  * Added library scoring functionality supporting both local and CDN/npm libraries
  * Added CDN/npm library resolution capability with component counting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->