### PR TITLE
fix: API consistency — size prop, help-text slot, event names (P1-01, P1-02, P1-06)

### DIFF
--- a/packages/hx-library/src/components/hx-button/hx-button.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.ts
@@ -64,7 +64,7 @@ export class HelixButton extends LitElement {
    * @attr hx-size
    */
   @property({ type: String, reflect: true, attribute: 'hx-size' })
-  hxSize: 'sm' | 'md' | 'lg' = 'md';
+  size: 'sm' | 'md' | 'lg' = 'md';
 
   /**
    * Whether the button is disabled. Prevents all interaction and form actions.
@@ -207,7 +207,7 @@ export class HelixButton extends LitElement {
     const classes = {
       button: true,
       [`button--${this.variant}`]: true,
-      [`button--${this.hxSize}`]: true,
+      [`button--${this.size}`]: true,
       'button--loading': this.loading,
     };
 

--- a/packages/hx-library/src/components/hx-card/hx-card.stories.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.stories.ts
@@ -309,7 +309,7 @@ export const Interactive: Story = {
       hx-href="https://ehr.example.com/patient/12345"
       elevation="raised"
       style="max-width: 400px;"
-      @hx-card-click=${cardClickHandler}
+      @hx-click=${cardClickHandler}
     >
       <span slot="heading">Patient Record: James Wilson</span>
       <p>
@@ -830,10 +830,10 @@ export const InteractiveClickTest: Story = {
       hx-href="https://ehr.example.com/patient/67890"
       elevation="raised"
       style="max-width: 400px;"
-      @hx-card-click=${interactiveClickHandler}
+      @hx-click=${interactiveClickHandler}
     >
       <span slot="heading">Clickable Patient Card</span>
-      <p>Click this card to verify the hx-card-click event fires correctly.</p>
+      <p>Click this card to verify the hx-click event fires correctly.</p>
     </hx-card>
   `,
   play: async ({ canvasElement }) => {
@@ -865,7 +865,7 @@ export const InteractiveKeyboardEnter: Story = {
       hx-href="https://ehr.example.com/orders"
       elevation="raised"
       style="max-width: 400px;"
-      @hx-card-click=${keyboardEnterHandler}
+      @hx-click=${keyboardEnterHandler}
     >
       <span slot="heading">Keyboard Navigation Test</span>
       <p>Focus this card and press Enter to activate it.</p>
@@ -898,7 +898,7 @@ export const InteractiveKeyboardSpace: Story = {
       hx-href="https://ehr.example.com/labs"
       elevation="raised"
       style="max-width: 400px;"
-      @hx-card-click=${keyboardSpaceHandler}
+      @hx-click=${keyboardSpaceHandler}
     >
       <span slot="heading">Space Key Activation Test</span>
       <p>Focus this card and press Space to activate it.</p>
@@ -932,7 +932,7 @@ export const InteractiveFocusManagement: Story = {
       <hx-card
         hx-href="https://ehr.example.com/vitals"
         elevation="raised"
-        @hx-card-click=${focusTestHandler}
+        @hx-click=${focusTestHandler}
       >
         <span slot="heading">Focus Target Card</span>
         <p>Tab to this card to verify it receives focus in the tab order.</p>

--- a/packages/hx-library/src/components/hx-card/hx-card.test.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.test.ts
@@ -168,19 +168,19 @@ describe('hx-card', () => {
   // ─── Events (3) ───
 
   describe('Events', () => {
-    it('dispatches hx-card-click when hx-href + click', async () => {
+    it('dispatches hx-click when hx-href + click', async () => {
       const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
-      const eventPromise = oneEvent(el, 'hx-card-click');
+      const eventPromise = oneEvent(el, 'hx-click');
       card.click();
       const event = await eventPromise;
       expect(event).toBeTruthy();
     });
 
-    it('hx-card-click detail contains href and originalEvent', async () => {
+    it('hx-click detail contains href and originalEvent', async () => {
       const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
-      const eventPromise = oneEvent<CustomEvent>(el, 'hx-card-click');
+      const eventPromise = oneEvent<CustomEvent>(el, 'hx-click');
       card.click();
       const event = await eventPromise;
       expect(event.detail.href).toBe('/test');
@@ -191,7 +191,7 @@ describe('hx-card', () => {
       const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       let fired = false;
-      el.addEventListener('hx-card-click', () => {
+      el.addEventListener('hx-click', () => {
         fired = true;
       });
       card.click();
@@ -203,19 +203,19 @@ describe('hx-card', () => {
   // ─── Keyboard (3) ───
 
   describe('Keyboard', () => {
-    it('Enter fires hx-card-click when interactive', async () => {
+    it('Enter fires hx-click when interactive', async () => {
       const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
-      const eventPromise = oneEvent<CustomEvent>(el, 'hx-card-click');
+      const eventPromise = oneEvent<CustomEvent>(el, 'hx-click');
       card.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       const event = await eventPromise;
       expect(event.detail.href).toBe('/test');
     });
 
-    it('Space fires hx-card-click when interactive', async () => {
+    it('Space fires hx-click when interactive', async () => {
       const el = await fixture<HelixCard>('<hx-card hx-href="/test">Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
-      const eventPromise = oneEvent<CustomEvent>(el, 'hx-card-click');
+      const eventPromise = oneEvent<CustomEvent>(el, 'hx-click');
       card.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       const event = await eventPromise;
       expect(event.detail.href).toBe('/test');
@@ -225,7 +225,7 @@ describe('hx-card', () => {
       const el = await fixture<HelixCard>('<hx-card>Content</hx-card>');
       const card = shadowQuery(el, '.card')!;
       let fired = false;
-      el.addEventListener('hx-card-click', () => {
+      el.addEventListener('hx-click', () => {
         fired = true;
       });
       card.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));

--- a/packages/hx-library/src/components/hx-card/hx-card.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.ts
@@ -17,7 +17,7 @@ import { helixCardStyles } from './hx-card.styles.js';
  * @slot footer - Optional footer content below the body.
  * @slot actions - Optional action buttons, rendered with a top border separator. Do NOT use together with hx-href (interactive card + focusable actions is an ARIA anti-pattern).
  *
- * @fires {CustomEvent<{href: string, originalEvent: MouseEvent | KeyboardEvent}>} hx-card-click - Dispatched when an interactive card (with hx-href) is clicked.
+ * @fires {CustomEvent<{href: string, originalEvent: MouseEvent | KeyboardEvent}>} hx-click - Dispatched when an interactive card (with hx-href) is clicked.
  *
  * @csspart card - The outer card container element.
  * @csspart image - The image slot container.
@@ -112,17 +112,14 @@ export class HelixCard extends LitElement {
     /**
      * Dispatched when an interactive card is clicked.
      * Includes the target href in the detail.
-     * @event hx-card-click
+     * @event hx-click
      */
     this.dispatchEvent(
-      new CustomEvent<{ href: string; originalEvent: MouseEvent | KeyboardEvent }>(
-        'hx-card-click',
-        {
-          bubbles: true,
-          composed: true,
-          detail: { href: this.hxHref, originalEvent },
-        },
-      ),
+      new CustomEvent<{ href: string; originalEvent: MouseEvent | KeyboardEvent }>('hx-click', {
+        bubbles: true,
+        composed: true,
+        detail: { href: this.hxHref, originalEvent },
+      }),
     );
   }
 

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.stories.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.stories.ts
@@ -95,7 +95,7 @@ const meta = {
         type: { summary: 'string' },
       },
     },
