### PR TITLE
Phase 2: REST API Routes for Library Registry

### DIFF
--- a/apps/admin/src/app/api/libraries/[id]/route.ts
+++ b/apps/admin/src/app/api/libraries/[id]/route.ts
@@ -18,13 +18,16 @@ export async function GET(_request: Request, { params }: RouteParams): Promise<N
     const library = getLibrary(id);
 
     if (!library) {
-      return NextResponse.json({ error: `Library "${id}" not found.` }, { status: 404 });
+      return NextResponse.json({ error: `Library "${id}" not found` }, { status: 404 });
     }
 
     return NextResponse.json(library);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error occurred';
-    return NextResponse.json({ error: 'Failed to load library', detail: message }, { status: 500 });
+    return NextResponse.json(
+      { error: 'Failed to load library', details: [message] },
+      { status: 500 },
+    );
   }
 }
 
@@ -55,10 +58,13 @@ export async function PATCH(request: Request, { params }: RouteParams): Promise<
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error occurred';
     if (message.includes('not found')) {
-      return NextResponse.json({ error: message }, { status: 404 });
+      return NextResponse.json({ error: message, details: [message] }, { status: 404 });
+    }
+    if (message.includes('required')) {
+      return NextResponse.json({ error: 'Validation failed', details: [message] }, { status: 400 });
     }
     return NextResponse.json(
-      { error: 'Failed to update library', detail: message },
+      { error: 'Failed to update library', details: [message] },
       { status: 500 },
     );
   }
@@ -67,24 +73,33 @@ export async function PATCH(request: Request, { params }: RouteParams): Promise<
 /**
  * DELETE /api/libraries/[id]
  * Removes a library entry by ID.
- * Returns 400 if the library is the default.
+ * Returns 403 if the library id is 'hx-library'.
  * Returns 404 if not found.
+ * Returns 204 on success.
  */
 export async function DELETE(_request: Request, { params }: RouteParams): Promise<NextResponse> {
   try {
     const { id } = await params;
+
+    if (id === 'hx-library') {
+      return NextResponse.json(
+        { error: 'The hx-library entry cannot be removed' },
+        { status: 403 },
+      );
+    }
+
     removeLibrary(id);
-    return NextResponse.json({ success: true, id });
+    return new NextResponse(null, { status: 204 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error occurred';
-    if (message.includes('Cannot remove the default library')) {
-      return NextResponse.json({ error: message }, { status: 400 });
-    }
     if (message.includes('not found')) {
-      return NextResponse.json({ error: message }, { status: 404 });
+      return NextResponse.json({ error: message, details: [message] }, { status: 404 });
+    }
+    if (message.includes('Cannot remove the default library')) {
+      return NextResponse.json({ error: message, details: [message] }, { status: 400 });
     }
     return NextResponse.json(
-      { error: 'Failed to delete library', detail: message },
+      { error: 'Failed to delete library', details: [message] },
       { status: 500 },
     );
   }

--- a/apps/admin/src/app/api/libraries/route.ts
+++ b/apps/admin/src/app/api/libraries/route.ts
@@ -6,16 +6,16 @@ export const dynamic = 'force-dynamic';
 
 /**
  * GET /api/libraries
- * Returns all library entries from the registry.
+ * Returns all library entries from the registry as a JSON array.
  */
 export async function GET(): Promise<NextResponse> {
   try {
     const libraries = getRegistry();
-    return NextResponse.json({ libraries });
+    return NextResponse.json(libraries);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error occurred';
     return NextResponse.json(
-      { error: 'Failed to load libraries', detail: message },
+      { error: 'Failed to load libraries', details: [message] },
       { status: 500 },
     );
   }
@@ -48,26 +48,23 @@ export async function POST(request: Request): Promise<NextResponse> {
   try {
     const body = (await request.json()) as CreateLibraryBody;
 
-    if (!body.name || !body.source || !body.prefix) {
-      return NextResponse.json(
-        {
-          error: 'Missing required fields',
-          required: ['name', 'source', 'prefix'],
-        },
-        { status: 400 },
-      );
-    }
+    const validationErrors: string[] = [];
+
+    if (!body.name) validationErrors.push('name is required');
+    if (!body.source) validationErrors.push('source is required');
+    if (!body.prefix) validationErrors.push('prefix is required');
 
     if (body.source === 'local' && !body.cemPath) {
-      return NextResponse.json(
-        { error: 'cemPath is required for local libraries' },
-        { status: 400 },
-      );
+      validationErrors.push('cemPath is required for local libraries');
     }
 
     if ((body.source === 'cdn' || body.source === 'npm') && !body.packageName) {
+      validationErrors.push('packageName is required for cdn and npm libraries');
+    }
+
+    if (validationErrors.length > 0) {
       return NextResponse.json(
-        { error: 'packageName is required for cdn and npm libraries' },
+        { error: 'Validation failed', details: validationErrors },
         { status: 400 },
       );
     }
@@ -87,6 +84,12 @@ export async function POST(request: Request): Promise<NextResponse> {
     return NextResponse.json(newEntry, { status: 201 });
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Unknown error occurred';
-    return NextResponse.json({ error: 'Failed to add library', detail: message }, { status: 500 });
+    if (message.includes('already exists')) {
+      return NextResponse.json({ error: message, details: [message] }, { status: 400 });
+    }
+    return NextResponse.json(
+      { error: 'Failed to add library', details: [message] },
+      { status: 500 },
+    );
   }
 }


### PR DESCRIPTION
## Summary

Implement Next.js 15 Route Handlers for CRUD operations on the library registry, consuming the registry-store utilities from Phase 1. Create two route files: (1) apps/admin/src/app/api/libraries/route.ts — GET returns all entries as JSON array; POST accepts a LibraryEntry body, runs validateEntry, calls addEntry, returns 201 with the new entry or 400 with validation errors. (2) apps/admin/src/app/api/libraries/[id]/route.ts — GET returns single entry by id or 404; PATCH accepts partial LibraryEn...

---
*Recovered automatically by Automaker post-agent hook*