### PR TITLE
Audit Fix: hx-tile

### DIFF
--- a/packages/hx-library/src/components/hx-tile/hx-tile.behaviors.js
+++ b/packages/hx-library/src/components/hx-tile/hx-tile.behaviors.js
@@ -1,0 +1,87 @@
+/* global window, CustomEvent, Drupal */
+
+/**
+ * @file hx-tile.behaviors.js
+ * Drupal behavior for the hx-tile web component.
+ *
+ * Attach this behavior to wire up hx-tile events to Drupal navigation and selection patterns.
+ *
+ * Usage in a Drupal module:
+ *   import 'path/to/hx-tile.behaviors.js';
+ *
+ * Or include via the library definition in *.libraries.yml:
+ *   hx_tile:
+ *     js:
+ *       js/hx-tile.behaviors.js: {}
+ *     dependencies:
+ *       - core/drupal
+ */
+
+(function (Drupal) {
+  'use strict';
+
+  /**
+   * Attaches hx-tile event handling for Drupal contexts.
+   *
+   * hx-tile components intercept native anchor navigation with e.preventDefault()
+   * and emit custom events instead. This behavior re-connects those events to
+   * Drupal's navigation system.
+   *
+   * Events handled:
+   *   - hx-click: Fired when a link tile (href set) is activated. Detail: { href, originalEvent }
+   *   - hx-select: Fired when a selectable tile (no href) is toggled. Detail: { selected, originalEvent }
+   */
+  Drupal.behaviors.hxTile = {
+    attach: function (context) {
+      // Handle link tile navigation (hx-click)
+      context.querySelectorAll('hx-tile[href]').forEach(function (tile) {
+        if (tile.dataset.hxTileBehaviorAttached) return;
+        tile.dataset.hxTileBehaviorAttached = 'true';
+
+        tile.addEventListener('hx-click', function (event) {
+          const { href, originalEvent } = event.detail;
+
+          // Open in new tab if modifier key held
+          if (originalEvent.ctrlKey || originalEvent.metaKey || originalEvent.shiftKey) {
+            window.open(href, '_blank', 'noopener,noreferrer');
+            return;
+          }
+
+          // Standard Drupal navigation
+          window.location.href = href;
+        });
+      });
+
+      // Handle selectable tile state (hx-select)
+      context.querySelectorAll('hx-tile:not([href])').forEach(function (tile) {
+        if (tile.dataset.hxTileSelectAttached) return;
+        tile.dataset.hxTileSelectAttached = 'true';
+
+        tile.addEventListener('hx-select', function (event) {
+          const { selected } = event.detail;
+
+          // Dispatch a native Drupal event for other behaviors to hook into
+          const drupalEvent = new CustomEvent('drupal:tile-selected', {
+            bubbles: true,
+            composed: true,
+            detail: { tile: tile, selected: selected },
+          });
+          tile.dispatchEvent(drupalEvent);
+        });
+      });
+    },
+
+    detach: function (context, settings, trigger) {
+      if (trigger === 'unload') {
+        context
+          .querySelectorAll('hx-tile[data-hx-tile-behavior-attached]')
+          .forEach(function (tile) {
+            delete tile.dataset.hxTileBehaviorAttached;
+          });
+        context.querySelectorAll('hx-tile[data-hx-tile-select-attached]').forEach(function (tile) {
+          delete tile.dataset.hxTileSelectAttached;
+        });
+      }
+    },
+  };
+})(Drupal);

--- a/packages/hx-library/src/components/hx-tile/hx-tile.stories.ts
+++ b/packages/hx-library/src/components/hx-tile/hx-tile.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { expect, fn } from 'storybook/test';
 import './hx-tile.js';
 
@@ -29,6 +30,16 @@ const meta = {
         type: { summary: 'string' },
       },
     },
