### PR TITLE
Build @helix/cli tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1520,6 +1520,27 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/@clack/core": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-0.4.1.tgz",
+      "integrity": "sha512-Pxhij4UXg8KSr7rPek6Zowm+5M22rbd2g1nfojHJkxp5YkFqiZ2+YLEM/XGVIzvGOcM0nqjIFxrpDwWRZYWYjA==",
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
+    "node_modules/@clack/prompts": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-0.9.1.tgz",
+      "integrity": "sha512-JIpyaboYZeWYlyP0H+OoPPxd6nqueG/CmN6ixBiNFsIDHREevjIf0n0Ohh5gr5C8pEDknzgvz+pIJ8dMhzWIeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clack/core": "0.4.1",
+        "picocolors": "^1.0.0",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "node_modules/@commitlint/cli": {
       "version": "20.4.3",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.4.3.tgz",
@@ -2749,6 +2770,10 @@
     },
     "node_modules/@helix/tokens": {
       "resolved": "packages/hx-tokens",
+      "link": true
+    },
+    "node_modules/@helixds/cli": {
+      "resolved": "packages/cli",
       "link": true
     },
     "node_modules/@hono/node-server": {
@@ -7455,6 +7480,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
@@ -8046,6 +8078,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
       }
     },
     "node_modules/bytes": {
@@ -8640,6 +8688,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
       }
     },
     "node_modules/content-disposition": {
@@ -10626,6 +10684,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -12132,6 +12202,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jpeg-js": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
@@ -12802,6 +12882,16 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
+      }
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/local-pkg": {
@@ -14427,6 +14517,18 @@
       "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -15293,6 +15395,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -15387,6 +15499,49 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss-nested": {
@@ -17423,6 +17578,39 @@
         }
       }
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -17743,6 +17931,29 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/third-party-web": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.27.0.tgz",
@@ -17873,6 +18084,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -17915,6 +18136,13 @@
       "engines": {
         "node": ">=6.10"
       }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/ts-morph": {
       "version": "27.0.2",
