### PR TITLE
fix(hx-form): fix @fires tags, add WcForm type, fix getFormData multi-value, fix stylesheet ref counting

### DIFF
--- a/packages/hx-library/src/components/hx-form/hx-form.test.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.test.ts
@@ -63,7 +63,7 @@ describe('hx-form', () => {
   // ─── Events (3) ───
 
   describe('Events', () => {
-    it('dispatches wc-submit on valid client-side submit', async () => {
+    it('dispatches hx-submit on valid client-side submit', async () => {
       const el = await fixture<WcForm>(`
         <hx-form action="">
           <form>
@@ -85,7 +85,30 @@ describe('hx-form', () => {
       expect(event.composed).toBe(true);
     });
 
-    it('dispatches wc-invalid when validation fails on submit', async () => {
+    it('hx-submit detail.values preserves multi-value fields as arrays', async () => {
+      const el = await fixture<WcForm>(`
+        <hx-form action="">
+          <form>
+            <input type="checkbox" name="allergies" value="peanuts" checked />
+            <input type="checkbox" name="allergies" value="dairy" checked />
+            <input type="text" name="patient" value="jdoe" />
+            <button type="submit">Submit</button>
+          </form>
+        </hx-form>
+      `);
+
+      const form = el.querySelector('form')!;
+      const eventPromise = oneEvent<CustomEvent>(el, 'hx-submit');
+      form.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+      const event = await eventPromise;
+
+      expect(Array.isArray(event.detail.values['allergies'])).toBe(true);
+      expect(event.detail.values['allergies']).toContain('peanuts');
+      expect(event.detail.values['allergies']).toContain('dairy');
+      expect(event.detail.values['patient']).toBe('jdoe');
+    });
+
+    it('dispatches hx-invalid when validation fails on submit', async () => {
       const el = await fixture<WcForm>(`
         <hx-form action="">
           <form>
@@ -109,7 +132,32 @@ describe('hx-form', () => {
       expect(event.detail.errors.length).toBeGreaterThan(0);
     });
 
-    it('dispatches wc-reset when form is reset', async () => {
+    it('does not dispatch hx-submit when action is set (native passthrough)', async () => {
+      const el = await fixture<WcForm>(`
+        <hx-form action="/api/submit">
+          <form action="/api/submit" method="post">
+            <input type="text" name="field" value="value" />
+            <button type="submit">Submit</button>
+          </form>
+        </hx-form>
+      `);
+
+      const form = el.querySelector('form')!;
+      let dispatched = false;
+      el.addEventListener('hx-submit', () => {
+        dispatched = true;
+      });
+
+      const submitEvent = new SubmitEvent('submit', { bubbles: true, cancelable: true });
+      form.dispatchEvent(submitEvent);
+
+      // Native submission passthrough: event should NOT have been prevented
+      // and hx-submit should NOT have been dispatched
+      expect(dispatched).toBe(false);
+      expect(submitEvent.defaultPrevented).toBe(false);
+    });
+
+    it('dispatches hx-reset when form is reset', async () => {
       const el = await fixture<WcForm>(`
         <hx-form action="">
           <form>
@@ -173,6 +221,43 @@ describe('hx-form', () => {
       const formData = el.getFormData();
       expect(formData.get('username')).toBe('jdoe');
       expect(formData.get('email')).toBe('jdoe@example.com');
+    });
+
+    it('getFormData() preserves multi-value fields (checkboxes with same name)', async () => {
+      const el = await fixture<WcForm>(`
+        <hx-form>
+          <form>
+            <input type="checkbox" name="allergies" value="peanuts" checked />
+            <input type="checkbox" name="allergies" value="shellfish" checked />
+            <input type="checkbox" name="allergies" value="dairy" />
+          </form>
+        </hx-form>
+      `);
+
+      const formData = el.getFormData();
+      const allValues = formData.getAll('allergies');
+      expect(allValues).toHaveLength(2);
+      expect(allValues).toContain('peanuts');
+      expect(allValues).toContain('shellfish');
+    });
+
+    it('getFormData() collects from named inputs manually when no child <form>', async () => {
+      const el = await fixture<WcForm>(`
+        <hx-form>
+          <input type="text" name="patient" value="Jane Doe" />
+          <input type="checkbox" name="consent" value="yes" checked />
+          <input type="checkbox" name="medications" value="aspirin" checked />
+          <input type="checkbox" name="medications" value="ibuprofen" checked />
+        </hx-form>
+      `);
+
+      const formData = el.getFormData();
+      expect(formData.get('patient')).toBe('Jane Doe');
+      expect(formData.get('consent')).toBe('yes');
+      const meds = formData.getAll('medications');
+      expect(meds).toHaveLength(2);
+      expect(meds).toContain('aspirin');
+      expect(meds).toContain('ibuprofen');
     });
   });
 

--- a/packages/hx-library/src/components/hx-form/hx-form.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.ts
@@ -21,9 +21,9 @@ import { helixFormScopedCss } from './hx-form.styles.js';
  *
  * @slot - Default slot for form fields and controls.
  *
- * @fires {CustomEvent<{valid: boolean, values: Record<string, FormDataEntryValue>}>} wc-submit - Dispatched on valid client-side submit when no action is set.
- * @fires {CustomEvent<{errors: Array<{name: string, message: string}>}>} wc-invalid - Dispatched when validation fails on submit.
- * @fires {CustomEvent} wc-reset - Dispatched when the form is reset.
+ * @fires {CustomEvent<{valid: boolean, values: Record<string, FormDataEntryValue | FormDataEntryValue[]>}>} hx-submit - Dispatched on valid client-side submit when no action is set.
+ * @fires {CustomEvent<{errors: Array<{name: string, message: string}>}>} hx-invalid - Dispatched when validation fails on submit.
+ * @fires {CustomEvent} hx-reset - Dispatched when the form is reset.
  *
  * @cssprop [--hx-form-gap=var(--hx-space-4)] - Gap between form fields.
  * @cssprop [--hx-form-max-width=none] - Maximum width of the form.
@@ -225,10 +225,15 @@ export class HelixForm extends LitElement {
     }
 
     const formData = this.getFormData();
-    const values: Record<string, FormDataEntryValue> = {};
-    formData.forEach((value, key) => {
-      values[key] = value;
-    });
+    const values: Record<string, FormDataEntryValue | FormDataEntryValue[]> = {};
+    for (const key of new Set(formData.keys())) {
+      const all = formData.getAll(key);
+      if (all.length === 1 && all[0] !== undefined) {
+        values[key] = all[0];
+      } else {
+        values[key] = all;
+      }
+    }
 
     /**
      * Dispatched on valid client-side submit.
@@ -300,3 +305,6 @@ declare global {
     'hx-form': HelixForm;
   }
 }
+
+/** @deprecated Use `HelixForm` directly. Alias for backwards compatibility with tests that import `WcForm`. */
+export type WcForm = HelixForm;

--- a/packages/hx-library/src/controllers/adopted-stylesheets.ts
+++ b/packages/hx-library/src/controllers/adopted-stylesheets.ts
@@ -22,12 +22,18 @@ import type { ReactiveController, ReactiveControllerHost } from 'lit';
 
 /**
  * Manages adopted stylesheets on a given root (`document` or `ShadowRoot`),
- * ensuring each unique stylesheet is created only once and cleaned up on
- * disconnect.
+ * ensuring each unique stylesheet is created only once and cleaned up only
+ * when the last consumer disconnects (reference counting).
  */
 export class AdoptedStylesheetsController implements ReactiveController {
   /** Global cache keyed by cssText to avoid creating duplicate CSSStyleSheet instances. */
   private static _cache = new Map<string, CSSStyleSheet>();
+
+  /**
+   * Reference counter keyed by a compound key of `cssText + root identity`.
+   * Tracks how many live instances are using a given stylesheet on a given root.
+   */
+  private static _refCounts = new Map<string, number>();
 
   private readonly _host: ReactiveControllerHost & HTMLElement;
   private readonly _cssText: string;
@@ -43,6 +49,28 @@ export class AdoptedStylesheetsController implements ReactiveController {
     this._cssText = cssText;
     this._root = root;
     this._host.addController(this);
+  }
+
+  /**
+   * Produces a stable string key that uniquely identifies the combination of
+   * cssText and the specific root so reference counts don't bleed across roots.
+   */
+  private _refKey(): string {
+    // document has no unique property exposed safely, so we use a WeakMap tag.
+    return `${this._cssText}__${AdoptedStylesheetsController._getRootId(this._root)}`;
+  }
+
+  /** WeakMap used to assign a stable numeric ID to each root instance. */
+  private static _rootIds = new WeakMap<Document | ShadowRoot, number>();
+  private static _nextRootId = 0;
+
+  private static _getRootId(root: Document | ShadowRoot): number {
+    let id = AdoptedStylesheetsController._rootIds.get(root);
+    if (id === undefined) {
+      id = AdoptedStylesheetsController._nextRootId++;
+      AdoptedStylesheetsController._rootIds.set(root, id);
+    }
+    return id;
   }
 
   hostConnected(): void {
@@ -61,10 +89,23 @@ export class AdoptedStylesheetsController implements ReactiveController {
     if (!this._root.adoptedStyleSheets.includes(sheet)) {
       this._root.adoptedStyleSheets = [...this._root.adoptedStyleSheets, sheet];
     }
+
+    // Increment reference count.
+    const key = this._refKey();
+    const current = AdoptedStylesheetsController._refCounts.get(key) ?? 0;
+    AdoptedStylesheetsController._refCounts.set(key, current + 1);
   }
 
   hostDisconnected(): void {
-    if (this._sheet) {
+    if (!this._sheet) return;
+
+    const key = this._refKey();
+    const current = AdoptedStylesheetsController._refCounts.get(key) ?? 0;
+    const next = Math.max(0, current - 1);
+    AdoptedStylesheetsController._refCounts.set(key, next);
+
+    // Only remove the stylesheet from the root when no more instances are using it.
+    if (next === 0) {
       this._root.adoptedStyleSheets = this._root.adoptedStyleSheets.filter(
         (s) => s !== this._sheet,
       );


### PR DESCRIPTION
Quality audit fixes for hx-form:

## Changes

- **Fix \`@fires\` JSDoc tags**: `wc-submit`, `wc-invalid`, `wc-reset` corrected to `hx-submit`, `hx-invalid`, `hx-reset` to match actual dispatched event names and project convention
- **Add \`WcForm\` type export**: `export type WcForm = HelixForm` added at bottom of `hx-form.ts` — tests import this type and the missing export was a TypeScript build break
- **Fix \`getFormData()\` multi-value data loss**: The `hx-submit` event detail `values` object previously silently dropped all but one value for repeated field names (e.g. checkboxes sharing a name like `allergies`, `medications`). Now uses `formData.getAll(key)` and stores arrays when multiple values exist
- **Fix \`AdoptedStylesheetsController\` reference counting**: Disconnecting any single `hx-form` instance was removing the adopted stylesheet from the document, breaking all other `hx-form` instances on the page. Added per-root reference counting — the stylesheet is only removed when the last consumer disconnects
- **Fix stale `wc-*` event name strings** in `it()` test labels (cosmetic correctness)

## New Tests Added

- `getFormData() preserves multi-value fields (checkboxes with same name)`
- `getFormData() collects from named inputs manually when no child <form>`
- `hx-submit detail.values preserves multi-value fields as arrays`
- `does not dispatch hx-submit when action is set (native passthrough)`