### PR TITLE
FIX P0: hx-checkbox keyboard accessibility (completely inaccessible)

### DIFF
--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
@@ -225,6 +225,7 @@ export class HelixCheckbox extends LitElement {
   private _handleKeyDown(e: KeyboardEvent): void {
     if (e.key === ' ') {
       e.preventDefault();
+      e.stopPropagation();
       this._handleChange();
     }
   }
@@ -287,9 +288,13 @@ export class HelixCheckbox extends LitElement {
             aria-invalid=${hasError ? 'true' : nothing}
             aria-describedby=${ifDefined(describedBy)}
             aria-labelledby=${this._labelId}
-            tabindex="-1"
+            tabindex="0"
+            @keydown=${this._handleKeyDown}
             @change=${(e: Event) => e.stopPropagation()}
-            @click=${(e: Event) => e.preventDefault()}
+            @click=${(e: Event) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
           />
 
           <span part="checkbox" class="checkbox__box">


### PR DESCRIPTION
## Summary

**Audit Finding — P0 Critical / Healthcare Mandate**

`hx-checkbox` is completely keyboard inaccessible. Users cannot interact with it using keyboard alone. This is a WCAG 2.1 AA violation and unacceptable for healthcare software.

**Problems:**
- Space key does not toggle the checkbox
- Tab focus does not reach the component or is not visible
- No keyboard event handlers implemented
- ARIA `role=checkbox` missing or incorrect
- `aria-checked` not updated on toggle

**Fix:**
1. Implement proper ...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved checkbox keyboard accessibility—checkboxes can now be focused and toggled using the spacebar.
  * Standardized interaction handling to ensure consistent and reliable behavior across keyboard and mouse inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->