+    clickable: {
+      control: 'boolean',
+      description:
+        'When false, the tile is purely static/decorative with no interactive role or behavior.',
+      table: {
+        category: 'Interaction',
+        defaultValue: { summary: 'true' },
+        type: { summary: 'boolean' },
+      },
+    },
     selected: {
       control: 'boolean',
       description: 'Whether the tile is in a selected/pressed state.',
@@ -51,6 +62,7 @@ const meta = {
   args: {
     variant: 'default',
     href: '',
+    clickable: true,
     selected: false,
     disabled: false,
   },
@@ -59,7 +71,8 @@ const meta = {
       variant=${args.variant}
       ?selected=${args.selected}
       ?disabled=${args.disabled}
-      href=${args.href || ''}
+      ?clickable=${args.clickable}
+      href=${ifDefined(args.href || undefined)}
       style="width: 160px;"
     >
       <span slot="icon">&#127968;</span>
@@ -76,6 +89,13 @@ type Story = StoryObj;
 
 export const Default: Story = {
   args: {},
+};
+
+export const Static: Story = {
+  name: 'Static (non-interactive)',
+  args: {
+    clickable: false,
+  },
 };
 
 export const Outlined: Story = {
@@ -118,14 +138,15 @@ export const WithBadge: Story = {
       <span
         slot="badge"
         style="
-          background: #ef4444;
-          color: white;
-          border-radius: 9999px;
-          font-size: 0.75rem;
-          padding: 2px 6px;
-          font-weight: 600;
+          background: var(--hx-color-error-500, #ef4444);
+          color: var(--hx-color-neutral-0, #ffffff);
+          border-radius: var(--hx-border-radius-full, 9999px);
+          font-size: var(--hx-font-size-xs, 0.75rem);
+          padding: var(--hx-space-0-5, 2px) var(--hx-space-1-5, 6px);
+          font-weight: var(--hx-font-weight-semibold, 600);
         "
-      >3</span>
+        >3</span
+      >
     </hx-tile>
   `,
 };
@@ -170,23 +191,23 @@ export const NavigationGrid: Story = {
         gap: 1rem;
       "
     >
-      <hx-tile>
+      <hx-tile href="/dashboard">
         <span slot="icon">&#127968;</span>
         <span slot="label">Dashboard</span>
       </hx-tile>
-      <hx-tile>
+      <hx-tile href="/patients">
         <span slot="icon">&#128100;</span>
         <span slot="label">Patients</span>
       </hx-tile>
-      <hx-tile>
+      <hx-tile href="/reports">
         <span slot="icon">&#128203;</span>
         <span slot="label">Reports</span>
       </hx-tile>
-      <hx-tile>
+      <hx-tile href="/analytics">
         <span slot="icon">&#128200;</span>
         <span slot="label">Analytics</span>
       </hx-tile>
-      <hx-tile>
+      <hx-tile href="/settings">
         <span slot="icon">&#9881;</span>
         <span slot="label">Settings</span>
       </hx-tile>
@@ -235,8 +256,26 @@ export const InteractiveEvents: Story = {
   },
   play: async ({ canvasElement }) => {
     const tile = canvasElement.querySelector('hx-tile')!;
-    const base = tile.shadowRoot?.querySelector('[part="base"]') as HTMLElement;
+    const base = tile.shadowRoot?.querySelector('[part="tile"]') as HTMLElement;
+
+    // Test click activation
     base.click();
+    await expect(tile.selected).toBe(true);
+
+    // Reset
+    base.click();
+    await expect(tile.selected).toBe(false);
+
+    // Test keyboard activation (Enter)
+    base.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    await expect(tile.selected).toBe(true);
+
+    // Reset
+    base.click();
+    await expect(tile.selected).toBe(false);
+
+    // Test keyboard activation (Space)
+    base.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
     await expect(tile.selected).toBe(true);
   },
 };

--- a/packages/hx-library/src/components/hx-tile/hx-tile.styles.ts
+++ b/packages/hx-library/src/components/hx-tile/hx-tile.styles.ts
@@ -65,9 +65,9 @@ export const helixTileStyles = css`
   /* ─── Selected ─── */
 
   .tile--selected {
-    border-color: var(--hx-color-primary-500, #2563eb);
+    border-color: var(--hx-tile-selected-border-color, var(--hx-color-primary-500, #2563eb));
     border-width: var(--hx-border-width-medium, 2px);
-    background-color: var(--hx-color-primary-50, #eff6ff);
+    background-color: var(--hx-tile-selected-bg, var(--hx-color-primary-50, #eff6ff));
   }
 
   /* ─── Disabled ─── */
@@ -117,5 +117,21 @@ export const helixTileStyles = css`
 
   [hidden] {
     display: none !important;
+  }
+
+  /* ─── Motion safety ─── */
+
+  @media (prefers-reduced-motion: reduce) {
+    .tile {
+      transition: none;
+    }
+
+    .tile--interactive:hover {
+      transform: none;
+    }
+
+    .tile--interactive:active {
+      transform: none;
+    }
   }
 `;

--- a/packages/hx-library/src/components/hx-tile/hx-tile.test.ts
+++ b/packages/hx-library/src/components/hx-tile/hx-tile.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { page } from '@vitest/browser/context';
 import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixTile } from './hx-tile.js';
 import './index.js';
@@ -7,7 +6,7 @@ import './index.js';
 afterEach(cleanup);
 
 describe('hx-tile', () => {
-  // ─── Rendering (3) ───
+  // ─── Rendering ───
 
   describe('Rendering', () => {
     it('renders with shadow DOM', async () => {
@@ -15,42 +14,87 @@ describe('hx-tile', () => {
       expect(el.shadowRoot).toBeTruthy();
     });
 
-    it('exposes "base" CSS part', async () => {
+    it('exposes "tile" CSS part', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]');
-      expect(base).toBeTruthy();
+      const tile = shadowQuery(el, '[part="tile"]');
+      expect(tile).toBeTruthy();
     });
 
     it('applies default variant class', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.classList.contains('tile--default')).toBe(true);
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.classList.contains('tile--default')).toBe(true);
     });
   });
 
-  // ─── Property: variant (3) ───
+  // ─── Property: variant ───
 
   describe('Property: variant', () => {
-    it('applies default class', async () => {
-      const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.classList.contains('tile--default')).toBe(true);
-    });
-
     it('applies outlined class', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile variant="outlined"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.classList.contains('tile--outlined')).toBe(true);
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.classList.contains('tile--outlined')).toBe(true);
     });
 
     it('applies filled class', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile variant="filled"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.classList.contains('tile--filled')).toBe(true);
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.classList.contains('tile--filled')).toBe(true);
+    });
+  });
+
+  // ─── Static mode (clickable=false) ───
+
+  describe('Static mode (clickable=false)', () => {
+    it('renders as div with no role when clickable=false', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile clickable="false"><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.tagName.toLowerCase()).toBe('div');
+      expect(tile.hasAttribute('role')).toBe(false);
+    });
+
+    it('has no tabindex in static mode', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile clickable="false"><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.hasAttribute('tabindex')).toBe(false);
+    });
+
+    it('has no aria-pressed in static mode', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile clickable="false"><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.hasAttribute('aria-pressed')).toBe(false);
+    });
+
+    it('applies tile--static class in static mode', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile clickable="false"><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.classList.contains('tile--static')).toBe(true);
+    });
+
+    it('does not dispatch hx-select when clicked in static mode', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile clickable="false"><span slot="label">Test</span></hx-tile>',
+      );
+      let fired = false;
+      el.addEventListener('hx-select', () => {
+        fired = true;
+      });
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      tile.click();
+      await new Promise((r) => setTimeout(r, 50));
+      expect(fired).toBe(false);
     });
   });
 
