### PR TITLE
FIX P0: Fix package.json exports to point to built output (not TS source)

### DIFF
--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -8,17 +8,17 @@
     "**/*.css",
     "src/components/**/*.ts"
   ],
-  "main": "./src/index.ts",
-  "module": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     },
     "./components/*": {
-      "types": "./src/components/*/index.ts",
-      "import": "./src/components/*/index.ts"
+      "types": "./dist/components/*/index.d.ts",
+      "import": "./dist/components/*/index.js"
     },
     "./custom-elements.json": "./custom-elements.json"
   },


### PR DESCRIPTION
## Summary

**Audit Finding — P0 Critical**

`packages/hx-library/package.json` exports map points to TypeScript source files (`src/`) instead of built output (`dist/`). This breaks consumers who import from `@helix/library` — they get raw TS that needs transpilation.

**Fix:**
1. Update `package.json` `exports` field to point to `dist/` files
2. Add proper `types` field pointing to `.d.ts` declarations
3. Add `main` and `module` fields for CJS/ESM compatibility
4. Ensure `files` field includes `dist/` and ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library entry points and module exports to reference compiled JavaScript and TypeScript type definitions instead of source files, ensuring consumers receive optimized, pre-built artifacts.
  * Added explicit package distribution configuration to ensure all necessary compiled code and type definition files are included in published releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->