### PR TITLE
AUDIT FIX: Accessibility minor — dropdown aria-expanded, checkbox indeterminate, popover aria-controls

### DIFF
--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
@@ -298,6 +298,7 @@ export class HelixCheckbox extends LitElement {
             ?required=${this.required}
             name=${ifDefined(this.name || undefined)}
             .value=${this.value}
+            aria-checked=${this.indeterminate ? 'mixed' : nothing}
             aria-invalid=${hasError ? 'true' : nothing}
             aria-describedby=${ifDefined(describedBy)}
             aria-label=${ifDefined(hostAriaLabel)}

--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
@@ -335,6 +335,11 @@ export class HelixDropdown extends LitElement {
       trigger.setAttribute('aria-expanded', String(this.open));
       // P1-02: Link trigger to panel for screen reader navigation.
       trigger.setAttribute('aria-controls', this._panelId);
+      // P2-06: Remove host fallback when a trigger element is present.
+      this.removeAttribute('aria-expanded');
+    } else {
+      // P2-06: Fallback — set aria-expanded on host when trigger slot is empty or unassigned.
+      this.setAttribute('aria-expanded', String(this.open));
     }
   }
 
@@ -345,6 +350,9 @@ export class HelixDropdown extends LitElement {
       const trigger = slot?.assignedElements()[0] as HTMLElement | undefined;
       if (trigger) {
         trigger.setAttribute('aria-expanded', String(this.open));
+      } else {
+        // P2-06: Fallback — keep host aria-expanded in sync when trigger slot is empty.
+        this.setAttribute('aria-expanded', String(this.open));
       }
     }
   }


### PR DESCRIPTION
## Summary

**Source:** Deep Audit P2-06, P2-08, P2-11 | **Effort:** 2 hours | **Priority:** MEDIUM

**Findings:**

1. **P2-06 — Missing aria-expanded fallback in dropdown.** `aria-expanded` is set on trigger via slot assignment. If trigger slot empty or assignment fails, no element receives it.
   - File: `packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts` (lines 334-337)
   - Fix: Add fallback aria-expanded on host or trigger wrapper

2. **P2-08 — Checkbox indeterminate lacks ARIA clarity.** V...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-10T03:38:38.049Z -->