### PR TITLE
fix(hx-card): fix @fires tag, rename wcHref→hxHref, fix event type, bound handlers, @state

### DIFF
--- a/packages/hx-library/src/components/hx-card/hx-card.test.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.test.ts
@@ -3,12 +3,11 @@ import { page } from '@vitest/browser/context';
 import {
   fixture,
   shadowQuery,
-  _shadowQueryAll,
   oneEvent,
   cleanup,
   checkA11y,
 } from '../../test-utils.js';
-import type { WcCard } from './hx-card.js';
+import type { HelixCard } from './hx-card.js';
 import './index.js';
 
 afterEach(cleanup);
@@ -18,25 +17,25 @@ describe('hx-card', () => {
 
   describe('Rendering', () => {
     it('renders with shadow DOM', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       expect(el.shadowRoot).toBeTruthy();
     });
 
     it('exposes "card" CSS part', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '[part="card"]');
       expect(card).toBeTruthy();
     });
 
     it('applies default variant + elevation classes', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--default')).toBe(true);
       expect(card.classList.contains('card--flat')).toBe(true);
     });
 
     it('renders container div', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, 'div.card');
       expect(card).toBeTruthy();
     });
@@ -46,19 +45,19 @@ describe('hx-card', () => {
 
   describe('Property: variant', () => {
     it('applies default class', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--default')).toBe(true);
     });
 
     it('applies featured class', async () => {
-      const el = await fixture<WcCard>('<hx-card variant="featured">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card variant="featured">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--featured')).toBe(true);
     });
 
     it('applies compact class', async () => {
-      const el = await fixture<WcCard>('<hx-card variant="compact">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card variant="compact">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--compact')).toBe(true);
     });
@@ -68,19 +67,19 @@ describe('hx-card', () => {
 
   describe('Property: elevation', () => {
     it('flat applies no shadow class', async () => {
-      const el = await fixture<WcCard>('<hx-card elevation="flat">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card elevation="flat">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--flat')).toBe(true);
     });
 
     it('raised applies medium shadow class', async () => {
-      const el = await fixture<WcCard>('<hx-card elevation="raised">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card elevation="raised">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--raised')).toBe(true);
     });
 
     it('floating applies large shadow class', async () => {
-      const el = await fixture<WcCard>('<hx-card elevation="floating">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card elevation="floating">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--floating')).toBe(true);
     });
@@ -90,25 +89,25 @@ describe('hx-card', () => {
 
   describe('Property: hx-href', () => {
     it('has no role when no hx-href', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.hasAttribute('role')).toBe(false);
     });
 
     it('has role="link" when hx-href set', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.getAttribute('role')).toBe('link');
     });
 
     it('has tabindex="0" when hx-href set', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.getAttribute('tabindex')).toBe('0');
     });
 
     it('has aria-label="Navigate to {hx-href}" when hx-href set', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.getAttribute('aria-label')).toBe('Navigate to /test');
     });
