### PR TITLE
Deep Audit v2: hx-date-picker

### DIFF
--- a/packages/hx-library/src/components/hx-date-picker/hx-date-picker.styles.ts
+++ b/packages/hx-library/src/components/hx-date-picker/hx-date-picker.styles.ts
@@ -235,6 +235,12 @@ export const helixDatePickerStyles = css`
   /* ─── Calendar Grid ─── */
 
   .calendar__grid {
+    display: flex;
+    flex-direction: column;
+    gap: var(--hx-space-1, 0.25rem);
+  }
+
+  .calendar__row {
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     gap: var(--hx-space-1, 0.25rem);
@@ -278,7 +284,6 @@ export const helixDatePickerStyles = css`
       color var(--hx-transition-fast, 150ms ease);
     outline: none;
     position: relative;
-    tabindex: 0;
   }
 
   .calendar__day:hover:not(.calendar__day--disabled):not(.calendar__day--selected) {
@@ -325,14 +330,6 @@ export const helixDatePickerStyles = css`
     pointer-events: none;
   }
 
-  .calendar__day--other-month {
-    color: var(--hx-color-neutral-400, #adb5bd);
-  }
-
-  .calendar__day--other-month.calendar__day--disabled {
-    opacity: 0.2;
-  }
-
   /* ─── Live Region ─── */
 
   .calendar__live-region {
@@ -359,5 +356,57 @@ export const helixDatePickerStyles = css`
     font-size: var(--hx-font-size-xs, 0.75rem);
     color: var(--hx-date-picker-error-color, var(--hx-color-error-500, #dc3545));
     line-height: var(--hx-line-height-normal, 1.5);
+  }
+
+  .calendar__nav-btn:disabled {
+    opacity: var(--hx-opacity-disabled, 0.4);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  /* ─── Forced Colors (High Contrast Mode) ─── */
+
+  @media (forced-colors: active) {
+    .field__input-wrapper {
+      border: 1px solid ButtonText;
+    }
+
+    .field__input-wrapper:focus-within {
+      outline: 2px solid Highlight;
+      outline-offset: 1px;
+      box-shadow: none;
+    }
+
+    .calendar__day:focus-visible {
+      outline: 2px solid Highlight;
+      box-shadow: none;
+    }
+
+    .calendar__day--selected {
+      background-color: Highlight;
+      color: HighlightText;
+      border: 1px solid Highlight;
+    }
+
+    .calendar__day--today:not(.calendar__day--selected) {
+      border: 2px solid LinkText;
+    }
+
+    .calendar__day--today:not(.calendar__day--selected)::after {
+      display: none;
+    }
+
+    .calendar__day--disabled {
+      color: GrayText;
+    }
+
+    .calendar__nav-btn:focus-visible {
+      outline: 2px solid Highlight;
+      box-shadow: none;
+    }
+
+    .field--error .field__input-wrapper {
+      border-color: LinkText;
+    }
   }
 `;

--- a/packages/hx-library/src/components/hx-date-picker/hx-date-picker.test.ts
+++ b/packages/hx-library/src/components/hx-date-picker/hx-date-picker.test.ts
@@ -652,16 +652,15 @@ describe('hx-date-picker', () => {
       expect(firstDay?.getAttribute('aria-label')).toBeTruthy();
     });
 
-    it('selected day has aria-pressed="true"', async () => {
+    it('selected day gridcell has aria-selected="true"', async () => {
       const el = await fixture<HelixDatePicker>(
         '<hx-date-picker value="2026-03-04"></hx-date-picker>',
       );
-      // Navigate to March 2026 by setting value — calendar syncs view on open.
       await openCalendar(el);
-      const selectedDay = el.shadowRoot!.querySelector<HTMLButtonElement>(
-        '[part="day"][aria-pressed="true"]',
+      const selectedCell = el.shadowRoot!.querySelector<HTMLElement>(
+        '[role="gridcell"][aria-selected="true"]',
       );
-      expect(selectedDay).toBeTruthy();
+      expect(selectedCell).toBeTruthy();
     });
   });
 
@@ -712,6 +711,164 @@ describe('hx-date-picker', () => {
       );
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
+    });
+
+    it('has no axe violations with calendar open', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker label="Appointment Date"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const { violations } = await checkA11y(el);
+      expect(violations).toEqual([]);
+    });
+  });
+
+  // ─── ARIA Grid Structure (3) ────────────────────────────────────────
+
+  describe('ARIA Grid Structure', () => {
+    it('calendar grid contains role="row" elements', async () => {
+      const el = await fixture<HelixDatePicker>('<hx-date-picker></hx-date-picker>');
+      await openCalendar(el);
+      const rows = el.shadowRoot!.querySelectorAll('[role="grid"] [role="row"]');
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    it('gridcells are nested within role="row" elements', async () => {
+      const el = await fixture<HelixDatePicker>('<hx-date-picker></hx-date-picker>');
+      await openCalendar(el);
+      const gridcells = el.shadowRoot!.querySelectorAll('[role="row"] > [role="gridcell"]');
+      expect(gridcells.length).toBeGreaterThan(0);
+    });
+
+    it('today button has aria-current="date"', async () => {
+      const el = await fixture<HelixDatePicker>('<hx-date-picker></hx-date-picker>');
+      await openCalendar(el);
+      const todayBtn = el.shadowRoot!.querySelector<HTMLButtonElement>('[aria-current="date"]');
+      expect(todayBtn).toBeTruthy();
+    });
+  });
+
+  // ─── Keyboard Navigation: Arrow Keys (4) ───────────────────────────
+
+  describe('Keyboard Navigation: Arrow Keys', () => {
+    it('ArrowRight moves focus to the next day', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const calendar = shadowQuery(el, '[part="calendar"]')!;
+      calendar.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+      const focused = el.shadowRoot!.querySelector<HTMLButtonElement>(
+        '[data-day="11"][tabindex="0"]',
+      );
+      expect(focused).toBeTruthy();
+    });
+
+    it('ArrowLeft moves focus to the previous day', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const calendar = shadowQuery(el, '[part="calendar"]')!;
+      calendar.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+      const focused = el.shadowRoot!.querySelector<HTMLButtonElement>(
+        '[data-day="9"][tabindex="0"]',
+      );
+      expect(focused).toBeTruthy();
+    });
+
+    it('ArrowDown moves focus down one week', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const calendar = shadowQuery(el, '[part="calendar"]')!;
+      calendar.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+      const focused = el.shadowRoot!.querySelector<HTMLButtonElement>(
+        '[data-day="17"][tabindex="0"]',
+      );
+      expect(focused).toBeTruthy();
+    });
+
+    it('ArrowUp moves focus up one week', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const calendar = shadowQuery(el, '[part="calendar"]')!;
+      calendar.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+      const focused = el.shadowRoot!.querySelector<HTMLButtonElement>(
+        '[data-day="3"][tabindex="0"]',
+      );
+      expect(focused).toBeTruthy();
+    });
+  });
+
+  // ─── Keyboard Navigation: PageUp/PageDown (2) ──────────────────────
+
+  describe('Keyboard Navigation: PageUp/PageDown', () => {
+    it('PageDown navigates to next month', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const monthLabelBefore = shadowQuery(el, '.calendar__month-label')?.textContent?.trim() ?? '';
+      const calendar = shadowQuery(el, '[part="calendar"]')!;
+      calendar.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'PageDown', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+      const monthLabelAfter = shadowQuery(el, '.calendar__month-label')?.textContent?.trim() ?? '';
+      expect(monthLabelAfter).not.toBe(monthLabelBefore);
+    });
+
+    it('PageUp navigates to previous month', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const monthLabelBefore = shadowQuery(el, '.calendar__month-label')?.textContent?.trim() ?? '';
+      const calendar = shadowQuery(el, '[part="calendar"]')!;
+      calendar.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'PageUp', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+      const monthLabelAfter = shadowQuery(el, '.calendar__month-label')?.textContent?.trim() ?? '';
+      expect(monthLabelAfter).not.toBe(monthLabelBefore);
+    });
+  });
+
+  // ─── Navigation Boundaries (2) ─────────────────────────────────────
+
+  describe('Navigation Boundaries', () => {
+    it('prev-month button is disabled when at min boundary', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10" min="2026-03-01"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const prevBtn = shadowQuery<HTMLButtonElement>(el, '[aria-label="Previous month"]')!;
+      expect(prevBtn.disabled).toBe(true);
+    });
+
+    it('next-month button is disabled when at max boundary', async () => {
+      const el = await fixture<HelixDatePicker>(
+        '<hx-date-picker value="2026-03-10" max="2026-03-31"></hx-date-picker>',
+      );
+      await openCalendar(el);
+      const nextBtn = shadowQuery<HTMLButtonElement>(el, '[aria-label="Next month"]')!;
+      expect(nextBtn.disabled).toBe(true);
     });
   });
 });

--- a/packages/hx-library/src/components/hx-date-picker/hx-date-picker.ts
+++ b/packages/hx-library/src/components/hx-date-picker/hx-date-picker.ts
@@ -520,6 +520,11 @@ export class HelixDatePicker extends LitElement {
   private _handleCalendarKeydown(e: KeyboardEvent): void {
     const { key } = e;
 
+    if (key === 'Tab') {
+      this._handleCalendarTab(e);
+      return;
+    }
+
     if (
       key !== 'ArrowLeft' &&
       key !== 'ArrowRight' &&
@@ -624,71 +629,123 @@ export class HelixDatePicker extends LitElement {
     });
   }
 
+  // ─── Navigation Boundary Checks ───
+
+  private _isPrevMonthDisabled(): boolean {
+    if (!this.min) return false;
+    const firstOfCurrentView = new Date(this._viewYear, this._viewMonth, 1);
+    const minDate = this._parseISODate(this.min);
+    if (!minDate) return false;
+    return firstOfCurrentView <= minDate;
+  }
+
+  private _isNextMonthDisabled(): boolean {
+    if (!this.max) return false;
+    const lastOfCurrentView = new Date(this._viewYear, this._viewMonth + 1, 0);
+    const maxDate = this._parseISODate(this.max);
+    if (!maxDate) return false;
+    return lastOfCurrentView >= maxDate;
+  }
+
+  // ─── Focus Trap ───
+
+  private _handleCalendarTab(e: KeyboardEvent): void {
+    if (e.key !== 'Tab' || !this._isOpen) return;
+
+    const focusableEls = this._calendar?.querySelectorAll<HTMLElement>(
+      'button:not([disabled]), [tabindex="0"]',
+    );
+    if (!focusableEls || focusableEls.length === 0) return;
+
+    const first = focusableEls[0];
+    const last = focusableEls[focusableEls.length - 1];
+
+    if (e.shiftKey) {
+      if (document.activeElement === first || this.shadowRoot?.activeElement === first) {
+        e.preventDefault();
+        last?.focus();
+      }
+    } else {
+      if (document.activeElement === last || this.shadowRoot?.activeElement === last) {
+        e.preventDefault();
+        first?.focus();
+      }
+    }
+  }
+
   // ─── Render Helpers ───
 
   private _renderWeekdayHeaders() {
-    return Array.from(
+    const headers = Array.from(
       { length: 7 },
       (_, i) =>
         html`<div class="calendar__weekday" role="columnheader" aria-label=${this._getDayName(i)}>
           ${this._getDayName(i).slice(0, 2)}
         </div>`,
     );
+    return html`<div class="calendar__row" role="row">${headers}</div>`;
   }
 
   private _renderDayGrid() {
     const cells = this._getDaysInGrid();
     const selectedDate = this._parseISODate(this.value);
 
-    return cells.map((date, index) => {
-      if (date === null) {
+    const rows: ReturnType<typeof html>[] = [];
+
+    for (let rowStart = 0; rowStart < cells.length; rowStart += 7) {
+      const rowCells = cells.slice(rowStart, rowStart + 7).map((date) => {
+        if (date === null) {
+          return html`<div class="calendar__day-cell" role="gridcell"></div>`;
+        }
+
+        const isSelected = selectedDate ? this._isSameDay(date, selectedDate) : false;
+        const isToday = this._isToday(date);
+        const isDisabled = this._isDateDisabled(date);
+        const isFocused = this._focusedDay === date.getDate();
+        const dayNumber = date.getDate();
+
+        const ariaLabel = date.toLocaleDateString(this.locale, {
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        });
+
+        const dayClasses = {
+          calendar__day: true,
+          'calendar__day--selected': isSelected,
+          'calendar__day--today': isToday,
+          'calendar__day--disabled': isDisabled,
+        };
+
         return html`<div
           class="calendar__day-cell"
           role="gridcell"
-          aria-hidden="true"
-          key=${index}
-        ></div>`;
-      }
-
-      const isSelected = selectedDate ? this._isSameDay(date, selectedDate) : false;
-      const isToday = this._isToday(date);
-      const isDisabled = this._isDateDisabled(date);
-      const isFocused = this._focusedDay === date.getDate();
-      const dayNumber = date.getDate();
-
-      const ariaLabel = date.toLocaleDateString(this.locale, {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
+          aria-selected=${isSelected ? 'true' : 'false'}
+        >
+          <button
+            part="day"
+            class=${classMap(dayClasses)}
+            type="button"
+            data-day=${dayNumber}
+            aria-label=${ariaLabel}
+            aria-disabled=${isDisabled ? 'true' : nothing}
+            aria-current=${isToday ? 'date' : nothing}
+            tabindex=${isFocused ? '0' : '-1'}
+            ?disabled=${isDisabled}
+            @click=${() => {
+              this._selectDay(date);
+            }}
+          >
+            ${dayNumber}
+          </button>
+        </div>`;
       });
 
-      const dayClasses = {
-        calendar__day: true,
-        'calendar__day--selected': isSelected,
-        'calendar__day--today': isToday,
-        'calendar__day--disabled': isDisabled,
-      };
+      rows.push(html`<div class="calendar__row" role="row">${rowCells}</div>`);
+    }
 