@@ -59,37 +103,37 @@ describe('hx-tile', () => {
   describe('Button mode (no href)', () => {
     it('renders as div with role="button"', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.tagName.toLowerCase()).toBe('div');
-      expect(base.getAttribute('role')).toBe('button');
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.tagName.toLowerCase()).toBe('div');
+      expect(tile.getAttribute('role')).toBe('button');
     });
 
     it('has aria-pressed="false" by default', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.getAttribute('aria-pressed')).toBe('false');
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.getAttribute('aria-pressed')).toBe('false');
     });
 
     it('has aria-pressed="true" when selected', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile selected><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.getAttribute('aria-pressed')).toBe('true');
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.getAttribute('aria-pressed')).toBe('true');
     });
 
     it('has tabindex="0"', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.getAttribute('tabindex')).toBe('0');
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.getAttribute('tabindex')).toBe('0');
     });
 
     it('applies tile--selected class when selected', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile selected><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.classList.contains('tile--selected')).toBe(true);
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.classList.contains('tile--selected')).toBe(true);
     });
   });
 
@@ -100,33 +144,49 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/dashboard"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.tagName.toLowerCase()).toBe('a');
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.tagName.toLowerCase()).toBe('a');
     });
 
     it('anchor has correct href', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/dashboard"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, 'a[part="base"]') as HTMLAnchorElement;
-      expect(base.getAttribute('href')).toBe('/dashboard');
+      const tile = shadowQuery(el, 'a[part="tile"]') as HTMLAnchorElement;
+      expect(tile.getAttribute('href')).toBe('/dashboard');
     });
 
     it('does not render role="button" in link mode', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/dashboard"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.hasAttribute('role')).toBe(false);
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.hasAttribute('role')).toBe(false);
     });
 
     it('removes href from anchor when disabled', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/dashboard" disabled><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, 'a[part="base"]') as HTMLAnchorElement;
-      expect(base.hasAttribute('href')).toBe(false);
-      expect(base.getAttribute('aria-disabled')).toBe('true');
+      const tile = shadowQuery(el, 'a[part="tile"]') as HTMLAnchorElement;
+      expect(tile.hasAttribute('href')).toBe(false);
+      expect(tile.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('sets tabindex="-1" on disabled anchor', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile href="/dashboard" disabled><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, 'a[part="tile"]') as HTMLAnchorElement;
+      expect(tile.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('does not apply tile--selected class in link mode', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile href="/dashboard" selected><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.classList.contains('tile--selected')).toBe(false);
     });
   });
 