-    hxSize: {
+    size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
       description: 'The size of the checkbox.',
@@ -116,7 +116,7 @@ const meta = {
     error: '',
     helpText: '',
     name: '',
-    hxSize: 'md',
+    size: 'md',
   },
   render: (args) => html`
     <hx-checkbox
@@ -129,7 +129,7 @@ const meta = {
       error=${ifDefined(args.error || undefined)}
       help-text=${ifDefined(args.helpText || undefined)}
       name=${ifDefined(args.name || undefined)}
-      hx-size=${args.hxSize}
+      hx-size=${args.size}
     ></hx-checkbox>
   `,
 } satisfies Meta;

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
@@ -136,7 +136,7 @@ export class HelixCheckbox extends LitElement {
    * @attr hx-size
    */
   @property({ type: String, attribute: 'hx-size', reflect: true })
-  hxSize: 'sm' | 'md' | 'lg' = 'md';
+  size: 'sm' | 'md' | 'lg' = 'md';
 
   @query('.checkbox__input')
   private _inputEl!: HTMLInputElement;
@@ -271,9 +271,9 @@ export class HelixCheckbox extends LitElement {
       'checkbox--error': hasError,
       'checkbox--disabled': this.disabled,
       'checkbox--required': this.required,
-      'checkbox--sm': this.hxSize === 'sm',
-      'checkbox--md': this.hxSize === 'md',
-      'checkbox--lg': this.hxSize === 'lg',
+      'checkbox--sm': this.size === 'sm',
+      'checkbox--md': this.size === 'md',
+      'checkbox--lg': this.size === 'lg',
     };
 
     // P2-06: simplified — hasError already includes _hasErrorSlot

--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.stories.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.stories.ts
@@ -376,7 +376,7 @@ export const SmallSize: Story = {
   args: {
     label: 'Count',
     value: 3,
-    hxSize: 'sm',
+    size: 'sm',
   },
   parameters: {
     docs: {
@@ -395,7 +395,7 @@ export const LargeSize: Story = {
   args: {
     label: 'Count',
     value: 3,
-    hxSize: 'lg',
+    size: 'lg',
   },
   parameters: {
     docs: {

--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.test.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.test.ts
@@ -859,11 +859,11 @@ describe('hx-number-input', () => {
       expect(suffix?.textContent).toBe('kg');
     });
 
-    it('help slot renders custom content inside help-text container', async () => {
+    it('help-text slot renders custom content inside help-text container', async () => {
       const el = await fixture<HelixNumberInput>(
-        '<hx-number-input help-text="fallback"><em slot="help">Custom help</em></hx-number-input>',
+        '<hx-number-input help-text="fallback"><em slot="help-text">Custom help</em></hx-number-input>',
       );
-      const helpSlot = el.querySelector('[slot="help"]');
+      const helpSlot = el.querySelector('[slot="help-text"]');
       expect(helpSlot).toBeTruthy();
       expect(helpSlot?.textContent).toBe('Custom help');
     });
@@ -877,9 +877,9 @@ describe('hx-number-input', () => {
       expect(field?.classList.contains('field--error')).toBe(true);
     });
 
-    it('slotted help sets aria-describedby without help-text prop', async () => {
+    it('slotted help-text sets aria-describedby without help-text prop', async () => {
       const el = await fixture<HelixNumberInput>(
-        '<hx-number-input label="Qty"><em slot="help">Enter a number</em></hx-number-input>',
+        '<hx-number-input label="Qty"><em slot="help-text">Enter a number</em></hx-number-input>',
       );
       await el.updateComplete;
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;

--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.ts
@@ -17,7 +17,7 @@ import { helixNumberInputStyles } from './hx-number-input.styles.js';
  * @tag hx-number-input
  *
  * @slot label - Custom label content (overrides the label property). Use for Drupal Form API rendered labels.
- * @slot help - Custom help text content (overrides the helpText property).
+ * @slot help-text - Custom help text content (overrides the helpText property).
  * @slot error - Custom error content (overrides the error property). Use for Drupal Form API rendered errors.
  * @slot prefix - Content rendered before the input (e.g., a unit icon).
  * @slot suffix - Content rendered after the input and before the stepper buttons (e.g., a unit label).
@@ -153,7 +153,7 @@ export class HelixNumberInput extends LitElement {
    * @attr hx-size
    */
   @property({ type: String, attribute: 'hx-size' })
-  hxSize: 'sm' | 'md' | 'lg' = 'md';
+  size: 'sm' | 'md' | 'lg' = 'md';
 
   /**
    * When set, hides the +/- stepper buttons.
@@ -502,9 +502,9 @@ export class HelixNumberInput extends LitElement {
       'field--error': hasError,
       'field--disabled': this.disabled,
       'field--required': this.required,
-      'field--sm': this.hxSize === 'sm',
-      'field--md': this.hxSize === 'md',
-      'field--lg': this.hxSize === 'lg',
+      'field--sm': this.size === 'sm',
+      'field--md': this.size === 'md',
+      'field--lg': this.size === 'lg',
     };
 
     const describedBy =
@@ -618,7 +618,7 @@ export class HelixNumberInput extends LitElement {
           id=${this._helpTextId}
           ?hidden=${hasError || (!this.helpText && !this._hasHelpSlot)}
         >
-          <slot name="help" @slotchange=${this._handleHelpSlotChange}>${this.helpText}</slot>
+          <slot name="help-text" @slotchange=${this._handleHelpSlotChange}>${this.helpText}</slot>
         </div>
       </div>
     `;

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
@@ -18,7 +18,7 @@ let _groupCounter = 0;
  * @slot error - Custom error content (overrides the error property).
  * @slot help-text - Custom help text content (overrides the helpText property).
  *
- * @fires {CustomEvent<{value: string}>} hx-change - Dispatched when the selected radio changes.
+ * @fires {CustomEvent<{value: string, checked: boolean}>} hx-change - Dispatched when the selected radio changes.
  *
  * @csspart fieldset - The fieldset wrapper.
  * @csspart legend - The legend/label.
@@ -230,7 +230,7 @@ export class HelixRadioGroup extends LitElement {
       new CustomEvent('hx-change', {
         bubbles: true,
         composed: true,
-        detail: { value: this.value },
+        detail: { value: this.value, checked: true },
       }),
     );
   };

--- a/packages/hx-library/src/components/hx-slider/hx-slider.test.ts
+++ b/packages/hx-library/src/components/hx-slider/hx-slider.test.ts
@@ -436,11 +436,11 @@ describe('hx-slider', () => {
       expect(slotContent?.textContent).toBe('Custom Label');
     });
 
-    it('help slot content is rendered and accessible in light DOM', async () => {
+    it('help-text slot content is rendered and accessible in light DOM', async () => {
       const el = await fixture<HelixSlider>(
-        '<hx-slider><em slot="help">Extra help</em></hx-slider>',
+        '<hx-slider><em slot="help-text">Extra help</em></hx-slider>',
       );
-      const slotContent = el.querySelector('[slot="help"]');
+      const slotContent = el.querySelector('[slot="help-text"]');
       expect(slotContent).toBeTruthy();
       expect(slotContent?.textContent).toBe('Extra help');
     });

--- a/packages/hx-library/src/components/hx-slider/hx-slider.ts
+++ b/packages/hx-library/src/components/hx-slider/hx-slider.ts
@@ -23,7 +23,7 @@ import { helixSliderStyles } from './hx-slider.styles.js';
  * @tag hx-slider
  *
  * @slot label - Custom label content (overrides the label property).
- * @slot help - Custom help text content (overrides the helpText property).
+ * @slot help-text - Custom help text content (overrides the helpText property).
  * @slot min-label - Label rendered at the minimum end of the slider.
  * @slot max-label - Label rendered at the maximum end of the slider.
  *
@@ -448,7 +448,7 @@ export class HelixSlider extends LitElement {
             `}
 
         <!-- Help text -->
-        <slot name="help" @slotchange=${this._handleHelpSlotChange}>
+        <slot name="help-text" @slotchange=${this._handleHelpSlotChange}>
           ${this.helpText
             ? html`<div part="help-text" class="slider__help-text" id=${this._helpId}>
                 ${this.helpText}

--- a/packages/hx-library/src/components/hx-switch/hx-switch.stories.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.stories.ts
@@ -48,7 +48,7 @@ const meta = {
         type: { summary: 'string' },
       },
     },
-    hxSize: {
+    size: {
       control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
       description: 'Size variant of the switch.',
@@ -100,7 +100,7 @@ const meta = {
     disabled: false,
     required: false,
     label: 'Enable notifications',
-    hxSize: 'md',
+    size: 'md',
     error: '',
     helpText: '',
     value: 'on',
@@ -109,7 +109,7 @@ const meta = {
   render: (args) => html`
     <hx-switch
       label=${args.label}
-      hx-size=${args.hxSize}
+      hx-size=${args.size}
       ?checked=${args.checked}
       ?disabled=${args.disabled}
       ?required=${args.required}
@@ -174,21 +174,21 @@ export const Default: Story = {
 export const SizeSmall: Story = {
   args: {
     label: 'Compact toggle',
-    hxSize: 'sm',
+    size: 'sm',
   },
 };
 
 export const SizeMedium: Story = {
   args: {
     label: 'Default toggle',
-    hxSize: 'md',
+    size: 'md',
   },
 };
 
 export const SizeLarge: Story = {
   args: {
     label: 'Large toggle',
-    hxSize: 'lg',
+    size: 'lg',
   },
 };
 

--- a/packages/hx-library/src/components/hx-switch/hx-switch.test.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.test.ts
@@ -106,12 +106,12 @@ describe('hx-switch', () => {
   describe('Property: size', () => {
     it('defaults to md', async () => {
       const el = await fixture<WcSwitch>('<hx-switch></hx-switch>');
-      expect(el.hxSize).toBe('md');
+      expect(el.size).toBe('md');
     });
 
     it('reflects hx-size attribute for sm', async () => {
       const el = await fixture<WcSwitch>('<hx-switch hx-size="sm"></hx-switch>');
-      expect(el.hxSize).toBe('sm');
+      expect(el.size).toBe('sm');
       expect(el.getAttribute('hx-size')).toBe('sm');
     });
 

--- a/packages/hx-library/src/components/hx-switch/hx-switch.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.ts
@@ -108,7 +108,7 @@ export class HelixSwitch extends LitElement {
    * @attr hx-size
    */
   @property({ type: String, reflect: true, attribute: 'hx-size' })
-  hxSize: 'sm' | 'md' | 'lg' = 'md';
+  size: 'sm' | 'md' | 'lg' = 'md';
 
   /**
    * Error message to display. When set, the switch enters an error state.
@@ -271,7 +271,7 @@ export class HelixSwitch extends LitElement {
       'switch--disabled': this.disabled,
       'switch--required': this.required,
       'switch--error': hasError,
-      [`switch--${this.hxSize}`]: true,
+      [`switch--${this.size}`]: true,
     };
 
     const describedBy =

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.stories.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.stories.ts
@@ -114,7 +114,7 @@ const meta = {
         type: { summary: 'boolean' },
       },
     },
-    hxSize: {
+    size: {
       control: { type: 'select' },
       options: ['sm', 'md', 'lg'],
       description: 'Visual size of the input field.',

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.test.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.test.ts
@@ -501,7 +501,7 @@ describe('hx-text-input', () => {
   describe('Property: hxSize', () => {
     it('defaults to md', async () => {
       const el = await fixture<WcTextInput>('<hx-text-input></hx-text-input>');
-      expect(el.hxSize).toBe('md');
+      expect(el.size).toBe('md');
     });
 
     it('applies field--size-sm class', async () => {

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
@@ -175,7 +175,7 @@ export class HelixTextInput extends LitElement {
    * @attr hx-size
    */
   @property({ type: String, attribute: 'hx-size', reflect: true })
-  hxSize: 'sm' | 'md' | 'lg' = 'md';
+  size: 'sm' | 'md' | 'lg' = 'md';
 
   // ─── Internal References ───
 
@@ -391,7 +391,7 @@ export class HelixTextInput extends LitElement {
       'field--error': hasError,
       'field--disabled': this.disabled,
       'field--required': this.required,
-      [`field--size-${this.hxSize}`]: true,
+      [`field--size-${this.size}`]: true,
     };
 
     const describedBy =


### PR DESCRIPTION
## Summary

- **P1-01:** Renamed `hxSize` JS property → `size` (HTML attribute `hx-size` unchanged) in hx-button, hx-checkbox, hx-text-input, hx-switch, hx-number-input — aligns with hx-select, hx-combobox, hx-slider, hx-copy-button, hx-icon which already used `size`
- **P1-02:** Renamed slot `help` → `help-text` in hx-slider and hx-number-input — aligns with all other form components
- **P1-06:** Added `checked: true` to hx-radio-group `hx-change` event detail; renamed hx-card event from `hx-card-click` → `hx-click`

## Test plan
- [ ] `npm run verify` passes (lint + format:check + type-check) — confirmed ✅
- [ ] `npm run test:library` passes for all 8 modified components — confirmed ✅
- [ ] All story and test files updated to use new property/slot/event names
- [ ] No unintended files changed (18 files: 8 component .ts, 5 test .test.ts, 5 story .stories.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)