### PR TITLE
AUDIT Fix: hx-field-label

### DIFF
--- a/packages/hx-library/src/components/hx-field-label/hx-field-label.stories.ts
+++ b/packages/hx-library/src/components/hx-field-label/hx-field-label.stories.ts
@@ -89,9 +89,8 @@ export const Default: Story = {
     const host = getLabelHost(canvasElement);
     await expect(host).toBeTruthy();
 
-    const shadow = within(getShadowRoot(host));
-    const base = shadow.getByRole('generic', { hidden: true });
-    await expect(base.tagName.toLowerCase()).toBe('span');
+    const base = host.shadowRoot!.querySelector('[part="base"]');
+    await expect(base?.tagName.toLowerCase()).toBe('span');
   },
 };
 
@@ -112,14 +111,21 @@ export const WithFor: Story = {
       />
     </div>
   `,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Note:** Due to the shadow DOM boundary, the `for` attribute on `hx-field-label` only creates a label association when the input is in the same shadow root. For inputs in light DOM, use `aria-labelledby` pointing to the `hx-field-label` host's `id` instead.",
+      },
+    },
+  },
   play: async ({ canvasElement }) => {
     const host = getLabelHost(canvasElement);
     await expect(host).toBeTruthy();
 
-    const shadow = within(getShadowRoot(host));
-    const label = shadow.getByRole('generic', { hidden: true });
-    await expect(label.tagName.toLowerCase()).toBe('label');
-    await expect(label.getAttribute('for')).toBe('patient-email');
+    const base = host.shadowRoot!.querySelector('[part="base"]');
+    await expect(base?.tagName.toLowerCase()).toBe('label');
+    await expect(base?.getAttribute('for')).toBe('patient-email');
   },
 };
 
@@ -196,16 +202,16 @@ export const CSSParts: Story = {
         font-size: 0.6875rem;
         text-transform: uppercase;
         letter-spacing: 0.08em;
-        color: #0d6efd;
+        color: var(--hx-color-primary-600, #0d6efd);
         font-weight: 700;
       }
       .parts-demo hx-field-label::part(required-indicator) {
         font-size: 1rem;
-        color: #dc3545;
+        color: var(--hx-color-error-600, #dc3545);
       }
       .parts-demo hx-field-label::part(optional-indicator) {
         font-style: italic;
-        color: #6c757d;
+        color: var(--hx-color-neutral-500, #6c757d);
       }
     </style>
     <div class="parts-demo" style="display: flex; flex-direction: column; gap: 1rem;">
@@ -228,37 +234,48 @@ export const HealthcareFormLabels: Story = {
   render: () => html`
     <form style="display: flex; flex-direction: column; gap: 1.25rem; max-width: 400px;">
       <div>
-        <hx-field-label required for="patient-name">Full Name</hx-field-label>
+        <hx-field-label id="label-patient-name" required>Full Name</hx-field-label>
         <input
           id="patient-name"
           type="text"
           placeholder="First Middle Last"
           required
+          aria-labelledby="label-patient-name"
           style="display: block; width: 100%; margin-top: 0.25rem; padding: 0.5rem 0.75rem; border: 1px solid var(--hx-color-neutral-300, #dee2e6); border-radius: 0.375rem; font-size: 0.875rem;"
         />
       </div>
 
       <div>
-        <hx-field-label required for="dob">Date of Birth</hx-field-label>
+        <hx-field-label id="label-dob" required>Date of Birth</hx-field-label>
         <input
           id="dob"
           type="date"
           required
+          aria-labelledby="label-dob"
           style="display: block; width: 100%; margin-top: 0.25rem; padding: 0.5rem 0.75rem; border: 1px solid var(--hx-color-neutral-300, #dee2e6); border-radius: 0.375rem; font-size: 0.875rem;"
         />
       </div>
 
       <div>
-        <hx-field-label optional for="pcp">Primary Care Provider</hx-field-label>
+        <hx-field-label id="label-pcp" optional>Primary Care Provider</hx-field-label>
         <input
           id="pcp"
           type="text"
           placeholder="Dr. Eleanor Vance, MD"
+          aria-labelledby="label-pcp"
           style="display: block; width: 100%; margin-top: 0.25rem; padding: 0.5rem 0.75rem; border: 1px solid var(--hx-color-neutral-300, #dee2e6); border-radius: 0.375rem; font-size: 0.875rem;"
         />
       </div>
     </form>
   `,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Healthcare form labels using the `aria-labelledby` pattern — the correct approach when the input is in light DOM outside the shadow root.',
+      },
+    },
+  },
 };
 
 // ─────────────────────────────────────────────────
@@ -284,7 +301,7 @@ export const CSSCustomProperties: Story = {
         >
           --hx-field-label-color
         </p>
-        <hx-field-label required style="--hx-field-label-color: #2563eb;">
+        <hx-field-label required style="--hx-field-label-color: var(--hx-color-primary-600, #2563eb);">
           Custom brand label color
         </hx-field-label>
       </div>
@@ -293,9 +310,9 @@ export const CSSCustomProperties: Story = {
         <p
           style="margin: 0 0 0.5rem; font-size: 0.75rem; color: var(--hx-color-neutral-500, #6c757d); text-transform: uppercase; letter-spacing: 0.05em;"
         >
-          --hx-color-danger (required indicator)
+          --hx-field-label-required-color (required indicator)
         </p>
-        <hx-field-label required style="--hx-color-danger: #d97706;">
+        <hx-field-label required style="--hx-field-label-required-color: var(--hx-color-warning-600, #d97706);">
           Custom amber required indicator
         </hx-field-label>
       </div>

--- a/packages/hx-library/src/components/hx-field-label/hx-field-label.styles.ts
+++ b/packages/hx-library/src/components/hx-field-label/hx-field-label.styles.ts
@@ -17,7 +17,10 @@ export const helixFieldLabelStyles = css`
   }
 
   .required-indicator {
-    color: var(--hx-color-danger, var(--hx-color-error-500, #ef4444));
+    color: var(
+      --hx-field-label-required-color,
+      var(--hx-color-danger, var(--hx-color-error-500, #ef4444))
+    );
     font-weight: var(--hx-font-weight-bold, 700);
   }
 
@@ -25,5 +28,17 @@ export const helixFieldLabelStyles = css`
     font-size: var(--hx-font-size-xs, 0.75rem);
     font-weight: var(--hx-font-weight-normal, 400);
     color: var(--hx-color-neutral-500, #6b7280);
+  }
+
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 `;

--- a/packages/hx-library/src/components/hx-field-label/hx-field-label.test.ts
+++ b/packages/hx-library/src/components/hx-field-label/hx-field-label.test.ts
@@ -84,10 +84,21 @@ describe('hx-field-label', () => {
       expect(indicator).toBeTruthy();
     });
 
-    it('required indicator has aria-hidden="true"', async () => {
+    it('required indicator visual asterisk is aria-hidden', async () => {
       const el = await fixture<HelixFieldLabel>('<hx-field-label required>Label</hx-field-label>');
       const indicator = shadowQuery(el, '[part="required-indicator"]');
-      expect(indicator?.getAttribute('aria-hidden')).toBe('true');
+      expect(indicator).toBeTruthy();
+      // The visual asterisk wrapper is aria-hidden; a visually-hidden "required" text is available to AT
+      const visualAsterisk = indicator?.querySelector('[aria-hidden="true"]');
+      expect(visualAsterisk).toBeTruthy();
+    });
+
+    it('required indicator includes visually-hidden text for AT', async () => {
+      const el = await fixture<HelixFieldLabel>('<hx-field-label required>Label</hx-field-label>');
+      const indicator = shadowQuery(el, '[part="required-indicator"]');
+      const visuallyHidden = indicator?.querySelector('.visually-hidden');
+      expect(visuallyHidden).toBeTruthy();
+      expect(visuallyHidden?.textContent?.trim()).toBe('required');
     });
 
     it('does not show required indicator when required is false', async () => {
@@ -138,8 +149,13 @@ describe('hx-field-label', () => {
       const el = await fixture<HelixFieldLabel>(
         '<hx-field-label required><span slot="required-indicator">(req)</span></hx-field-label>',
       );
+      // verify light DOM content exists
       const slotted = el.querySelector('[slot="required-indicator"]');
       expect(slotted?.textContent).toBe('(req)');
+      // verify shadow DOM slot has assigned nodes
+      const slot = el.shadowRoot!.querySelector('slot[name="required-indicator"]') as HTMLSlotElement;
+      expect(slot).toBeTruthy();
+      expect(slot.assignedNodes().length).toBeGreaterThan(0);
     });
 
     it('required-indicator slot is not rendered when required is false', async () => {

--- a/packages/hx-library/src/components/hx-field-label/hx-field-label.ts
+++ b/packages/hx-library/src/components/hx-field-label/hx-field-label.ts
@@ -7,8 +7,11 @@ import { helixFieldLabelStyles } from './hx-field-label.styles.js';
  * Standardized label for form fields. Used as a consistent sub-component
  * for hx-field and other form field components.
  *
- * When the `for` attribute is set, renders a native `<label for="...">` element
- * for direct label association with a same-document form control.
+ * When the `for` attribute is set, renders a native `<label for="...">` element.
+ * **Note:** Due to the shadow DOM boundary, this label association only works
+ * when the associated input is in the **same shadow root**. For inputs in
+ * light DOM (the typical consumer deployment), use `aria-labelledby` pointing
+ * to the host element's `id` instead of the `for` attribute.
  *
  * When `for` is unset, renders a `<span>` that can be referenced via
  * `aria-labelledby` for labeling controls in a shadow DOM boundary.
@@ -25,6 +28,7 @@ import { helixFieldLabelStyles } from './hx-field-label.styles.js';
  * @csspart optional-indicator - The optional text indicator.
  *
  * @cssprop [--hx-field-label-color=var(--hx-color-neutral-700)] - Label text color.
+ * @cssprop [--hx-field-label-required-color=var(--hx-color-danger, var(--hx-color-error-500, #ef4444))] - Required indicator color.
  * @cssprop [--hx-font-label-size=var(--hx-font-size-sm)] - Label font size.
  * @cssprop [--hx-font-label-weight=var(--hx-font-weight-medium)] - Label font weight.
  * @cssprop [--hx-font-label-line-height=var(--hx-line-height-normal)] - Label line height.
@@ -58,8 +62,9 @@ export class HelixFieldLabel extends LitElement {
 
   override render() {
     const requiredIndicator = this.required
-      ? html`<span part="required-indicator" class="required-indicator" aria-hidden="true"
-          ><slot name="required-indicator">*</slot></span
+      ? html`<span part="required-indicator" class="required-indicator"
+          ><span aria-hidden="true"><slot name="required-indicator">*</slot></span
+          ><span class="visually-hidden">required</span></span
         >`
       : nothing;
 


### PR DESCRIPTION
## Summary
- **P0-01/P0-02**: Documented shadow DOM `for` attribute limitation in JSDoc; migrated `HealthcareFormLabels` story to `aria-labelledby` as the canonical light-DOM labeling pattern
- **P1-01**: Added visually-hidden "required" text inside the required indicator — asterisk is `aria-hidden` but AT now receives the "required" announcement (WCAG 1.3.1 fix)
- **P1-02**: Replaced `getByRole('generic')` play test queries with direct `shadowRoot.querySelector('[part="base"]')` — correct DOM targeting for `<label>` and `<span>` elements
- **P1-03**: Introduced `--hx-field-label-required-color` component token with fallback to `--hx-color-danger`; documented in `@cssprop` JSDoc
- **P2-01**: Replaced hardcoded hex values in `CSSParts` and `CSSCustomProperties` stories with `--hx-*` semantic token references
- **P2-02**: Enhanced slot test to assert `assignedNodes().length > 0` — verifies shadow DOM slot distribution, not just light DOM element presence

## Test plan
- [x] 31 Vitest browser tests pass (`npm run test:library`)
- [x] Build succeeds with zero errors (`npm run build:library`)
- [x] `npm run verify` clean (lint + format:check + type-check all pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)