@@ -137,24 +197,24 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile disabled><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.classList.contains('tile--disabled')).toBe(true);
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.classList.contains('tile--disabled')).toBe(true);
     });
 
     it('has aria-disabled="true" when disabled', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile disabled><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.getAttribute('aria-disabled')).toBe('true');
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.getAttribute('aria-disabled')).toBe('true');
     });
 
     it('has tabindex="-1" when disabled', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile disabled><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
-      expect(base.getAttribute('tabindex')).toBe('-1');
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      expect(tile.getAttribute('tabindex')).toBe('-1');
     });
   });
 
@@ -163,18 +223,18 @@ describe('hx-tile', () => {
   describe('Events: button mode', () => {
     it('dispatches hx-select on click', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-select');
-      base.click();
+      tile.click();
       const event = await eventPromise;
       expect(event).toBeTruthy();
     });
 
     it('hx-select detail contains selected state and originalEvent', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-select');
-      base.click();
+      tile.click();
       const event = await eventPromise;
       expect(typeof event.detail.selected).toBe('boolean');
       expect(event.detail.originalEvent).toBeInstanceOf(MouseEvent);
@@ -182,9 +242,9 @@ describe('hx-tile', () => {
 
     it('toggles selected property on click', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       expect(el.selected).toBe(false);
-      base.click();
+      tile.click();
       await el.updateComplete;
       expect(el.selected).toBe(true);
     });
@@ -197,7 +257,9 @@ describe('hx-tile', () => {
       el.addEventListener('hx-select', () => {
         fired = true;
       });
-      el.click();
+      // Click on shadow tile element (disabled tile has pointer-events: none, so use dispatchEvent)
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      tile.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true }));
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });
@@ -206,12 +268,26 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile disabled><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       let fired = false;
       el.addEventListener('hx-select', () => {
         fired = true;
       });
-      base.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      tile.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      await new Promise((r) => setTimeout(r, 50));
+      expect(fired).toBe(false);
+    });
+
+    it('does not dispatch hx-select via Space when disabled', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile disabled><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      let fired = false;
+      el.addEventListener('hx-select', () => {
+        fired = true;
+      });
+      tile.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });
@@ -224,10 +300,10 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/test"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-click');
       // Use dispatchEvent (untrusted) to avoid anchor navigation in headless browser
