### PR TITLE
AUDIT FIX: Cross-browser testing — add Safari + Firefox to vitest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build:admin": "turbo build --filter=@helix/admin",
     "test": "turbo test",
     "test:library": "turbo test --filter=@helix/library",
+    "test:cross-browser": "npm run test:cross-browser --workspace=packages/hx-library",
     "test:vrt": "playwright test",
     "test:vrt:update": "playwright test --update-snapshots",
     "format": "prettier --write .",

--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -33,6 +33,7 @@
     "build": "vite build && npm run cem",
     "type-check": "tsc --noEmit",
     "test": "vitest run",
+    "test:cross-browser": "vitest run --config vitest.config.cross-browser.ts",
     "test:coverage": "vitest run --coverage.enabled",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/packages/hx-library/vitest.config.cross-browser.ts
+++ b/packages/hx-library/vitest.config.cross-browser.ts
@@ -1,0 +1,59 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+
+// Cross-browser config for release validation.
+// Run via: npm run test:cross-browser
+// Includes Chromium, Firefox, and WebKit (Safari) instances.
+// Default `npm run test` uses Chromium-only for speed.
+export default defineConfig({
+  server: {
+    fs: {
+      // Allow access to parent directories where node_modules may live.
+      // Required when running from a git worktree (node_modules in main repo root).
+      allow: [resolve(__dirname, '../..'), resolve(__dirname, '../../../..')],
+    },
+  },
+  test: {
+    browser: {
+      enabled: true,
+      provider: 'playwright',
+      headless: true,
+      instances: [{ browser: 'chromium' }, { browser: 'firefox' }, { browser: 'webkit' }],
+    },
+    include: ['src/components/**/*.test.ts'],
+    exclude: ['.worktrees/**', 'node_modules/**'],
+    reporters: ['verbose', 'json'],
+    outputFile: { json: '.cache/test-results-cross-browser.json' },
+    testTimeout: 30000,
+    globals: true,
+    pool: 'threads',
+    poolOptions: {
+      threads: {
+        minThreads: 2,
+        maxThreads: 4,
+      },
+    },
+    coverage: {
+      provider: 'istanbul',
+      enabled: false,
+      include: ['src/components/**/*.ts'],
+      exclude: [
+        'src/components/**/*.test.ts',
+        'src/components/**/*.stories.ts',
+        'src/components/**/*.styles.ts',
+        'src/components/**/index.ts',
+      ],
+      reporter: ['text', 'json-summary'],
+      reportsDirectory: '.cache/coverage',
+      thresholds: {
+        statements: 75,
+        branches: 70,
+        functions: 75,
+        lines: 75,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

**Source:** Deep Audit P1-12, P3-06 | **Effort:** 2 hours | **Priority:** HIGH

**Problem:** Tests run exclusively in Chromium. No Safari, Firefox, or Edge testing. Shadow DOM behavior varies across browsers — healthcare organizations may use different browsers.

**Files:** `packages/hx-library/vitest.config.ts`

**Fix:**
1. Add Safari (WebKit) and Firefox browser instances to vitest config
2. Configure as optional/release-only so they don't slow down dev workflow
3. Add `npm run test:cross-brow...

---
*Recovered automatically by Automaker post-agent hook*