### PR TITLE
docs: complete hx-field-label Astro doc page

### DIFF
--- a/apps/docs/src/content/docs/component-library/hx-field-label.mdx
+++ b/apps/docs/src/content/docs/component-library/hx-field-label.mdx
@@ -76,6 +76,9 @@ association automatically.
 npm install @helix/library
 
 # Or import only this component (tree-shaking friendly)
+```
+
+```js
 import '@helix/library/components/hx-field-label';
 ```
 
@@ -88,7 +91,9 @@ Minimal HTML snippet — no build tool required:
 <hx-field-label id="lbl-name" required>Patient Name</hx-field-label>
 <input type="text" aria-labelledby="lbl-name" aria-required="true" />
 
-<!-- Pattern 2: native label association (within same shadow root only) -->
+<!-- Pattern 2: native label association (label and input must be in the same shadow root only) -->
+<!-- Note: The `for` attribute cannot cross shadow DOM boundaries. Use aria-labelledby for -->
+<!-- inputs outside the component's shadow DOM (see Pattern 1). -->
 <hx-field-label for="dob-input">Date of Birth</hx-field-label>
 <input id="dob-input" type="date" />
 
@@ -136,14 +141,14 @@ This component does not emit custom events.
 
 ## Accessibility
 
-| Topic               | Details                                                                                                                                                                                                                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| ARIA role           | None applied — renders as a native `<label>` (with `for`) or `<span>` (without), inheriting their native semantics.                                                                                                         |
-| Keyboard            | No keyboard interaction. This is a semantic label element; consumers manage focus on the associated input.                                                                                                                  |
-| Screen reader       | When `required` is true, the visual asterisk is `aria-hidden="true"`. A visually-hidden `<span>required</span>` is included so screen readers announce "required" rather than reading `*`.                                  |
-| Focus               | No focus management. Associate inputs using `aria-labelledby` (light DOM) or the `for` attribute (same shadow root).                                                                                                        |
-| Shadow DOM labeling | The `for` attribute only associates labels to inputs **within the same shadow root**. For inputs in light DOM (standard Drupal pattern), set an `id` on the `<hx-field-label>` host and use `aria-labelledby` on the input. |
-| WCAG 2.1 AA         | Verified with axe-core: zero violations in default, required, optional, and `for`-attribute states.                                                                                                                         |
+| Topic               | Details                                                                                                                                                                                                                                                                                                        |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ARIA role           | Renders as a native `<label>` element when `for` is set, providing implicit label semantics for the associated input within the same shadow root. When `for` is omitted, renders as a generic `<span>` container — consumer must associate the input using `aria-labelledby` referencing the component's `id`. |
+| Keyboard            | No keyboard interaction. This is a semantic label element; consumers manage focus on the associated input.                                                                                                                                                                                                     |
+| Screen reader       | When `required` is true, the visual asterisk is `aria-hidden="true"`. A visually-hidden `<span>required</span>` is included so screen readers announce "required" rather than reading `*`.                                                                                                                     |
+| Focus               | No focus management. Associate inputs using `aria-labelledby` (light DOM) or the `for` attribute (same shadow root).                                                                                                                                                                                           |
+| Shadow DOM labeling | The `for` attribute only associates labels to inputs **within the same shadow root**. For inputs in light DOM (standard Drupal pattern), set an `id` on the `<hx-field-label>` host and use `aria-labelledby` on the input.                                                                                    |
+| WCAG 2.1 AA         | Checked with axe-core during development; no violations observed in tested states (default, required, optional, and `for`-attribute scenarios).                                                                                                                                                                |
 
 ## Drupal Integration
 


### PR DESCRIPTION
## Summary

- Expanded `hx-field-label.mdx` from a 3-line stub to a full 16-section documentation page
- All 12 template sections covered: Overview, Live Demo (4 variants), Installation, Basic Usage, Properties, Events, CSS Custom Properties, CSS Parts, Slots, Accessibility, Drupal Integration, Standalone HTML Example, API Reference
- Accessibility section documents the shadow DOM labeling boundary pattern (`aria-labelledby` vs `for`) with clear Drupal guidance
- Standalone HTML example includes all three indicator states (required, optional, plain)

## Test plan

- [x] `npm run verify` — zero errors (lint + format:check + type-check all pass)
- [x] Content verification — 24 checks confirmed all sections, CDN reference, all properties, parts, slots, and a11y guidance present
- [x] `git diff --stat` — only `hx-field-label.mdx` modified (239 insertions, 1 deletion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Significantly expanded hx-field-label component documentation with new overview and live demo sections
* Added detailed API documentation including properties, CSS customization, and accessibility guidelines
* Included practical examples demonstrating default, required, optional, and cross-boundary labeling usage patterns
* Enhanced guidance for proper component integration and accessibility best practices

<!-- end of auto-generated comment: release notes by coderabbit.ai -->