-      base.dispatchEvent(
+      tile.dispatchEvent(
         new MouseEvent('click', { bubbles: true, composed: true, cancelable: true }),
       );
       const event = await eventPromise;
@@ -239,13 +315,13 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/test"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       let fired = false;
       el.addEventListener('hx-select', () => {
         fired = true;
       });
       // Use dispatchEvent (untrusted) to avoid anchor navigation in headless browser
-      base.dispatchEvent(
+      tile.dispatchEvent(
         new MouseEvent('click', { bubbles: true, composed: true, cancelable: true }),
       );
       await new Promise((r) => setTimeout(r, 50));
@@ -258,18 +334,18 @@ describe('hx-tile', () => {
   describe('Keyboard', () => {
     it('Enter fires hx-select in button mode', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-select');
-      base.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      tile.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       const event = await eventPromise;
       expect(event).toBeTruthy();
     });
 
     it('Space fires hx-select in button mode', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-select');
-      base.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
+      tile.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       const event = await eventPromise;
       expect(event).toBeTruthy();
     });
@@ -278,9 +354,20 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/test"><span slot="label">Test</span></hx-tile>',
       );
-      const base = shadowQuery(el, '[part="base"]')!;
+      const tile = shadowQuery(el, '[part="tile"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-click');
-      base.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      tile.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      const event = await eventPromise;
+      expect(event.detail.href).toBe('/test');
+    });
+
+    it('Space fires hx-click in link mode', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile href="/test"><span slot="label">Test</span></hx-tile>',
+      );
+      const tile = shadowQuery(el, '[part="tile"]')!;
+      const eventPromise = oneEvent<CustomEvent>(el, 'hx-click');
+      tile.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       const event = await eventPromise;
       expect(event.detail.href).toBe('/test');
     });
