### PR TITLE
fix(hx-toast): resolve 13 audit defects (P1/P2)

### DIFF
--- a/packages/hx-library/src/components/hx-toast/hx-toast.drupal.js
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.drupal.js
@@ -1,0 +1,85 @@
+/* global Drupal */
+
+/**
+ * @file hx-toast.drupal.js
+ * Drupal behaviors for programmatic toast triggering via hx-toast.
+ *
+ * Attach trigger elements with a `data-hx-toast` attribute containing a JSON
+ * object of toast options. The behavior calls the imperative `toast()` utility
+ * from @wc-2026/library when the trigger is clicked.
+ *
+ * @example Twig template
+ *   <button
+ *     data-hx-toast='{"message":"Record saved.","variant":"success","duration":4000}'
+ *   >
+ *     Save Record
+ *   </button>
+ *
+ * @example Programmatic trigger (data attributes)
+ *   <button
+ *     data-hx-toast='{"message":"Medication interaction detected.","variant":"warning"}'
+ *   >
+ *     Check Interactions
+ *   </button>
+ */
+
+(function (Drupal) {
+  'use strict';
+
+  Drupal.behaviors.hxToast = {
+    /**
+     * Attach click handlers to elements with `data-hx-toast` attributes.
+     *
+     * @param {HTMLElement|Document} context - The DOM context from Drupal.
+     */
+    attach: function (context) {
+      context.querySelectorAll('[data-hx-toast]').forEach(function (trigger) {
+        if (trigger.dataset.hxToastAttached) {
+          return;
+        }
+        trigger.dataset.hxToastAttached = 'true';
+
+        trigger.addEventListener('click', function () {
+          var rawOptions;
+          try {
+            rawOptions = JSON.parse(trigger.dataset.hxToast);
+          } catch {
+            Drupal.announce(
+              Drupal.t('Toast configuration is invalid. Contact your site administrator.'),
+              'assertive',
+            );
+            return;
+          }
+
+          import('@wc-2026/library/components/hx-toast/index.js')
+            .then(function (module) {
+              module.toast(rawOptions);
+            })
+            .catch(function () {
+              Drupal.announce(
+                Drupal.t('Unable to display notification. Please try again.'),
+                'assertive',
+              );
+            });
+        });
+      });
+    },
+
+    /**
+     * Detach: remove the attached marker so re-attachment works on partial DOM
+     * updates (e.g., AJAX replaced content).
+     *
+     * @param {HTMLElement|Document} context - The DOM context from Drupal.
+     * @param {object} _settings - Drupal settings (unused).
+     * @param {string} trigger - Detach trigger ('unload' | 'serialize').
+     */
+    detach: function (context, _settings, trigger) {
+      if (trigger !== 'unload') {
+        return;
+      }
+      context.querySelectorAll('[data-hx-toast]').forEach(function (el) {
+        delete el.dataset.hxToastAttached;
+      });
+    },
+  };
+})(Drupal);

--- a/packages/hx-library/src/components/hx-toast/hx-toast.stories.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.stories.ts
@@ -285,7 +285,7 @@ export const StackTopCenter: Story = {
       <p style="padding: 1rem; color: #6b7280; font-size: 0.875rem; margin: 0;">
         Top-center placement
       </p>
-      <hx-toast-stack placement="top-center" style="position: absolute; left: 0; right: 0; top: 0; transform: none;">
+      <hx-toast-stack placement="top-center" style="position: absolute; left: 0; right: 0; top: 0;">
         <hx-toast variant="info" ?open=${true} ?closable=${true}
           >Appointment confirmed for 3:00 PM.</hx-toast
         >

--- a/packages/hx-library/src/components/hx-toast/hx-toast.styles.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.styles.ts
@@ -31,7 +31,7 @@ export const helixToastStyles = css`
       0 2px 4px -2px rgb(0 0 0 / 0.1)
     );
     opacity: 0;
-    transform: translateY(var(--hx-space-2, 0.5rem));
+    transform: translateY(var(--hx-toast-enter-translate, var(--hx-space-2, 0.5rem)));
     transition:
       opacity var(--hx-transition-normal, 250ms ease),
       transform var(--hx-transition-normal, 250ms ease);
@@ -174,8 +174,7 @@ export const helixToastStackStyles = css`
     bottom: auto;
   }
 
