### PR TITLE
AUDIT FIX: Build — remove redundant package.json fields + document coverage config

### DIFF
--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -8,7 +8,6 @@
     "src/components/**/*.ts"
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

**Source:** Deep Audit P2-04, P2-10 | **Effort:** 30 min | **Priority:** MEDIUM

**Findings:**

1. **P2-04 — hx-library redundant main/module fields.** Both `main` and `module` point to `./dist/index.js`. Redundant since `exports` field is the modern standard.
   - File: `packages/hx-library/package.json` (lines 11-13)
   - Fix: Remove `module` field, keep `main` for legacy tools

2. **P2-10 — Coverage disabled by default.** `coverage.enabled: false` in vitest config. Developers may not realize ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-10T03:15:37.809Z -->