@@ -118,19 +117,19 @@ describe('hx-card', () => {
 
   describe('Interactivity', () => {
     it('applies card--interactive class when hx-href', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--interactive')).toBe(true);
     });
 
     it('does not apply card--interactive without hx-href', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       expect(card.classList.contains('card--interactive')).toBe(false);
     });
 
     it('has cursor:pointer when interactive', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       const styles = getComputedStyle(card);
       expect(styles.cursor).toBe('pointer');
@@ -140,8 +139,8 @@ describe('hx-card', () => {
   // ─── Events (3) ───
 
   describe('Events', () => {
-    it('dispatches wc-card-click when hx-href + click', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+    it('dispatches hx-card-click when hx-href + click', async () => {
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       const eventPromise = oneEvent(el, 'hx-card-click');
       card.click();
@@ -149,18 +148,18 @@ describe('hx-card', () => {
       expect(event).toBeTruthy();
     });
 
-    it('hx-card-click detail contains url and originalEvent', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+    it('hx-card-click detail contains href and originalEvent', async () => {
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-card-click');
       card.click();
       const event = await eventPromise;
-      expect(event.detail.url).toBe('/test');
+      expect(event.detail.href).toBe('/test');
       expect(event.detail.originalEvent).toBeInstanceOf(MouseEvent);
     });
 
     it('does NOT dispatch event without hx-href', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       let fired = false;
       el.addEventListener('hx-card-click', () => {
@@ -175,26 +174,26 @@ describe('hx-card', () => {
   // ─── Keyboard (3) ───
 
   describe('Keyboard', () => {
-    it('Enter fires wc-card-click when interactive', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+    it('Enter fires hx-card-click when interactive', async () => {
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-card-click');
       card.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       const event = await eventPromise;
-      expect(event.detail.url).toBe('/test');
+      expect(event.detail.href).toBe('/test');
     });
 
-    it('Space fires wc-card-click when interactive', async () => {
-      const el = await fixture<WcCard>('<hx-card hx-href="/test">Content</hx-card>');
+    it('Space fires hx-card-click when interactive', async () => {
+      const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-card-click');
       card.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       const event = await eventPromise;
-      expect(event.detail.url).toBe('/test');
+      expect(event.detail.href).toBe('/test');
     });
 
     it('no keyboard action without hx-href', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       let fired = false;
       el.addEventListener('hx-card-click', () => {
@@ -210,7 +209,7 @@ describe('hx-card', () => {
 
   describe('Slot: default', () => {
     it('body content renders in card__body', async () => {
-      const el = await fixture<WcCard>('<hx-card>Body content here</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Body content here</hx-card>');
       const body = shadowQuery(el, '.card__body');
       expect(body).toBeTruthy();
       expect(el.textContent?.trim()).toContain('Body content here');
@@ -221,14 +220,14 @@ describe('hx-card', () => {
 
   describe('Slot: heading', () => {
     it('heading content renders', async () => {
-      const el = await fixture<WcCard>('<hx-card><span slot="heading">Title</span>Body</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card><span slot="heading">Title</span>Body</hx-card>');
       const headingSlot = el.querySelector('[slot="heading"]');
       expect(headingSlot).toBeTruthy();
       expect(headingSlot?.textContent).toBe('Title');
     });
 
     it('heading section hidden when empty', async () => {
-      const el = await fixture<WcCard>('<hx-card>Body only</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Body only</hx-card>');
       const headingDiv = shadowQuery(el, '.card__heading')!;
       expect(headingDiv.hasAttribute('hidden')).toBe(true);
     });
@@ -238,7 +237,7 @@ describe('hx-card', () => {
 
   describe('Slot: image', () => {
     it('image content renders', async () => {
-      const el = await fixture<WcCard>(
+      const el = await fixture<HelixCard>(
         '<hx-card><img slot="image" src="test.jpg" alt="test" />Body</hx-card>',
       );
       const img = el.querySelector('[slot="image"]');
@@ -246,7 +245,7 @@ describe('hx-card', () => {
     });
 
     it('image section hidden when empty', async () => {
-      const el = await fixture<WcCard>('<hx-card>Body only</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Body only</hx-card>');
       const imageDiv = shadowQuery(el, '.card__image')!;
       expect(imageDiv.hasAttribute('hidden')).toBe(true);
     });
@@ -256,7 +255,7 @@ describe('hx-card', () => {
 
   describe('Slot: footer', () => {
     it('footer content renders', async () => {
-      const el = await fixture<WcCard>(
+      const el = await fixture<HelixCard>(
         '<hx-card><span slot="footer">Footer text</span>Body</hx-card>',
       );
       const footer = el.querySelector('[slot="footer"]');
@@ -265,7 +264,7 @@ describe('hx-card', () => {
     });
 
     it('footer section hidden when empty', async () => {
-      const el = await fixture<WcCard>('<hx-card>Body only</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Body only</hx-card>');
       const footerDiv = shadowQuery(el, '.card__footer')!;
       expect(footerDiv.hasAttribute('hidden')).toBe(true);
     });
@@ -275,7 +274,7 @@ describe('hx-card', () => {
 
   describe('Slot: actions', () => {
     it('actions content renders', async () => {
-      const el = await fixture<WcCard>(
+      const el = await fixture<HelixCard>(
         '<hx-card><button slot="actions">Action</button>Body</hx-card>',
       );
       const action = el.querySelector('[slot="actions"]');
@@ -284,7 +283,7 @@ describe('hx-card', () => {
     });
 
     it('actions section hidden when empty', async () => {
-      const el = await fixture<WcCard>('<hx-card>Body only</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Body only</hx-card>');
       const actionsDiv = shadowQuery(el, '.card__actions')!;
       expect(actionsDiv.hasAttribute('hidden')).toBe(true);
     });
@@ -294,19 +293,19 @@ describe('hx-card', () => {
 
   describe('CSS Parts', () => {
     it('heading part exposed', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const heading = shadowQuery(el, '[part="heading"]');
       expect(heading).toBeTruthy();
     });
 
     it('body part exposed', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const body = shadowQuery(el, '[part="body"]');
       expect(body).toBeTruthy();
     });
 
     it('footer part exposed', async () => {
-      const el = await fixture<WcCard>('<hx-card>Content</hx-card>');
+      const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const footer = shadowQuery(el, '[part="footer"]');
       expect(footer).toBeTruthy();
     });
@@ -316,7 +315,7 @@ describe('hx-card', () => {
 
   describe('Accessibility (axe-core)', () => {
     it('has no axe violations in default state', async () => {
-      const el = await fixture<WcCard>(
+      const el = await fixture<HelixCard>(
         '<hx-card><span slot="heading">Title</span><p>Content</p></hx-card>',
       );
       await page.screenshot();
@@ -325,7 +324,7 @@ describe('hx-card', () => {
     });
 
     it('has no axe violations when interactive', async () => {
-      const el = await fixture<WcCard>(
+      const el = await fixture<HelixCard>(
         '<hx-card hx-href="https://example.com"><span slot="heading">Title</span><p>Content</p></hx-card>',
       );
       await page.screenshot();
@@ -335,7 +334,7 @@ describe('hx-card', () => {
 
     it('has no axe violations for all variants', async () => {
       for (const variant of ['default', 'featured', 'compact']) {
-        const el = await fixture<WcCard>(
+        const el = await fixture<HelixCard>(
           `<hx-card variant="${variant}"><span slot="heading">Title</span><p>Content</p></hx-card>`,
         );
         await page.screenshot();

--- a/packages/hx-library/src/components/hx-card/hx-card.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { tokenStyles } from '@helix/tokens/lit';
 import { helixCardStyles } from './hx-card.styles.js';
@@ -17,7 +17,7 @@ import { helixCardStyles } from './hx-card.styles.js';
  * @slot footer - Optional footer content below the body.
  * @slot actions - Optional action buttons, rendered with a top border separator.
  *
- * @fires {CustomEvent<{url: string, originalEvent: MouseEvent}>} wc-card-click - Dispatched when an interactive card (with wc-href) is clicked.
+ * @fires {CustomEvent<{href: string, originalEvent: MouseEvent}>} hx-card-click - Dispatched when an interactive card (with hx-href) is clicked.
  *
  * @csspart card - The outer card container element.
  * @csspart image - The image slot container.
@@ -54,33 +54,43 @@ export class HelixCard extends LitElement {
   /**
    * Optional URL. When set, the card becomes interactive (clickable)
    * and navigates to this URL on click.
-   * Uses wc-href to avoid conflicting with the native HTML href attribute.
+   * Uses hx-href to avoid conflicting with the native HTML href attribute.
    * @attr hx-href
    */
   @property({ type: String, attribute: 'hx-href' })
-  wcHref = '';
+  hxHref = '';
 
   // ─── Slot Detection ───
 
-  private _hasSlotContent: Record<string, boolean> = {
-    image: false,
-    heading: false,
-    footer: false,
-    actions: false,
-  };
+  @state() private _hasImage = false;
+  @state() private _hasHeading = false;
+  @state() private _hasFooter = false;
+  @state() private _hasActions = false;
 
-  private _handleSlotChange(slotName: string) {
-    return (e: Event) => {
-      const slot = e.target as HTMLSlotElement;
-      this._hasSlotContent[slotName] = slot.assignedNodes({ flatten: true }).length > 0;
-      this.requestUpdate();
-    };
+  private _onImageSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasImage = slot.assignedNodes({ flatten: true }).length > 0;
+  }
+
+  private _onHeadingSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasHeading = slot.assignedNodes({ flatten: true }).length > 0;
+  }
+
+  private _onFooterSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasFooter = slot.assignedNodes({ flatten: true }).length > 0;
+  }
+
+  private _onActionsSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasActions = slot.assignedNodes({ flatten: true }).length > 0;
   }
 
   // ─── Event Handling ───
 
-  private _handleClick(e: MouseEvent): void {
-    if (!this.wcHref) return;
+  private _dispatchCardClick(originalEvent: MouseEvent | KeyboardEvent): void {
+    if (!this.hxHref) return;
 
     /**
      * Dispatched when an interactive card is clicked.
@@ -91,24 +101,28 @@ export class HelixCard extends LitElement {
       new CustomEvent('hx-card-click', {
         bubbles: true,
         composed: true,
-        detail: { url: this.wcHref, originalEvent: e },
+        detail: { href: this.hxHref, originalEvent },
       }),
     );
   }
 
+  private _handleClick(e: MouseEvent): void {
+    this._dispatchCardClick(e);
+  }
+
   private _handleKeyDown(e: KeyboardEvent): void {
-    if (!this.wcHref) return;
+    if (!this.hxHref) return;
 
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      this._handleClick(e as unknown as MouseEvent);
+      this._dispatchCardClick(e);
     }
   }
 
   // ─── Render ───
 
   override render() {
-    const isInteractive = !!this.wcHref;
+    const isInteractive = !!this.hxHref;
 
     const classes = {
       card: true,
@@ -123,28 +137,28 @@ export class HelixCard extends LitElement {
         class=${classMap(classes)}
         role=${isInteractive ? 'link' : nothing}
         tabindex=${isInteractive ? '0' : nothing}
-        aria-label=${isInteractive ? `Navigate to ${this.wcHref}` : nothing}
+        aria-label=${isInteractive ? `Navigate to ${this.hxHref}` : nothing}
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
       >
-        <div class="card__image" part="image" ?hidden=${!this._hasSlotContent['image']}>
-          <slot name="image" @slotchange=${this._handleSlotChange('image')}></slot>
+        <div class="card__image" part="image" ?hidden=${!this._hasImage}>
+          <slot name="image" @slotchange=${this._onImageSlotChange}></slot>
         </div>
 
-        <div class="card__heading" part="heading" ?hidden=${!this._hasSlotContent['heading']}>
-          <slot name="heading" @slotchange=${this._handleSlotChange('heading')}></slot>
+        <div class="card__heading" part="heading" ?hidden=${!this._hasHeading}>
+          <slot name="heading" @slotchange=${this._onHeadingSlotChange}></slot>
         </div>
 
         <div class="card__body" part="body">
           <slot></slot>
         </div>
 
-        <div class="card__footer" part="footer" ?hidden=${!this._hasSlotContent['footer']}>
-          <slot name="footer" @slotchange=${this._handleSlotChange('footer')}></slot>
+        <div class="card__footer" part="footer" ?hidden=${!this._hasFooter}>
+          <slot name="footer" @slotchange=${this._onFooterSlotChange}></slot>
         </div>
 
-        <div class="card__actions" part="actions" ?hidden=${!this._hasSlotContent['actions']}>
-          <slot name="actions" @slotchange=${this._handleSlotChange('actions')}></slot>
+        <div class="card__actions" part="actions" ?hidden=${!this._hasActions}>
+          <slot name="actions" @slotchange=${this._onActionsSlotChange}></slot>
         </div>
       </div>
     `;


### PR DESCRIPTION
## Summary

Fixes all quality audit findings identified in the hx-card component code review.

- **Fix `@fires` JSDoc tag** — changed `wc-card-click` to `hx-card-click` to match the `hx-` event prefix convention
- **Rename `wcHref` → `hxHref`** — property declaration, all internal references, and render() usage updated; attribute binding `hx-href` was already correct
- **Fix event detail key** — changed `{ url: ... }` to `{ href: ... }` to match the attribute name and eliminate the semantic mismatch
- **Replace slot change closure factory with stable bound handlers** — `_handleSlotChange(slotName)` returning a new closure each render replaced with four explicit bound methods (`_onImageSlotChange`, `_onHeadingSlotChange`, `_onFooterSlotChange`, `_onActionsSlotChange`), preventing unnecessary re-registration on every render cycle
- **Convert `_hasSlotContent` to `@state()` properties** — plain object with manual `requestUpdate()` calls replaced with four individual `@state()` decorated private properties (`_hasImage`, `_hasHeading`, `_hasFooter`, `_hasActions`); Lit now tracks reactivity correctly
- **Eliminate `KeyboardEvent→MouseEvent` type cast** — extracted `_dispatchCardClick(e: MouseEvent | KeyboardEvent)` so both `_handleClick` and `_handleKeyDown` call it directly without `as unknown as MouseEvent`
- **Remove unused `_shadowQueryAll` import** from test file (was never exported with that name; the export is `shadowQueryAll`)
- **Fix test type import** — `WcCard` → `HelixCard` to match the actual exported class name

## Test plan

- [ ] `npm run type-check` — zero errors (confirmed: 0 errors, 11/11 tasks passing)
- [ ] `npm run test:library` — all hx-card tests pass
- [ ] Slot visibility tests verify `@state()` properties trigger correct re-renders
- [ ] Event detail tests verify `event.detail.href` contains the correct URL
- [ ] Keyboard tests verify Enter/Space fire `hx-card-click` without type cast errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)