-  :host([placement='bottom-start']),
-  :host(:not([placement])) {
+  :host([placement='bottom-start']) {
     bottom: 0;
     left: 0;
     right: auto;
@@ -199,8 +198,13 @@ export const helixToastStackStyles = css`
 
   /* ─── Bottom placements: reverse order so newest is on top ─── */
 
-  :host([placement^='bottom']) .toast-stack,
-  :host(:not([placement])) .toast-stack {
+  :host([placement^='bottom']) .toast-stack {
     flex-direction: column-reverse;
+  }
+
+  /* ─── Slide direction by placement ─── */
+
+  :host([placement^='top']) ::slotted(hx-toast) {
+    --hx-toast-enter-translate: calc(var(--hx-space-2, 0.5rem) * -1);
   }
 `;

--- a/packages/hx-library/src/components/hx-toast/hx-toast.test.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import { page } from '@vitest/browser/context';
 import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixToast, HelixToastStack } from './hx-toast.js';
+import { toast } from './hx-toast.js';
 import './index.js';
 
 afterEach(cleanup);
@@ -426,5 +427,182 @@ describe('hx-toast-stack', () => {
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
+  });
+
+  // ─── Stack limit enforcement (P2-02) ───
+
+  describe('Stack limit enforcement', () => {
+    afterEach(() => {
+      document.querySelectorAll('hx-toast-stack').forEach((s) => s.remove());
+    });
+
+    it('hides the oldest open toast when stack limit is exceeded via toast()', async () => {
+      // Use a unique placement so this test gets its own isolated stack
+      const placement = 'top-center';
+      const first = toast({ message: 'First', placement });
+      await first.updateComplete;
+
+      const second = toast({ message: 'Second', placement });
+      await second.updateComplete;
+
+      // Both within the default stackLimit=3, so both are open
+      expect(first.open).toBe(true);
+      expect(second.open).toBe(true);
+
+      const third = toast({ message: 'Third', placement });
+      await third.updateComplete;
+
+      // Stack is now at capacity (3). Next call should hide the oldest.
+      const fourth = toast({ message: 'Fourth', placement });
+      await fourth.updateComplete;
+
+      // First toast should now be hidden
+      expect(first.open).toBe(false);
+      // Most recently added should be open
+      expect(fourth.open).toBe(true);
+    });
+
+    it('does not hide any toast when under the stack limit', async () => {
+      const placement = 'top-start';
+      const first = toast({ message: 'First', placement });
+      await first.updateComplete;
+
+      const second = toast({ message: 'Second', placement });
+      await second.updateComplete;
+
+      // Two toasts, default limit is 3 — neither should be hidden
+      expect(first.open).toBe(true);
+      expect(second.open).toBe(true);
+    });
+  });
+});
+
+// ─── toast() utility (P1-03) ───
+
+describe('toast() utility', () => {
+  afterEach(() => {
+    cleanup();
+    document.querySelectorAll('hx-toast-stack').forEach((s) => s.remove());
+  });
+
+  it('creates an hx-toast-stack on document.body when none exists', async () => {
+    // Ensure clean slate for this placement
+    document
+      .querySelectorAll('hx-toast-stack[placement="bottom-start"]')
+      .forEach((s) => s.remove());
+
+    const el = toast({ message: 'Hello', placement: 'bottom-start' });
+    await el.updateComplete;
+
+    const stack = document.querySelector('hx-toast-stack[placement="bottom-start"]');
+    expect(stack).toBeTruthy();
+    expect(document.body.contains(stack)).toBe(true);
+  });
+
+  it('reuses an existing hx-toast-stack for the same placement', async () => {
+    const placement = 'bottom-center';
+    document
+      .querySelectorAll(`hx-toast-stack[placement="${placement}"]`)
+      .forEach((s) => s.remove());
+
+    const first = toast({ message: 'First', placement });
+    await first.updateComplete;
+
+    const second = toast({ message: 'Second', placement });
+    await second.updateComplete;
+
+    const stacks = document.querySelectorAll(`hx-toast-stack[placement="${placement}"]`);
+    expect(stacks.length).toBe(1);
+  });
+
+  it('returns the created hx-toast element', async () => {
+    const el = toast({ message: 'Test', placement: 'top-end' });
+    await el.updateComplete;
+
+    expect(el.tagName.toLowerCase()).toBe('hx-toast');
+    expect(el.open).toBe(true);
+  });
+
+  it('enforces stack limit: oldest open toast is hidden when at capacity', async () => {
+    const placement = 'bottom-end';
+    document
+      .querySelectorAll(`hx-toast-stack[placement="${placement}"]`)
+      .forEach((s) => s.remove());
+
+    // Default stackLimit is 3. Fill to capacity.
+    const t1 = toast({ message: 'Toast 1', placement });
+    await t1.updateComplete;
+    const t2 = toast({ message: 'Toast 2', placement });
+    await t2.updateComplete;
+    const t3 = toast({ message: 'Toast 3', placement });
+    await t3.updateComplete;
+
+    // All three should be open at this point
+    expect(t1.open).toBe(true);
+    expect(t2.open).toBe(true);
+    expect(t3.open).toBe(true);
+
+    // Fourth call exceeds limit — oldest (t1) should be hidden
+    const t4 = toast({ message: 'Toast 4', placement });
+    await t4.updateComplete;
+
+    expect(t1.open).toBe(false);
+    expect(t4.open).toBe(true);
+  });
+
+  it('removes the toast element from DOM after hx-after-hide fires', async () => {
+    const el = toast({ message: 'Remove me', duration: 0, placement: 'top-start' });
+    await el.updateComplete;
+    expect(document.body.contains(el)).toBe(true);
+
+    const afterHidePromise = oneEvent(el, 'hx-after-hide');
+    el.hide();
+    await afterHidePromise;
+
+    expect(document.body.contains(el)).toBe(false);
+  });
+});
+
+// ─── disconnectedCallback timer cleanup (P2-03) ───
+
+describe('hx-toast disconnectedCallback timer cleanup', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it('cancels auto-dismiss timer when element is removed from DOM', async () => {
+    const duration = 5000;
+    const el = await fixture<HelixToast>(`<hx-toast duration="${duration}">Test</hx-toast>`);
+    el.show();
+    await el.updateComplete;
+    expect(el.open).toBe(true);
+
+    const hideSpy = vi.spyOn(el, 'hide');
+
+    // Detach from DOM — disconnectedCallback should clear the timer
+    el.remove();
+
+    // Advance well past the duration
+    vi.advanceTimersByTime(duration * 2);
+
+    // hide() should not have been called by the timer after disconnection
+    expect(hideSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when removed from DOM before timer fires', async () => {
+    const el = await fixture<HelixToast>('<hx-toast duration="2000">Test</hx-toast>');
+    el.show();
+    await el.updateComplete;
+
+    // Remove mid-flight — should be a no-op with no errors
+    expect(() => {
+      el.remove();
+      vi.advanceTimersByTime(5000);
+    }).not.toThrow();
   });
 });

