### PR TITLE
Deep Audit v2: hx-number-input

### DIFF
--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.test.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.test.ts
@@ -102,10 +102,10 @@ describe('hx-number-input', () => {
       expect(el.hasAttribute('required')).toBe(true);
     });
 
-    it('sets aria-required="true" on native input', async () => {
+    it('sets native required attribute on input', async () => {
       const el = await fixture<HelixNumberInput>('<hx-number-input required></hx-number-input>');
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
-      expect(input.getAttribute('aria-required')).toBe('true');
+      expect(input.required).toBe(true);
     });
 
     it('marks validity as valueMissing when required and no value', async () => {
@@ -317,12 +317,12 @@ describe('hx-number-input', () => {
       expect(errorDiv?.textContent?.trim()).toBe('Value is required');
     });
 
-    it('error div has aria-live="polite"', async () => {
+    it('error div has role="alert"', async () => {
       const el = await fixture<HelixNumberInput>(
         '<hx-number-input error="Invalid"></hx-number-input>',
       );
       const errorDiv = shadowQuery(el, '.field__error');
-      expect(errorDiv?.getAttribute('aria-live')).toBe('polite');
+      expect(errorDiv?.getAttribute('role')).toBe('alert');
     });
 
     it('applies field--error class to field container', async () => {
@@ -548,8 +548,19 @@ describe('hx-number-input', () => {
       expect(el.form).toBe(form);
     });
 
-    it('formResetCallback resets value to null', async () => {
+    it('formResetCallback restores value to default', async () => {
       const el = await fixture<HelixNumberInput>('<hx-number-input value="42"></hx-number-input>');
+      el.value = 99;
+      await el.updateComplete;
+      el.formResetCallback();
+      await el.updateComplete;
+      expect(el.value).toBe(42);
+    });
+
+    it('formResetCallback restores to null when no default value', async () => {
+      const el = await fixture<HelixNumberInput>('<hx-number-input></hx-number-input>');
+      el.value = 50;
+      await el.updateComplete;
       el.formResetCallback();
       await el.updateComplete;
       expect(el.value).toBeNull();
@@ -595,6 +606,13 @@ describe('hx-number-input', () => {
     it('formStateRestoreCallback sets null for non-numeric state', async () => {
       const el = await fixture<HelixNumberInput>('<hx-number-input></hx-number-input>');
       el.formStateRestoreCallback('not-a-number');
+      await el.updateComplete;
+      expect(el.value).toBeNull();
+    });
+
+    it('formStateRestoreCallback rejects partial numeric strings like "77abc"', async () => {
+      const el = await fixture<HelixNumberInput>('<hx-number-input></hx-number-input>');
+      el.formStateRestoreCallback('77abc');
       await el.updateComplete;
       expect(el.value).toBeNull();
     });

--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.ts
@@ -16,7 +16,7 @@ import { helixNumberInputStyles } from './hx-number-input.styles.js';
  *
  * @tag hx-number-input
  *
- * @slot - Default slot — label override for Drupal Form API rendered labels.
+ * @slot label - Custom label content (overrides the label property). Use for Drupal Form API rendered labels.
  * @slot help - Custom help text content (overrides the helpText property).
  * @slot error - Custom error content (overrides the error property). Use for Drupal Form API rendered errors.
  * @slot prefix - Content rendered before the input (e.g., a unit icon).
@@ -41,6 +41,8 @@ import { helixNumberInputStyles } from './hx-number-input.styles.js';
  * @cssprop [--hx-number-input-border-radius=var(--hx-border-radius-md)] - Input border radius.
  * @cssprop [--hx-number-input-error-color=var(--hx-color-error-500)] - Error state color.
  * @cssprop [--hx-number-input-focus-ring-color=var(--hx-focus-ring-color)] - Focus ring color.
+ * @cssprop [--hx-number-input-label-color=var(--hx-color-neutral-700)] - Label text color.
+ * @cssprop [--hx-number-input-font-family=var(--hx-font-family-sans)] - Font family.
  */
 @customElement('hx-number-input')
 export class HelixNumberInput extends LitElement {
@@ -171,6 +173,9 @@ export class HelixNumberInput extends LitElement {
   @state() private _hasErrorSlot = false;
   @state() private _hasHelpSlot = false;
 
+  /** The value captured at first render, used by formResetCallback. */
+  private _defaultValue: number | null = null;
+
   /** Timer ID for the long-press initial delay. */
   private _longPressTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -211,6 +216,10 @@ export class HelixNumberInput extends LitElement {
   }
 
   // ─── Lifecycle ───
+
+  override firstUpdated(): void {
+    this._defaultValue = this.value;
+  }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
@@ -310,13 +319,13 @@ export class HelixNumberInput extends LitElement {
 
   /** Called by the form when it resets. */
   formResetCallback(): void {
-    this.value = null;
-    this._internals.setFormValue(null);
+    this.value = this._defaultValue;
+    this._internals.setFormValue(this.value !== null ? String(this.value) : null);
   }
 
   /** Called when the form restores state (e.g., back/forward navigation). */
   formStateRestoreCallback(state: string): void {
-    const parsed = parseFloat(state);
+    const parsed = Number(state);
     this.value = isNaN(parsed) ? null : parsed;
   }
 
@@ -361,13 +370,6 @@ export class HelixNumberInput extends LitElement {
     if (next === this.value) return;
     this.value = next;
 
-    this.dispatchEvent(
-      new CustomEvent<{ value: number | null }>('hx-input', {
-        bubbles: true,
-        composed: true,
-        detail: { value: this.value },
-      }),
-    );
     this.dispatchEvent(
       new CustomEvent<{ value: number | null }>('hx-change', {
         bubbles: true,
@@ -545,7 +547,7 @@ export class HelixNumberInput extends LitElement {
             .value=${live(displayValue)}
             min=${ifDefined(this.min)}
             max=${ifDefined(this.max)}
-            step=${ifDefined(this.step !== 1 ? this.step : undefined)}
+            step=${this.step}
             ?required=${this.required}
             ?disabled=${this.disabled}
             ?readonly=${this.readonly}
@@ -555,7 +557,6 @@ export class HelixNumberInput extends LitElement {
             )}
             aria-invalid=${hasError ? 'true' : nothing}
             aria-describedby=${ifDefined(describedBy)}
-            aria-required=${this.required ? 'true' : nothing}
             @input=${this._handleInput}
             @change=${this._handleChange}
             @keydown=${this._handleKeyDown}
@@ -568,7 +569,7 @@ export class HelixNumberInput extends LitElement {
           ${this.noStepper
             ? nothing
             : html`
-                <div part="stepper" class="field__stepper" aria-hidden="true">
+                <div part="stepper" class="field__stepper">
                   <button
                     part="increment"
                     class="field__stepper-btn"
@@ -604,13 +605,7 @@ export class HelixNumberInput extends LitElement {
         <slot name="error" @slotchange=${this._handleErrorSlotChange}>
           ${this.error
             ? html`
-                <div
-                  part="error-message"
-                  class="field__error"
-                  id=${this._errorId}
-                  role="alert"
-                  aria-live="polite"
-                >
+                <div part="error-message" class="field__error" id=${this._errorId} role="alert">
                   ${this.error}
                 </div>
               `


### PR DESCRIPTION
## Summary

## Deep Component Audit — hx-number-input

**Component directory:** `packages/hx-library/src/components/hx-number-input/`
**NOTE:** No index.ts — may be incomplete/from PR 175 rescue.

### wc-mcp Tools — USE THESE
- `score_component`, `get_component`, `analyze_accessibility`, `validate_usage`
- **Report wc-mcp bugs to `/Volumes/Development/booked/wc-tools` board.**

### Audit Scope
1. **Existence Check** — Complete implementation? Document gaps.
2. **Design Tokens** — `--hx-` tokens. Input, step...

---
*Recovered automatically by Automaker post-agent hook*