### PR TITLE
Audit Fix: hx-text-input

### DIFF
--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.styles.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.styles.ts
@@ -91,9 +91,17 @@ export const helixTextInputStyles = css`
   .field__suffix {
     display: flex;
     align-items: center;
-    padding: 0 var(--hx-space-3, 0.75rem);
     color: var(--hx-color-neutral-500, #6c757d);
     flex-shrink: 0;
+  }
+
+  /* Only add padding when slot has content — avoids phantom space on empty slots */
+  .field__prefix--filled {
+    padding: 0 var(--hx-space-3, 0.75rem);
+  }
+
+  .field__suffix--filled {
+    padding: 0 var(--hx-space-3, 0.75rem);
   }
 
   /* ─── Native Input ─── */
@@ -150,5 +158,13 @@ export const helixTextInputStyles = css`
     font-size: var(--hx-font-size-xs, 0.75rem);
     color: var(--hx-input-error-color, var(--hx-color-error-500, #dc3545));
     line-height: var(--hx-line-height-normal, 1.5);
+  }
+
+  /* ─── Motion ─── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .field__input-wrapper {
+      transition: none;
+    }
   }
 `;

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.test.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
-import type { WcTextInput } from './hx-text-input.js';
+import type { HxTextInput } from './hx-text-input.js';
 import './index.js';
+
+// Backward-compat alias used throughout tests
+type WcTextInput = HxTextInput;
 
 afterEach(cleanup);
 
@@ -114,6 +117,30 @@ describe('hx-text-input', () => {
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       expect(input.getAttribute('type')).toBe('number');
     });
+
+    it('sets tel type', async () => {
+      const el = await fixture<WcTextInput>('<hx-text-input type="tel"></hx-text-input>');
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('type')).toBe('tel');
+    });
+
+    it('sets url type', async () => {
+      const el = await fixture<WcTextInput>('<hx-text-input type="url"></hx-text-input>');
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('type')).toBe('url');
+    });
+
+    it('sets search type', async () => {
+      const el = await fixture<WcTextInput>('<hx-text-input type="search"></hx-text-input>');
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('type')).toBe('search');
+    });
+
+    it('sets date type', async () => {
+      const el = await fixture<WcTextInput>('<hx-text-input type="date"></hx-text-input>');
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('type')).toBe('date');
+    });
   });
 
   // ─── Property: required (2) ───
@@ -125,10 +152,13 @@ describe('hx-text-input', () => {
       expect(input.required).toBe(true);
     });
 
-    it('sets aria-required="true" on native input', async () => {
+    it('native required attribute implies aria-required — no explicit aria-required set', async () => {
       const el = await fixture<WcTextInput>('<hx-text-input required></hx-text-input>');
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
-      expect(input.getAttribute('aria-required')).toBe('true');
+      // Native `required` maps to aria-required implicitly; we do NOT set it explicitly
+      // to follow the "prefer native semantics" principle (avoids redundant ARIA).
+      expect(input.required).toBe(true);
+      expect(input.getAttribute('aria-required')).toBeNull();
     });
   });
 
@@ -389,6 +419,22 @@ describe('hx-text-input', () => {
       await el.updateComplete;
       expect(el.validationMessage).toBeTruthy();
     });
+
+    it('tooShort validity flag set when value shorter than minlength', async () => {
+      const el = await fixture<WcTextInput>(
+        '<hx-text-input minlength="5" value="ab"></hx-text-input>',
+      );
+      await el.updateComplete;
+      expect(el.validity.tooShort).toBe(true);
+    });
+
+    it('tooLong validity flag set when value longer than maxlength', async () => {
+      const el = await fixture<WcTextInput>(
+        '<hx-text-input maxlength="3" value="toolong"></hx-text-input>',
+      );
+      await el.updateComplete;
+      expect(el.validity.tooLong).toBe(true);
+    });
   });
 
   // ─── Methods (2) ───
@@ -491,9 +537,7 @@ describe('hx-text-input', () => {
 
   describe('Property: pattern', () => {
     it('sets pattern attr on native input', async () => {
-      const el = await fixture<WcTextInput>(
-        '<hx-text-input pattern="[A-Z]+"></hx-text-input>',
-      );
+      const el = await fixture<WcTextInput>('<hx-text-input pattern="[A-Z]+"></hx-text-input>');
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       expect(input.getAttribute('pattern')).toBe('[A-Z]+');
     });
@@ -503,9 +547,7 @@ describe('hx-text-input', () => {
 
   describe('Property: autocomplete', () => {
     it('sets autocomplete attr on native input', async () => {
-      const el = await fixture<WcTextInput>(
-        '<hx-text-input autocomplete="email"></hx-text-input>',
-      );
+      const el = await fixture<WcTextInput>('<hx-text-input autocomplete="email"></hx-text-input>');
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       expect(input.getAttribute('autocomplete')).toBe('email');
     });
@@ -533,6 +575,50 @@ describe('hx-text-input', () => {
     });
   });
 
+  // ─── Slot: P0/P1 correctness ───
+
+  describe('Slot: error and help-text ARIA correctness', () => {
+    it('slotted error activates error state (aria-invalid) without error attr', async () => {
+      const el = await fixture<WcTextInput>(
+        '<hx-text-input><div slot="error">Slotted error</div></hx-text-input>',
+      );
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('slotted error wrapper has ID for aria-describedby', async () => {
+      const el = await fixture<WcTextInput>(
+        '<hx-text-input><div slot="error">Slotted error</div></hx-text-input>',
+      );
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const errorWrapper = shadowQuery(el, '[part="error"]');
+      expect(errorWrapper).toBeTruthy();
+      expect(input.getAttribute('aria-describedby')).toContain(errorWrapper!.id);
+    });
+
+    it('help-text slot renders wrapper without helpText property (P0-01)', async () => {
+      const el = await fixture<WcTextInput>(
+        '<hx-text-input><em slot="help-text">Rich help</em></hx-text-input>',
+      );
+      await el.updateComplete;
+      const wrapper = shadowQuery(el, '[part="help-text"]');
+      expect(wrapper).toBeTruthy();
+    });
+
+    it('slotted help-text is included in aria-describedby (P1-03)', async () => {
+      const el = await fixture<WcTextInput>(
+        '<hx-text-input><em slot="help-text">Rich help</em></hx-text-input>',
+      );
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const wrapper = shadowQuery(el, '[part="help-text"]');
+      expect(wrapper).toBeTruthy();
+      expect(input.getAttribute('aria-describedby')).toContain(wrapper!.id);
+    });
+  });
+
   // ─── CSS Parts: help-text and error (2) ───
 
   describe('CSS Parts: help-text and error', () => {
@@ -545,9 +631,7 @@ describe('hx-text-input', () => {
     });
 
     it('error part exposed', async () => {
-      const el = await fixture<WcTextInput>(
-        '<hx-text-input error="An error"></hx-text-input>',
-      );
+      const el = await fixture<WcTextInput>('<hx-text-input error="An error"></hx-text-input>');
       const errorPart = shadowQuery(el, '[part="error"]');
       expect(errorPart).toBeTruthy();
     });

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
@@ -6,6 +6,9 @@ import { live } from 'lit/directives/live.js';
 import { tokenStyles } from '@helix/tokens/lit';
 import { helixTextInputStyles } from './hx-text-input.styles.js';
 
+// Module-level counter for stable, SSR-compatible IDs (avoids Math.random() hydration mismatch)
+let _hxTextInputIdCounter = 0;
+
 /**
  * A text input component with label, validation, and form association.
  * Supports accessible labeling via `label` property, `aria-label` attribute, or the `label` slot.
@@ -186,6 +189,12 @@ export class HelixTextInput extends LitElement {
   private _hasLabelSlot = false;
   /** @internal */
   private _hasErrorSlot = false;
+  /** @internal */
+  private _hasPrefixSlot = false;
+  /** @internal */
+  private _hasSuffixSlot = false;
+  /** @internal */
+  private _hasHelpTextSlot = false;
 
   /** @internal */
   private _handleLabelSlotChange(e: Event): void {
@@ -204,6 +213,27 @@ export class HelixTextInput extends LitElement {
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
     this._hasErrorSlot = slot.assignedElements().length > 0;
+    this.requestUpdate();
+  }
+
+  /** @internal */
+  private _handlePrefixSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasPrefixSlot = slot.assignedElements().length > 0;
+    this.requestUpdate();
+  }
+
+  /** @internal */
+  private _handleSuffixSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasSuffixSlot = slot.assignedElements().length > 0;
+    this.requestUpdate();
+  }
+
+  /** @internal */
+  private _handleHelpTextSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasHelpTextSlot = slot.assignedElements().length > 0;
     this.requestUpdate();
   }
 