@@ -289,6 +376,12 @@ describe('hx-tile', () => {
   // ─── CSS Parts ───
 
   describe('CSS Parts', () => {
+    it('tile part exposed', async () => {
+      const el = await fixture<HelixTile>('<hx-tile><span slot="label">Test</span></hx-tile>');
+      const tile = shadowQuery(el, '[part="tile"]');
+      expect(tile).toBeTruthy();
+    });
+
     it('icon part exposed', async () => {
       const el = await fixture<HelixTile>(
         '<hx-tile><span slot="icon">&#127968;</span><span slot="label">Test</span></hx-tile>',
@@ -359,7 +452,6 @@ describe('hx-tile', () => {
   describe('Accessibility (axe-core)', () => {
     it('has no axe violations in button mode', async () => {
       const el = await fixture<HelixTile>('<hx-tile><span slot="label">Dashboard</span></hx-tile>');
-      await page.screenshot();
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
@@ -368,7 +460,6 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile selected><span slot="label">Selected Tile</span></hx-tile>',
       );
-      await page.screenshot();
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
@@ -377,7 +468,6 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile disabled><span slot="label">Disabled Tile</span></hx-tile>',
       );
-      await page.screenshot();
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
@@ -386,7 +476,14 @@ describe('hx-tile', () => {
       const el = await fixture<HelixTile>(
         '<hx-tile href="/dashboard"><span slot="label">Dashboard</span></hx-tile>',
       );
-      await page.screenshot();
+      const { violations } = await checkA11y(el);
+      expect(violations).toEqual([]);
+    });
+
+    it('has no axe violations in static mode', async () => {
+      const el = await fixture<HelixTile>(
+        '<hx-tile clickable="false"><span slot="label">Info Tile</span></hx-tile>',
+      );
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
@@ -396,7 +493,6 @@ describe('hx-tile', () => {
         const el = await fixture<HelixTile>(
           `<hx-tile variant="${variant}"><span slot="label">Tile</span></hx-tile>`,
         );
-        await page.screenshot();
         const { violations } = await checkA11y(el);
         expect(violations, `variant="${variant}" should have no violations`).toEqual([]);
         el.remove();

--- a/packages/hx-library/src/components/hx-tile/hx-tile.ts
+++ b/packages/hx-library/src/components/hx-tile/hx-tile.ts
@@ -5,9 +5,10 @@ import { tokenStyles } from '@helix/tokens/lit';
 import { helixTileStyles } from './hx-tile.styles.js';
 
 /**
- * A clickable tile component for dashboards, navigation grids, and selection patterns.
+ * A tile component for dashboards, navigation grids, and selection patterns.
+ * Supports static (non-interactive), selectable (toggle button), and link modes.
  *
- * @summary Clickable tile with icon, label, description, and badge slots.
+ * @summary Tile with icon, label, description, and badge slots.
  *
  * @tag hx-tile
  *
@@ -16,10 +17,10 @@ import { helixTileStyles } from './hx-tile.styles.js';
  * @slot description - Optional descriptive text below the label.
  * @slot badge - Optional overlay badge positioned at the top-right corner.
  *
- * @fires {CustomEvent<{href: string, originalEvent: MouseEvent | KeyboardEvent}>} hx-click - Dispatched when a link tile is clicked.
+ * @fires {CustomEvent<{href: string, originalEvent: MouseEvent | KeyboardEvent}>} hx-click - Dispatched when a link tile is activated.
  * @fires {CustomEvent<{selected: boolean, originalEvent: MouseEvent | KeyboardEvent}>} hx-select - Dispatched when a selectable tile is toggled.
  *
- * @csspart base - The outer tile container element.
+ * @csspart tile - The outer tile container element.
  * @csspart icon - The icon slot container.
  * @csspart label - The label slot container.
  * @csspart description - The description slot container.
@@ -34,12 +35,16 @@ import { helixTileStyles } from './hx-tile.styles.js';
  * @cssprop [--hx-tile-icon-size=var(--hx-size-icon-lg)] - Icon size.
  * @cssprop [--hx-tile-label-color=var(--hx-color-neutral-800)] - Label text color.
  * @cssprop [--hx-tile-description-color=var(--hx-color-neutral-600)] - Description text color.
+ * @cssprop [--hx-tile-selected-border-color=var(--hx-color-primary-500)] - Selected state border color.
+ * @cssprop [--hx-tile-selected-bg=var(--hx-color-primary-50)] - Selected state background color.
  *
  * @accessibility
- * - **Button mode (no href)**: Uses `role="button"`, `tabindex="0"`, `aria-pressed` for toggle state, and `aria-disabled` when disabled.
+ * - **Static mode (clickable=false)**: Renders as a plain `<div>` with no interactive role or event handling.
+ * - **Button mode (no href, clickable=true)**: Uses `role="button"`, `tabindex="0"`, `aria-pressed` for toggle state, and `aria-disabled` when disabled.
  * - **Link mode (href set)**: Renders a native `<a>` element with `aria-disabled` when disabled.
- * - **Keyboard**: Activates on `Enter` and `Space` in both modes.
+ * - **Keyboard**: Activates on `Enter` and `Space` in button and link modes. Space on anchor elements prevents default scroll.
  * - **Focus**: Visible focus ring via `:focus-visible` using `--hx-focus-ring-*` tokens.
+ * - **Icon-only tiles**: Provide an `aria-label` attribute for accessible naming when no label slot is used.
  */
 @customElement('hx-tile')
 export class HelixTile extends LitElement {
@@ -53,8 +58,26 @@ export class HelixTile extends LitElement {
   href = '';
 
   /**
+   * When false, the tile is purely static/decorative: no interactive role, no event handlers.
+   * Use for read-only informational tiles in dashboards where interaction is not needed.
+   * Ignored when `href` is set (link mode is always interactive).
+   *
+   * Accepts `clickable="false"` from HTML/Twig templates (Drupal-compatible).
+   * @attr clickable
+   */
+  @property({
+    reflect: true,
+    converter: {
+      fromAttribute: (value: string | null) => value !== 'false',
+      toAttribute: (value: boolean) => String(value),
+    },
+  })
+  clickable = true;
+
+  /**
    * Whether the tile is in a selected/pressed state.
-   * Only meaningful when the tile is selectable (no href).
+   * Only meaningful in button mode (no href, clickable=true).
+   * Setting this in link mode has no visual effect — use navigation patterns instead.
    * @attr selected
    */
   @property({ type: Boolean, reflect: true })
@@ -107,6 +130,17 @@ export class HelixTile extends LitElement {
   private _onBadgeSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
     this._hasBadge = slot.assignedNodes({ flatten: true }).length > 0;
+  }
+
+  // ─── Lifecycle ───
+
+  override updated(changedProperties: Map<string, unknown>): void {
+    super.updated(changedProperties);
+    if (changedProperties.has('selected') && this.href && this.selected) {
+      console.warn(
+        '[hx-tile] `selected` has no visual effect in link mode (href is set). Use navigation patterns instead.',
+      );
+    }
   }
 
   // ─── Event Handling ───
@@ -165,47 +199,63 @@ export class HelixTile extends LitElement {
 
   // ─── Render ───
 
+  /** @internal */
+  private _renderSlots() {
+    return html`
+      <div class="tile__icon" part="icon" ?hidden=${!this._hasIcon}>
+        <slot name="icon" @slotchange=${this._onIconSlotChange}></slot>
+      </div>
+      <div class="tile__label" part="label" ?hidden=${!this._hasLabel}>
+        <slot name="label" @slotchange=${this._onLabelSlotChange}></slot>
+      </div>
+      <div class="tile__description" part="description" ?hidden=${!this._hasDescription}>
+        <slot name="description" @slotchange=${this._onDescriptionSlotChange}></slot>
+      </div>
+      <div class="tile__badge" part="badge" ?hidden=${!this._hasBadge}>
+        <slot name="badge" @slotchange=${this._onBadgeSlotChange}></slot>
+      </div>
+    `;
+  }
+
   override render() {
     const isLink = !!this.href;
-    const isInteractive = !this.disabled;
+    const isButtonMode = !isLink && this.clickable;
+    const isStaticMode = !isLink && !this.clickable;
+    const isActivatable = (isLink || isButtonMode) && !this.disabled;
 
     const classes = {
       tile: true,
       [`tile--${this.variant}`]: true,
-      'tile--interactive': isInteractive,
-      'tile--selected': this.selected && !isLink,
+      'tile--interactive': isActivatable,
+      'tile--static': isStaticMode,
+      'tile--selected': this.selected && isButtonMode,
       'tile--disabled': this.disabled,
     };
 
     if (isLink) {
       return html`
         <a
-          part="base"
+          part="tile"
           class=${classMap(classes)}
           href=${this.disabled ? nothing : this.href}
           aria-disabled=${this.disabled ? 'true' : nothing}
+          tabindex=${this.disabled ? '-1' : nothing}
           @click=${this._handleClick}
           @keydown=${this._handleKeyDown}
         >
-          <div class="tile__icon" part="icon" ?hidden=${!this._hasIcon}>
-            <slot name="icon" @slotchange=${this._onIconSlotChange}></slot>
-          </div>
-          <div class="tile__label" part="label" ?hidden=${!this._hasLabel}>
-            <slot name="label" @slotchange=${this._onLabelSlotChange}></slot>
-          </div>
-          <div class="tile__description" part="description" ?hidden=${!this._hasDescription}>
-            <slot name="description" @slotchange=${this._onDescriptionSlotChange}></slot>
-          </div>
-          <div class="tile__badge" part="badge" ?hidden=${!this._hasBadge}>
-            <slot name="badge" @slotchange=${this._onBadgeSlotChange}></slot>
-          </div>
+          ${this._renderSlots()}
         </a>
       `;
     }
 
+    if (isStaticMode) {
+      return html` <div part="tile" class=${classMap(classes)}>${this._renderSlots()}</div> `;
+    }
+
+    // Button mode (clickable=true, no href)
     return html`
       <div
-        part="base"
+        part="tile"
         class=${classMap(classes)}
         role="button"
         tabindex=${this.disabled ? '-1' : '0'}
@@ -214,18 +264,7 @@ export class HelixTile extends LitElement {
         @click=${this._handleClick}
         @keydown=${this._handleKeyDown}
       >
-        <div class="tile__icon" part="icon" ?hidden=${!this._hasIcon}>
-          <slot name="icon" @slotchange=${this._onIconSlotChange}></slot>
-        </div>
-        <div class="tile__label" part="label" ?hidden=${!this._hasLabel}>
-          <slot name="label" @slotchange=${this._onLabelSlotChange}></slot>
-        </div>
-        <div class="tile__description" part="description" ?hidden=${!this._hasDescription}>
-          <slot name="description" @slotchange=${this._onDescriptionSlotChange}></slot>
-        </div>
-        <div class="tile__badge" part="badge" ?hidden=${!this._hasBadge}>
-          <slot name="badge" @slotchange=${this._onBadgeSlotChange}></slot>
-        </div>
+        ${this._renderSlots()}
       </div>
     `;
   }

--- a/packages/hx-library/src/components/hx-tile/hx-tile.twig
+++ b/packages/hx-library/src/components/hx-tile/hx-tile.twig
@@ -1,0 +1,53 @@
+{#
+/**
+ * @file hx-tile.twig
+ * Twig template for the hx-tile web component.
+ *
+ * Variables:
+ *   - label (string, required): The tile label/title text.
+ *   - description (string, optional): Descriptive text below the label.
+ *   - icon (string, optional): Icon HTML or emoji rendered in the icon slot.
+ *   - href (string, optional): URL for link mode. Omit for button/static mode.
+ *   - clickable (boolean, optional): Set to false for non-interactive static tiles. Default: true.
+ *   - selected (boolean, optional): Selected/pressed state for selectable tiles. Default: false.
+ *   - disabled (boolean, optional): When true, tile is non-interactive and dimmed. Default: false.
+ *   - variant (string, optional): 'default', 'outlined', or 'filled'. Default: 'default'.
+ *   - badge (string, optional): Badge HTML rendered in the badge slot.
+ *   - attributes (Drupal\Core\Template\Attribute, optional): Additional HTML attributes.
+ */
+#}
+
+<hx-tile
+  {% if variant %}variant="{{ variant }}"{% endif %}
+  {% if href %}href="{{ href }}"{% endif %}
+  {% if clickable is defined and not clickable %}clickable="false"{% endif %}
+  {% if selected %}selected{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {{ attributes }}
+>
+  {% if icon %}
+    <span slot="icon">{{ icon }}</span>
+  {% endif %}
+
+  {% if label %}
+    <span slot="label">{{ label }}</span>
+  {% endif %}
+
+  {% if description %}
+    <span slot="description">{{ description }}</span>
+  {% endif %}
+
+  {% if badge %}
+    <span
+      slot="badge"
+      style="
+        background: var(--hx-color-error-500, #ef4444);
+        color: var(--hx-color-neutral-0, #ffffff);
+        border-radius: var(--hx-border-radius-full, 9999px);
+        font-size: var(--hx-font-size-xs, 0.75rem);
+        padding: var(--hx-space-0-5, 2px) var(--hx-space-1-5, 6px);
+        font-weight: var(--hx-font-weight-semibold, 600);
+      "
+    >{{ badge }}</span>
+  {% endif %}
+</hx-tile>


### PR DESCRIPTION
## Summary

Resolve all defects found in the Deep Audit v2 for `hx-tile`.
Source: `packages/hx-library/src/components/hx-tile/AUDIT.md`

**Summary:** 23 defects — 1 P0, 9 P1, 13 P2, 0 P3

### P0 — Critical
- [ ] [P0] 01: No static (non-interactive) mode — every enabled tile is always interactive

Reference the AUDIT.md in the component directory for full details and code locations.

---
*Recovered automatically by Automaker post-agent hook*