### PR TITLE
Build @helix/vue package with CEM-generated wrappers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2751,6 +2751,10 @@
       "resolved": "packages/hx-tokens",
       "link": true
     },
+    "node_modules/@helixds/vue": {
+      "resolved": "packages/vue",
+      "link": true
+    },
     "node_modules/@hono/node-server": {
       "version": "1.19.9",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
@@ -3971,6 +3975,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3994,6 +3999,7 @@
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -4007,6 +4013,7 @@
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -4033,6 +4040,7 @@
       "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api-logs": "0.57.2",
         "@types/shimmer": "^1.2.0",
@@ -4463,6 +4471,7 @@
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -4490,6 +4499,7 @@
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -4518,6 +4528,7 @@
       "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4939,6 +4950,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -6052,6 +6064,7 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -6332,6 +6345,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
       "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -6364,6 +6378,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6472,6 +6487,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -6689,12 +6705,27 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "license": "ISC"
     },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
     "node_modules/@vitest/browser": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/browser/-/browser-3.2.4.tgz",
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -6834,6 +6865,7 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -6977,14 +7009,14 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.28.tgz",
-      "integrity": "sha512-kviccYxTgoE8n6OCw96BNdYlBg2GOWfBuOW4Vqwrt7mSKWKwFVvI8egdTltqRgITGPsTFYtKYfxIG8ptX2PJHQ==",
-      "dev": true,
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.29.tgz",
+      "integrity": "sha512-cuzPhD8fwRHk8IGfmYaR4eEe4cAyJEL66Ove/WZL7yWNL134nqLddSLwNRIsFlnnW1kK+p8Ck3viFnC0chXCXw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
-        "@vue/shared": "3.5.28",
+        "@vue/shared": "3.5.29",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -6994,7 +7026,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -7007,18 +7039,54 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.28.tgz",
-      "integrity": "sha512-/1ZepxAb159jKR1btkefDP+J2xuWL5V3WtleRmxaT+K2Aqiek/Ab/+Ebrw2pPj0sdHO8ViAyyJWfhXXOP/+LQA==",
-      "dev": true,
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.29.tgz",
+      "integrity": "sha512-n0G5o7R3uBVmVxjTIYcz7ovr8sy7QObFG8OQJ3xGCDNhbG60biP/P5KnyY8NLd81OuT1WJflG7N4KWYHaeeaIg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.28",
-        "@vue/shared": "3.5.28"
+        "@vue/compiler-core": "3.5.29",
+        "@vue/shared": "3.5.29"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.29.tgz",
+      "integrity": "sha512-oJZhN5XJs35Gzr50E82jg2cYdZQ78wEwvRO6Y63TvLVTc+6xICzJHP1UIecdSPPYIbkautNBanDiWYa64QSFIA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.29",
+        "@vue/compiler-dom": "3.5.29",
+        "@vue/compiler-ssr": "3.5.29",
+        "@vue/shared": "3.5.29",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.6",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.29.tgz",
+      "integrity": "sha512-Y/ARJZE6fpjzL5GH/phJmsFwx3g6t2KmHKHx5q+MLl2kencADKIrhH5MLF6HHpRMmlRAYBRSvv347Mepf1zVNw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.29",
+        "@vue/shared": "3.5.29"
       }
     },
     "node_modules/@vue/compiler-vue2": {
@@ -7083,11 +7151,59 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.29.tgz",
+      "integrity": "sha512-zcrANcrRdcLtmGZETBxWqIkoQei8HaFpZWx/GHKxx79JZsiZ8j1du0VUJtu4eJjgFvU/iKL5lRXFXksVmI+5DA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.29"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.29.tgz",
+      "integrity": "sha512-8DpW2QfdwIWOLqtsNcds4s+QgwSaHSJY/SUe04LptianUQ/0xi6KVsu/pYVh+HO3NTVvVJjIPL2t6GdeKbS4Lg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.29",
+        "@vue/shared": "3.5.29"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.29.tgz",
+      "integrity": "sha512-AHvvJEtcY9tw/uk+s/YRLSlxxQnqnAkjqvK25ZiM4CllCZWzElRAoQnCM42m9AHRLNJ6oe2kC5DCgD4AUdlvXg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.29",
+        "@vue/runtime-core": "3.5.29",
+        "@vue/shared": "3.5.29",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.29.tgz",
+      "integrity": "sha512-G/1k6WK5MusLlbxSE2YTcqAAezS+VuwHhOvLx2KnQU7G2zCH6KIb+5Wyt6UjMq7a3qPzNEjJXs1hvAxDclQH+g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.29",
+        "@vue/shared": "3.5.29"
+      },
+      "peerDependencies": {
+        "vue": "3.5.29"
+      }
+    },
     "node_modules/@vue/shared": {
-      "version": "3.5.28",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.28.tgz",
-      "integrity": "sha512-cfWa1fCGBxrvaHRhvV3Is0MgmrbSCxYTXCSCau2I0a1Xw1N1pHAvkWCiXPRAqjvToILvguNyEwjevUqAuBQWvQ==",
-      "dev": true,
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.29.tgz",
+      "integrity": "sha512-w7SR0A5zyRByL9XUkCfdLs7t9XOHUyJ67qPGQjOou3p6GvBeBW+AVjUUmlxtZ4PIYaRvE+1LmK44O4uajlZwcg==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@web/config-loader": {
@@ -7274,6 +7390,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7595,6 +7712,7 @@
       "resolved": "https://registry.npmjs.org/astro/-/astro-5.17.2.tgz",
       "integrity": "sha512-7jnMqGo53hOQNwo1N/wqeOvUp8wwW/p+DeerSjSkHNx8L/1mhy6P7rVo7EhdmF8DpKqw0tl/B5Fx1WcIzg1ysA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@astrojs/compiler": "^2.13.0",
         "@astrojs/internal-helpers": "0.7.5",
@@ -8758,6 +8876,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -9323,7 +9442,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1507524.tgz",
       "integrity": "sha512-OjaNE7qpk6GRTXtqQjAE5bGx6+c4F1zZH0YXtpZQLM92HNXx4zMAaqlKhP4T52DosG6hDW8gPMNhGOF8xbwk/w==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "8.0.3",
@@ -9808,6 +9928,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11432,6 +11553,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.4.tgz",
       "integrity": "sha512-ooiZW1Xy8rQ4oELQ++otI2T9DsKpV0M6c6cO6JGx4RTfav9poFFLlet9UMXHZnoM1yG0HWGlQLswBGX3RZmHtg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12778,6 +12900,7 @@
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
       "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@lit/reactive-element": "^2.1.0",
         "lit-element": "^4.2.0",
@@ -15320,6 +15443,7 @@
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.2"
       },
@@ -15380,6 +15504,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15485,6 +15610,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -15791,6 +15917,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15800,6 +15927,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -16501,6 +16629,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -17130,6 +17259,7 @@
       "integrity": "sha512-HGAgLbDAAbLOgjERsBXPpHUMxynHumYgoCRNBnAH57HfKuHL9LA3nKvKpbhFbYb/8PSG5X3hiKukki0R6Op7Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -18131,6 +18261,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -18631,6 +18762,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -19232,6 +19364,7 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -19542,6 +19675,133 @@
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
       "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.29.tgz",
+      "integrity": "sha512-BZqN4Ze6mDQVNAni0IHeMJ5mwr8VAJ3MQC9FmprRhcBYENw+wOAAjRj8jfmN6FLl0j96OXbR+CjWhmAmM+QGnA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.29",
+        "@vue/compiler-sfc": "3.5.29",
+        "@vue/runtime-dom": "3.5.29",
+        "@vue/server-renderer": "3.5.29",
+        "@vue/shared": "3.5.29"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
+      "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.15",
+        "@vue/language-core": "2.2.12"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/@volar/language-core": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
+      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.15"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/@volar/source-map": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
+      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-tsc/node_modules/@volar/typescript": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
+      "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/@vue/language-core": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
+      "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^1.0.3",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-tsc/node_modules/alien-signals": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
+      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue-tsc/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/vue-tsc/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/web-namespaces": {
       "version": "2.0.1",
@@ -19973,6 +20233,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -20033,6 +20294,24 @@
       "devDependencies": {
         "tsx": "^4.19.0",
         "typescript": "^5.7.2"
+      }
+    },
+    "packages/vue": {
+      "name": "@helixds/vue",
+      "version": "0.1.0",
+      "dependencies": {
+        "@helix/library": "*"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.0.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.7.2",
+        "vite": "^6.2.0",
+        "vue": "^3.5.0",
+        "vue-tsc": "^2.0.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "packages/wc-library": {

--- a/packages/vue/nuxt-kit.d.ts
+++ b/packages/vue/nuxt-kit.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Minimal type stubs for @nuxt/kit to avoid installing the full package
+ * as a dev dependency. Only the symbols used in nuxt/module.ts are declared.
+ */
+declare module '@nuxt/kit' {
+  export interface NuxtModuleMeta {
+    name?: string
+    configKey?: string
+    compatibility?: { nuxt?: string }
+  }
+
+  export interface AddComponentOptions {
+    name: string
+    export?: string
+    filePath: string
+  }
+
+  export interface NuxtModuleSetupOptions {
+    meta?: NuxtModuleMeta
+    setup?: () => void
+  }
+
+  export function defineNuxtModule(options: NuxtModuleSetupOptions): unknown
+  export function addComponent(options: AddComponentOptions): void
+}

--- a/packages/vue/nuxt/module.ts
+++ b/packages/vue/nuxt/module.ts
@@ -1,0 +1,56 @@
+import { defineNuxtModule, addComponent } from '@nuxt/kit'
+
+/**
+ * Nuxt 3 module for @helixds/vue.
+ *
+ * Registers all Helix Vue wrapper components as auto-imports so they can be
+ * used in Nuxt templates without explicit import statements.
+ *
+ * @example
+ * // nuxt.config.ts
+ * export default defineNuxtConfig({
+ *   modules: ['@helixds/vue/nuxt'],
+ * })
+ */
+export default defineNuxtModule({
+  meta: {
+    name: '@helixds/vue',
+    configKey: 'helixVue',
+    compatibility: {
+      nuxt: '>=3.0.0',
+    },
+  },
+  setup() {
+    const components = [
+      'HxAlert',
+      'HxAvatar',
+      'HxBadge',
+      'HxBreadcrumb',
+      'HxBreadcrumbItem',
+      'HxButton',
+      'HxButtonGroup',
+      'HxCard',
+      'HxCheckbox',
+      'HxContainer',
+      'HxField',
+      'HxForm',
+      'HxIconButton',
+      'HxProse',
+      'HxRadio',
+      'HxRadioGroup',
+      'HxSelect',
+      'HxSlider',
+      'HxSwitch',
+      'HxTextInput',
+      'HxTextarea',
+    ] as const
+
+    for (const name of components) {
+      addComponent({
+        name,
+        export: name,
+        filePath: '@helixds/vue',
+      })
+    }
+  },
+})

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@helixds/vue",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Vue 3 wrapper components for the Helix Design System",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./nuxt": {
+      "types": "./nuxt/module.d.ts",
+      "import": "./nuxt/module.js"
+    }
+  },
+  "files": [
+    "dist",
+    "nuxt"
+  ],
+  "scripts": {
+    "build": "vue-tsc --noEmit && vite build",
+    "type-check": "vue-tsc --noEmit",
+    "generate": "tsx scripts/generate-wrappers.ts",
+    "dev": "vite build --watch"
+  },
+  "peerDependencies": {
+    "vue": "^3.0.0"
+  },
+  "dependencies": {
+    "@helix/library": "*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "typescript": "^5.7.2",
+    "tsx": "^4.21.0",
+    "vite": "^6.2.0",
+    "vue": "^3.5.0",
+    "vue-tsc": "^2.0.0"
+  }
+}