-      return html`<div class="calendar__day-cell" role="gridcell">
-        <button
-          part="day"
-          class=${classMap(dayClasses)}
-          type="button"
-          data-day=${dayNumber}
-          aria-label=${ariaLabel}
-          aria-pressed=${isSelected ? 'true' : 'false'}
-          aria-disabled=${isDisabled ? 'true' : nothing}
-          tabindex=${isFocused ? '0' : '-1'}
-          ?disabled=${isDisabled}
-          @click=${() => {
-            this._selectDay(date);
-          }}
-        >
-          ${dayNumber}
-        </button>
-      </div>`;
-    });
+    return rows;
   }
 
   // ─── Render ───
@@ -735,7 +792,6 @@ export class HelixDatePicker extends LitElement {
             class="field__input"
             id=${this._inputId}
             type="text"
-            role="combobox"
             readonly
             .value=${live(displayValue)}
             placeholder=${ifDefined(this.format || undefined)}
@@ -748,8 +804,6 @@ export class HelixDatePicker extends LitElement {
             aria-describedby=${ifDefined(describedBy)}
             aria-required=${this.required ? 'true' : nothing}
             aria-haspopup="dialog"
-            aria-expanded=${this._isOpen ? 'true' : 'false'}
-            aria-controls=${this._calendarId}
             @click=${this._openCalendar}
           />
           <button
@@ -812,6 +866,7 @@ export class HelixDatePicker extends LitElement {
                     class="calendar__nav-btn"
                     type="button"
                     aria-label="Previous month"
+                    ?disabled=${this._isPrevMonthDisabled()}
                     @click=${this._prevMonth}
                   >
                     &#8249;
@@ -823,6 +878,7 @@ export class HelixDatePicker extends LitElement {
                     class="calendar__nav-btn"
                     type="button"
                     aria-label="Next month"
+                    ?disabled=${this._isNextMonthDisabled()}
                     @click=${this._nextMonth}
                   >
                     &#8250;
@@ -841,13 +897,7 @@ export class HelixDatePicker extends LitElement {
         <slot name="error" @slotchange=${this._handleErrorSlotChange}>
           ${this.error
             ? html`
-                <div
-                  part="error"
-                  class="field__error"
-                  id=${this._errorId}
-                  role="alert"
-                  aria-live="polite"
-                >
+                <div part="error" class="field__error" id=${this._errorId} role="alert">
                   ${this.error}
                 </div>
               `


### PR DESCRIPTION
## Summary

## Deep Component Audit — hx-date-picker

**Component directory:** `packages/hx-library/src/components/hx-date-picker/`
**NOTE:** No index.ts — may be incomplete/from PR 175 rescue.

### wc-mcp Tools — USE THESE FOR SCORING
- `score_component`, `get_component`, `analyze_accessibility`, `validate_usage`
- **Report any wc-mcp bugs to `/Volumes/Development/booked/wc-tools` board.**

### Audit Scope
1. **Existence Check** — Complete implementation? Document gaps if incomplete.
2. **Design Tokens** —...

---
*Recovered automatically by Automaker post-agent hook*