### PR TITLE
FOUNDATION: Create Astro component documentation template

### DIFF
--- a/apps/docs/src/content/docs/component-library/_TEMPLATE.md
+++ b/apps/docs/src/content/docs/component-library/_TEMPLATE.md
@@ -1,0 +1,207 @@
+# Component Doc Page Template
+
+> **Usage:** Copy this template when writing a new component doc page under
+> `apps/docs/src/content/docs/component-library/`. Replace every
+> `<!-- PLACEHOLDER -->` comment with real content pulled from the component
+> source and CEM output (`packages/hx-library/custom-elements.json`).
+>
+> The rendered file must be `.mdx` so it can import Astro components.
+> Rename this file `hx-<component-name>.mdx` and delete this callout block.
+
+---
+
+```mdx
+---
+title: 'hx-<component-name>'
+description: <!-- ONE-LINE DESCRIPTION: what the component does -->
+---
+
+import ComponentLoader from '../../../components/ComponentLoader.astro';
+import ComponentDemo from '../../../components/ComponentDemo.astro';
+import ComponentDoc from '../../../components/ComponentDoc.astro';
+
+<!-- Injects the component bundle into the page so live demos work. Required. -->
+<ComponentLoader />
+
+<!-- Renders the CEM-derived summary paragraph for this component. -->
+<ComponentDoc tagName="hx-<component-name>" section="summary" />
+
+## Overview
+
+<!-- COMPONENT OVERVIEW
+  Brief description (2–4 sentences):
+  - What problem it solves
+  - Typical use cases in a healthcare or enterprise UI
+  - When to prefer this component over alternatives (e.g. "use hx-button for
+    actions; use hx-link when navigating the user to another page")
+-->
+
+## Live Demo
+
+<!-- Add ComponentDemo blocks for the most important variants.
+     Each demo title appears as a visible label above the live preview.
+     Use real hx-* attributes, not placeholder values. -->
+
+<ComponentDemo title="<!-- DEMO TITLE -->">
+  <!-- hx-<component-name> usage here -->
+</ComponentDemo>
+
+<!-- Add more <ComponentDemo> blocks for additional variants / states. -->
+
+## Installation
+
+Install the full library or import the component individually:
+
+```bash
+# Full library
+npm install @helix/library
+
+# Or import only this component (tree-shaking friendly)
+import '@helix/library/components/hx-<component-name>';
+```
+
+## Basic Usage
+
+Minimal HTML snippet — no build tool required:
+
+```html
+<!-- REPLACE with the simplest meaningful use of the component -->
+<hx-<component-name>><!-- content --></hx-<component-name>>
+```
+
+## Properties
+
+<!-- PROPERTIES TABLE
+  Pull from CEM: custom-elements.json → members where kind = "field".
+  Include every @property-decorated member in the component class.
+  Omit private/internal members.
+-->
+
+| Property | Attribute | Type | Default | Description |
+|----------|-----------|------|---------|-------------|
+| <!-- propName --> | <!-- attr-name --> | <!-- `'a' \| 'b'` --> | <!-- `'a'` --> | <!-- Description --> |
+
+## Events
+
+<!-- EVENTS TABLE
+  Pull from CEM: custom-elements.json → events[].
+  Include every @fires / dispatchEvent call documented in the source.
+-->
+
+| Event | Detail Type | Description |
+|-------|-------------|-------------|
+| <!-- `hx-event-name` --> | <!-- `{ key: Type }` --> | <!-- When it fires --> |
+
+## CSS Custom Properties
+
+<!-- CSS CUSTOM PROPERTIES TABLE
+  Pull from CEM: custom-elements.json → cssProperties[].
+  Document every @cssprop in the component JSDoc.
+-->
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| <!-- `--hx-<component>-<token>` --> | <!-- `var(--hx-...)` --> | <!-- What it controls --> |
+
+## CSS Parts
+
+<!-- CSS PARTS TABLE
+  Pull from CEM: custom-elements.json → cssParts[].
+  Document every @csspart in the component JSDoc.
+-->
+
+| Part | Description |
+|------|-------------|
+| <!-- `part-name` --> | <!-- What element it targets --> |
+
+## Slots
+
+<!-- SLOTS TABLE
+  Pull from CEM: custom-elements.json → slots[].
+  List the default (unnamed) slot first, then named slots.
+-->
+
+| Slot | Description |
+|------|-------------|
+| *(default)* | <!-- Content placed without a slot attribute --> |
+| <!-- `slot-name` --> | <!-- Purpose of named slot --> |
+
+## Accessibility
+
+<!-- ACCESSIBILITY SECTION
+  Cover ALL of the following (delete rows that don't apply):
+  - ARIA role applied by the component
+  - aria-* attributes set automatically
+  - Keyboard interactions (Tab, Enter, Space, Arrow keys, Escape, etc.)
+  - Screen reader announcements
+  - Focus management on open/close/select
+  - Any WCAG 2.1 AA requirements specific to this component
+-->
+
+| Topic | Details |
+|-------|---------|
+| ARIA role | <!-- e.g. `button`, `combobox`, `dialog` --> |
+| Keyboard | <!-- Tab / Enter / Space / Arrow behavior --> |
+| Screen reader | <!-- What is announced and when --> |
+| Focus | <!-- Where focus moves on interaction --> |
+
+## Drupal Integration
+
+Use the component in a Twig template after registering the library:
+
+```twig
+{# my-module/templates/my-template.html.twig #}
+
+{# REPLACE with a real Twig example for this component #}
+<hx-<component-name>
+  <!-- attribute="value" -->
+>
+  {{ label }}
+</hx-<component-name>>
+```
+
+Load the library in your module's `.libraries.yml`:
+
+```yaml
+helix-components:
+  js:
+    /libraries/helix/helix.min.js: { minified: true }
+```
+
+## Standalone HTML Example
+
+Copy-paste this into a `.html` file and open it in a browser — no build tool needed:
+
+```html
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>hx-<component-name> example</title>
+  <!-- Load the full Helix bundle from CDN -->
+  <script type="module" src="https://cdn.jsdelivr.net/npm/@helix/library/dist/helix.min.js"></script>
+</head>
+<body>
+  <!-- REPLACE with a complete, realistic usage example -->
+  <hx-<component-name>
+    <!-- attribute="value" -->
+  >
+    <!-- content -->
+  </hx-<component-name>>
+
+  <script>
+    // Optional: listen for component events
+    document.querySelector('hx-<component-name>').addEventListener('hx-<event>', (e) => {
+      console.log('Event detail:', e.detail);
+    });
+  </script>
+</body>
+</html>
+```
+
+## API Reference
+
+<!-- Renders the full CEM-driven API table (properties, events, slots, parts). -->
+<ComponentDoc tagName="hx-<component-name>" section="api" />
+```

--- a/apps/docs/src/content/docs/component-library/hx-button.mdx
+++ b/apps/docs/src/content/docs/component-library/hx-button.mdx
@@ -11,7 +11,16 @@ import ComponentDoc from '../../../components/ComponentDoc.astro';
 
 <ComponentDoc tagName="hx-button" section="summary" />
 
-## Variants
+## Overview
+
+`hx-button` is the primary interactive element for triggering actions and form submissions in Helix. It supports six visual variants, three sizes, a loading state with spinner, prefix/suffix icon slots, and anchor rendering via `href`. When used inside a `<form>`, it participates via `ElementInternals` for full form association.
+
+**Use `hx-button` when:** the user triggers an action (submit, delete, open dialog).
+**Use `hx-link` instead when:** the user navigates to another page or URL.
+
+## Live Demo
+
+### Variants
 
 Primary, secondary, tertiary, danger, ghost, and outline visual styles.
 
@@ -26,7 +35,7 @@ Primary, secondary, tertiary, danger, ghost, and outline visual styles.
   </div>
 </ComponentDemo>
 
-## Sizes
+### Sizes
 
 Small, medium, and large button sizes.
 
@@ -38,7 +47,7 @@ Small, medium, and large button sizes.
   </div>
 </ComponentDemo>
 
-## Loading
+### Loading
 
 Buttons in loading state show a spinner and prevent interaction.
 
@@ -53,7 +62,7 @@ Buttons in loading state show a spinner and prevent interaction.
   </div>
 </ComponentDemo>
 
-## Disabled
+### Disabled
 
 Buttons in disabled state across all variants.
 
@@ -74,7 +83,7 @@ Buttons in disabled state across all variants.
   </div>
 </ComponentDemo>
 
-## With Prefix and Suffix Slots
+### Prefix and Suffix Slots
 
 Use `prefix` and `suffix` slots to add icons or content before/after the label.
 
@@ -91,7 +100,7 @@ Use `prefix` and `suffix` slots to add icons or content before/after the label.
   </div>
 </ComponentDemo>
 
-## As Link
+### As Link
 
 Set `href` to render the button as an anchor element.
 
@@ -100,6 +109,135 @@ Set `href` to render the button as an anchor element.
     Visit Site
   </hx-button>
 </ComponentDemo>
+
+## Installation
+
+```bash
+# Full library
+npm install @helix/library
+
+# Or import only this component (tree-shaking friendly)
+import '@helix/library/components/hx-button';
+```
+
+## Basic Usage
+
+```html
+<hx-button variant="primary">Save Changes</hx-button>
+```
+
+## Properties
+
+| Property   | Attribute  | Type                                                                         | Default     | Description                                                    |
+| ---------- | ---------- | ---------------------------------------------------------------------------- | ----------- | -------------------------------------------------------------- |
+| `variant`  | `variant`  | `'primary' \| 'secondary' \| 'tertiary' \| 'danger' \| 'ghost' \| 'outline'` | `'primary'` | Visual style variant.                                          |
+| `hxSize`   | `hx-size`  | `'sm' \| 'md' \| 'lg'`                                                       | `'md'`      | Button size.                                                   |
+| `disabled` | `disabled` | `boolean`                                                                    | `false`     | Prevents all interaction.                                      |
+| `loading`  | `loading`  | `boolean`                                                                    | `false`     | Shows spinner; sets `aria-busy`. Does not disable the element. |
+| `type`     | `type`     | `'button' \| 'submit' \| 'reset'`                                            | `'button'`  | Native button type. Ignored when `href` is set.                |
+| `href`     | `href`     | `string \| undefined`                                                        | `undefined` | When set, renders an `<a>` element instead of `<button>`.      |
+| `target`   | `target`   | `string \| undefined`                                                        | `undefined` | Anchor `target`. Used only when `href` is set.                 |
+| `name`     | `name`     | `string \| undefined`                                                        | `undefined` | Form field name for `ElementInternals.setFormValue`.           |
+| `value`    | `value`    | `string \| undefined`                                                        | `undefined` | Form field value submitted on form submit.                     |
+
+## Events
+
+| Event      | Detail Type                     | Description                                                                              |
+| ---------- | ------------------------------- | ---------------------------------------------------------------------------------------- |
+| `hx-click` | `{ originalEvent: MouseEvent }` | Fired on click when the button is neither disabled nor loading. Bubbles and is composed. |
+
+## CSS Custom Properties
+
+| Property                       | Default                          | Description              |
+| ------------------------------ | -------------------------------- | ------------------------ |
+| `--hx-button-bg`               | `var(--hx-color-primary-500)`    | Button background color. |
+| `--hx-button-color`            | `var(--hx-color-neutral-0)`      | Button text color.       |
+| `--hx-button-border-color`     | `transparent`                    | Button border color.     |
+| `--hx-button-border-radius`    | `var(--hx-border-radius-md)`     | Button border radius.    |
+| `--hx-button-font-family`      | `var(--hx-font-family-sans)`     | Button font family.      |
+| `--hx-button-font-weight`      | `var(--hx-font-weight-semibold)` | Button font weight.      |
+| `--hx-button-focus-ring-color` | `var(--hx-focus-ring-color)`     | Focus ring color.        |
+
+## CSS Parts
+
+| Part      | Description                             |
+| --------- | --------------------------------------- |
+| `button`  | The native `<button>` or `<a>` element. |
+| `label`   | The label text wrapper `<span>`.        |
+| `prefix`  | The prefix slot container `<span>`.     |
+| `suffix`  | The suffix slot container `<span>`.     |
+| `spinner` | The loading spinner `<svg>` element.    |
+
+## Slots
+
+| Slot        | Description                                |
+| ----------- | ------------------------------------------ |
+| _(default)_ | Button label text or content.              |
+| `prefix`    | Icon or content rendered before the label. |
+| `suffix`    | Icon or content rendered after the label.  |
+
+## Accessibility
+
+| Topic           | Details                                                                   |
+| --------------- | ------------------------------------------------------------------------- |
+| ARIA role       | Inherits native `button` role (or `link` when `href` is set).             |
+| `aria-busy`     | Set to `true` automatically when `loading` is active.                     |
+| `aria-disabled` | Set to `true` on the `<a>` element when `disabled` + `href` are combined. |
+| Keyboard        | `Tab` to focus; `Enter` / `Space` to activate.                            |
+| Screen reader   | Loading state is announced via `aria-busy`; spinner SVG is `aria-hidden`. |
+| Focus           | Focus stays on the button after click; no focus movement.                 |
+
+## Drupal Integration
+
+```twig
+{# my-module/templates/my-template.html.twig #}
+<hx-button
+  variant="{{ variant|default('primary') }}"
+  {% if disabled %}disabled{% endif %}
+>
+  {{ label }}
+</hx-button>
+```
+
+Load the library in your module's `.libraries.yml`:
+
+```yaml
+helix-components:
+  js:
+    /libraries/helix/helix.min.js: { minified: true }
+```
+
+## Standalone HTML Example
+
+Copy-paste into a `.html` file and open in any browser — no build tool required:
+
+```html
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>hx-button example</title>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@helix/library/dist/helix.min.js"
+    ></script>
+  </head>
+  <body style="font-family: sans-serif; padding: 2rem; display: flex; gap: 1rem; flex-wrap: wrap;">
+    <hx-button variant="primary" id="save-btn">Save Changes</hx-button>
+    <hx-button variant="secondary">Cancel</hx-button>
+    <hx-button variant="danger">Delete</hx-button>
+    <hx-button variant="primary" loading>Saving...</hx-button>
+    <hx-button variant="primary" disabled>Disabled</hx-button>
+
+    <script>
+      document.getElementById('save-btn').addEventListener('hx-click', (e) => {
+        console.log('Button clicked:', e.detail.originalEvent);
+      });
+    </script>
+  </body>
+</html>
+```
 
 ## API Reference
 


### PR DESCRIPTION
## Summary

Create a reusable Astro/Starlight documentation page template that every component doc page will follow. This template will be used by agents working on per-component launch readiness tickets.

The template should be placed at `apps/docs/src/content/docs/component-library/_TEMPLATE.md` (or similar discoverable location) and include:

1. **Component overview** — Brief description, use cases, when to use vs alternatives
2. **Live demo section** — Embedded web component with interactive example (im...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added a new component documentation template with structured sections for Overview, Live Demo, Installation, Properties, Events, Accessibility, and API Reference
* Enhanced hx-button documentation with comprehensive sections including Installation, Basic Usage, Properties table, Events, CSS Custom Properties, Slots, Accessibility, Drupal Integration, and Standalone HTML Examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->