### PR TITLE
FIX P0: Purge 71 phantom tests (passing but testing nothing)

### DIFF
--- a/apps/mcp-servers/cem-analyzer/src/index.test.ts
+++ b/apps/mcp-servers/cem-analyzer/src/index.test.ts
@@ -6,27 +6,12 @@ import { registerCemTools } from './tools.js';
 describe('MCP Server Lifecycle - CEM Analyzer', () => {
   describe('Server Creation', () => {
     it('creates server with correct metadata', () => {
-      const server = new Server(
-        { name: '@helix/mcp-cem-analyzer', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
-    });
-
-    it('server has correct name', () => {
-      const server = new Server(
-        { name: '@helix/mcp-cem-analyzer', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
-    });
-
-    it('server has correct version', () => {
-      const server = new Server(
-        { name: '@helix/mcp-cem-analyzer', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
+      expect(() => {
+        new Server(
+          { name: '@helix/mcp-cem-analyzer', version: '0.1.0' },
+          { capabilities: { tools: {} } },
+        );
+      }).not.toThrow();
     });
   });
 
@@ -36,7 +21,7 @@ describe('MCP Server Lifecycle - CEM Analyzer', () => {
         { name: '@helix/mcp-cem-analyzer', version: '0.1.0' },
         { capabilities: { tools: {} } },
       );
-      expect(server).toBeDefined();
+      expect(server).toBeInstanceOf(Server);
     });
 
     it('tools are registered successfully', () => {
@@ -50,8 +35,7 @@ describe('MCP Server Lifecycle - CEM Analyzer', () => {
 
   describe('Transport', () => {
     it('can create stdio transport', () => {
-      const transport = new StdioServerTransport();
-      expect(transport).toBeDefined();
+      expect(() => new StdioServerTransport()).not.toThrow();
     });
 
     it('transport has required methods', () => {

--- a/apps/mcp-servers/health-scorer/src/index.test.ts
+++ b/apps/mcp-servers/health-scorer/src/index.test.ts
@@ -6,28 +6,12 @@ import { registerHealthTools } from './tools.js';
 describe('MCP Server Lifecycle - Health Scorer', () => {
   describe('Server Creation', () => {
     it('creates server with correct metadata', () => {
-      const server = new Server(
-        { name: '@helix/mcp-health-scorer', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
-    });
-
-    it('server has correct name', () => {
-      const server = new Server(
-        { name: '@helix/mcp-health-scorer', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
-      // Server info is accessible via protocol methods
-    });
-
-    it('server has correct version', () => {
-      const server = new Server(
-        { name: '@helix/mcp-health-scorer', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
+      expect(() => {
+        new Server(
+          { name: '@helix/mcp-health-scorer', version: '0.1.0' },
+          { capabilities: { tools: {} } },
+        );
+      }).not.toThrow();
     });
   });
 
@@ -37,7 +21,7 @@ describe('MCP Server Lifecycle - Health Scorer', () => {
         { name: '@helix/mcp-health-scorer', version: '0.1.0' },
         { capabilities: { tools: {} } },
       );
-      expect(server).toBeDefined();
+      expect(server).toBeInstanceOf(Server);
     });
 
     it('tools are registered successfully', () => {
@@ -51,8 +35,7 @@ describe('MCP Server Lifecycle - Health Scorer', () => {
 
   describe('Transport', () => {
     it('can create stdio transport', () => {
-      const transport = new StdioServerTransport();
-      expect(transport).toBeDefined();
+      expect(() => new StdioServerTransport()).not.toThrow();
     });
 
     it('transport has required methods', () => {

--- a/apps/mcp-servers/typescript-diagnostics/src/index.test.ts
+++ b/apps/mcp-servers/typescript-diagnostics/src/index.test.ts
@@ -6,27 +6,12 @@ import { registerTypeScriptTools } from './tools.js';
 describe('MCP Server Lifecycle - TypeScript Diagnostics', () => {
   describe('Server Creation', () => {
     it('creates server with correct metadata', () => {
-      const server = new Server(
-        { name: '@helix/mcp-typescript-diagnostics', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
-    });
-
-    it('server has correct name', () => {
-      const server = new Server(
-        { name: '@helix/mcp-typescript-diagnostics', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
-    });
-
-    it('server has correct version', () => {
-      const server = new Server(
-        { name: '@helix/mcp-typescript-diagnostics', version: '0.1.0' },
-        { capabilities: { tools: {} } },
-      );
-      expect(server).toBeDefined();
+      expect(() => {
+        new Server(
+          { name: '@helix/mcp-typescript-diagnostics', version: '0.1.0' },
+          { capabilities: { tools: {} } },
+        );
+      }).not.toThrow();
     });
   });
 
@@ -36,7 +21,7 @@ describe('MCP Server Lifecycle - TypeScript Diagnostics', () => {
         { name: '@helix/mcp-typescript-diagnostics', version: '0.1.0' },
         { capabilities: { tools: {} } },
       );
-      expect(server).toBeDefined();
+      expect(server).toBeInstanceOf(Server);
     });
 
     it('tools are registered successfully', () => {
@@ -50,8 +35,7 @@ describe('MCP Server Lifecycle - TypeScript Diagnostics', () => {
 
   describe('Transport', () => {
     it('can create stdio transport', () => {
-      const transport = new StdioServerTransport();
-      expect(transport).toBeDefined();
+      expect(() => new StdioServerTransport()).not.toThrow();
     });
 
     it('transport has required methods', () => {

--- a/scripts/hooks/component-test-required.test.ts
+++ b/scripts/hooks/component-test-required.test.ts
@@ -28,65 +28,6 @@ describe('component-test-required (H10)', () => {
       expect(result.exitCode).toBe(0);
       expect(result.output).toContain('[PASS]');
     });
-
-    it('detects components without test files', () => {
-      // This would require git staging simulation
-      expect(true).toBe(true);
-    });
-
-    it('passes when component has test file', () => {
-      expect(true).toBe(true);
-    });
-
-    it('checks only hx-*.ts component files', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Exclusions', () => {
-    it('ignores test files themselves', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores style files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores index files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores utility files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores stories files', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Validation', () => {
-    it('validates test file is in same directory', () => {
-      expect(true).toBe(true);
-    });
-
-    it('validates test file follows naming convention', () => {
-      expect(true).toBe(true);
-    });
-
-    it('accepts component and test in same commit', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Error Handling', () => {
-    it('handles git command failures', () => {
-      expect(true).toBe(true);
-    });
-
-    it('handles missing components directory', () => {
-      expect(true).toBe(true);
-    });
   });
 
   describe('Performance', () => {
@@ -102,14 +43,6 @@ describe('component-test-required (H10)', () => {
     it('provides clear error messages', () => {
       const result = runHook();
       expect(result.output).toContain('[HOOK] component-test-required');
-    });
-
-    it('shows statistics for checked components', () => {
-      expect(true).toBe(true);
-    });
-
-    it('suggests test template location', () => {
-      expect(true).toBe(true);
     });
   });
 });

--- a/scripts/hooks/no-console-logs.test.ts
+++ b/scripts/hooks/no-console-logs.test.ts
@@ -4,13 +4,10 @@ import { execSync } from 'node:child_process';
 describe('no-console-logs (H12)', () => {
   const hookPath = './scripts/hooks/no-console-logs.ts';
 
-  // Helper to create a mock git environment
-  function runHook(_files: Record<string, string> = {}): {
+  function runHook(): {
     exitCode: number;
     output: string;
   } {
-    // Create temporary git environment would go here
-    // For now, just run the hook directly
     try {
       const output = execSync(`tsx ${hookPath}`, {
         encoding: 'utf-8',
@@ -33,66 +30,6 @@ describe('no-console-logs (H12)', () => {
       const result = runHook();
       expect(result.exitCode).toBe(0);
       expect(result.output).toContain('[PASS]');
-    });
-
-    it('detects console.log statements', () => {
-      // This test would need actual git staging simulation
-      // Skipping implementation for now - pattern is correct
-      expect(true).toBe(true);
-    });
-
-    it('detects console.debug statements', () => {
-      expect(true).toBe(true);
-    });
-
-    it('detects console.warn statements', () => {
-      expect(true).toBe(true);
-    });
-
-    it('detects console.error statements', () => {
-      expect(true).toBe(true);
-    });
-
-    it('detects console.info statements', () => {
-      expect(true).toBe(true);
-    });
-
-    it('detects console.trace statements', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Exclusions', () => {
-    it('ignores console statements in test files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores console statements in story files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores console statements in config files', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Approval Mechanism', () => {
-    it('allows console statements with @console-approved comment on same line', () => {
-      expect(true).toBe(true);
-    });
-
-    it('allows console statements with @console-approved comment on previous line', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Error Handling', () => {
-    it('handles files that cannot be read', () => {
-      expect(true).toBe(true);
-    });
-
-    it('handles git command failures gracefully', () => {
-      expect(true).toBe(true);
     });
   });
 

--- a/scripts/hooks/storybook-validation.test.ts
+++ b/scripts/hooks/storybook-validation.test.ts
@@ -28,61 +28,6 @@ describe('storybook-validation (H09)', () => {
       expect(result.exitCode).toBe(0);
       expect(result.output).toContain('[PASS]');
     });
-
-    it('detects components without stories', () => {
-      // This would require git staging simulation
-      expect(true).toBe(true);
-    });
-
-    it('passes when component has stories', () => {
-      expect(true).toBe(true);
-    });
-
-    it('checks only hx-*.ts component files', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Exclusions', () => {
-    it('ignores test files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores style files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores index files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores utility files', () => {
-      expect(true).toBe(true);
-    });
-
-    it('ignores stories files themselves', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Validation', () => {
-    it('validates stories are in same directory', () => {
-      expect(true).toBe(true);
-    });
-
-    it('validates stories follow naming convention', () => {
-      expect(true).toBe(true);
-    });
-  });
-
-  describe('Error Handling', () => {
-    it('handles git command failures', () => {
-      expect(true).toBe(true);
-    });
-
-    it('handles missing components directory', () => {
-      expect(true).toBe(true);
-    });
   });
 
   describe('Performance', () => {
@@ -98,14 +43,6 @@ describe('storybook-validation (H09)', () => {
     it('provides clear error messages', () => {
       const result = runHook();
       expect(result.output).toContain('[HOOK] storybook-validation');
-    });
-
-    it('shows statistics for checked components', () => {
-      expect(true).toBe(true);
-    });
-
-    it('suggests how to create stories', () => {
-      expect(true).toBe(true);
     });
   });
 });

--- a/scripts/hooks/vrt-critical-paths.test.ts
+++ b/scripts/hooks/vrt-critical-paths.test.ts
@@ -440,30 +440,6 @@ export const Secondary: Story = {
       expect(defaultStory?.hasVRTTag).toBe(true);
     });
   });
-
-  describe('findSnapshotFiles - Playwright naming', () => {
-    it('should match Playwright snapshot naming format', () => {
-      const _deps = createMockDeps({
-        fileExists: () => true,
-      });
-
-      // Mock readdirSync to simulate Playwright snapshot structure
-      const _mockReaddir = (_dir: string) => {
-        if (dir.includes('__screenshots__/vrt.spec.ts')) {
-          return [
-            { name: 'hx-button--primary.png', isFile: () => true, isDirectory: () => false },
-            { name: 'hx-button--secondary.png', isFile: () => true, isDirectory: () => false },
-            { name: 'hx-card--default.png', isFile: () => true, isDirectory: () => false },
-          ];
-        }
-        return [];
-      };
-
-      // Note: This test would require mocking readdirSync which isn't trivial in this setup
-      // The actual implementation correctly handles this format
-      expect(true).toBe(true);
-    });
-  });
 });
 
 // ─── Integration Tests ────────────────────────────────────────────────────
@@ -661,8 +637,15 @@ describe('vrt-critical-paths (H14) - Integration Tests', () => {
 
       const result = await validateVRTCriticalPaths(deps, true);
 
-      // Should handle gracefully - either skip the file or report an error
-      expect(result.passed || result.violations.length >= 0).toBe(true);
+      // Should handle gracefully - return a valid result shape without throwing
+      expect(typeof result.passed).toBe('boolean');
+      expect(Array.isArray(result.violations)).toBe(true);
+      expect(typeof result.stats.filesChecked).toBe('number');
+      expect(
+        result.violations.every(
+          (v) => typeof v.message === 'string' && typeof v.severity === 'string',
+        ),
+      ).toBe(true);
     });
 
     it('should respect bail-fast mode', async () => {
@@ -769,43 +752,6 @@ describe('vrt-critical-paths (H14) - Integration Tests', () => {
         const perfViolation = result.violations.find((v) => v.file === '<performance>');
         expect(perfViolation).toBeDefined();
         expect(perfViolation?.severity).toBe('warning');
-      }
-    });
-  });
-
-  describe('Real Codebase Integration', () => {
-    it('should detect real hx-button component', async () => {
-      const realButtonPath = 'packages/hx-library/src/components/hx-button/hx-button.ts';
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const fs = require('fs');
-
-      // Only run if file exists
-      if (!fs.existsSync(realButtonPath)) {
-        expect(true).toBe(true);
-        return;
-      }
-
-      const componentName = extractComponentName(realButtonPath);
-      expect(componentName).toBe('hx-button');
-    });
-
-    it('should find real snapshots for hx-button', () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const fs = require('fs');
-      const snapshotDir = 'packages/hx-library/__screenshots__';
-
-      // Only run if directory exists
-      if (!fs.existsSync(snapshotDir)) {
-        expect(true).toBe(true);
-        return;
-      }
-
-      const deps = createMockDeps();
-      const snapshots = findSnapshotFiles('hx-button', deps);
-
-      // If snapshots exist, they should be found
-      if (snapshots.length > 0) {
-        expect(snapshots.some((s) => s.includes('hx-button--primary.png'))).toBe(true);
       }
     });
   });


### PR DESCRIPTION
## Summary

**Audit Finding — P0 Critical**

71 tests in the suite pass but exercise no meaningful code. These are stale, dangling, or improperly written tests that give a false sense of quality coverage.

**Problem:** Tests either have empty bodies, assert trivially true conditions, or test stale APIs that no longer exist on the components. They pass because they never actually fail — not because the code is correct.

**Fix:**
1. Identify all phantom tests (empty `it()` blocks, always-true assertions, orph...

---
*Recovered automatically by Automaker post-agent hook*