### PR TITLE
Phase 3: Libraries Management UI, Components & Navigation

### DIFF
--- a/apps/admin/src/app/layout.tsx
+++ b/apps/admin/src/app/layout.tsx
@@ -13,6 +13,7 @@ import {
   HeartPulse,
   GitBranch,
   Cpu,
+  Library,
 } from 'lucide-react';
 import { DOCS_URL, STORYBOOK_URL } from '@/lib/env';
 import './globals.css';
@@ -68,6 +69,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
               <SidebarLink href="/components" icon={<Boxes className="w-4 h-4" />}>
                 Components
+              </SidebarLink>
+
+              <SidebarLink href="/libraries" icon={<Library className="w-4 h-4" />}>
+                Libraries
               </SidebarLink>
 
               <SidebarLink href="/tests" icon={<FileCheck2 className="w-4 h-4" />}>

--- a/apps/admin/src/app/libraries/components/LibraryCard.tsx
+++ b/apps/admin/src/app/libraries/components/LibraryCard.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import type { LibraryEntry, LibrarySource } from '@/lib/library-registry';
+import { Pencil, Trash2 } from 'lucide-react';
+
+interface LibraryCardProps {
+  library: LibraryEntry;
+  onEdit: (library: LibraryEntry) => void;
+  onDelete: (library: LibraryEntry) => void;
+}
+
+function sourceBadgeClass(source: LibrarySource): string {
+  switch (source) {
+    case 'local':
+      return 'border-blue-500/30 text-blue-400 bg-blue-500/10';
+    case 'cdn':
+      return 'border-purple-500/30 text-purple-400 bg-purple-500/10';
+    case 'npm':
+      return 'border-green-500/30 text-green-400 bg-green-500/10';
+  }
+}
+
+function formatLastScored(lastScored: string | null): string {
+  if (!lastScored) return 'Never scored';
+  const date = new Date(lastScored);
+  return date.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+export function LibraryCard({ library, onEdit, onDelete }: LibraryCardProps): React.JSX.Element {
+  const isProtected = library.isDefault;
+
+  return (
+    <Card className="flex flex-col transition-colors hover:border-white/20">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0 flex-1">
+            <h3 className="text-base font-semibold text-foreground truncate">{library.name}</h3>
+            <div className="flex items-center gap-2 mt-1 flex-wrap">
+              <Badge
+                variant="outline"
+                className="font-mono text-[10px] border-white/10 text-muted-foreground"
+              >
+                {library.id}
+              </Badge>
+              <Badge
+                variant="outline"
+                className={cn('text-[10px] font-semibold', sourceBadgeClass(library.source))}
+              >
+                {library.source}
+              </Badge>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={() => onEdit(library)}
+              className="inline-flex items-center justify-center w-8 h-8 rounded-lg text-muted-foreground transition-colors hover:bg-white/[0.06] hover:text-foreground"
+              aria-label={`Edit ${library.name}`}
+            >
+              <Pencil className="w-3.5 h-3.5" />
+            </button>
+
+            <div className="relative group">
+              <button
+                onClick={() => !isProtected && onDelete(library)}
+                disabled={isProtected}
+                className={cn(
+                  'inline-flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
+                  isProtected
+                    ? 'text-muted-foreground/40 cursor-not-allowed'
+                    : 'text-muted-foreground hover:bg-red-500/10 hover:text-red-400',
+                )}
+                aria-label={
+                  isProtected ? 'Cannot delete the default library' : `Delete ${library.name}`
+                }
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+              {isProtected && (
+                <div className="absolute right-0 top-full mt-1.5 z-10 hidden group-hover:block">
+                  <div className="rounded-lg border border-border bg-popover px-2.5 py-1.5 text-xs text-muted-foreground shadow-lg whitespace-nowrap">
+                    Default library cannot be deleted
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="pt-0 flex-1">
+        <div className="space-y-2.5">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Prefix</span>
+            <span className="font-mono text-xs bg-white/[0.04] border border-white/[0.06] rounded px-1.5 py-0.5 text-foreground">
+              {library.prefix}
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Components</span>
+            <span className="font-semibold tabular-nums text-foreground">
+              {library.componentCount}
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Last scored</span>
+            <span
+              className={cn(
+                'text-xs',
+                library.lastScored ? 'text-foreground' : 'text-muted-foreground/60 italic',
+              )}
+            >
+              {formatLastScored(library.lastScored)}
+            </span>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/admin/src/app/libraries/components/LibraryFormModal.tsx
+++ b/apps/admin/src/app/libraries/components/LibraryFormModal.tsx
@@ -1,0 +1,305 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { LibraryEntry, LibrarySource } from '@/lib/library-registry';
+
+interface LibraryFormModalProps {
+  mode: 'add' | 'edit';
+  library?: LibraryEntry;
+  onClose: () => void;
+  onSuccess: (library: LibraryEntry) => void;
+}
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+interface FormErrors {
+  name?: string;
+  id?: string;
+  source?: string;
+  cemPath?: string;
+  packageName?: string;
+  prefix?: string;
+  general?: string;
+}
+
+export function LibraryFormModal({
+  mode,
+  library,
+  onClose,
+  onSuccess,
+}: LibraryFormModalProps): React.JSX.Element {
+  const [name, setName] = useState(library?.name ?? '');
+  const [id, setId] = useState(library?.id ?? '');
+  const [source, setSource] = useState<LibrarySource>(library?.source ?? 'local');
+  const [cemPath, setCemPath] = useState(library?.cemPath ?? '');
+  const [packageName, setPackageName] = useState(library?.packageName ?? '');
+  const [prefix, setPrefix] = useState(library?.prefix ?? '');
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const firstInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    firstInputRef.current?.focus();
+  }, []);
+
+  // Auto-slugify ID from name in add mode
+  useEffect(() => {
+    if (mode === 'add') {
+      setId(slugify(name));
+    }
+  }, [name, mode]);
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      const body: Record<string, unknown> = { name, source, prefix };
+      if (source === 'local') body.cemPath = cemPath;
+      if (source === 'cdn' || source === 'npm') body.packageName = packageName;
+
+      const url = mode === 'add' ? '/api/libraries' : `/api/libraries/${library?.id}`;
+      const method = mode === 'add' ? 'POST' : 'PATCH';
+
+      const response = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+
+      const data = (await response.json()) as
+        | LibraryEntry
+        | { error: string; detail?: string; required?: string[] };
+
+      if (!response.ok) {
+        const errData = data as { error: string; detail?: string };
+        setErrors({ general: errData.error ?? 'Something went wrong' });
+        return;
+      }
+
+      onSuccess(data as LibraryEntry);
+    } catch {
+      setErrors({ general: 'Network error — please try again' });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleBackdropClick(e: React.MouseEvent<HTMLDivElement>): void {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  }
+
+  const title = mode === 'add' ? 'Add Library' : 'Edit Library';
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onClick={handleBackdropClick}
+    >
+      <div className="w-full max-w-md rounded-xl border border-border bg-card shadow-2xl">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+          <h2 className="text-base font-semibold text-foreground">{title}</h2>
+          <button
+            onClick={onClose}
+            className="inline-flex items-center justify-center w-7 h-7 rounded-lg text-muted-foreground hover:bg-white/[0.06] hover:text-foreground transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} noValidate>
+          <div className="px-6 py-5 space-y-4">
+            {/* General error */}
+            {errors.general && (
+              <div className="rounded-lg bg-red-500/10 border border-red-500/20 px-3 py-2.5 text-sm text-red-400">
+                {errors.general}
+              </div>
+            )}
+
+            {/* Name */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-foreground" htmlFor="lib-name">
+                Name
+              </label>
+              <input
+                ref={firstInputRef}
+                id="lib-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My Component Library"
+                className={cn(
+                  'w-full rounded-lg border bg-white/[0.03] px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 transition-colors',
+                  errors.name
+                    ? 'border-red-500/50 focus:ring-red-500/50'
+                    : 'border-border focus:ring-white/20',
+                )}
+                required
+              />
+              {errors.name && <p className="text-xs text-red-400">{errors.name}</p>}
+            </div>
+
+            {/* ID */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-foreground" htmlFor="lib-id">
+                ID
+                {mode === 'add' && (
+                  <span className="ml-1.5 text-xs text-muted-foreground font-normal">
+                    (auto-generated from name)
+                  </span>
+                )}
+              </label>
+              <input
+                id="lib-id"
+                type="text"
+                value={id}
+                readOnly={mode === 'edit'}
+                onChange={(e) => mode === 'add' && setId(e.target.value)}
+                placeholder="my-component-library"
+                className={cn(
+                  'w-full rounded-lg border px-3 py-2 text-sm font-mono transition-colors focus:outline-none focus:ring-1',
+                  mode === 'edit'
+                    ? 'bg-white/[0.02] border-border/50 text-muted-foreground cursor-not-allowed'
+                    : errors.id
+                      ? 'bg-white/[0.03] border-red-500/50 text-foreground focus:ring-red-500/50'
+                      : 'bg-white/[0.03] border-border text-foreground focus:ring-white/20',
+                )}
+              />
+              {errors.id && <p className="text-xs text-red-400">{errors.id}</p>}
+            </div>
+
+            {/* Source */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-foreground" htmlFor="lib-source">
+                Source
+              </label>
+              <select
+                id="lib-source"
+                value={source}
+                onChange={(e) => setSource(e.target.value as LibrarySource)}
+                disabled={mode === 'edit'}
+                className={cn(
+                  'w-full rounded-lg border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-1',
+                  mode === 'edit'
+                    ? 'bg-white/[0.02] border-border/50 text-muted-foreground cursor-not-allowed'
+                    : 'bg-white/[0.03] border-border text-foreground focus:ring-white/20',
+                )}
+              >
+                <option value="local">local</option>
+                <option value="cdn">cdn</option>
+                <option value="npm">npm</option>
+              </select>
+              {errors.source && <p className="text-xs text-red-400">{errors.source}</p>}
+            </div>
+
+            {/* cemPath — local only */}
+            {source === 'local' && (
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground" htmlFor="lib-cem-path">
+                  CEM Path
+                  <span className="ml-1.5 text-xs text-muted-foreground font-normal">
+                    (path to custom-elements.json)
+                  </span>
+                </label>
+                <input
+                  id="lib-cem-path"
+                  type="text"
+                  value={cemPath}
+                  onChange={(e) => setCemPath(e.target.value)}
+                  placeholder="packages/hx-library/custom-elements.json"
+                  className={cn(
+                    'w-full rounded-lg border bg-white/[0.03] px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 transition-colors',
+                    errors.cemPath
+                      ? 'border-red-500/50 focus:ring-red-500/50'
+                      : 'border-border focus:ring-white/20',
+                  )}
+                />
+                {errors.cemPath && <p className="text-xs text-red-400">{errors.cemPath}</p>}
+              </div>
+            )}
+
+            {/* packageName — cdn or npm */}
+            {(source === 'cdn' || source === 'npm') && (
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-foreground" htmlFor="lib-package-name">
+                  Package Name
+                </label>
+                <input
+                  id="lib-package-name"
+                  type="text"
+                  value={packageName}
+                  onChange={(e) => setPackageName(e.target.value)}
+                  placeholder="@my-org/components"
+                  className={cn(
+                    'w-full rounded-lg border bg-white/[0.03] px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 transition-colors',
+                    errors.packageName
+                      ? 'border-red-500/50 focus:ring-red-500/50'
+                      : 'border-border focus:ring-white/20',
+                  )}
+                />
+                {errors.packageName && <p className="text-xs text-red-400">{errors.packageName}</p>}
+              </div>
+            )}
+
+            {/* Prefix */}
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-foreground" htmlFor="lib-prefix">
+                Prefix
+                <span className="ml-1.5 text-xs text-muted-foreground font-normal">
+                  (e.g. hx-, sl-, my-)
+                </span>
+              </label>
+              <input
+                id="lib-prefix"
+                type="text"
+                value={prefix}
+                onChange={(e) => setPrefix(e.target.value)}
+                placeholder="hx-"
+                className={cn(
+                  'w-full rounded-lg border bg-white/[0.03] px-3 py-2 text-sm font-mono text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 transition-colors',
+                  errors.prefix
+                    ? 'border-red-500/50 focus:ring-red-500/50'
+                    : 'border-border focus:ring-white/20',
+                )}
+                required
+              />
+              {errors.prefix && <p className="text-xs text-red-400">{errors.prefix}</p>}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-border">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg text-sm font-medium text-muted-foreground hover:bg-white/[0.06] hover:text-foreground transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-colors"
+            >
+              {isSubmitting ? 'Saving…' : mode === 'add' ? 'Add Library' : 'Save Changes'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/libraries/components/LibraryList.tsx
+++ b/apps/admin/src/app/libraries/components/LibraryList.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Plus, Library } from 'lucide-react';
+import type { LibraryEntry } from '@/lib/library-registry';
+import { LibraryCard } from './LibraryCard';
+import { LibraryFormModal } from './LibraryFormModal';
+
+interface LibrariesResponse {
+  libraries: LibraryEntry[];
+}
+
+type ModalState =
+  | { open: false }
+  | { open: true; mode: 'add' }
+  | { open: true; mode: 'edit'; library: LibraryEntry };
+
+export function LibraryList(): React.JSX.Element {
+  const [libraries, setLibraries] = useState<LibraryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [modal, setModal] = useState<ModalState>({ open: false });
+
+  useEffect(() => {
+    void fetchLibraries();
+  }, []);
+
+  async function fetchLibraries(): Promise<void> {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/libraries');
+      if (!response.ok) {
+        throw new Error(`Failed to load libraries (${response.status})`);
+      }
+      const data = (await response.json()) as LibrariesResponse;
+      setLibraries(data.libraries);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load libraries');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleAddSuccess(newLibrary: LibraryEntry): void {
+    setLibraries((prev) => [...prev, newLibrary]);
+    setModal({ open: false });
+  }
+
+  function handleEditSuccess(updatedLibrary: LibraryEntry): void {
+    setLibraries((prev) =>
+      prev.map((lib) => (lib.id === updatedLibrary.id ? updatedLibrary : lib)),
+    );
+    setModal({ open: false });
+  }
+
+  async function handleDelete(library: LibraryEntry): Promise<void> {
+    if (!window.confirm(`Delete "${library.name}"? This cannot be undone.`)) return;
+
+    // Optimistic update
+    setLibraries((prev) => prev.filter((lib) => lib.id !== library.id));
+
+    try {
+      const response = await fetch(`/api/libraries/${library.id}`, { method: 'DELETE' });
+      if (!response.ok) {
+        // Revert on failure
+        setLibraries((prev) => {
+          const index = prev.findIndex((lib) => lib.id > library.id);
+          if (index === -1) return [...prev, library];
+          const next = [...prev];
+          next.splice(index, 0, library);
+          return next;
+        });
+        const data = (await response.json()) as { error: string };
+        setError(data.error ?? 'Failed to delete library');
+      }
+    } catch {
+      setLibraries((prev) => [...prev, library]);
+      setError('Network error — failed to delete library');
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-24 text-muted-foreground text-sm">
+        Loading libraries…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-red-500/20 bg-red-500/5 p-8 text-center">
+        <p className="text-red-400 font-medium mb-2">Failed to load libraries</p>
+        <p className="text-muted-foreground text-sm mb-4">{error}</p>
+        <button
+          onClick={() => void fetchLibraries()}
+          className="px-4 py-2 rounded-lg text-sm font-medium border border-border text-muted-foreground hover:bg-white/[0.06] hover:text-foreground transition-colors"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {/* Count + Add button */}
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {libraries.length} {libraries.length === 1 ? 'library' : 'libraries'} registered
+        </p>
+        <button
+          onClick={() => setModal({ open: true, mode: 'add' })}
+          className="inline-flex items-center gap-2 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+        >
+          <Plus className="w-4 h-4" />
+          Add Library
+        </button>
+      </div>
+
+      {/* Grid or empty state */}
+      {libraries.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border py-20 text-center">
+          <Library className="w-10 h-10 text-muted-foreground/40 mb-3" />
+          <p className="text-sm font-medium text-foreground mb-1">No libraries yet</p>
+          <p className="text-xs text-muted-foreground mb-5">
+            Add your first library to get started.
+          </p>
+          <button
+            onClick={() => setModal({ open: true, mode: 'add' })}
+            className="inline-flex items-center gap-2 rounded-lg border border-border px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-white/[0.06] hover:text-foreground transition-colors"
+          >
+            <Plus className="w-4 h-4" />
+            Add Library
+          </button>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {libraries.map((library) => (
+            <LibraryCard
+              key={library.id}
+              library={library}
+              onEdit={(lib) => setModal({ open: true, mode: 'edit', library: lib })}
+              onDelete={(lib) => void handleDelete(lib)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Modal */}
+      {modal.open && modal.mode === 'add' && (
+        <LibraryFormModal
+          mode="add"
+          onClose={() => setModal({ open: false })}
+          onSuccess={handleAddSuccess}
+        />
+      )}
+      {modal.open && modal.mode === 'edit' && (
+        <LibraryFormModal
+          mode="edit"
+          library={modal.library}
+          onClose={() => setModal({ open: false })}
+          onSuccess={handleEditSuccess}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/admin/src/app/libraries/page.tsx
+++ b/apps/admin/src/app/libraries/page.tsx
@@ -1,0 +1,19 @@
+import { Breadcrumb } from '@/components/dashboard/Breadcrumb';
+import { getBreadcrumbItems } from '@/lib/breadcrumb-utils';
+import { LibraryList } from './components/LibraryList';
+
+export default function LibrariesPage(): React.JSX.Element {
+  return (
+    <div className="space-y-8">
+      <div>
+        <Breadcrumb items={getBreadcrumbItems('/libraries')} />
+        <h1 className="text-2xl font-bold tracking-tight">Libraries</h1>
+        <p className="text-muted-foreground mt-1">
+          Manage web component libraries registered with the admin dashboard.
+        </p>
+      </div>
+
+      <LibraryList />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Build the /libraries page with full CRUD UI and wire up navigation. All data fetching uses the /api/libraries REST endpoints from Phase 2. Deliverables: (1) apps/admin/src/app/libraries/page.tsx — Server component that renders the page shell and a client-rendered LibraryList. Shows library count in header. (2) apps/admin/src/app/libraries/components/LibraryCard.tsx — Client component displaying a single library: name, id badge, source badge (color-coded: local=blue, cdn=purple, npm=green), prefi...

---
*Recovered automatically by Automaker post-agent hook*