--- a/packages/hx-library/src/components/hx-toast/hx-toast.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.ts
@@ -76,21 +76,36 @@ export class HelixToast extends LitElement {
   @property({ type: Boolean, reflect: true })
   open = false;
 
+  /**
+   * Accessible label for the close button. Override for localization.
+   * @attr close-label
+   */
+  @property({ attribute: 'close-label' })
+  closeLabel = 'Dismiss notification';
+
   // ─── Private State ───
 
   /** @internal */
   private _timer: ReturnType<typeof setTimeout> | null = null;
+
+  /** @internal */
+  private _timerStartedAt: number | null = null;
+
+  /** @internal */
+  private _timerRemaining: number | null = null;
 
   // ─── Lifecycle ───
 
   override updated(changedProperties: Map<PropertyKey, unknown>): void {
     if (changedProperties.has('open')) {
       if (this.open) {
+        this.removeAttribute('aria-hidden');
         this._emitShow();
         if (this.duration > 0) {
           this._startTimer();
         }
       } else {
+        this.setAttribute('aria-hidden', 'true');
         this._clearTimer();
         this._emitHide();
       }
@@ -121,19 +136,42 @@ export class HelixToast extends LitElement {
   // ─── Private Helpers ───
 
   /** @internal */
-  private _startTimer(): void {
-    this._clearTimer();
+  private _startTimer(remaining?: number): void {
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      return;
+    }
+    this._clearTimerHandle();
+    const delay = remaining ?? this.duration;
+    this._timerStartedAt = Date.now();
+    this._timerRemaining = delay;
     this._timer = setTimeout(() => {
       this.open = false;
-    }, this.duration);
+    }, delay);
   }
 
   /** @internal */
-  private _clearTimer(): void {
+  private _pauseTimer(): void {
+    if (this._timer === null || this._timerStartedAt === null || this._timerRemaining === null) {
+      return;
+    }
+    const elapsed = Date.now() - this._timerStartedAt;
+    this._timerRemaining = Math.max(0, this._timerRemaining - elapsed);
+    this._clearTimerHandle();
+  }
+
+  /** @internal */
+  private _clearTimerHandle(): void {
     if (this._timer !== null) {
       clearTimeout(this._timer);
       this._timer = null;
     }
+  }
+
+  /** @internal */
+  private _clearTimer(): void {
+    this._clearTimerHandle();
+    this._timerStartedAt = null;
+    this._timerRemaining = null;
   }
 
   /** @internal */
@@ -166,25 +204,25 @@ export class HelixToast extends LitElement {
 
   /** @internal */
   private _handleMouseEnter(): void {
-    this._clearTimer();
+    this._pauseTimer();
   }
 
   /** @internal */
   private _handleMouseLeave(): void {
     if (this.open && this.duration > 0) {
-      this._startTimer();
+      this._startTimer(this._timerRemaining ?? undefined);
     }
   }
 
   /** @internal */
   private _handleFocusIn(): void {
-    this._clearTimer();
+    this._pauseTimer();
   }
 
   /** @internal */
   private _handleFocusOut(): void {
     if (this.open && this.duration > 0) {
-      this._startTimer();
+      this._startTimer(this._timerRemaining ?? undefined);
     }
   }
 
@@ -217,6 +255,7 @@ export class HelixToast extends LitElement {
         })}
         role=${this._role}
         aria-live=${this._ariaLive}
+        aria-atomic="true"
         @mouseenter=${this._handleMouseEnter}
         @mouseleave=${this._handleMouseLeave}
         @focusin=${this._handleFocusIn}
@@ -236,7 +275,7 @@ export class HelixToast extends LitElement {
               <button
                 part="close-button"
                 class="toast__close"
-                aria-label="Dismiss notification"
+                aria-label=${this.closeLabel}
                 @click=${this._handleClose}
               >
                 <svg


### PR DESCRIPTION
## Summary

- **P1 (5 fixes):** `aria-hidden` on host when closed, `aria-atomic` on live region, full `toast()` utility test coverage, Drupal behaviors file (`hx-toast.drupal.js`), hover/focus-resume now uses remaining timer time instead of restarting at full duration
- **P2 (8 fixes):** `prefers-reduced-motion` suppresses auto-dismiss, `stackLimit` enforcement tested, `disconnectedCallback` cleanup tested, slide animation direction varies by placement (`top-*` slides down, `bottom-*` slides up), `closeLabel` property for i18n, `StackTopCenter` story `transform: none` override removed, CSS `:host(:not([placement]))` fallback mismatch fixed
- All 59 tests pass (9 new tests added); `npm run verify` clean

## Test plan
- [x] `npm run verify` — 11/11 tasks pass
- [x] `npm run build` (library) — clean
- [x] Vitest browser mode (Chromium) — 59/59 tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)