--- a/packages/vue/scripts/generate-wrappers.ts
+++ b/packages/vue/scripts/generate-wrappers.ts
@@ -1,0 +1,461 @@
+/**
+ * CEM-to-Vue codegen script for @helixds/vue
+ *
+ * Reads packages/hx-library/custom-elements.json (Custom Elements Manifest)
+ * and generates Vue 3 SFC wrapper files for each discovered custom element.
+ *
+ * Usage:
+ *   npm run generate
+ *   # or directly:
+ *   tsx scripts/generate-wrappers.ts
+ *
+ * The script is intentionally standalone (no Vite/build involvement).
+ * Run it after hx-library components change to regenerate wrappers.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+// ---------------------------------------------------------------------------
+// CEM type definitions (subset we care about)
+// ---------------------------------------------------------------------------
+
+interface CemAttribute {
+  name: string
+  type?: { text: string }
+  default?: string
+  description?: string
+}
+
+interface CemProperty {
+  name: string
+  attribute?: string
+  type?: { text: string }
+  default?: string
+  description?: string
+  readonly?: boolean
+}
+
+interface CemEvent {
+  name: string
+  type?: { text: string }
+  description?: string
+}
+
+interface CemSlot {
+  name: string
+  description?: string
+}
+
+interface CemDeclaration {
+  kind: string
+  name: string
+  tagName?: string
+  attributes?: CemAttribute[]
+  members?: CemProperty[]
+  events?: CemEvent[]
+  slots?: CemSlot[]
+}
+
+interface CemModule {
+  kind: string
+  path: string
+  declarations?: CemDeclaration[]
+}
+
+interface CemManifest {
+  schemaVersion: string
+  readme?: string
+  modules: CemModule[]
+}
+
+// ---------------------------------------------------------------------------
+// Form component configuration
+// ---------------------------------------------------------------------------
+
+/** Components that need v-model support and how they map */
+interface FormConfig {
+  modelType: 'string' | 'boolean' | 'number'
+  modelDefault: string
+  /** Name of the wc property that carries the model value */
+  wcProp: 'value' | 'checked'
+  /** hx-* event that fires on change */
+  changeEvent: string
+  /** Optional separate input event (text-like components) */
+  inputEvent?: string
+  /** Property on event.detail that holds the new value */
+  detailProp: 'value' | 'checked'
+}
+
+const FORM_COMPONENTS: Record<string, FormConfig> = {
+  'hx-text-input': {
+    modelType: 'string',
+    modelDefault: "''",
+    wcProp: 'value',
+    changeEvent: 'hx-change',
+    inputEvent: 'hx-input',
+    detailProp: 'value',
+  },
+  'hx-textarea': {
+    modelType: 'string',
+    modelDefault: "''",
+    wcProp: 'value',
+    changeEvent: 'hx-change',
+    inputEvent: 'hx-input',
+    detailProp: 'value',
+  },
+  'hx-select': {
+    modelType: 'string',
+    modelDefault: "''",
+    wcProp: 'value',
+    changeEvent: 'hx-change',
+    detailProp: 'value',
+  },
+  'hx-radio-group': {
+    modelType: 'string',
+    modelDefault: "''",
+    wcProp: 'value',
+    changeEvent: 'hx-change',
+    detailProp: 'value',
+  },
+  'hx-slider': {
+    modelType: 'number',
+    modelDefault: '0',
+    wcProp: 'value',
+    changeEvent: 'hx-change',
+    detailProp: 'value',
+  },
+  'hx-checkbox': {
+    modelType: 'boolean',
+    modelDefault: 'false',
+    wcProp: 'checked',
+    changeEvent: 'hx-change',
+    detailProp: 'checked',
+  },
+  'hx-switch': {
+    modelType: 'boolean',
+    modelDefault: 'false',
+    wcProp: 'checked',
+    changeEvent: 'hx-change',
+    detailProp: 'checked',
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Converts a kebab-case tag name to PascalCase component name.
+ * e.g. "hx-text-input" -> "HxTextInput"
+ */
+function toPascalCase(tag: string): string {
+  return tag
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('')
+}
+
+/**
+ * Converts a kebab-case attribute name to camelCase prop name.
+ * e.g. "hx-size" -> "hxSize", "help-text" -> "helpText"
+ */
+function toCamelCase(attr: string): string {
+  return attr.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase())
+}
+
+/**
+ * Resolves a CEM type text to a TypeScript type string.
+ * Falls back to `string` for unknown named types that aren't resolvable
+ * in the generated SFC scope.
+ */
+function resolveType(typeText: string | undefined): string {
+  if (!typeText) return 'string'
+  // Normalize whitespace (CEM sometimes emits multi-line type unions)
+  const cleaned = typeText.trim().replace(/\s+/g, ' ')
+  if (cleaned === 'boolean') return 'boolean'
+  if (cleaned === 'number') return 'number'
+  if (cleaned === 'string') return 'string'
+  // Pass through types that contain quotes (string literals) or pipes
+  // These are inline union types that are valid TypeScript
+  if (cleaned.includes("'") || cleaned.includes('"')) return cleaned
+  // Handle primitives with undefined: "string | undefined" etc.
+  if (/^(string|number|boolean)(\s*\|\s*undefined)?$/.test(cleaned)) return cleaned
+  // Plain identifier (e.g. "AlertVariant") — not resolvable in SFC scope;
+  // fall back to string to keep the generated file compilable
+  return 'string'
+}
+
+/**
+ * Builds the TypeScript interface block for component props.
+ */
+function buildPropsInterface(
+  attrs: CemAttribute[],
+  formConfig: FormConfig | undefined,
+): string {
+  const lines: string[] = ['interface Props {']
+
+  for (const attr of attrs) {
+    // Skip the model-bound prop from the Props interface (handled via defineModel)
+    if (formConfig && attr.name === formConfig.wcProp) continue
+
+    const camel = toCamelCase(attr.name)
+    const tsType = resolveType(attr.type?.text)
+    const optional = '?'
+    if (attr.description) {
+      lines.push(`  /** ${attr.description} */`)
+    }
+    lines.push(`  ${camel}${optional}: ${tsType}`)
+  }
+
+  lines.push('}')
+  return lines.join('\n')
+}
+
+/**
+ * Builds the template attribute bindings for the host custom element.
+ */
+function buildTemplateBindings(
+  attrs: CemAttribute[],
+  formConfig: FormConfig | undefined,
+): string {
+  const lines: string[] = []
+
+  // Model binding
+  if (formConfig) {
+    lines.push(`    :${formConfig.wcProp}="model"`)
+  }
+
+  for (const attr of attrs) {
+    if (formConfig && attr.name === formConfig.wcProp) continue
+    const camel = toCamelCase(attr.name)
+    // Attribute names with uppercase letters need :kebab-case binding
+    lines.push(`    :${attr.name}="props.${camel}"`)
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Builds the event bindings for the template.
+ */
+function buildEventBindings(
+  events: CemEvent[],
+  formConfig: FormConfig | undefined,
+): string {
+  const lines: string[] = []
+
+  if (formConfig) {
+    if (formConfig.inputEvent) {
+      lines.push(`    @${formConfig.inputEvent}="handleInput"`)
+    }
+    lines.push(`    @${formConfig.changeEvent}="handleChange"`)
+    // Passthrough for remaining non-model events
+    const nonModelEvents = events.filter(
+      (e) =>
+        e.name !== formConfig.changeEvent && e.name !== formConfig.inputEvent,
+    )
+    for (const ev of nonModelEvents) {
+      lines.push(`    @${ev.name}="emit('${ev.name}', $event as CustomEvent)"`)
+    }
+  } else {
+    for (const ev of events) {
+      lines.push(`    @${ev.name}="emit('${ev.name}', $event as CustomEvent)"`)
+    }
+  }
+
+  return lines.join('\n')
+}
+
+/**
+ * Builds the slot elements for the template.
+ */
+function buildSlots(slots: CemSlot[]): string {
+  const lines: string[] = []
+  for (const slot of slots) {
+    if (!slot.name) {
+      lines.push('    <slot />')
+    } else {
+      lines.push(`    <slot name="${slot.name}" slot="${slot.name}" />`)
+    }
+  }
+  // Always ensure a default slot exists
+  if (!slots.find((s) => !s.name)) {
+    lines.push('    <slot />')
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Generates the complete Vue SFC source for a custom element.
+ */
+function generateSfc(decl: CemDeclaration): string {
+  const tag = decl.tagName ?? ''
+  const componentName = toPascalCase(tag)
+  const formConfig = FORM_COMPONENTS[tag]
+
+  // Collect attributes (prefer attributes over members for template bindings)
+  const attrs: CemAttribute[] = decl.attributes ?? []
+  const events: CemEvent[] = decl.events ?? []
+  const slots: CemSlot[] = decl.slots ?? []
+
+  const propsInterface = buildPropsInterface(attrs, formConfig)
+  const templateBindings = buildTemplateBindings(attrs, formConfig)
+  const eventBindings = buildEventBindings(events, formConfig)
+  const slotMarkup = buildSlots(slots)
+
+  // Build emit declarations
+  const emitLines: string[] = []
+  const passedEvents = formConfig
+    ? events.filter(
+        (e) =>
+          e.name !== formConfig.changeEvent &&
+          e.name !== formConfig.inputEvent,
+      )
+    : events
+  for (const ev of passedEvents) {
+    emitLines.push(`  '${ev.name}': [event: CustomEvent]`)
+  }
+
+  // Build handler functions for form components
+  const handlerLines: string[] = []
+  if (formConfig) {
+    const detailType =
+      formConfig.modelType === 'boolean'
+        ? '{ checked: boolean; value: string }'
+        : formConfig.modelType === 'number'
+          ? '{ value: number }'
+          : '{ value: string }'
+
+    if (formConfig.inputEvent) {
+      handlerLines.push(
+        `function handleInput(e: Event): void {`,
+        `  const detail = (e as CustomEvent<${detailType}>).detail`,
+        `  model.value = detail.${formConfig.detailProp} as ${formConfig.modelType}`,
+        `  emit('${formConfig.inputEvent}', e as CustomEvent)`,
+        `}`,
+      )
+    }
+
+    handlerLines.push(
+      `function handleChange(e: Event): void {`,
+      `  const detail = (e as CustomEvent<${detailType}>).detail`,
+      `  model.value = detail.${formConfig.detailProp} as ${formConfig.modelType}`,
+      `  emit('${formConfig.changeEvent}', e as CustomEvent)`,
+      `}`,
+    )
+  }
+
+  // Assemble script block
+  const scriptParts: string[] = [
+    `import '@helix/library/components/${tag}'`,
+    '',
+    propsInterface,
+    '',
+  ]
+
+  if (formConfig) {
+    scriptParts.push(
+      `const model = defineModel<${formConfig.modelType}>({ default: ${formConfig.modelDefault} })`,
+      '',
+    )
+  }
+
+  if (attrs.length > 0) {
+    scriptParts.push(`const props = defineProps<Props>()`, '')
+  }
+
+  if (emitLines.length > 0 || (formConfig && events.length > 0)) {
+    const allEmitLines = [...emitLines]
+    if (formConfig) {
+      if (formConfig.inputEvent) {
+        allEmitLines.push(`  '${formConfig.inputEvent}': [event: CustomEvent]`)
+      }
+      allEmitLines.push(`  '${formConfig.changeEvent}': [event: CustomEvent]`)
+    }
+    scriptParts.push(
+      `const emit = defineEmits<{`,
+      allEmitLines.join('\n'),
+      `}>()`,
+      '',
+    )
+  }
+
+  if (handlerLines.length > 0) {
+    scriptParts.push(...handlerLines, '')
+  }
+
+  const templateBindingStr = templateBindings ? `\n${templateBindings}` : ''
+  const eventBindingStr = eventBindings ? `\n${eventBindings}` : ''
+
+  const sfc = `<script setup lang="ts">
+${scriptParts.join('\n').trimEnd()}
+</script>
+
+<template>
+  <${tag}${templateBindingStr}${eventBindingStr}
+  >
+${slotMarkup}
+  </${tag}>
+</template>
+`
+
+  return sfc
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = dirname(__filename)
+
+  const cemPath = resolve(
+    __dirname,
+    '../../hx-library/custom-elements.json',
+  )
+  const outputDir = resolve(__dirname, '../src/components')
+
+  // Read and parse the CEM manifest
+  let manifest: CemManifest
+  try {
+    const raw = readFileSync(cemPath, 'utf-8')
+    manifest = JSON.parse(raw) as CemManifest
+  } catch (err) {
+    console.error(`Failed to read CEM at ${cemPath}:`, err)
+    process.exit(1)
+  }
+
+  // Collect all custom element declarations
+  const elements: CemDeclaration[] = []
+  for (const mod of manifest.modules) {
+    for (const decl of mod.declarations ?? []) {
+      if (decl.kind === 'class' && decl.tagName) {
+        elements.push(decl)
+      }
+    }
+  }
+
+  if (elements.length === 0) {
+    console.warn('No custom element declarations found in CEM manifest.')
+    return
+  }
+
+  mkdirSync(outputDir, { recursive: true })
+
+  let generated = 0
+  for (const decl of elements) {
+    const componentName = toPascalCase(decl.tagName ?? '')
+    const sfc = generateSfc(decl)
+    const outPath = resolve(outputDir, `${componentName}.vue`)
+    writeFileSync(outPath, sfc, 'utf-8')
+    console.log(`  Generated ${outPath}`)
+    generated++
+  }
+
+  console.log(`\nDone. Generated ${generated} Vue wrapper(s) from CEM.`)
+}
+
+main()

--- a/packages/vue/src/components/HxAlert.vue
+++ b/packages/vue/src/components/HxAlert.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-alert'
+
+interface Props {
+  /** Visual variant of the alert that determines colors and ARIA semantics. */
+  variant?: string
+  /** Whether the alert can be dismissed by the user. */
+  dismissible?: boolean
+  /** Whether the alert is visible. Set to false to hide the alert. */
+  open?: boolean
+  /** Whether to show the default variant icon. Set to false to hide the icon container entirely. */
+  icon?: boolean
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-dismiss': [event: CustomEvent]
+  'hx-after-dismiss': [event: CustomEvent]
+}>()
+</script>
+
+<template>
+  <hx-alert
+    :variant="props.variant"
+    :dismissible="props.dismissible"
+    :open="props.open"
+    :icon="props.icon"
+    @hx-dismiss="emit('hx-dismiss', $event as CustomEvent)"
+    @hx-after-dismiss="emit('hx-after-dismiss', $event as CustomEvent)"
+  >
+    <slot />
+    <slot name="icon" slot="icon" />
+    <slot name="actions" slot="actions" />
+  </hx-alert>
+</template>

--- a/packages/vue/src/components/HxAvatar.vue
+++ b/packages/vue/src/components/HxAvatar.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-avatar'
+
+interface Props {
+  /** Image URL. When provided and successfully loaded, displays the image. */
+  src?: string | undefined
+  /** Accessible label for the image or avatar. */
+  alt?: string
+  /** Fallback initials text displayed when no image is available. */
+  initials?: string
+  /** Size variant of the avatar. */
+  hxSize?: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+  /** Shape variant of the avatar. */
+  shape?: 'circle' | 'square'
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-avatar
+    :src="props.src"
+    :alt="props.alt"
+    :initials="props.initials"
+    :hx-size="props.hxSize"
+    :shape="props.shape"
+  >
+    <slot />
+    <slot name="badge" slot="badge" />
+  </hx-avatar>
+</template>

--- a/packages/vue/src/components/HxBadge.vue
+++ b/packages/vue/src/components/HxBadge.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-badge'
+
+interface Props {
+  /** Visual style variant of the badge. */
+  variant?: | 'primary' | 'secondary' | 'success' | 'warning' | 'danger' | 'error' | 'neutral' | 'info'
+  /** Size of the badge. */
+  hxSize?: 'sm' | 'md' | 'lg'
+  /** Whether the badge uses fully rounded (pill) styling. */
+  pill?: boolean
+  /** Whether the badge displays an animated pulse for attention. */
+  pulse?: boolean
+  /** Whether the badge renders a dismiss button. */
+  removable?: boolean
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-remove': [event: CustomEvent]
+}>()
+</script>
+
+<template>
+  <hx-badge
+    :variant="props.variant"
+    :hx-size="props.hxSize"
+    :pill="props.pill"
+    :pulse="props.pulse"
+    :removable="props.removable"
+    @hx-remove="emit('hx-remove', $event as CustomEvent)"
+  >
+    <slot />
+    <slot name="prefix" slot="prefix" />
+  </hx-badge>
+</template>

--- a/packages/vue/src/components/HxBreadcrumb.vue
+++ b/packages/vue/src/components/HxBreadcrumb.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-breadcrumb'
+
+interface Props {
+  /** The separator character displayed between breadcrumb items. */
+  separator?: string
+  /** The accessible label for the nav landmark. */
+  label?: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-breadcrumb
+    :separator="props.separator"
+    :label="props.label"
+  >
+    <slot />
+  </hx-breadcrumb>
+</template>

--- a/packages/vue/src/components/HxBreadcrumbItem.vue
+++ b/packages/vue/src/components/HxBreadcrumbItem.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-breadcrumb-item'
+
+interface Props {
+  /** The URL for this breadcrumb link. Omit for the current page (last item). */
+  href?: string | undefined
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-breadcrumb-item
+    :href="props.href"
+  >
+    <slot />
+  </hx-breadcrumb-item>
+</template>

--- a/packages/vue/src/components/HxButton.vue
+++ b/packages/vue/src/components/HxButton.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-button'
+
+interface Props {
+  /** Visual style variant of the button. */
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'ghost' | 'outline'
+  /** Size of the button. */
+  hxSize?: 'sm' | 'md' | 'lg'
+  /** Whether the button is disabled. Prevents all interaction and form actions. */
+  disabled?: boolean
+  /** Whether the button is in a loading state. Shows spinner, prevents interaction,
+and sets aria-busy. Does not set the disabled attribute. */
+  loading?: boolean
+  /** The type attribute for the underlying button element. Ignored when href is set. */
+  type?: 'button' | 'submit' | 'reset'
+  /** When set, renders an anchor element instead of a button. */
+  href?: string | undefined
+  /** Anchor target attribute. Only used when href is set. */
+  target?: string | undefined
+  /** Form field name submitted via ElementInternals.setFormValue on submit. */
+  name?: string | undefined
+  /** Form field value submitted via ElementInternals.setFormValue on submit. */
+  value?: string | undefined
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-click': [event: CustomEvent]
+}>()
+</script>
+
+<template>
+  <hx-button
+    :variant="props.variant"
+    :hx-size="props.hxSize"
+    :disabled="props.disabled"
+    :loading="props.loading"
+    :type="props.type"
+    :href="props.href"
+    :target="props.target"
+    :name="props.name"
+    :value="props.value"
+    @hx-click="emit('hx-click', $event as CustomEvent)"
+  >
+    <slot />
+    <slot name="prefix" slot="prefix" />
+    <slot name="suffix" slot="suffix" />
+  </hx-button>
+</template>

--- a/packages/vue/src/components/HxButtonGroup.vue
+++ b/packages/vue/src/components/HxButtonGroup.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-button-group'
+
+interface Props {
+  /** Layout orientation of the button group. */
+  orientation?: 'horizontal' | 'vertical'
+  /** Size applied to the button group and cascaded to child buttons via
+the --hx-button-group-size CSS custom property. */
+  hxSize?: 'sm' | 'md' | 'lg'
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-button-group
+    :orientation="props.orientation"
+    :hx-size="props.hxSize"
+  >
+    <slot />
+  </hx-button-group>
+</template>

--- a/packages/vue/src/components/HxCard.vue
+++ b/packages/vue/src/components/HxCard.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-card'
+
+interface Props {
+  /** Visual style variant of the card. */
+  variant?: 'default' | 'featured' | 'compact'
+  /** Elevation (shadow depth) of the card. */
+  elevation?: 'flat' | 'raised' | 'floating'
+  /** Optional URL. When set, the card becomes interactive (clickable)
+and navigates to this URL on click.
+Uses wc-href to avoid conflicting with the native HTML href attribute. */
+  hxHref?: string
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-card-click': [event: CustomEvent]
+  'wc-card-click': [event: CustomEvent]
+}>()
+</script>
+
+<template>
+  <hx-card
+    :variant="props.variant"
+    :elevation="props.elevation"
+    :hx-href="props.hxHref"
+    @hx-card-click="emit('hx-card-click', $event as CustomEvent)"
+    @wc-card-click="emit('wc-card-click', $event as CustomEvent)"
+  >
+    <slot name="image" slot="image" />
+    <slot name="heading" slot="heading" />
+    <slot />
+    <slot name="footer" slot="footer" />
+    <slot name="actions" slot="actions" />
+  </hx-card>
+</template>

--- a/packages/vue/src/components/HxCheckbox.vue
+++ b/packages/vue/src/components/HxCheckbox.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-checkbox'
+
+interface Props {
+  /** Whether the checkbox is in an indeterminate state (e.g., for "select all" patterns). */
+  indeterminate?: boolean
+  /** Whether the checkbox is disabled. */
+  disabled?: boolean
+  /** Whether the checkbox is required for form submission. */
+  required?: boolean
+  /** The name of the checkbox, used for form submission. */
+  name?: string
+  /** The value submitted when the checkbox is checked. */
+  value?: string
+  /** The visible label text for the checkbox. */
+  label?: string
+  /** Error message to display. When set, the checkbox enters an error state. */
+  error?: string
+  /** Help text displayed below the checkbox for guidance. */
+  helpText?: string
+  /** The size of the checkbox. */
+  hxSize?: 'sm' | 'md' | 'lg'
+}
+
+const model = defineModel<boolean>({ default: false })
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-change': [event: CustomEvent]
+}>()
+
+function handleChange(e: Event): void {
+  const detail = (e as CustomEvent<{ checked: boolean; value: string }>).detail
+  model.value = detail.checked as boolean
+  emit('hx-change', e as CustomEvent)
+}
+</script>
+
+<template>
+  <hx-checkbox
+    :checked="model"
+    :indeterminate="props.indeterminate"
+    :disabled="props.disabled"
+    :required="props.required"
+    :name="props.name"
+    :value="props.value"
+    :label="props.label"
+    :error="props.error"
+    :help-text="props.helpText"
+    :hx-size="props.hxSize"
+    @hx-change="handleChange"
+  >
+    <slot />
+    <slot name="error" slot="error" />
+    <slot name="help-text" slot="help-text" />
+  </hx-checkbox>
+</template>

--- a/packages/vue/src/components/HxContainer.vue
+++ b/packages/vue/src/components/HxContainer.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-container'
+
+interface Props {
+  /** Controls the max-width of the inner content wrapper. */
+  width?: 'full' | 'content' | 'narrow' | 'sm' | 'md' | 'lg' | 'xl'
+  /** Vertical padding applied to the outer wrapper. */
+  padding?: 'none' | 'sm' | 'md' | 'lg' | 'xl' | '2xl'
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-container
+    :width="props.width"
+    :padding="props.padding"
+  >
+    <slot />
+  </hx-container>
+</template>

--- a/packages/vue/src/components/HxField.vue
+++ b/packages/vue/src/components/HxField.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-field'
+
+interface Props {
+  /** The visible label text for the field. */
+  label?: string
+  /** Whether the field is required. Shows a required indicator on the label. */
+  required?: boolean
+  /** Error message to display. When set, the field enters an error state. */
+  error?: string
+  /** Help text displayed below the control for guidance. */
+  helpText?: string
+  /** Visual disabled state applied via opacity. Does not affect slotted control
+interactivity — set disabled on the slotted control directly. */
+  disabled?: boolean
+  /** Size variant controlling label and help text font sizes. */
+  hxSize?: 'sm' | 'md' | 'lg'
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-field
+    :label="props.label"
+    :required="props.required"
+    :error="props.error"
+    :help-text="props.helpText"
+    :disabled="props.disabled"
+    :hx-size="props.hxSize"
+  >
+    <slot />
+    <slot name="label" slot="label" />
+    <slot name="help" slot="help" />
+    <slot name="error" slot="error" />
+    <slot name="description" slot="description" />
+  </hx-field>
+</template>

--- a/packages/vue/src/components/HxForm.vue
+++ b/packages/vue/src/components/HxForm.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-form'
+
+interface Props {
+  /** The URL to submit the form to. When empty, the form handles
+submission client-side only and dispatches `wc-submit`. */
+  action?: string
+  /** The HTTP method used when submitting the form. */
+  method?: 'get' | 'post'
+  /** When true, disables the browser's built-in constraint validation
+on form submission. */
+  novalidate?: boolean
+  /** Identifies the form for scripting and form discovery. */
+  name?: string
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'wc-submit': [event: CustomEvent]
+  'wc-invalid': [event: CustomEvent]
+  'wc-reset': [event: CustomEvent]
+}>()
+</script>
+
+<template>
+  <hx-form
+    :action="props.action"
+    :method="props.method"
+    :novalidate="props.novalidate"
+    :name="props.name"
+    @wc-submit="emit('wc-submit', $event as CustomEvent)"
+    @wc-invalid="emit('wc-invalid', $event as CustomEvent)"
+    @wc-reset="emit('wc-reset', $event as CustomEvent)"
+  >
+    <slot />
+  </hx-form>
+</template>

--- a/packages/vue/src/components/HxIconButton.vue
+++ b/packages/vue/src/components/HxIconButton.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-icon-button'
+
+interface Props {
+  /** Accessible name for the button. Required. Rendered as `aria-label` and
+`title` on the underlying element. A console warning is emitted when absent. */
+  label?: string
+  /** Visual style variant of the button. */
+  variant?: 'primary' | 'secondary' | 'tertiary' | 'danger' | 'ghost'
+  /** Size of the button. */
+  hxSize?: 'sm' | 'md' | 'lg'
+  /** The type attribute for the underlying button element.
+Has no effect when `href` is set. */
+  type?: 'button' | 'submit' | 'reset'
+  /** Whether the button is disabled. */
+  disabled?: boolean
+  /** When set, renders an `<a>` element instead of a `<button>`. */
+  href?: string | undefined
+  /** Name submitted with form data. Only applicable when rendering as a button. */
+  name?: string | undefined
+  /** Value submitted with form data. Only applicable when rendering as a button. */
+  value?: string | undefined
+}
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-click': [event: CustomEvent]
+}>()
+</script>
+
+<template>
+  <hx-icon-button
+    :label="props.label"
+    :variant="props.variant"
+    :hx-size="props.hxSize"
+    :type="props.type"
+    :disabled="props.disabled"
+    :href="props.href"
+    :name="props.name"
+    :value="props.value"
+    @hx-click="emit('hx-click', $event as CustomEvent)"
+  >
+    <slot />
+  </hx-icon-button>
+</template>

--- a/packages/vue/src/components/HxProse.vue
+++ b/packages/vue/src/components/HxProse.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-prose'
+
+interface Props {
+  /** Typography scale for the prose content. */
+  size?: 'sm' | 'base' | 'lg'
+  /** Maximum content width. When set, overrides the --hx-prose-max-width token.
+Accepts any valid CSS width value (e.g., '640px', '80ch', '100%'). */
+  maxWidth?: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-prose
+    :size="props.size"
+    :max-width="props.maxWidth"
+  >
+    <slot />
+  </hx-prose>
+</template>

--- a/packages/vue/src/components/HxRadio.vue
+++ b/packages/vue/src/components/HxRadio.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-radio'
+
+interface Props {
+  /** The value this radio represents. */
+  value?: string
+  /** Visible label text for the radio. */
+  label?: string
+  /** Whether this radio is disabled. */
+  disabled?: boolean
+  /** Whether this radio is checked. Managed by the parent group. */
+  checked?: boolean
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <hx-radio
+    :value="props.value"
+    :label="props.label"
+    :disabled="props.disabled"
+    :checked="props.checked"
+  >
+    <slot />
+  </hx-radio>
+</template>

--- a/packages/vue/src/components/HxRadioGroup.vue
+++ b/packages/vue/src/components/HxRadioGroup.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-radio-group'
+
+interface Props {
+  /** The name used for form submission. */
+  name?: string
+  /** The fieldset legend/label text. */
+  label?: string
+  /** Whether a selection is required for form submission. */
+  required?: boolean
+  /** Whether the entire group is disabled. */
+  disabled?: boolean
+  /** Error message to display. When set, the group enters an error state. */
+  error?: string
+  /** Help text displayed below the group for guidance. */
+  helpText?: string
+  /** Layout orientation of the radio items. */
+  orientation?: 'vertical' | 'horizontal'
+}
+
+const model = defineModel<string>({ default: '' })
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-change': [event: CustomEvent]
+}>()
+
+function handleChange(e: Event): void {
+  const detail = (e as CustomEvent<{ value: string }>).detail
+  model.value = detail.value as string
+  emit('hx-change', e as CustomEvent)
+}
+</script>
+
+<template>
+  <hx-radio-group
+    :value="model"
+    :name="props.name"
+    :label="props.label"
+    :required="props.required"
+    :disabled="props.disabled"
+    :error="props.error"
+    :help-text="props.helpText"
+    :orientation="props.orientation"
+    @hx-change="handleChange"
+  >
+    <slot />
+    <slot name="error" slot="error" />
+    <slot name="help-text" slot="help-text" />
+  </hx-radio-group>
+</template>

--- a/packages/vue/src/components/HxSelect.vue
+++ b/packages/vue/src/components/HxSelect.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-select'
+
+interface Props {
+  /** The visible label text for the select. */
+  label?: string
+  /** Placeholder text shown in the trigger when no option is selected. */
+  placeholder?: string
+  /** Whether the select is required for form submission. */
+  required?: boolean
+  /** Whether the select is disabled. */
+  disabled?: boolean
+  /** The name used for form submission. */
+  name?: string
+  /** Error message to display. When set, the field enters an error state. */
+  error?: string
+  /** Help text displayed below the select for guidance. */
+  helpText?: string
+  /** Size variant of the select trigger. */
+  hxSize?: 'sm' | 'md' | 'lg'
+  /** Accessible name for screen readers, if different from the visible label. */
+  ariaLabel?: string
+  /** Enables multi-select mode. Selected values are stored internally as a Set
+and surfaced as removable tags inside the trigger. */
+  multiple?: boolean
+  /** Enables a search/filter input inside the listbox. */
+  searchable?: boolean
+  /** Controls whether the dropdown listbox is open. */
+  open?: boolean
+}
+
+const model = defineModel<string>({ default: '' })
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-input': [event: CustomEvent]
+  'hx-change': [event: CustomEvent]
+}>()
+
+function handleChange(e: Event): void {
+  const detail = (e as CustomEvent<{ value: string }>).detail
+  model.value = detail.value as string
+  emit('hx-change', e as CustomEvent)
+}
+</script>
+
+<template>
+  <hx-select
+    :value="model"
+    :label="props.label"
+    :placeholder="props.placeholder"
+    :required="props.required"
+    :disabled="props.disabled"
+    :name="props.name"
+    :error="props.error"
+    :help-text="props.helpText"
+    :hx-size="props.hxSize"
+    :aria-label="props.ariaLabel"
+    :multiple="props.multiple"
+    :searchable="props.searchable"
+    :open="props.open"
+    @hx-change="handleChange"
+    @hx-input="emit('hx-input', $event as CustomEvent)"
+  >
+    <slot />
+    <slot name="label" slot="label" />
+    <slot name="error" slot="error" />
+    <slot name="help-text" slot="help-text" />
+  </hx-select>
+</template>

--- a/packages/vue/src/components/HxSlider.vue
+++ b/packages/vue/src/components/HxSlider.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-slider'
+
+interface Props {
+  /** The name submitted with the form. */
+  name?: string
+  /** The minimum allowed value. */
+  min?: number
+  /** The maximum allowed value. */
+  max?: number
+  /** The stepping interval between values. */
+  step?: number
+  /** Whether the slider is disabled. */
+  disabled?: boolean
+  /** The visible label text for the slider. */
+  label?: string
+  /** Help text displayed below the slider for guidance. */
+  helpText?: string
+  /** When true, the current value is shown next to the label. */
+  showValue?: boolean
+  /** When true, tick marks are rendered at each step interval. */
+  showTicks?: boolean
+  /** The size variant of the slider. */
+  hxSize?: 'sm' | 'md' | 'lg'
+}
+
+const model = defineModel<number>({ default: 0 })
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-input': [event: CustomEvent]
+  'hx-change': [event: CustomEvent]
+}>()
+
+function handleChange(e: Event): void {
+  const detail = (e as CustomEvent<{ value: number }>).detail
+  model.value = detail.value as number
+  emit('hx-change', e as CustomEvent)
+}
+</script>
+
+<template>
+  <hx-slider
+    :value="model"
+    :name="props.name"
+    :min="props.min"
+    :max="props.max"
+    :step="props.step"
+    :disabled="props.disabled"
+    :label="props.label"
+    :help-text="props.helpText"
+    :show-value="props.showValue"
+    :show-ticks="props.showTicks"
+    :hx-size="props.hxSize"
+    @hx-change="handleChange"
+    @hx-input="emit('hx-input', $event as CustomEvent)"
+  >
+    <slot name="label" slot="label" />
+    <slot name="help" slot="help" />
+    <slot name="min-label" slot="min-label" />
+    <slot name="max-label" slot="max-label" />
+    <slot />
+  </hx-slider>
+</template>

--- a/packages/vue/src/components/HxSwitch.vue
+++ b/packages/vue/src/components/HxSwitch.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-switch'
+
+interface Props {
+  /** Whether the switch is disabled. */
+  disabled?: boolean
+  /** Whether the switch is required for form submission. */
+  required?: boolean
+  /** The name of the switch, used for form submission. */
+  name?: string
+  /** The value submitted when the switch is checked. */
+  value?: string
+  /** The visible label text for the switch. */
+  label?: string
+  /** Size variant of the switch. */
+  hxSize?: 'sm' | 'md' | 'lg'
+  /** Error message to display. When set, the switch enters an error state. */
+  error?: string
+  /** Help text displayed below the switch for guidance. */
+  helpText?: string
+}
+
+const model = defineModel<boolean>({ default: false })
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-change': [event: CustomEvent]
+}>()
+
+function handleChange(e: Event): void {
+  const detail = (e as CustomEvent<{ checked: boolean; value: string }>).detail
+  model.value = detail.checked as boolean
+  emit('hx-change', e as CustomEvent)
+}
+</script>
+
+<template>
+  <hx-switch
+    :checked="model"
+    :disabled="props.disabled"
+    :required="props.required"
+    :name="props.name"
+    :value="props.value"
+    :label="props.label"
+    :hx-size="props.hxSize"
+    :error="props.error"
+    :help-text="props.helpText"
+    @hx-change="handleChange"
+  >
+    <slot />
+    <slot name="error" slot="error" />
+    <slot name="help-text" slot="help-text" />
+  </hx-switch>
+</template>

--- a/packages/vue/src/components/HxTextInput.vue
+++ b/packages/vue/src/components/HxTextInput.vue
@@ -1,0 +1,86 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-text-input'
+
+interface Props {
+  /** The visible label text for the input. */
+  label?: string
+  /** Placeholder text shown when the input is empty. */
+  placeholder?: string
+  /** The type of the native input element. */
+  type?: 'text' | 'email' | 'password' | 'tel' | 'url' | 'search' | 'number' | 'date'
+  /** Whether the input is required for form submission. */
+  required?: boolean
+  /** Whether the input is disabled. */
+  disabled?: boolean
+  /** Error message to display. When set, the input enters an error state. */
+  error?: string
+  /** Help text displayed below the input for guidance. */
+  helpText?: string
+  /** The name of the input, used for form submission. */
+  name?: string
+  /** Accessible name for screen readers, if different from the visible label. */
+  ariaLabel?: string
+  /** Whether the input is read-only. */
+  readonly?: boolean
+  /** Minimum number of characters allowed. */
+  minlength?: number | undefined
+  /** Maximum number of characters allowed. */
+  maxlength?: number | undefined
+  /** A regular expression pattern the value must match for form validation. */
+  pattern?: string
+  /** Hint for the browser's autocomplete feature. Accepts standard HTML autocomplete values. */
+  autocomplete?: string
+  /** Visual size of the input field. */
+  hxSize?: 'sm' | 'md' | 'lg'
+}
+
+const model = defineModel<string>({ default: '' })
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-input': [event: CustomEvent]
+  'hx-change': [event: CustomEvent]
+}>()
+
+function handleInput(e: Event): void {
+  const detail = (e as CustomEvent<{ value: string }>).detail
+  model.value = detail.value as string
+  emit('hx-input', e as CustomEvent)
+}
+function handleChange(e: Event): void {
+  const detail = (e as CustomEvent<{ value: string }>).detail
+  model.value = detail.value as string
+  emit('hx-change', e as CustomEvent)
+}
+</script>
+
+<template>
+  <hx-text-input
+    :value="model"
+    :label="props.label"
+    :placeholder="props.placeholder"
+    :type="props.type"
+    :required="props.required"
+    :disabled="props.disabled"
+    :error="props.error"
+    :help-text="props.helpText"
+    :name="props.name"
+    :aria-label="props.ariaLabel"
+    :readonly="props.readonly"
+    :minlength="props.minlength"
+    :maxlength="props.maxlength"
+    :pattern="props.pattern"
+    :autocomplete="props.autocomplete"
+    :hx-size="props.hxSize"
+    @hx-input="handleInput"
+    @hx-change="handleChange"
+  >
+    <slot name="label" slot="label" />
+    <slot name="prefix" slot="prefix" />
+    <slot name="suffix" slot="suffix" />
+    <slot name="help-text" slot="help-text" />
+    <slot name="error" slot="error" />
+    <slot />
+  </hx-text-input>
+</template>

--- a/packages/vue/src/components/HxTextarea.vue
+++ b/packages/vue/src/components/HxTextarea.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import '@helix/library/components/hx-textarea'
+
+interface Props {
+  /** The visible label text for the textarea. */
+  label?: string
+  /** Placeholder text shown when the textarea is empty. */
+  placeholder?: string
+  /** Whether the textarea is required for form submission. */
+  required?: boolean
+  /** Whether the textarea is disabled. */
+  disabled?: boolean
+  /** Error message to display. When set, the textarea enters an error state. */
+  error?: string
+  /** Help text displayed below the textarea for guidance. */
+  helpText?: string
+  /** The name of the textarea, used for form submission. */
+  name?: string
+  /** The number of visible text rows. */
+  rows?: number
+  /** Maximum number of characters allowed. */
+  maxlength?: number | undefined
+  /** Controls how the textarea can be resized. Use 'auto' for auto-grow behavior. */
+  resize?: 'none' | 'vertical' | 'both' | 'auto'
+  /** Whether to show a character count below the textarea. */
+  showCount?: boolean
+  /** Accessible name for screen readers, if different from the visible label. */
+  ariaLabel?: string
+}
+
+const model = defineModel<string>({ default: '' })
+
+const props = defineProps<Props>()
+
+const emit = defineEmits<{
+  'hx-input': [event: CustomEvent]
+  'hx-change': [event: CustomEvent]
+}>()
+
+function handleInput(e: Event): void {
+  const detail = (e as CustomEvent<{ value: string }>).detail
+  model.value = detail.value as string
+  emit('hx-input', e as CustomEvent)
+}
+function handleChange(e: Event): void {
+  const detail = (e as CustomEvent<{ value: string }>).detail
+  model.value = detail.value as string
+  emit('hx-change', e as CustomEvent)
+}
+</script>
+
+<template>
+  <hx-textarea
+    :value="model"
+    :label="props.label"
+    :placeholder="props.placeholder"
+    :required="props.required"
+    :disabled="props.disabled"
+    :error="props.error"
+    :help-text="props.helpText"
+    :name="props.name"
+    :rows="props.rows"
+    :maxlength="props.maxlength"
+    :resize="props.resize"
+    :show-count="props.showCount"
+    :aria-label="props.ariaLabel"
+    @hx-input="handleInput"
+    @hx-change="handleChange"
+  >
+    <slot name="label" slot="label" />
+    <slot name="help-text" slot="help-text" />
+    <slot name="error" slot="error" />
+    <slot />
+  </hx-textarea>
+</template>

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,0 +1,63 @@
+/**
+ * @helixds/vue — Vue 3 wrapper components for the Helix Design System
+ *
+ * Thin adapter layer over @helix/library web components. Each component
+ * provides typed props, v-model support (where applicable), and proper
+ * slot pass-through for Shadow DOM composition.
+ *
+ * @example
+ * import { HxButton, HxTextInput } from '@helixds/vue'
+ */
+
+// Layout & structure
+export { default as HxContainer } from './components/HxContainer.vue'
+export { default as HxCard } from './components/HxCard.vue'
+export { default as HxProse } from './components/HxProse.vue'
+
+// Navigation & wayfinding
+export { default as HxBreadcrumb } from './components/HxBreadcrumb.vue'
+export { default as HxBreadcrumbItem } from './components/HxBreadcrumbItem.vue'
+
+// Feedback & status
+export { default as HxAlert } from './components/HxAlert.vue'
+export { default as HxAvatar } from './components/HxAvatar.vue'
+export { default as HxBadge } from './components/HxBadge.vue'
+
+// Actions
+export { default as HxButton } from './components/HxButton.vue'
+export { default as HxButtonGroup } from './components/HxButtonGroup.vue'
+export { default as HxIconButton } from './components/HxIconButton.vue'
+
+// Form structure
+export { default as HxForm } from './components/HxForm.vue'
+export { default as HxField } from './components/HxField.vue'
+
+// Form controls (with v-model support)
+export { default as HxTextInput } from './components/HxTextInput.vue'
+export { default as HxTextarea } from './components/HxTextarea.vue'
+export { default as HxSelect } from './components/HxSelect.vue'
+export { default as HxRadioGroup } from './components/HxRadioGroup.vue'
+export { default as HxRadio } from './components/HxRadio.vue'
+export { default as HxSlider } from './components/HxSlider.vue'
+export { default as HxCheckbox } from './components/HxCheckbox.vue'
+export { default as HxSwitch } from './components/HxSwitch.vue'
+
+// Shared types
+export type {
+  HxSize,
+  HxSizeXl,
+  HxButtonVariant,
+  HxButtonType,
+  HxAlertVariant,
+  HxBadgeVariant,
+  HxAvatarShape,
+  HxOrientation,
+  HxInputType,
+  HxTextareaResize,
+  HxInputEventDetail,
+  HxChangeStringEventDetail,
+  HxChangeNumberEventDetail,
+  HxChangeBooleanEventDetail,
+  HxClickEventDetail,
+  HxDismissEventDetail,
+} from './types'

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,0 +1,89 @@
+/**
+ * Shared TypeScript interfaces and types for the @helixds/vue package.
+ * These mirror the design token constraint values used across Helix components.
+ */
+
+/** Size variants shared across multiple components */
+export type HxSize = 'sm' | 'md' | 'lg'
+
+/** Extended size variants that include xl */
+export type HxSizeXl = 'sm' | 'md' | 'lg' | 'xl'
+
+/** Button variant options */
+export type HxButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'tertiary'
+  | 'danger'
+  | 'ghost'
+  | 'outline'
+
+/** Button type attribute values */
+export type HxButtonType = 'button' | 'submit' | 'reset'
+
+/** Alert severity variants */
+export type HxAlertVariant = 'info' | 'success' | 'warning' | 'error'
+
+/** Badge display variants */
+export type HxBadgeVariant = 'default' | 'primary' | 'success' | 'warning' | 'error'
+
+/** Avatar shape options */
+export type HxAvatarShape = 'circle' | 'square'
+
+/** ButtonGroup layout orientation */
+export type HxOrientation = 'horizontal' | 'vertical'
+
+/** Text input type attribute values */
+export type HxInputType =
+  | 'text'
+  | 'email'
+  | 'password'
+  | 'tel'
+  | 'url'
+  | 'search'
+  | 'number'
+  | 'date'
+
+/** Textarea resize behavior */
+export type HxTextareaResize = 'none' | 'vertical' | 'horizontal' | 'both'
+
+/**
+ * Base event detail shape for hx-input events on text-like components.
+ */
+export interface HxInputEventDetail {
+  value: string
+}
+
+/**
+ * Base event detail shape for hx-change events on text-like components.
+ */
+export interface HxChangeStringEventDetail {
+  value: string
+}
+
+/**
+ * Event detail shape for hx-change on numeric components (e.g. hx-slider).
+ */
+export interface HxChangeNumberEventDetail {
+  value: number
+}
+
+/**
+ * Event detail shape for hx-change on boolean/toggle components (e.g. hx-checkbox, hx-switch).
+ */
+export interface HxChangeBooleanEventDetail {
+  checked: boolean
+  value: string
+}
+
+/**
+ * Event detail shape for hx-click events on button components.
+ */
+export interface HxClickEventDetail {
+  originalEvent: MouseEvent
+}
+
+/**
+ * Event detail shape for hx-dismiss on dismissible components.
+ */
+export type HxDismissEventDetail = Record<string, never>

--- a/packages/vue/tsconfig.json
+++ b/packages/vue/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "strict": true,
+    "exactOptionalPropertyTypes": false,
+    "skipLibCheck": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*", "nuxt/**/*", "*.d.ts"],
+  "exclude": ["dist", "node_modules", "scripts"]
+}

--- a/packages/vue/vite.config.ts
+++ b/packages/vue/vite.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import { resolve } from 'path'
+
+export default defineConfig({
+  plugins: [
+    vue({
+      template: {
+        compilerOptions: {
+          // Tell Vue compiler all hx-* tags are custom elements
+          isCustomElement: (tag) => tag.startsWith('hx-'),
+        },
+      },
+    }),
+  ],
+  build: {
+    lib: {
+      entry: resolve(__dirname, 'src/index.ts'),
+      name: 'HelixVue',
+      formats: ['es'],
+      fileName: 'index',
+    },
+    rollupOptions: {
+      external: ['vue', /^@helix\//],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

**Milestone:** Phase 3: Framework Adapters

Create Vue wrapper components auto-generated from CEM. Thin typed wrappers over native web component support. Two-way binding (v-model) support for form components.

**Files to Modify:**
- packages/vue/

**Acceptance Criteria:**
- [ ] CEM-to-Vue codegen script
- [ ] Typed Vue wrappers for all components
- [ ] v-model support for form components
- [ ] TypeScript declarations generated
- [ ] Works with Nuxt 3 SSR
- [ ] Published as @helixds/vue

**Comple...

---
*Recovered automatically by Automaker post-agent hook*