### PR TITLE
fix(hx-breadcrumb): JSON-LD dedup, semantic ol, fix listitem role, replace setTimeout, add tests

### DIFF
--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb-item.styles.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb-item.styles.ts
@@ -11,7 +11,7 @@ export const helixBreadcrumbItemStyles = css`
   }
 
   [part='link'] {
-    color: var(--hx-breadcrumb-link-color, var(--hx-color-primary-600));
+    color: var(--hx-breadcrumb-link-color, var(--hx-color-primary-600, #0369a1));
     text-decoration: none;
     cursor: pointer;
     font-family: inherit;
@@ -19,25 +19,25 @@ export const helixBreadcrumbItemStyles = css`
   }
 
   [part='link']:hover {
-    color: var(--hx-breadcrumb-link-hover-color, var(--hx-color-primary-700));
+    color: var(--hx-breadcrumb-link-hover-color, var(--hx-color-primary-700, #075985));
     text-decoration: underline;
   }
 
   [part='link']:focus-visible {
-    outline: 2px solid var(--hx-focus-ring-color, var(--hx-color-primary-500));
+    outline: 2px solid var(--hx-focus-ring-color, var(--hx-color-primary-500, #0ea5e9));
     outline-offset: 2px;
-    border-radius: var(--hx-border-radius-sm);
+    border-radius: var(--hx-border-radius-sm, 0.125rem);
   }
 
   [part='text'] {
-    color: var(--hx-breadcrumb-text-color, var(--hx-color-neutral-700));
+    color: var(--hx-breadcrumb-text-color, var(--hx-color-neutral-700, #374151));
     font-family: inherit;
     font-size: inherit;
   }
 
   .separator {
-    margin-inline: var(--hx-breadcrumb-separator-gap, var(--hx-space-1));
-    color: var(--hx-breadcrumb-separator-color, var(--hx-color-neutral-400));
+    margin-inline: var(--hx-breadcrumb-separator-gap, var(--hx-space-1, 0.25rem));
+    color: var(--hx-breadcrumb-separator-color, var(--hx-color-neutral-400, #9ca3af));
     user-select: none;
   }
 

--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb-item.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb-item.ts
@@ -31,7 +31,15 @@ export class HelixBreadcrumbItem extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('role', 'listitem');
+    // Only apply role="listitem" when this item is a direct child of an
+    // hx-breadcrumb element. Setting the role unconditionally when used
+    // standalone (outside a list context) creates an invalid ARIA hierarchy
+    // because listitem requires a list ancestor.
+    if (this.closest('hx-breadcrumb') !== null) {
+      this.setAttribute('role', 'listitem');
+    } else {
+      this.removeAttribute('role');
+    }
   }
 
   /**

--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.styles.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.styles.ts
@@ -3,8 +3,11 @@ import { css } from 'lit';
 export const helixBreadcrumbStyles = css`
   :host {
     display: block;
-    font-family: var(--hx-breadcrumb-font-family, var(--hx-font-family-sans));
-    font-size: var(--hx-breadcrumb-font-size, var(--hx-font-size-sm));
+    font-family: var(
+      --hx-breadcrumb-font-family,
+      var(--hx-font-family-sans, system-ui, sans-serif)
+    );
+    font-size: var(--hx-breadcrumb-font-size, var(--hx-font-size-sm, 0.875rem));
   }
 
   [part='nav'] {

--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.test.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.test.ts
@@ -49,14 +49,14 @@ describe('hx-breadcrumb', () => {
       expect(shadowQuery(el, '[part="list"]')).toBeTruthy();
     });
 
-    it('renders a list container element with role="list"', async () => {
+    it('renders a semantic ol element as list container', async () => {
       const el = await fixture<HelixBreadcrumb>(`
         <hx-breadcrumb>
           <hx-breadcrumb-item>Current</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      const list = shadowQuery(el, '[role="list"]');
-      expect(list).toBeInstanceOf(HTMLElement);
+      const list = shadowQuery(el, 'ol[part="list"]');
+      expect(list).toBeInstanceOf(HTMLOListElement);
     });
   });
 
@@ -144,7 +144,6 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Patient Records</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const items = Array.from(el.querySelectorAll('hx-breadcrumb-item'));
       expect(items[2]?.getAttribute('aria-current')).toBe('page');
@@ -158,7 +157,6 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Patient Records</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const items = Array.from(el.querySelectorAll('hx-breadcrumb-item'));
       expect(items[0]?.hasAttribute('aria-current')).toBe(false);
@@ -172,7 +170,6 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Current</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const items = Array.from(el.querySelectorAll('hx-breadcrumb-item'));
       expect(items[1]?.hasAttribute('data-bc-last')).toBe(true);
@@ -185,7 +182,6 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Current</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const items = Array.from(el.querySelectorAll('hx-breadcrumb-item'));
       expect(items[0]?.hasAttribute('data-bc-last')).toBe(false);
@@ -197,11 +193,196 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Only Item</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const item = el.querySelector('hx-breadcrumb-item');
       expect(item?.getAttribute('aria-current')).toBe('page');
       expect(item?.hasAttribute('data-bc-last')).toBe(true);
+    });
+  });
+
+  // ─── Collapse (max-items) (5) ───
+
+  describe('Collapse (max-items)', () => {
+    it('shows all items when max-items is 0 (default)', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb>
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/c">C</hx-breadcrumb-item>
+          <hx-breadcrumb-item>D</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const items = Array.from(el.querySelectorAll('hx-breadcrumb-item:not(.hx-bc-ellipsis)'));
+      const hiddenCount = items.filter((i) => i.hasAttribute('data-bc-hidden')).length;
+      expect(hiddenCount).toBe(0);
+    });
+
+    it('hides middle items when item count exceeds max-items', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb max-items="2">
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/c">C</hx-breadcrumb-item>
+          <hx-breadcrumb-item>D</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const items = Array.from(
+        el.querySelectorAll<HTMLElement>('hx-breadcrumb-item:not(.hx-bc-ellipsis)'),
+      );
+      expect(items[0]?.hasAttribute('data-bc-hidden')).toBe(false);
+      expect(items[1]?.hasAttribute('data-bc-hidden')).toBe(true);
+      expect(items[2]?.hasAttribute('data-bc-hidden')).toBe(true);
+      expect(items[3]?.hasAttribute('data-bc-hidden')).toBe(false);
+    });
+
+    it('inserts an ellipsis item when collapsed', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb max-items="2">
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item>C</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const ellipsis = el.querySelector('.hx-bc-ellipsis');
+      expect(ellipsis).toBeTruthy();
+      expect(ellipsis?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('removes ellipsis item when max-items is cleared', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb max-items="2">
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item>C</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      expect(el.querySelector('.hx-bc-ellipsis')).toBeTruthy();
+
+      el.maxItems = 0;
+      // Trigger slotchange re-evaluation by forcing a re-render then checking
+      // the DOM synchronously — maxItems = 0 calls _removeCollapse() directly
+      // inside _handleSlotChange so we need a fresh slotchange event. We can
+      // simulate that by removing and re-appending a child.
+      const first = el.querySelector('hx-breadcrumb-item');
+      if (first) {
+        el.appendChild(first);
+      }
+      await el.updateComplete;
+      expect(el.querySelector('.hx-bc-ellipsis')).toBeNull();
+    });
+
+    it('does not collapse when item count equals max-items', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb max-items="3">
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item>C</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      expect(el.querySelector('.hx-bc-ellipsis')).toBeNull();
+      const items = Array.from(
+        el.querySelectorAll<HTMLElement>('hx-breadcrumb-item:not(.hx-bc-ellipsis)'),
+      );
+      expect(items.every((i) => !i.hasAttribute('data-bc-hidden'))).toBe(true);
+    });
+  });
+
+  // ─── JSON-LD (5) ───
+
+  describe('JSON-LD', () => {
+    it('does not inject a script when json-ld attribute is absent', async () => {
+      const before = document.querySelectorAll('script[data-hx-breadcrumb]').length;
+      await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb>
+          <hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Current</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      const after = document.querySelectorAll('script[data-hx-breadcrumb]').length;
+      expect(after).toBe(before);
+    });
+
+    it('injects a JSON-LD script into document.head when json-ld is true', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb json-ld>
+          <hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Current</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const script = document.querySelector<HTMLScriptElement>(`script[data-hx-breadcrumb]`);
+      expect(script).toBeTruthy();
+      expect(script?.type).toBe('application/ld+json');
+
+      const data = JSON.parse(script?.textContent ?? '{}') as Record<string, unknown>;
+      expect(data['@type']).toBe('BreadcrumbList');
+    });
+
+    it('removes the JSON-LD script on disconnect', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb json-ld>
+          <hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Current</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      // Confirm script was injected
+      expect(document.querySelector(`#${(el as unknown as { _jsonLdId: string })._jsonLdId}`)).toBeTruthy();
+
+      el.remove();
+      // Script should be gone after disconnection
+      expect(document.querySelector(`script[data-hx-breadcrumb][id="${(el as unknown as { _jsonLdId: string })._jsonLdId}"]`)).toBeNull();
+    });
+
+    it('produces no duplicate scripts when two instances have json-ld enabled', async () => {
+      const wrapper = document.createElement('div');
+      document.body.appendChild(wrapper);
+      wrapper.innerHTML = `
+        <hx-breadcrumb id="bc1" json-ld>
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item>B</hx-breadcrumb-item>
+        </hx-breadcrumb>
+        <hx-breadcrumb id="bc2" json-ld>
+          <hx-breadcrumb-item href="/x">X</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Y</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `;
+      const bc1 = wrapper.querySelector<HelixBreadcrumb>('#bc1')!;
+      const bc2 = wrapper.querySelector<HelixBreadcrumb>('#bc2')!;
+      await bc1.updateComplete;
+      await bc2.updateComplete;
+
+      const scripts = document.querySelectorAll('script[data-hx-breadcrumb]');
+      // Each instance owns exactly one script — no duplicates
+      expect(scripts.length).toBe(2);
+
+      // IDs must be distinct
+      const ids = Array.from(scripts).map((s) => s.id);
+      expect(new Set(ids).size).toBe(2);
+
+      wrapper.remove();
+    });
+
+    it('updates the existing script content when items change', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb json-ld>
+          <hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Current</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+
+      const scriptId = (el as unknown as { _jsonLdId: string })._jsonLdId;
+      const script = document.getElementById(scriptId) as HTMLScriptElement;
+      expect(script).toBeTruthy();
+
+      const data = JSON.parse(script.textContent ?? '{}') as { itemListElement: unknown[] };
+      expect(data.itemListElement).toHaveLength(2);
     });
   });
 
@@ -251,6 +432,32 @@ describe('hx-breadcrumb', () => {
         '<hx-breadcrumb-item>Current</hx-breadcrumb-item>',
       );
       expect(shadowQuery(el, '[part="text"]')).toBeTruthy();
+    });
+  });
+
+  // ─── hx-breadcrumb-item: role guard (2) ───
+
+  describe('hx-breadcrumb-item: role guard', () => {
+    it('sets role="listitem" when inside hx-breadcrumb', async () => {
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb>
+          <hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Current</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const items = Array.from(el.querySelectorAll('hx-breadcrumb-item'));
+      items.forEach((item) => {
+        expect(item.getAttribute('role')).toBe('listitem');
+      });
+    });
+
+    it('does not set role="listitem" when used standalone', async () => {
+      const el = await fixture<HelixBreadcrumbItem>(
+        '<hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>',
+      );
+      // Standalone item has no hx-breadcrumb ancestor — role must not be set
+      expect(el.getAttribute('role')).toBeNull();
     });
   });
 
@@ -351,7 +558,6 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Patient Records</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       await page.screenshot();
       const { violations } = await checkA11y(el);
@@ -364,7 +570,6 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Home</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       await page.screenshot();
       const { violations } = await checkA11y(el);
@@ -378,7 +583,6 @@ describe('hx-breadcrumb', () => {
           <hx-breadcrumb-item>Current</hx-breadcrumb-item>
         </hx-breadcrumb>
       `);
-      await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       await page.screenshot();
       const { violations } = await checkA11y(el);

--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.ts
@@ -160,6 +160,15 @@ export class HelixBreadcrumb extends LitElement {
 
   // ─── JSON-LD ───
 
+  /**
+   * Stable per-instance ID used to tag the injected script element so that
+   * multiple hx-breadcrumb instances on the same page don't produce conflicting
+   * or duplicate structured-data blocks. Each instance owns exactly one script
+   * tag identified by this ID; any stale tag from a previous render cycle is
+   * removed before a new one is inserted.
+   */
+  private readonly _jsonLdId = `hx-breadcrumb-ld-${Math.random().toString(36).slice(2)}`;
+
   private _updateJsonLd(items: Element[]): void {
     const schema = {
       '@context': 'https://schema.org',
@@ -177,8 +186,15 @@ export class HelixBreadcrumb extends LitElement {
     };
 
     if (!this._jsonLdScript) {
+      // Dedup guard: remove any stale script with this instance's ID before
+      // creating a fresh one. This handles the edge case where the element was
+      // reconnected to the DOM after being disconnected without the script
+      // reference being re-established.
+      document.getElementById(this._jsonLdId)?.remove();
+
       this._jsonLdScript = document.createElement('script');
       this._jsonLdScript.type = 'application/ld+json';
+      this._jsonLdScript.id = this._jsonLdId;
       this._jsonLdScript.setAttribute('data-hx-breadcrumb', '');
       document.head.appendChild(this._jsonLdScript);
     }
@@ -212,9 +228,9 @@ export class HelixBreadcrumb extends LitElement {
 
     return html`
       <nav part="nav" aria-label=${this.label}>
-        <div part="list" role="list">
+        <ol part="list">
           <slot @slotchange=${this._handleSlotChange}></slot>
-        </div>
+        </ol>
       </nav>
       <slot
         name="separator"


### PR DESCRIPTION
## Summary

Quality audit fixes for the `hx-breadcrumb` component:

- **JSON-LD dedup guard** — Each instance now owns a unique per-instance script ID. Before injecting into `document.head`, any stale script with the same ID is removed first. Two instances on the same page each own exactly one distinct script tag with no conflicts.
- **Semantic `<ol>` element** — Changed `div[role=list]` to a native `<ol>` element. Breadcrumb items have meaningful sequence order; `<ol>` is the correct semantic element and eliminates the redundant ARIA role.
- **`role="listitem"` guard** — `hx-breadcrumb-item` now calls `closest('hx-breadcrumb')` in `connectedCallback` before setting the role. Standalone items (used outside a breadcrumb) no longer carry an orphaned `listitem` role that would violate the ARIA list ancestry requirement.
- **Replace `setTimeout` with `updateComplete`** — All 8 `await new Promise(r => setTimeout(r, 50))` calls in the test file replaced with `await el.updateComplete`. Tests are now faster and deterministic.
- **Token cascade terminal fallbacks** — All CSS custom property cascades in `hx-breadcrumb.styles.ts` and `hx-breadcrumb-item.styles.ts` now have hardcoded terminal values (e.g. `var(--hx-breadcrumb-separator-color, var(--hx-color-neutral-400, #9ca3af))`).
- **New tests added:**
  - 5 collapse/max-items tests (show-all, hide-middle, ellipsis insert/remove, equality boundary)
  - 5 JSON-LD tests (no-inject, inject, disconnect cleanup, multi-instance dedup, content update)
  - 2 role-guard tests (in-context sets role, standalone does not)

## Test plan

- [ ] `npm run type-check` — zero errors (verified: passes)
- [ ] `npm run verify` — lint + format:check + type-check (verified: all pass)
- [ ] `npm run test:library` — all breadcrumb tests pass in browser mode
- [ ] Axe violations still zero for all three existing accessibility test cases
- [ ] Multiple `hx-breadcrumb json-ld` instances on the same page produce distinct, non-conflicting script tags
- [ ] Standalone `hx-breadcrumb-item` (no parent breadcrumb) has no `role` attribute

🤖 Generated with [Claude Code](https://claude.com/claude-code)