### PR TITLE
Integrate local wc-tools MCP server for web component support

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
-    "wc-tools": {
+    "wc-mcp": {
       "command": "node",
-      "args": ["/Volumes/Development/booked/wc-tools/build/index.js"],
+      "args": ["/Volumes/Development/booked/wc-tools/build/src/index.js"],
       "env": {
         "MCP_WC_PROJECT_ROOT": "/Volumes/Development/booked/helix"
       }

--- a/mcpwc.config.json
+++ b/mcpwc.config.json
@@ -1,0 +1,6 @@
+{
+  "cemPath": "./packages/hx-library/custom-elements.json",
+  "projectRoot": "/Volumes/Development/booked/helix",
+  "componentPrefix": "hx",
+  "tsconfigPath": "./tsconfig.base.json"
+}


### PR DESCRIPTION
## Summary

## Goal
Replace the 3 broken custom MCP servers with the local `wc-tools` MCP server at `/Volumes/Development/booked/wc-tools/`. This single server provides comprehensive web component tooling that replaces `cem-analyzer`, `health-scorer`, and `typescript-diagnostics`.

## wc-tools Server Details
- **Location**: `/Volumes/Development/booked/wc-tools/`
- **Package**: `wc-tools` v0.1.0
- **Entry point**: `./build/index.js` (already built and present)
- **Binary**: `wc-tools`
- **Purpose**: 'Gives ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated MCP server configuration with refined path references.
  * Introduced new configuration file to centralize project-level settings, including custom element metadata location, project root directory, component naming conventions, and TypeScript configuration references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->