### PR TITLE
audit: hx-text antagonistic quality review (T3-12)

### DIFF
--- a/packages/hx-library/src/components/hx-text/AUDIT.md
+++ b/packages/hx-library/src/components/hx-text/AUDIT.md
@@ -9,12 +9,12 @@
 
 ## Summary
 
-| Severity | Count |
-|----------|-------|
-| P0 (Blocker) | 1 |
-| P1 (High) | 5 |
-| P2 (Medium) | 6 |
-| **Total** | **12** |
+| Severity     | Count  |
+| ------------ | ------ |
+| P0 (Blocker) | 1      |
+| P1 (High)    | 5      |
+| P2 (Medium)  | 6      |
+| **Total**    | **12** |
 
 ---
 


### PR DESCRIPTION
## Summary

Antagonistic quality review of `hx-text` — 12 findings across 7 audit areas.

| Severity | Count |
|----------|-------|
| P0 (Blocker) | 1 |
| P1 (High) | 5 |
| P2 (Medium) | 6 |

## Key Findings

**P0**
- Truncated text (`truncate` / `lines`) exposes no accessible full-text via `title` or `aria-label` — screen readers cannot access clipped clinical data

**P1**
- `:host([lines])` CSS selector fires for `lines="0"`, forcing `display:block` on non-clamping elements
- Variant set deviates from audit spec — `lead` and `small` are missing; deviation is undocumented
- No test verifies `-webkit-line-clamp` inline style is actually applied
- `inverse` color excluded from axe test loop without justification

**P2**
- Storybook meta render uses `weight=""` instead of `ifDefined(args.weight)`
- `code` variant excluded from a11y test loop without explanation
- Non-prefixed `line-clamp` in `styleMap` is a no-op in all current browsers
- No Drupal Twig integration documentation
- `WcText` type alias uses stale `wc-*` naming prefix

## Files Changed
- `packages/hx-library/src/components/hx-text/AUDIT.md` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)