### PR TITLE
AUDIT FIX: Test flakiness — document 31 setTimeout patterns in 14 test files

### DIFF
--- a/packages/hx-library/src/components/hx-card/hx-card.test.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.test.ts
@@ -1,12 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { page } from '@vitest/browser/context';
-import {
-  fixture,
-  shadowQuery,
-  oneEvent,
-  cleanup,
-  checkA11y,
-} from '../../test-utils.js';
+import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixCard } from './hx-card.js';
 import './index.js';
 
@@ -195,6 +189,7 @@ describe('hx-card', () => {
         fired = true;
       });
       card.click();
+      // Allow brief settle time to confirm hx-click is not dispatched on a non-interactive card
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });
@@ -229,6 +224,7 @@ describe('hx-card', () => {
         fired = true;
       });
       card.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      // Allow brief settle time to confirm hx-click is not dispatched on a non-interactive card
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });
@@ -249,7 +245,9 @@ describe('hx-card', () => {
 
   describe('Slot: heading', () => {
     it('heading content renders', async () => {
-      const el = await fixture<HelixCard>('<hx-card><span slot="heading">Title</span>Body</hx-card>');
+      const el = await fixture<HelixCard>(
+        '<hx-card><span slot="heading">Title</span>Body</hx-card>',
+      );
       const headingSlot = el.querySelector('[slot="heading"]');
       expect(headingSlot).toBeTruthy();
       expect(headingSlot?.textContent).toBe('Title');

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.test.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.test.ts
@@ -500,6 +500,7 @@ describe('hx-checkbox', () => {
     it('focus() moves focus to input element', async () => {
       const el = await fixture<HelixCheckbox>('<hx-checkbox label="Test"></hx-checkbox>');
       el.focus();
+      // Allow brief settle time for focus to propagate into the shadow DOM input
       await new Promise((r) => setTimeout(r, 50));
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       expect(el.shadowRoot?.activeElement).toBe(input);

--- a/packages/hx-library/src/components/hx-copy-button/hx-copy-button.test.ts
+++ b/packages/hx-library/src/components/hx-copy-button/hx-copy-button.test.ts
@@ -243,6 +243,7 @@ describe('hx-copy-button', () => {
         fired = true;
       });
       btn!.click();
+      // Allow brief settle time to confirm hx-copy is not dispatched on a disabled button
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
       expect(writeTextSpy).not.toHaveBeenCalled();

--- a/packages/hx-library/src/components/hx-date-picker/hx-date-picker.test.ts
+++ b/packages/hx-library/src/components/hx-date-picker/hx-date-picker.test.ts
@@ -671,7 +671,7 @@ describe('hx-date-picker', () => {
 
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
       await el.updateComplete;
-      // Wait for updateComplete.then() focus scheduling
+      // Allow microtask queue to flush so the updateComplete.then() focus-restoration callback runs
       await new Promise((r) => setTimeout(r, 0));
 
       const trigger = getTriggerButton(el);

--- a/packages/hx-library/src/components/hx-dialog/hx-dialog.test.ts
+++ b/packages/hx-library/src/components/hx-dialog/hx-dialog.test.ts
@@ -50,7 +50,7 @@ describe('hx-dialog', () => {
         '<hx-dialog open><button slot="footer">OK</button></hx-dialog>',
       );
       await el.updateComplete;
-      // Allow slotchange event to fire
+      // Wait for slotchange event to propagate so the footer part visibility is updated
       await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const footerPart = shadowQuery(el, '[part="footer"]');
@@ -265,6 +265,7 @@ describe('hx-dialog', () => {
       const el = await fixture<HelixDialog>(
         '<hx-dialog open><span slot="header" class="custom-header">Custom</span></hx-dialog>',
       );
+      // Wait for slotchange event to propagate and component to re-render with header slot content
       await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const slottedHeader = el.querySelector('span.custom-header');
@@ -276,6 +277,7 @@ describe('hx-dialog', () => {
       const el = await fixture<HelixDialog>(
         '<hx-dialog open><button slot="footer" class="confirm-btn">Confirm</button></hx-dialog>',
       );
+      // Wait for slotchange event to propagate and component to re-render with footer slot content
       await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const slottedFooter = el.querySelector('button.confirm-btn');
@@ -325,6 +327,7 @@ describe('hx-dialog', () => {
       const el = await fixture<HelixDialog>(
         '<hx-dialog open><button slot="footer">OK</button></hx-dialog>',
       );
+      // Wait for slotchange event to propagate so the footer CSS part is rendered
       await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const part = shadowQuery(el, '[part="footer"]');
@@ -354,7 +357,7 @@ describe('hx-dialog', () => {
       );
       el.modal = true;
       await el.updateComplete;
-      // Wait for focus cache to populate
+      // Allow brief settle time for the focus-trap focusable element cache to populate
       await new Promise((r) => setTimeout(r, 50));
 
       const dialogEl = shadowQuery<HTMLDialogElement>(el, 'dialog');
@@ -379,6 +382,7 @@ describe('hx-dialog', () => {
       );
       el.modal = true;
       await el.updateComplete;
+      // Allow brief settle time for the focus-trap focusable element cache to populate
       await new Promise((r) => setTimeout(r, 50));
 
       const dialogEl = shadowQuery<HTMLDialogElement>(el, 'dialog');
@@ -478,7 +482,7 @@ describe('hx-dialog', () => {
 
       el.showModal();
       await el.updateComplete;
-      // Allow updateComplete.then() callback to run (initial focus is set inside)
+      // Allow microtask queue to flush so the updateComplete.then() initial-focus callback runs
       await new Promise((r) => setTimeout(r, 50));
 
       const firstFocusable = el.querySelector('#first-focusable') as HTMLElement;
@@ -503,6 +507,7 @@ describe('hx-dialog', () => {
 
       el.showModal();
       await el.updateComplete;
+      // Allow microtask queue to flush so the updateComplete.then() initial-focus callback runs
       await new Promise((r) => setTimeout(r, 50));
 
       // Close the dialog

--- a/packages/hx-library/src/components/hx-drawer/hx-drawer.test.ts
+++ b/packages/hx-library/src/components/hx-drawer/hx-drawer.test.ts
@@ -96,6 +96,7 @@ describe('hx-drawer', () => {
     it('dispatches hx-hide when open is set to false', async () => {
       const el = await fixture<HelixDrawer>('<hx-drawer open></hx-drawer>');
       await el.updateComplete;
+      // Allow open animation to complete before toggling open to false
       await new Promise((r) => setTimeout(r, 50));
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-hide');
       el.open = false;
@@ -121,6 +122,7 @@ describe('hx-drawer', () => {
       el.addEventListener('hx-after-show', () => events.push('hx-after-show'));
 
       el.open = true;
+      // Allow CSS transition/animation to complete so hx-after-show fires after hx-show
       await new Promise((r) => setTimeout(r, 400));
 
       expect(events).toContain('hx-show');
@@ -131,6 +133,7 @@ describe('hx-drawer', () => {
     it('dispatches hx-hide and then hx-after-hide', async () => {
       const el = await fixture<HelixDrawer>('<hx-drawer open></hx-drawer>');
       await el.updateComplete;
+      // Allow open animation to complete before triggering close
       await new Promise((r) => setTimeout(r, 100));
 
       const events: string[] = [];
@@ -138,6 +141,7 @@ describe('hx-drawer', () => {
       el.addEventListener('hx-after-hide', () => events.push('hx-after-hide'));
 
       el.open = false;
+      // Allow CSS transition/animation to complete so hx-after-hide fires after hx-hide
       await new Promise((r) => setTimeout(r, 400));
 
       expect(events).toContain('hx-hide');
@@ -194,6 +198,7 @@ describe('hx-drawer', () => {
       const el = await fixture<HelixDrawer>(
         '<hx-drawer open><button slot="footer" class="confirm-btn">Confirm</button></hx-drawer>',
       );
+      // Wait for slotchange event to propagate and component to re-render with footer slot content
       await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
       const slottedFooter = el.querySelector('button.confirm-btn');
@@ -252,6 +257,7 @@ describe('hx-drawer', () => {
     it('Escape key closes the drawer when open', async () => {
       const el = await fixture<HelixDrawer>('<hx-drawer open></hx-drawer>');
       await el.updateComplete;
+      // Allow open animation to complete before testing Escape-key close
       await new Promise((r) => setTimeout(r, 50));
 
       expect(el.open).toBe(true);
@@ -283,6 +289,7 @@ describe('hx-drawer', () => {
     it('clicking the overlay backdrop closes the drawer', async () => {
       const el = await fixture<HelixDrawer>('<hx-drawer open></hx-drawer>');
       await el.updateComplete;
+      // Allow open animation to complete before testing overlay-click close
       await new Promise((r) => setTimeout(r, 50));
 
       expect(el.open).toBe(true);
@@ -363,6 +370,7 @@ describe('hx-drawer', () => {
     it('clicking close button closes the drawer', async () => {
       const el = await fixture<HelixDrawer>('<hx-drawer open></hx-drawer>');
       await el.updateComplete;
+      // Allow open animation to complete before testing close-button click
       await new Promise((r) => setTimeout(r, 50));
 
       expect(el.open).toBe(true);

--- a/packages/hx-library/src/components/hx-list/hx-list.test.ts
+++ b/packages/hx-library/src/components/hx-list/hx-list.test.ts
@@ -146,6 +146,7 @@ describe('hx-list', () => {
       const liEl = shadowQuery<HTMLElement>(item, '[part~="base"]')!;
       liEl.click();
       // Use a proper async tick to ensure all microtasks are flushed (not just updateComplete)
+      // Allow microtask queue to flush and Lit reactive updates to complete before asserting no event fired
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(fired).toBe(false);
     });
@@ -400,6 +401,7 @@ describe('hx-list-item', () => {
       });
       const liEl = shadowQuery<HTMLElement>(el, '[part~="base"]')!;
       liEl.click();
+      // Allow microtask queue to flush and Lit reactive updates to complete before asserting no event fired
       await new Promise((resolve) => setTimeout(resolve, 0));
       expect(fired).toBe(false);
     });

--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.test.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.test.ts
@@ -431,6 +431,7 @@ describe('hx-number-input', () => {
   // ─── Long-press stepper (5) ───
 
   describe('Long-press stepper', () => {
+    // Helper to pause execution for async animation/transition waits
     const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
     it('fires hx-change immediately on pointerdown', async () => {
@@ -929,6 +930,7 @@ describe('hx-number-input', () => {
     it('focus() moves focus to the native input', async () => {
       const el = await fixture<HelixNumberInput>('<hx-number-input></hx-number-input>');
       el.focus();
+      // Allow brief settle time for focus to propagate into the shadow DOM input
       await new Promise<void>((r) => setTimeout(r, 50));
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       expect(el.shadowRoot?.activeElement).toBe(input);

--- a/packages/hx-library/src/components/hx-popover/hx-popover.test.ts
+++ b/packages/hx-library/src/components/hx-popover/hx-popover.test.ts
@@ -317,7 +317,7 @@ describe('hx-popover', () => {
       const body = shadowQuery(el, '[part="body"]');
       expect(body?.classList.contains('visible')).toBe(true);
 
-      // Wait for the deferred document listener to be attached
+      // Allow brief settle time for the deferred document click listener to be attached after open
       await new Promise((r) => setTimeout(r, 10));
 
       // Simulate click on an unrelated element outside the component

--- a/packages/hx-library/src/components/hx-popup/hx-popup.test.ts
+++ b/packages/hx-library/src/components/hx-popup/hx-popup.test.ts
@@ -484,6 +484,7 @@ describe('hx-popup', () => {
         { once: true },
       );
       await el.reposition();
+      // Allow brief settle time for the async hx-reposition event to propagate after reposition()
       await new Promise((r) => setTimeout(r, 10));
 
       expect(caught).toBe(true);

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.test.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.test.ts
@@ -244,7 +244,7 @@ describe('hx-side-nav', () => {
       newItem.textContent = 'New Item';
       el.appendChild(newItem);
 
-      // Wait for slotchange to fire and propagate
+      // Yield to event loop to allow slotchange callback to run and component to re-render with new item
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
       await (el as HxSideNav & { updateComplete: Promise<boolean> }).updateComplete;
 

--- a/packages/hx-library/src/components/hx-slider/hx-slider.test.ts
+++ b/packages/hx-library/src/components/hx-slider/hx-slider.test.ts
@@ -514,6 +514,7 @@ describe('hx-slider', () => {
     it('focus() moves focus to the native range input', async () => {
       const el = await fixture<HelixSlider>('<hx-slider label="Level"></hx-slider>');
       el.focus();
+      // Allow brief settle time for focus to propagate into the shadow DOM input
       await new Promise<void>((r) => setTimeout(r, 50));
       const input = shadowQuery<HTMLInputElement>(el, 'input[type="range"]');
       expect(el.shadowRoot?.activeElement).toBe(input);

--- a/packages/hx-library/src/components/hx-split-button/hx-split-button.test.ts
+++ b/packages/hx-library/src/components/hx-split-button/hx-split-button.test.ts
@@ -182,6 +182,7 @@ describe('hx-split-button', () => {
         fired = true;
       });
       primary?.click();
+      // Allow brief settle time to confirm hx-click is not dispatched on a disabled split button
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });
@@ -266,6 +267,7 @@ describe('hx-split-button', () => {
         fired = true;
       });
       primary?.click();
+      // Allow brief settle time to confirm hx-click is not dispatched on a disabled split button
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });
@@ -281,6 +283,7 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete before asserting final state after menu open
       await new Promise((r) => setTimeout(r, 50));
 
       // Click the inner element of the menu item
@@ -304,6 +307,7 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete before asserting final state after menu open
       await new Promise((r) => setTimeout(r, 50));
 
       const menuItem = el.querySelector('hx-menu-item') as HelixMenuItem;
@@ -361,6 +365,7 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open before Escape is dispatched
       await new Promise((r) => setTimeout(r, 50));
 
       // Dispatch Escape on the menu panel
@@ -397,16 +402,19 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open and items are focusable
       await new Promise((r) => setTimeout(r, 50));
 
       const items = el.querySelectorAll<HelixMenuItem>('hx-menu-item');
       // Focus first item
       items[0].focus();
+      // Allow brief settle time for focus to propagate before dispatching ArrowDown
       await new Promise((r) => setTimeout(r, 10));
 
       // ArrowDown from first item should move to second
       const menu = shadowQuery(el, '.split-button__menu');
       menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      // Allow brief settle time for focus movement to take effect
       await new Promise((r) => setTimeout(r, 10));
 
       expect(document.activeElement).toBe(items[1]);
@@ -423,15 +431,18 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open and items are focusable
       await new Promise((r) => setTimeout(r, 50));
 
       const items = el.querySelectorAll<HelixMenuItem>('hx-menu-item');
       // Focus last item
       items[1].focus();
+      // Allow brief settle time for focus to propagate before dispatching ArrowDown
       await new Promise((r) => setTimeout(r, 10));
 
       const menu = shadowQuery(el, '.split-button__menu');
       menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+      // Allow brief settle time for focus wrap-around to take effect
       await new Promise((r) => setTimeout(r, 10));
 
       expect(document.activeElement).toBe(items[0]);
@@ -448,15 +459,18 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open and items are focusable
       await new Promise((r) => setTimeout(r, 50));
 
       const items = el.querySelectorAll<HelixMenuItem>('hx-menu-item');
       // Focus second item
       items[1].focus();
+      // Allow brief settle time for focus to propagate before dispatching ArrowUp
       await new Promise((r) => setTimeout(r, 10));
 
       const menu = shadowQuery(el, '.split-button__menu');
       menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      // Allow brief settle time for focus movement to take effect
       await new Promise((r) => setTimeout(r, 10));
 
       expect(document.activeElement).toBe(items[0]);
@@ -474,15 +488,18 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open and items are focusable
       await new Promise((r) => setTimeout(r, 50));
 
       const items = el.querySelectorAll<HelixMenuItem>('hx-menu-item');
       // Focus first item
       items[0].focus();
+      // Allow brief settle time for focus to propagate before dispatching ArrowUp
       await new Promise((r) => setTimeout(r, 10));
 
       const menu = shadowQuery(el, '.split-button__menu');
       menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      // Allow brief settle time for focus wrap-around to take effect
       await new Promise((r) => setTimeout(r, 10));
 
       expect(document.activeElement).toBe(items[2]);
@@ -500,14 +517,17 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open and items are focusable
       await new Promise((r) => setTimeout(r, 50));
 
       const items = el.querySelectorAll<HelixMenuItem>('hx-menu-item');
       items[2].focus();
+      // Allow brief settle time for focus to propagate before dispatching Home
       await new Promise((r) => setTimeout(r, 10));
 
       const menu = shadowQuery(el, '.split-button__menu');
       menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
+      // Allow brief settle time for focus movement to take effect
       await new Promise((r) => setTimeout(r, 10));
 
       expect(document.activeElement).toBe(items[0]);
@@ -525,14 +545,17 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open and items are focusable
       await new Promise((r) => setTimeout(r, 50));
 
       const items = el.querySelectorAll<HelixMenuItem>('hx-menu-item');
       items[0].focus();
+      // Allow brief settle time for focus to propagate before dispatching End
       await new Promise((r) => setTimeout(r, 10));
 
       const menu = shadowQuery(el, '.split-button__menu');
       menu?.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+      // Allow brief settle time for focus movement to take effect
       await new Promise((r) => setTimeout(r, 10));
 
       expect(document.activeElement).toBe(items[2]);
@@ -592,6 +615,7 @@ describe('hx-split-button', () => {
       const trigger = shadowQuery<HTMLButtonElement>(el, '.split-button__trigger');
       trigger?.click();
       await el.updateComplete;
+      // Allow CSS transition to complete so the menu is fully open before clicking a menu item
       await new Promise((r) => setTimeout(r, 50));
 
       const menuItem = el.querySelector('hx-menu-item') as HelixMenuItem;
@@ -744,6 +768,7 @@ describe('hx-menu-item', () => {
         fired = true;
       });
       item?.click();
+      // Allow brief settle time to confirm hx-item-select is not dispatched on a disabled menu item
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });

--- a/packages/hx-library/src/components/hx-tabs/hx-tabs.test.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tabs.test.ts
@@ -654,6 +654,7 @@ describe('hx-tabs', () => {
       el.appendChild(newPanel);
       // Wait for slot change to propagate
       await el.updateComplete;
+      // Yield to event loop to allow slotchange/DOM mutation callbacks to run after tab insertion
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
@@ -672,6 +673,7 @@ describe('hx-tabs', () => {
       el.appendChild(newTab);
       el.appendChild(newPanel);
       await el.updateComplete;
+      // Yield to event loop to allow slotchange/DOM mutation callbacks to run after tab insertion
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
@@ -687,6 +689,7 @@ describe('hx-tabs', () => {
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       el.removeChild(tabs[2]);
       await el.updateComplete;
+      // Yield to event loop to allow slotchange/DOM mutation callbacks to run after tab removal
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
       const remainingTabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];

--- a/packages/hx-library/src/components/hx-toggle-button/hx-toggle-button.test.ts
+++ b/packages/hx-library/src/components/hx-toggle-button/hx-toggle-button.test.ts
@@ -265,6 +265,7 @@ describe('hx-toggle-button', () => {
         fired = true;
       });
       btn.click();
+      // Allow brief settle time to confirm no hx-toggle event fires on a disabled button
       await new Promise((r) => setTimeout(r, 50));
       expect(fired).toBe(false);
     });

--- a/packages/hx-library/src/components/hx-tooltip/hx-tooltip.test.ts
+++ b/packages/hx-library/src/components/hx-tooltip/hx-tooltip.test.ts
@@ -300,7 +300,7 @@ describe('hx-tooltip', () => {
       );
       const wrapper = shadowQuery<HTMLElement>(el, '.trigger-wrapper')!;
       wrapper.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
-      // Allow the show-delay=0 timer to fire on the next tick
+      // Allow microtask queue to flush so the show-delay=0 timer fires and Lit reactive updates complete
       await new Promise<void>((resolve) => setTimeout(resolve, 0));
       await el.updateComplete;
       await page.screenshot();

--- a/packages/hx-library/src/components/hx-top-nav/hx-top-nav.test.ts
+++ b/packages/hx-library/src/components/hx-top-nav/hx-top-nav.test.ts
@@ -263,7 +263,7 @@ describe('hx-top-nav', () => {
       const btn = shadowQuery(el, '[part="mobile-toggle"]')! as HTMLButtonElement;
       btn.click();
       await el.updateComplete;
-      // Wait for the 150ms open animation to complete before axe checks contrast
+      // Allow CSS transition/animation to complete so the mobile menu is fully visible for axe contrast checks
       await new Promise((r) => setTimeout(r, 200));
 
       await page.screenshot();

--- a/packages/hx-library/src/components/hx-tree-view/hx-tree-view.test.ts
+++ b/packages/hx-library/src/components/hx-tree-view/hx-tree-view.test.ts
@@ -337,6 +337,7 @@ describe('hx-tree-view', () => {
           </hx-tree-item>
         </hx-tree-view>`,
       );
+      // Allow microtask queue to flush and Lit reactive updates to complete before axe audit
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
       const { violations } = await checkA11y(el);
@@ -546,6 +547,7 @@ describe('hx-tree-item', () => {
           <hx-tree-item slot="children">Child</hx-tree-item>
         </hx-tree-item>`,
       );
+      // Yield to event loop to allow slotchange callback to run so hasChildItems is updated
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
       expect(el.hasChildItems).toBe(true);
@@ -580,6 +582,7 @@ describe('hx-tree-item', () => {
           <hx-tree-item slot="children">Child</hx-tree-item>
         </hx-tree-item>`,
       );
+      // Yield to event loop to allow slotchange callback to run so the expand button is rendered
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
       const btn = shadowQuery(el, '.expand-btn');
@@ -672,6 +675,7 @@ describe('hx-tree-item', () => {
           <hx-tree-item slot="children">Child</hx-tree-item>
         </hx-tree-item>`,
       );
+      // Yield to event loop to allow slotchange callback to run so children are registered before key dispatch
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
 
@@ -690,6 +694,7 @@ describe('hx-tree-item', () => {
           <hx-tree-item slot="children">Child</hx-tree-item>
         </hx-tree-item>`,
       );
+      // Yield to event loop to allow slotchange callback to run so children are registered before key dispatch
       await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
 


### PR DESCRIPTION
## Summary

**Source:** Deep Audit P2-05 | **Effort:** 1 hour | **Priority:** MEDIUM

**Problem:** 31 instances of `setTimeout` in tests across 14 test files (hx-dialog, hx-split-button, hx-top-nav, etc.), mostly 50ms delays for slotchange events and animations. While justified, they lack comments explaining why.

**Fix:** Add JSDoc comments to each setTimeout explaining its purpose (e.g., 'Wait for slotchange event to propagate', 'Allow CSS transition to complete').

**Acceptance Criteria:**
- [ ] Every se...

---
*Recovered automatically by Automaker post-agent hook*