### PR TITLE
AUDIT FIX: Package export fix — hx-tokens points to source not dist

### DIFF
--- a/packages/hx-tokens/package.json
+++ b/packages/hx-tokens/package.json
@@ -4,28 +4,28 @@
   "private": true,
   "description": "Design tokens for the WC-2026 enterprise healthcare web component library",
   "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
     },
     "./css": {
-      "types": "./src/css.ts",
-      "import": "./src/css.ts",
-      "default": "./src/css.ts"
+      "types": "./dist/css.d.ts",
+      "import": "./dist/css.js",
+      "default": "./dist/css.js"
     },
     "./lit": {
-      "types": "./src/lit.ts",
-      "import": "./src/lit.ts",
-      "default": "./src/lit.ts"
+      "types": "./dist/lit.d.ts",
+      "import": "./dist/lit.js",
+      "default": "./dist/lit.js"
     },
     "./utils": {
-      "types": "./src/utils.ts",
-      "import": "./src/utils.ts",
-      "default": "./src/utils.ts"
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.js",
+      "default": "./dist/utils.js"
     },
     "./tokens.css": "./dist/tokens.css",
     "./tokens.json": "./src/tokens.json"


### PR DESCRIPTION
## Summary

**Source:** Deep Audit P0-01 | **Effort:** 30 min | **Priority:** CRITICAL

**Problem:** The `@helix/tokens` package exports TypeScript source files (`src/*.ts`) instead of compiled distribution files (`dist/*.js`). The `files` array includes only `dist/` and `src/tokens.json` — meaning the files referenced by `main`, `types`, and `exports` will NOT exist in the published npm package. Works inside monorepo only because workspace resolution finds source files directly.

**Files:** `packages/hx-to...

---
*Recovered automatically by Automaker post-agent hook*