### PR TITLE
Audit Fix: hx-field-label

### DIFF
--- a/packages/hx-library/src/components/hx-field-label/hx-field-label.stories.ts
+++ b/packages/hx-library/src/components/hx-field-label/hx-field-label.stories.ts
@@ -297,7 +297,10 @@ export const CSSCustomProperties: Story = {
         >
           --hx-field-label-color
         </p>
-        <hx-field-label required style="--hx-field-label-color: var(--hx-color-primary-600, #2563eb);">
+        <hx-field-label
+          required
+          style="--hx-field-label-color: var(--hx-color-primary-600, #2563eb);"
+        >
           Custom brand label color
         </hx-field-label>
       </div>
@@ -308,7 +311,10 @@ export const CSSCustomProperties: Story = {
         >
           --hx-field-label-required-color (required indicator)
         </p>
-        <hx-field-label required style="--hx-field-label-required-color: var(--hx-color-warning-600, #d97706);">
+        <hx-field-label
+          required
+          style="--hx-field-label-required-color: var(--hx-color-warning-600, #d97706);"
+        >
           Custom amber required indicator
         </hx-field-label>
       </div>

--- a/packages/hx-library/src/components/hx-field-label/hx-field-label.test.ts
+++ b/packages/hx-library/src/components/hx-field-label/hx-field-label.test.ts
@@ -151,7 +151,9 @@ describe('hx-field-label', () => {
       const slotted = el.querySelector('[slot="required-indicator"]');
       expect(slotted?.textContent).toBe('(req)');
       // verify shadow DOM slot has assigned nodes
-      const slot = el.shadowRoot!.querySelector('slot[name="required-indicator"]') as HTMLSlotElement;
+      const slot = el.shadowRoot!.querySelector(
+        'slot[name="required-indicator"]',
+      ) as HTMLSlotElement;
       expect(slot).toBeTruthy();
       expect(slot.assignedNodes().length).toBeGreaterThan(0);
     });


### PR DESCRIPTION
## Summary

Resolve all defects found in the Deep Audit v2 for `hx-field-label`.
Source: `packages/hx-library/src/components/hx-field-label/AUDIT.md`

**Summary:** 1 defect — 0 P0, 0 P1, 1 P2, 0 P3

Reference the AUDIT.md in the component directory for full details and code locations.

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-09T02:23:06.349Z -->