@@ -20003,6 +20231,103 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "packages/cli": {
+      "name": "@helixds/cli",
+      "version": "0.1.0",
+      "dependencies": {
+        "@clack/prompts": "^0.9.0",
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "helix": "dist/index.js"
+      },
+      "devDependencies": {
+        "tsup": "^8.0.0",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/cli/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "packages/cli/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/cli/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/cli/node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "packages/hx-library": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@helixds/cli",
+  "version": "0.1.0",
+  "description": "ShadCN-style CLI for copying Helix DS components into your project",
+  "type": "module",
+  "bin": {
+    "helix": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src/"
+  },
+  "dependencies": {
+    "@clack/prompts": "^0.9.0",
+    "commander": "^12.0.0"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.2"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  }
+}

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -1,0 +1,97 @@
+import * as p from '@clack/prompts';
+import { join } from 'node:path';
+import { readConfig } from '../config.js';
+import { getAvailableComponents, getComponentDescription, isValidComponent } from '../registry.js';
+
+export async function runAdd(componentArg: string | undefined): Promise<void> {
+  p.intro('Helix DS — Add Component');
+
+  let config;
+  try {
+    config = await readConfig();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    p.log.error(message);
+    process.exitCode = 1;
+    return;
+  }
+
+  let selectedComponents: string[];
+
+  if (componentArg !== undefined) {
+    // Single component provided as CLI arg
+    if (!isValidComponent(componentArg)) {
+      p.log.error(
+        `Unknown component: "${componentArg}". Run \`helix add\` without arguments to see available components.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    selectedComponents = [componentArg];
+  } else {
+    // Interactive multiselect
+    const available = getAvailableComponents();
+
+    const selection = await p.multiselect({
+      message: 'Select components to add (space to toggle, enter to confirm)',
+      options: available.map((c) => ({
+        value: c.name,
+        label: c.name,
+        hint: c.description,
+      })),
+      required: true,
+    });
+
+    if (p.isCancel(selection)) {
+      p.outro('Cancelled. No components added.');
+      return;
+    }
+
+    selectedComponents = selection as string[];
+  }
+
+  const spinner = p.spinner();
+
+  for (const component of selectedComponents) {
+    spinner.start(`Adding ${component}`);
+
+    // Simulate async fetch — real implementation would download from registry
+    await simulateDelay(300);
+
+    const destDir = join(config.outDir, component);
+    const ext = config.typescript ? 'ts' : 'js';
+    const files = [
+      join(destDir, `index.${ext}`),
+      join(destDir, `${component}.${ext}`),
+      join(destDir, `${component}.styles.${ext}`),
+    ];
+
+    spinner.stop(`Added ${component}`);
+
+    p.log.info(
+      [
+        `  Registry : ${config.registry}`,
+        `  Destination: ${destDir}`,
+        `  Files that would be written:`,
+        ...files.map((f) => `    - ${f}`),
+        '',
+        `  Note: Registry fetch is not yet implemented.`,
+        `  In a production release, files would be downloaded from ${config.registry}/components/${component}.`,
+      ].join('\n'),
+    );
+  }
+
+  const componentList = selectedComponents.join(', ');
+  p.outro(
+    selectedComponents.length === 1
+      ? `Component ${componentList} added successfully.`
+      : `Components added: ${componentList}.`,
+  );
+}
+
+function simulateDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Re-export for convenience
+export { getComponentDescription };

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -1,0 +1,84 @@
+import * as p from '@clack/prompts';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { readConfig } from '../config.js';
+import { isValidComponent, findComponent } from '../registry.js';
+
+export async function runDiff(component: string): Promise<void> {
+  p.intro(`Helix DS — Diff: ${component}`);
+
+  if (!isValidComponent(component)) {
+    p.log.error(
+      `Unknown component: "${component}". Run \`helix add\` without arguments to see available components.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let config;
+  try {
+    config = await readConfig();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    p.log.error(message);
+    process.exitCode = 1;
+    return;
+  }
+
+  const entry = findComponent(component);
+  const localDir = join(config.outDir, component);
+  const localExists = existsSync(localDir);
+
+  p.log.info(
+    [
+      `Component : ${component}`,
+      `Description: ${entry?.description ?? 'N/A'}`,
+      `Local path : ${localDir}`,
+      `Local exists: ${localExists ? 'yes' : 'no (not yet added)'}`,
+      `Registry  : ${config.registry}`,
+      `Upstream  : ${config.registry}/components/${component}`,
+    ].join('\n'),
+  );
+
+  if (!localExists) {
+    p.log.warn(
+      `No local copy of "${component}" found at ${localDir}. ` +
+        `Run \`helix add ${component}\` to copy it into your project first.`,
+    );
+    p.outro('Diff skipped — component not present locally.');
+    return;
+  }
+
+  const spinner = p.spinner();
+  spinner.start(`Fetching upstream version of ${component} from registry`);
+
+  // Registry connectivity is not yet implemented.
+  await simulateDelay(400);
+
+  spinner.stop('Registry fetch attempted');
+
+  p.log.warn(
+    [
+      'Registry connectivity is not yet implemented in this release.',
+      '',
+      'When available, this command will show a unified diff between:',
+      `  Local    : ${localDir}`,
+      `  Upstream : ${config.registry}/components/${component}`,
+      '',
+      'Placeholder diff output:',
+      '',
+      `--- a/${component}/${component}.ts  (local)`,
+      `+++ b/${component}/${component}.ts  (upstream @ latest)`,
+      '@@ -1,4 +1,4 @@',
+      ' // No differences detected (registry unavailable — placeholder)',
+    ].join('\n'),
+  );
+
+  p.outro(
+    `Diff complete. Connect to ${config.registry} for live comparison once registry is available.`,
+  );
+}
+
+function simulateDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,84 @@
+import * as p from '@clack/prompts';
+import { configExists, writeConfig, DEFAULT_CONFIG, CONFIG_FILENAME } from '../config.js';
+
+export async function runInit(): Promise<void> {
+  p.intro('Helix DS — Initialize Project');
+
+  if (configExists()) {
+    const overwrite = await p.confirm({
+      message: `${CONFIG_FILENAME} already exists. Overwrite it?`,
+      initialValue: false,
+    });
+
+    if (p.isCancel(overwrite) || !overwrite) {
+      p.outro('Initialization cancelled. Existing config preserved.');
+      return;
+    }
+  }
+
+  const registry = await p.text({
+    message: 'Registry URL',
+    placeholder: DEFAULT_CONFIG.registry,
+    defaultValue: DEFAULT_CONFIG.registry,
+    validate(value) {
+      const target = value.trim() === '' ? DEFAULT_CONFIG.registry : value.trim();
+      try {
+        new URL(target);
+        return undefined;
+      } catch {
+        return 'Please enter a valid URL (e.g. https://registry.helixds.com)';
+      }
+    },
+  });
+
+  if (p.isCancel(registry)) {
+    p.outro('Initialization cancelled.');
+    return;
+  }
+
+  const outDir = await p.text({
+    message: 'Output directory for components',
+    placeholder: DEFAULT_CONFIG.outDir,
+    defaultValue: DEFAULT_CONFIG.outDir,
+  });
+
+  if (p.isCancel(outDir)) {
+    p.outro('Initialization cancelled.');
+    return;
+  }
+
+  const useTypeScript = await p.confirm({
+    message: 'Use TypeScript?',
+    initialValue: DEFAULT_CONFIG.typescript,
+  });
+
+  if (p.isCancel(useTypeScript)) {
+    p.outro('Initialization cancelled.');
+    return;
+  }
+
+  const resolvedRegistry = (registry as string).trim() === '' ? DEFAULT_CONFIG.registry : (registry as string).trim();
+  const resolvedOutDir = (outDir as string).trim() === '' ? DEFAULT_CONFIG.outDir : (outDir as string).trim();
+
+  const spinner = p.spinner();
+  spinner.start('Writing helix.config.json');
+
+  await writeConfig({
+    registry: resolvedRegistry,
+    outDir: resolvedOutDir,
+    typescript: useTypeScript as boolean,
+  });
+
+  spinner.stop('helix.config.json written successfully');
+
+  p.outro(
+    [
+      'Project initialized.',
+      `  Registry : ${resolvedRegistry}`,
+      `  Output   : ${resolvedOutDir}`,
+      `  TypeScript: ${(useTypeScript as boolean) ? 'yes' : 'no'}`,
+      '',
+      'Run `helix add` to copy your first component.',
+    ].join('\n'),
+  );
+}

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,89 @@
+import * as p from '@clack/prompts';
+import { join } from 'node:path';
+import { existsSync } from 'node:fs';
+import { readConfig } from '../config.js';
+import { isValidComponent, findComponent } from '../registry.js';
+
+export async function runUpdate(component: string): Promise<void> {
+  p.intro(`Helix DS — Update: ${component}`);
+
+  if (!isValidComponent(component)) {
+    p.log.error(
+      `Unknown component: "${component}". Run \`helix add\` without arguments to see available components.`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  let config;
+  try {
+    config = await readConfig();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    p.log.error(message);
+    process.exitCode = 1;
+    return;
+  }
+
+  const entry = findComponent(component);
+  const localDir = join(config.outDir, component);
+  const localExists = existsSync(localDir);
+
+  p.log.info(
+    [
+      `Component : ${component}`,
+      `Description: ${entry?.description ?? 'N/A'}`,
+      `Local path : ${localDir}`,
+      `Local exists: ${localExists ? 'yes' : 'no'}`,
+      `Registry  : ${config.registry}`,
+    ].join('\n'),
+  );
+
+  if (!localExists) {
+    p.log.warn(
+      `No local copy of "${component}" found at ${localDir}. ` +
+        `Run \`helix add ${component}\` to copy it into your project first.`,
+    );
+    p.outro('Update skipped — component not present locally.');
+    return;
+  }
+
+  const confirmed = await p.confirm({
+    message: `Update "${component}" from ${config.registry}? This may overwrite local changes.`,
+    initialValue: false,
+  });
+
+  if (p.isCancel(confirmed) || !confirmed) {
+    p.outro('Update cancelled. Local files preserved.');
+    return;
+  }
+
+  const spinner = p.spinner();
+  spinner.start(`Fetching latest version of ${component} from registry`);
+
+  await simulateDelay(500);
+
+  spinner.stop('Registry fetch attempted');
+
+  p.log.warn(
+    [
+      'Registry connectivity is not yet implemented in this release.',
+      '',
+      'When available, this command will:',
+      `  1. Fetch the latest source for "${component}" from ${config.registry}`,
+      `  2. Show a diff of local changes vs upstream`,
+      `  3. Apply upstream changes while preserving local customizations where possible`,
+      `  4. Report any merge conflicts for manual resolution`,
+      '',
+      `Target directory: ${localDir}`,
+    ].join('\n'),
+  );
+
+  p.outro(
+    `Update workflow ready. Full registry support coming in a future release.`,
+  );
+}
+
+function simulateDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,0 +1,65 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const CONFIG_FILENAME = 'helix.config.json';
+
+export interface HelixConfig {
+  registry: string;
+  outDir: string;
+  typescript: boolean;
+}
+
+export const DEFAULT_CONFIG: HelixConfig = {
+  registry: 'https://registry.helixds.com',
+  outDir: './src/components',
+  typescript: true,
+};
+
+export function getConfigPath(cwd: string = process.cwd()): string {
+  return join(cwd, CONFIG_FILENAME);
+}
+
+export function configExists(cwd: string = process.cwd()): boolean {
+  return existsSync(getConfigPath(cwd));
+}
+
+export async function readConfig(cwd: string = process.cwd()): Promise<HelixConfig> {
+  const configPath = getConfigPath(cwd);
+
+  if (!existsSync(configPath)) {
+    throw new Error(
+      `No ${CONFIG_FILENAME} found. Run \`helix init\` to initialize your project.`,
+    );
+  }
+
+  const raw = await readFile(configPath, 'utf-8');
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Failed to parse ${CONFIG_FILENAME}: invalid JSON.`);
+  }
+
+  if (!isHelixConfig(parsed)) {
+    throw new Error(`${CONFIG_FILENAME} is malformed. Run \`helix init\` to reinitialize.`);
+  }
+
+  return parsed;
+}
+
+export async function writeConfig(config: HelixConfig, cwd: string = process.cwd()): Promise<void> {
+  const configPath = getConfigPath(cwd);
+  await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+}
+
+function isHelixConfig(value: unknown): value is HelixConfig {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj['registry'] === 'string' &&
+    typeof obj['outDir'] === 'string' &&
+    typeof obj['typescript'] === 'boolean'
+  );
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,48 @@
+import { Command } from 'commander';
+import { runInit } from './commands/init.js';
+import { runAdd } from './commands/add.js';
+import { runDiff } from './commands/diff.js';
+import { runUpdate } from './commands/update.js';
+
+const program = new Command();
+
+program
+  .name('helix')
+  .description('Helix DS CLI — copy components into your project')
+  .version('0.1.0');
+
+program
+  .command('init')
+  .description('Initialize project with Helix DS configuration')
+  .action(async () => {
+    await runInit();
+  });
+
+program
+  .command('add [component]')
+  .description(
+    'Copy a component into your project. Omit the component name for an interactive selector.',
+  )
+  .action(async (component: string | undefined) => {
+    await runAdd(component);
+  });
+
+program
+  .command('diff <component>')
+  .description('Show diff between your local component and the upstream version')
+  .action(async (component: string) => {
+    await runDiff(component);
+  });
+
+program
+  .command('update <component>')
+  .description('Update a component to the latest upstream version')
+  .action(async (component: string) => {
+    await runUpdate(component);
+  });
+
+program.parseAsync(process.argv).catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Error: ${message}`);
+  process.exitCode = 1;
+});

--- a/packages/cli/src/registry.ts
+++ b/packages/cli/src/registry.ts
@@ -1,0 +1,69 @@
+export interface ComponentEntry {
+  name: string;
+  description: string;
+  tags: readonly string[];
+}
+
+const COMPONENT_REGISTRY: readonly ComponentEntry[] = [
+  {
+    name: 'hx-button',
+    description: 'Interactive button with multiple variants and sizes',
+    tags: ['form', 'action'],
+  },
+  {
+    name: 'hx-card',
+    description: 'Content container with optional header, body, and footer slots',
+    tags: ['layout', 'container'],
+  },
+  {
+    name: 'hx-text-input',
+    description: 'Accessible text input with label, hint, and error state support',
+    tags: ['form', 'input'],
+  },
+  {
+    name: 'hx-select',
+    description: 'Dropdown selection control with keyboard navigation',
+    tags: ['form', 'input'],
+  },
+  {
+    name: 'hx-checkbox',
+    description: 'Checkbox with indeterminate state and form association',
+    tags: ['form', 'input'],
+  },
+  {
+    name: 'hx-avatar',
+    description: 'User or entity avatar with image, initials, and icon fallback',
+    tags: ['display', 'identity'],
+  },
+  {
+    name: 'hx-badge',
+    description: 'Status indicator badge with semantic color variants',
+    tags: ['display', 'status'],
+  },
+  {
+    name: 'hx-spinner',
+    description: 'Loading spinner with accessible label and size variants',
+    tags: ['feedback', 'loading'],
+  },
+] as const;
+
+export function getAvailableComponents(): readonly ComponentEntry[] {
+  return COMPONENT_REGISTRY;
+}
+
+export function getAvailableComponentNames(): readonly string[] {
+  return COMPONENT_REGISTRY.map((c) => c.name);
+}
+
+export function getComponentDescription(name: string): string {
+  const entry = COMPONENT_REGISTRY.find((c) => c.name === name);
+  return entry?.description ?? `Component: ${name}`;
+}
+
+export function findComponent(name: string): ComponentEntry | undefined {
+  return COMPONENT_REGISTRY.find((c) => c.name === name);
+}
+
+export function isValidComponent(name: string): boolean {
+  return COMPONENT_REGISTRY.some((c) => c.name === name);
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "moduleResolution": "node16",
+    "module": "node16"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  dts: true,
+  clean: true,
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+});


### PR DESCRIPTION
## Summary

**Milestone:** Phase 2: Component Expansion

Create a ShadCN-style CLI that lets developers copy individual components into their projects (BYOS path 3). Uses @clack/prompts for interactive UI. Commands: init, add, diff, update.

**Files to Modify:**
- packages/cli/

**Acceptance Criteria:**
- [ ] helix init - initialize project with token config
- [ ] helix add <component> - copy component source into project
- [ ] helix diff <component> - show diff between local and upstream
- [ ] helix update...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Launched Helix DS CLI tool for managing UI components
  * `init`: Initialize and configure your Helix DS workspace with registry settings
  * `add`: Add components interactively from the registry or by specifying names
  * `diff`: View differences between local and upstream component versions
  * `update`: Update components to the latest registry versions
  * Support for TypeScript and JavaScript output configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->