@@ -347,7 +377,7 @@ export class HelixTextInput extends LitElement {
   // ─── Render ───
 
   /** @internal */
-  private _inputId = `hx-text-input-${Math.random().toString(36).slice(2, 9)}`;
+  private _inputId = `hx-text-input-${++_hxTextInputIdCounter}`;
   /** @internal */
   private _helpTextId = `${this._inputId}-help`;
   /** @internal */
@@ -365,7 +395,10 @@ export class HelixTextInput extends LitElement {
     };
 
     const describedBy =
-      [hasError ? this._errorId : null, this.helpText ? this._helpTextId : null]
+      [
+        hasError ? this._errorId : null,
+        this.helpText || this._hasHelpTextSlot ? this._helpTextId : null,
+      ]
         .filter(Boolean)
         .join(' ') || undefined;
 
@@ -387,8 +420,13 @@ export class HelixTextInput extends LitElement {
         </div>
 
         <div part="input-wrapper" class="field__input-wrapper">
-          <span class="field__prefix">
-            <slot name="prefix"></slot>
+          <span
+            class=${classMap({
+              field__prefix: true,
+              'field__prefix--filled': this._hasPrefixSlot,
+            })}
+          >
+            <slot name="prefix" @slotchange=${this._handlePrefixSlotChange}></slot>
           </span>
 
           <input
@@ -412,33 +450,36 @@ export class HelixTextInput extends LitElement {
             )}
             aria-invalid=${hasError ? 'true' : nothing}
             aria-describedby=${ifDefined(describedBy)}
-            aria-required=${this.required ? 'true' : nothing}
             @input=${this._handleInput}
             @change=${this._handleChange}
           />
 
-          <span class="field__suffix">
-            <slot name="suffix"></slot>
+          <span
+            class=${classMap({
+              field__suffix: true,
+              'field__suffix--filled': this._hasSuffixSlot,
+            })}
+          >
+            <slot name="suffix" @slotchange=${this._handleSuffixSlotChange}></slot>
           </span>
         </div>
 
-        <slot name="error" @slotchange=${this._handleErrorSlotChange}>
-          ${this.error
-            ? html`
-                <div part="error" class="field__error" id=${this._errorId} role="alert">
-                  ${this.error}
-                </div>
-              `
-            : nothing}
-        </slot>
-
-        ${this.helpText && !hasError
+        ${hasError
           ? html`
-              <div part="help-text" class="field__help-text" id=${this._helpTextId}>
-                <slot name="help-text">${this.helpText}</slot>
+              <div part="error" class="field__error" id=${this._errorId} role="alert">
+                <slot name="error" @slotchange=${this._handleErrorSlotChange}> ${this.error} </slot>
               </div>
             `
-          : nothing}
+          : html`<slot name="error" @slotchange=${this._handleErrorSlotChange}></slot>`}
+        ${(this.helpText || this._hasHelpTextSlot) && !hasError
+          ? html`
+              <div part="help-text" class="field__help-text" id=${this._helpTextId}>
+                <slot name="help-text" @slotchange=${this._handleHelpTextSlotChange}>
+                  ${this.helpText}
+                </slot>
+              </div>
+            `
+          : html`<slot name="help-text" @slotchange=${this._handleHelpTextSlotChange}></slot>`}
       </div>
     `;
   }
@@ -450,4 +491,8 @@ declare global {
   }
 }
 
+/** Primary type alias for hx-text-input */
+export type HxTextInput = HelixTextInput;
+
+/** @deprecated Use HxTextInput instead */
 export type WcTextInput = HelixTextInput;


### PR DESCRIPTION
## Summary

Resolve all defects found in the Deep Audit v2 for `hx-text-input`.
Source: `packages/hx-library/src/components/hx-text-input/AUDIT.md`

**Summary:** 19 defects — 2 P0, 5 P1, 12 P2, 0 P3

### P0 — Critical
- [ ] [P0] 01: `help-text` slot is unusable without the `helpText` property
- [ ] [P0] 02: Slotted error (`slot='error'`) silently breaks `aria-describedby`

Reference the AUDIT.md in the component directory for full details and code locations.

---
*Recovered automatically by Automaker post-agent hook*