### PR TITLE
IMPLEMENT: hx-dropdown — T2 Dropdown Button with Menu

### DIFF
--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.styles.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.styles.ts
@@ -8,7 +8,7 @@ export const helixDropdownStyles = css`
 
   :host([disabled]) {
     pointer-events: none;
-    opacity: 0.5;
+    opacity: var(--hx-opacity-disabled, 0.5);
   }
 
   .trigger-wrapper {

--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.test.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.test.ts
@@ -75,15 +75,33 @@ describe('hx-dropdown', () => {
     });
 
     it('reflects open attribute', async () => {
-      const el = await fixture<HelixDropdown>('<hx-dropdown open><button slot="trigger">T</button><div role="menu" aria-label="Actions">Content</div></hx-dropdown>');
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown open><button slot="trigger">T</button><div role="menu" aria-label="Actions">Content</div></hx-dropdown>',
+      );
       expect(el.open).toBe(true);
       expect(el.getAttribute('open')).not.toBeNull();
     });
 
     it('reflects disabled attribute', async () => {
-      const el = await fixture<HelixDropdown>('<hx-dropdown disabled><button slot="trigger">T</button><div role="menu" aria-label="Actions">Content</div></hx-dropdown>');
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown disabled><button slot="trigger">T</button><div role="menu" aria-label="Actions">Content</div></hx-dropdown>',
+      );
       expect(el.disabled).toBe(true);
       expect(el.getAttribute('disabled')).not.toBeNull();
+    });
+
+    it('sets aria-disabled="true" when disabled', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown disabled><button slot="trigger">T</button><div role="menu" aria-label="Actions">Content</div></hx-dropdown>',
+      );
+      await el.updateComplete;
+      expect(el.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('removes aria-disabled when not disabled', async () => {
+      const el = await fixture<HelixDropdown>(triggerHtml);
+      await el.updateComplete;
+      expect(el.getAttribute('aria-disabled')).toBeNull();
     });
   });
 
@@ -132,7 +150,9 @@ describe('hx-dropdown', () => {
     });
 
     it('does not open when disabled', async () => {
-      const el = await fixture<HelixDropdown>('<hx-dropdown disabled><button slot="trigger">T</button><div role="menu" aria-label="Actions">Content</div></hx-dropdown>');
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown disabled><button slot="trigger">T</button><div role="menu" aria-label="Actions">Content</div></hx-dropdown>',
+      );
       const trigger = el.querySelector<HTMLElement>('[slot="trigger"]')!;
       trigger.click();
       await el.updateComplete;

--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
@@ -93,8 +93,8 @@ export class HelixDropdown extends LitElement {
 
   @state() private _panelVisible = false;
 
-  @query('[part="panel"]') private _panel!: HTMLElement;
-  @query('[part="trigger"]') private _triggerWrapper!: HTMLElement;
+  @query('[part="panel"]') private _panel: HTMLElement | null = null;
+  @query('[part="trigger"]') private _triggerWrapper: HTMLElement | null = null;
 
   // ─── Lifecycle ───
 
@@ -251,6 +251,7 @@ export class HelixDropdown extends LitElement {
 
   override firstUpdated(): void {
     this._setupTriggerAria();
+    this._syncAriaDisabled();
   }
 
   private _setupTriggerAria(): void {
@@ -271,6 +272,17 @@ export class HelixDropdown extends LitElement {
       if (trigger) {
         trigger.setAttribute('aria-expanded', String(this.open));
       }
+    }
+    if (changedProperties.has('disabled')) {
+      this._syncAriaDisabled();
+    }
+  }
+
+  private _syncAriaDisabled(): void {
+    if (this.disabled) {
+      this.setAttribute('aria-disabled', 'true');
+    } else {
+      this.removeAttribute('aria-disabled');
     }
   }
 }


### PR DESCRIPTION
## Summary

Implement `hx-dropdown` (T2 tier) — 5/6 enterprise libraries ship this. Button that opens a floating menu on click.

**Files to create** in `packages/hx-library/src/components/hx-dropdown/`:
- `index.ts`, `hx-dropdown.ts`, `hx-dropdown.styles.ts`, `hx-dropdown.stories.ts`, `hx-dropdown.test.ts`

**Props:** `open` (boolean), `placement` (top/bottom/start/end variants), `disabled` (boolean), `distance` (number, px gap)

**Slots:** `trigger` (the button/element that opens dropdown), default (hx-men...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-06T14:51:32.148Z -->