### PR TITLE
refactor: Deep Audit v2: hx-tag

### DIFF
--- a/packages/hx-library/src/components/hx-tag/hx-tag.test.ts
+++ b/packages/hx-library/src/components/hx-tag/hx-tag.test.ts
@@ -254,6 +254,12 @@ describe('hx-tag', () => {
       expect(base?.getAttribute('part')).toBe('base');
     });
 
+    it('suffix part is accessible for external styling', async () => {
+      const el = await fixture<WcTag>('<hx-tag>Tag</hx-tag>');
+      const suffix = shadowQuery(el, '[part="suffix"]');
+      expect(suffix?.getAttribute('part')).toBe('suffix');
+    });
+
     it('remove-button part is accessible for external styling when removable', async () => {
       const el = await fixture<WcTag>('<hx-tag removable>Tag</hx-tag>');
       const btn = shadowQuery(el, '[part="remove-button"]');

--- a/packages/hx-library/src/components/hx-tag/hx-tag.ts
+++ b/packages/hx-library/src/components/hx-tag/hx-tag.ts
@@ -20,6 +20,7 @@ import { helixTagStyles } from './hx-tag.styles.js';
  * @csspart base - The root tag element.
  * @csspart prefix - The prefix slot wrapper.
  * @csspart label - The label slot wrapper.
+ * @csspart suffix - The suffix slot wrapper.
  * @csspart remove-button - The remove/dismiss button.
  *
  * @cssprop [--hx-tag-bg=var(--hx-color-neutral-100)] - Tag background color.
@@ -73,6 +74,7 @@ export class HelixTag extends LitElement {
 
   // ─── Event Handling ───
 
+  /** @internal */
   private _handleRemove(): void {
     if (this.disabled) return;
     this.dispatchEvent(
@@ -107,7 +109,7 @@ export class HelixTag extends LitElement {
         <span part="label" class="tag__label">
           <slot></slot>
         </span>
-        <span class="tag__suffix">
+        <span part="suffix" class="tag__suffix">
           <slot name="suffix"></slot>
         </span>
         ${this.removable


### PR DESCRIPTION
Deep Audit v2: hx-tag — suffix CSS part, CEM docs, test coverage