### PR TITLE
REVIEW: hx-radio-group — Quality Audit Findings

### DIFF
--- a/packages/hx-library/src/components/hx-radio-group/hx-radio-group.test.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio-group.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import {
-  fixture,
-  shadowQuery,
-  _shadowQueryAll,
-  oneEvent,
-  cleanup,
-  checkA11y,
-} from '../../test-utils.js';
+import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
 import type { WcRadioGroup } from './hx-radio-group.js';
 import type { WcRadio } from './hx-radio.js';
 import './index.js';
@@ -56,13 +49,14 @@ describe('hx-radio-group', () => {
       expect(legend).toBeNull();
     });
 
-    it('has role="radiogroup" on host', async () => {
+    it('has role="radiogroup" on shadow fieldset', async () => {
       const el = await fixture<WcRadioGroup>(`
         <hx-radio-group label="Test">
           <hx-radio value="a" label="A"></hx-radio>
         </hx-radio-group>
       `);
-      expect(el.getAttribute('role')).toBe('radiogroup');
+      const fieldset = shadowQuery(el, 'fieldset');
+      expect(fieldset?.getAttribute('role')).toBe('radiogroup');
     });
   });
 
@@ -260,7 +254,7 @@ describe('hx-radio-group', () => {
   // ─── Events (3) ───
 
   describe('Events', () => {
-    it('dispatches wc-change when a radio is selected', async () => {
+    it('dispatches hx-change when a radio is selected', async () => {
       const el = await fixture<WcRadioGroup>(`
         <hx-radio-group label="Test">
           <hx-radio value="a" label="A"></hx-radio>
@@ -292,7 +286,7 @@ describe('hx-radio-group', () => {
       expect(event.composed).toBe(true);
     });
 
-    it('does not dispatch wc-change when selecting the already-selected radio', async () => {
+    it('does not dispatch hx-change when selecting the already-selected radio', async () => {
       const el = await fixture<WcRadioGroup>(`
         <hx-radio-group label="Test" value="a">
           <hx-radio value="a" label="A"></hx-radio>
@@ -306,7 +300,7 @@ describe('hx-radio-group', () => {
       const radioA = el.querySelector('hx-radio[value="a"]') as WcRadio;
       const label = shadowQuery(radioA, '.radio') as HTMLDivElement;
       label.click();
-      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
       expect(eventFired).toBe(false);
     });
   });
@@ -532,22 +526,24 @@ describe('hx-radio-group', () => {
   // ─── Accessibility (4) ───
 
   describe('Accessibility', () => {
-    it('host has role="radiogroup"', async () => {
+    it('shadow fieldset has role="radiogroup"', async () => {
       const el = await fixture<WcRadioGroup>(`
         <hx-radio-group label="Test">
           <hx-radio value="a" label="A"></hx-radio>
         </hx-radio-group>
       `);
-      expect(el.getAttribute('role')).toBe('radiogroup');
+      const fieldset = shadowQuery(el, 'fieldset');
+      expect(fieldset?.getAttribute('role')).toBe('radiogroup');
     });
 
-    it('sets aria-label on host from label property', async () => {
+    it('legend renders label text for accessible grouping', async () => {
       const el = await fixture<WcRadioGroup>(`
         <hx-radio-group label="My Group">
           <hx-radio value="a" label="A"></hx-radio>
         </hx-radio-group>
       `);
-      expect(el.getAttribute('aria-label')).toBe('My Group');
+      const legend = shadowQuery(el, 'legend');
+      expect(legend?.textContent?.trim()).toContain('My Group');
     });
 
     it('hx-radio contains a hidden native radio input', async () => {
@@ -605,7 +601,7 @@ describe('hx-radio-group', () => {
       const radioA = el.querySelector('hx-radio[value="a"]') as WcRadio;
       const label = shadowQuery(radioA, '.radio') as HTMLDivElement;
       label.click();
-      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
       expect(eventFired).toBe(false);
     });
 

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
@@ -125,7 +125,6 @@ export class HelixRadioGroup extends LitElement {
     super.connectedCallback();
     this.addEventListener('hx-radio-select', this._handleRadioSelect as EventListener);
     this.addEventListener('keydown', this._handleKeydown);
-    this.setAttribute('role', 'radiogroup');
   }
 
   override disconnectedCallback(): void {
@@ -144,11 +143,6 @@ export class HelixRadioGroup extends LitElement {
     if (changedProperties.has('disabled')) {
       this._syncRadios();
     }
-    if (changedProperties.has('label')) {
-      if (this.label) {
-        this.setAttribute('aria-label', this.label);
-      }
-    }
   }
 
   override firstUpdated(changedProperties: Map<string, unknown>): void {
@@ -158,8 +152,13 @@ export class HelixRadioGroup extends LitElement {
 
   // ─── Radio Management ───
 
+  private _cachedRadios: HelixRadio[] | null = null;
+
   private _getRadios(): HelixRadio[] {
-    return Array.from(this.querySelectorAll('hx-radio')) as HelixRadio[];
+    if (!this._cachedRadios) {
+      this._cachedRadios = Array.from(this.querySelectorAll('hx-radio')) as HelixRadio[];
+    }
+    return this._cachedRadios;
   }
 
   private _getEnabledRadios(): HelixRadio[] {
@@ -236,9 +235,10 @@ export class HelixRadioGroup extends LitElement {
 
     e.preventDefault();
 
-    const currentIndex = enabledRadios.findIndex(
-      (radio) => radio === (e.target as Element)?.closest?.('hx-radio') || radio.checked,
-    );
+    const targetRadio = (e.target as Element)?.closest?.('hx-radio') as HelixRadio | null;
+    const currentIndex = targetRadio
+      ? enabledRadios.indexOf(targetRadio)
+      : enabledRadios.findIndex((radio) => radio.checked);
 
     let nextIndex: number;
     if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
@@ -261,6 +261,7 @@ export class HelixRadioGroup extends LitElement {
   };
 
   private _handleSlotChange(): void {
+    this._cachedRadios = null;
     this._syncRadios();
   }
 
@@ -327,8 +328,15 @@ export class HelixRadioGroup extends LitElement {
       'fieldset--required': this.required,
     };
 
+    const describedBy = hasError ? this._errorId : this.helpText ? this._helpTextId : nothing;
+
     return html`
-      <fieldset part="fieldset" class=${classMap(fieldsetClasses)}>
+      <fieldset
+        part="fieldset"
+        class=${classMap(fieldsetClasses)}
+        role="radiogroup"
+        aria-describedby=${describedBy}
+      >
         ${this.label
           ? html`
               <legend part="legend" class="fieldset__legend">
@@ -375,3 +383,6 @@ declare global {
     'hx-radio-group': HelixRadioGroup;
   }
 }
+
+/** @public Type alias for use in test files and consumers. */
+export type WcRadioGroup = HelixRadioGroup;

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio.ts
@@ -63,9 +63,12 @@ export class HelixRadio extends LitElement {
   override connectedCallback(): void {
     super.connectedCallback();
     this.setAttribute('role', 'radio');
+    this.setAttribute('aria-checked', String(this.checked));
+    this.setAttribute('aria-disabled', String(this.disabled));
   }
 
   override updated(changedProperties: Map<string, unknown>): void {
+    super.updated(changedProperties);
     if (changedProperties.has('checked')) {
       this.setAttribute('aria-checked', String(this.checked));
     }
@@ -135,3 +138,6 @@ declare global {
     'hx-radio': HelixRadio;
   }
 }
+
+/** @public Type alias for use in test files and consumers. */
+export type WcRadio = HelixRadio;


### PR DESCRIPTION
## Summary

## Executive Summary
**Overall Grade: C** — Most architecturally ambitious with roving tabindex, but has keyboard navigation bug, conflicting ARIA strategies, and missing type exports.

## Findings (hx-radio-group + hx-radio combined)

### TypeScript [CRITICAL]
- **hx-radio-group.ts / hx-radio.ts**: Tests import WcRadioGroup/WcRadio but no type aliases exported.

### Lit Pattern [CRITICAL]
- **hx-radio.ts:63-74**: ARIA attributes set imperatively via setAttribute in connectedCallback/updated ins...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-05T19:27:18.932Z -->