### PR TITLE
DX: Add React/Vue/Angular integration guides

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -641,6 +641,18 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Framework Integration',
+          collapsed: true,
+          items: [
+            { label: 'Overview', slug: 'framework-integration' },
+            { label: 'React', slug: 'framework-integration/react' },
+            { label: 'Vue', slug: 'framework-integration/vue' },
+            { label: 'Angular', slug: 'framework-integration/angular' },
+            { label: 'Plain HTML / CDN', slug: 'framework-integration/html' },
+            { label: 'Drupal', slug: 'framework-integration/drupal' },
+          ],
+        },
+        {
           label: 'Architecture',
           collapsed: true,
           items: [

--- a/apps/docs/src/content/docs/framework-integration/angular.md
+++ b/apps/docs/src/content/docs/framework-integration/angular.md
@@ -1,0 +1,252 @@
+---
+title: 'Angular Integration'
+description: 'Using HELIX web components in Angular 16+, including CUSTOM_ELEMENTS_SCHEMA, event binding, form integration, and TypeScript types.'
+sidebar:
+  order: 4
+---
+
+# Angular Integration
+
+Angular requires an explicit schema declaration to allow custom elements in templates. Once configured, HELIX components work with Angular's standard template binding syntax.
+
+## Installation
+
+```bash
+npm install @helix/library
+```
+
+## Schema Configuration
+
+Add `CUSTOM_ELEMENTS_SCHEMA` to any module or standalone component that uses HELIX elements. Without it, Angular throws a template parsing error for unknown elements.
+
+### Standalone Components (Angular 16+)
+
+```ts
+// my.component.ts
+import { Component, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+@Component({
+  selector: 'app-my',
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template: `
+    <hx-button variant="primary" (hx-click)="save()">Save</hx-button>
+  `,
+})
+export class MyComponent {
+  save() {
+    console.log('saved');
+  }
+}
+```
+
+### NgModule
+
+```ts
+// app.module.ts
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { AppComponent } from './app.component';
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule],
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+## Importing Components
+
+Import HELIX once in `main.ts` (or `app.config.ts`):
+
+```ts
+// main.ts
+import { bootstrapApplication } from '@angular/platform-browser';
+import '@helix/library';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent);
+```
+
+## Basic Usage
+
+```html
+<!-- my.component.html -->
+<hx-button variant="primary">Save</hx-button>
+<hx-text-input name="search" placeholder="Search..."></hx-text-input>
+```
+
+## Event Binding
+
+Angular binds to DOM events using `(eventName)` syntax. HELIX dispatches `hx-` prefixed custom events — use the full event name in parentheses:
+
+```html
+<hx-button (hx-click)="onSave($event)">Save</hx-button>
+<hx-text-input (hx-input)="onInput($event)" (hx-change)="onChange($event)"></hx-text-input>
+```
+
+```ts
+export class MyComponent {
+  onSave(event: Event) {
+    console.log('button clicked', event);
+  }
+
+  onInput(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    console.log('input:', value);
+  }
+
+  onChange(event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    console.log('change:', value);
+  }
+}
+```
+
+## Property Binding
+
+Bind dynamic values to HELIX properties using `[property]` syntax:
+
+```html
+<hx-button
+  [disabled]="isLoading"
+  [attr.variant]="buttonVariant"
+  (hx-click)="submit()"
+>
+  {{ isLoading ? 'Saving...' : 'Save' }}
+</hx-button>
+```
+
+> **Note:** Use `[attr.variant]` (attribute binding) rather than `[variant]` (property binding) when binding to custom element string attributes. Angular's `[property]` binding sets DOM properties, which works for booleans and objects; `[attr.name]` sets HTML attributes, which is appropriate for string/enum values.
+
+## Boolean Attributes
+
+Angular's `[disabled]="false"` omits the attribute when the value is falsy, matching HELIX's [boolean attribute semantics](/guides/boolean-attributes):
+
+```html
+<!-- Correct: attribute absent when false, present when true -->
+<hx-button [disabled]="isDisabled">Submit</hx-button>
+```
+
+Avoid static string `"false"`:
+
+```html
+<!-- Wrong: disabled="false" still disables the button -->
+<hx-button disabled="false">Submit</hx-button>
+```
+
+## Form Integration
+
+### Template-Driven Forms
+
+HELIX components participate in native HTML forms via `ElementInternals`. Read submitted values with `FormData`:
+
+```html
+<form #myForm="ngForm" (ngSubmit)="onSubmit(myForm)">
+  <hx-text-input name="email" required></hx-text-input>
+  <hx-button type="submit">Send</hx-button>
+</form>
+```
+
+```ts
+import { Component } from '@angular/core';
+import { NgForm } from '@angular/forms';
+
+@Component({ /* ... */ })
+export class ContactComponent {
+  onSubmit(form: NgForm) {
+    const formEl = document.querySelector('form') as HTMLFormElement;
+    const data = new FormData(formEl);
+    console.log(data.get('email'));
+  }
+}
+```
+
+### Reactive Forms (Manual Sync)
+
+HELIX components are not `ControlValueAccessor` implementations by default. For Reactive Forms, sync values via event listeners using `ElementRef`:
+
+```ts
+import { Component, ElementRef, ViewChild, OnInit } from '@angular/core';
+import { FormControl } from '@angular/forms';
+
+@Component({
+  standalone: true,
+  schemas: [CUSTOM_ELEMENTS_SCHEMA],
+  template: `<hx-text-input #emailInput name="email"></hx-text-input>`,
+})
+export class EmailInputComponent implements OnInit {
+  @ViewChild('emailInput') emailInput!: ElementRef<HTMLElement>;
+
+  emailControl = new FormControl('');
+
+  ngOnInit() {
+    const el = this.emailInput.nativeElement;
+
+    el.addEventListener('hx-change', (e: Event) => {
+      this.emailControl.setValue((e.target as HTMLInputElement).value);
+    });
+
+    this.emailControl.valueChanges.subscribe((val) => {
+      (el as HTMLInputElement).value = val ?? '';
+    });
+  }
+}
+```
+
+## TypeScript Types
+
+Extend Angular's known elements for IDE autocompletion. Create a `helix-types.d.ts`:
+
+```ts
+// src/helix-types.d.ts
+declare global {
+  interface HTMLElementTagNameMap {
+    'hx-button': HTMLElement & {
+      variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+      size?: 'sm' | 'md' | 'lg';
+      disabled?: boolean;
+      loading?: boolean;
+      type?: 'button' | 'submit' | 'reset';
+    };
+    'hx-text-input': HTMLElement & {
+      value?: string;
+      placeholder?: string;
+      disabled?: boolean;
+      required?: boolean;
+      name?: string;
+    };
+  }
+}
+
+export {};
+```
+
+## SSR / Angular Universal
+
+Custom element registration is browser-only. Guard imports with a platform check:
+
+```ts
+// app.component.ts
+import { Component, Inject, PLATFORM_ID, OnInit } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+@Component({ selector: 'app-root', template: `<router-outlet />` })
+export class AppComponent implements OnInit {
+  constructor(@Inject(PLATFORM_ID) private platformId: object) {}
+
+  ngOnInit() {
+    if (isPlatformBrowser(this.platformId)) {
+      import('@helix/library');
+    }
+  }
+}
+```
+
+## Next Steps
+
+- [Plain HTML / CDN Integration](/framework-integration/html)
+- [Boolean Attributes reference](/guides/boolean-attributes)
+- [Component Library](/component-library/overview)

--- a/apps/docs/src/content/docs/framework-integration/drupal.md
+++ b/apps/docs/src/content/docs/framework-integration/drupal.md
@@ -1,0 +1,168 @@
+---
+title: 'Drupal Integration'
+description: 'Using HELIX web components in Drupal CMS — Twig templates, Drupal behaviors, and CDN/npm installation overview.'
+sidebar:
+  order: 6
+---
+
+# Drupal Integration
+
+HELIX is purpose-built for Drupal. The full integration guide lives in the [Drupal Integration](/drupal-integration/overview) section. This page is a quick-start summary covering the essential patterns.
+
+## Installation
+
+Two options are available:
+
+### Via npm (recommended for custom themes)
+
+```bash
+npm install @helix/library
+```
+
+Reference the built files from your theme's `.libraries.yml`.
+
+### Via CDN
+
+```yaml
+# mytheme.libraries.yml
+helix:
+  js:
+    https://cdn.jsdelivr.net/npm/@helix/library/dist/index.js: { type: external, attributes: { type: module } }
+```
+
+See [CDN Installation](/drupal-integration/installation/cdn) for the full setup.
+
+## Using Components in Twig
+
+HELIX elements are standard HTML — use them directly in `.html.twig` templates:
+
+```twig
+{# templates/block--my-block.html.twig #}
+
+<hx-button variant="primary" type="button">
+  {{ 'Save changes'|t }}
+</hx-button>
+```
+
+### Passing Dynamic Values
+
+Use Twig variable interpolation to set attributes:
+
+```twig
+<hx-button
+  variant="{{ button_variant|default('primary') }}"
+  {% if disabled %}disabled{% endif %}
+>
+  {{ label }}
+</hx-button>
+```
+
+### Boolean Attributes in Twig
+
+Follow HELIX's [boolean attribute semantics](/guides/boolean-attributes). Output the attribute name without a value when true; omit it entirely when false:
+
+```twig
+{# Correct #}
+<hx-button {% if is_disabled %}disabled{% endif %}>
+  {{ label }}
+</hx-button>
+
+{# Wrong — disabled="false" still disables #}
+<hx-button disabled="{{ is_disabled ? 'true' : 'false' }}">
+  {{ label }}
+</hx-button>
+```
+
+### Using Slots
+
+Twig child content maps to the default slot:
+
+```twig
+<hx-card>
+  <span slot="header">{{ card_title }}</span>
+  <div>{{ card_body }}</div>
+</hx-card>
+```
+
+See [Slots in Twig](/drupal-integration/twig/slots) for named slot patterns.
+
+## Drupal Behaviors for Event Handling
+
+Drupal Behaviors are the correct place to attach JavaScript event listeners to HELIX components. They re-fire on AJAX updates.
+
+```js
+// js/my-feature.js
+(function (Drupal) {
+  Drupal.behaviors.myFeature = {
+    attach(context) {
+      const buttons = context.querySelectorAll('hx-button[data-my-action]');
+
+      buttons.forEach((btn) => {
+        if (btn.dataset.behaviorAttached) return; // prevent double-attach
+        btn.dataset.behaviorAttached = 'true';
+
+        btn.addEventListener('hx-click', (event) => {
+          Drupal.ajax({ url: btn.dataset.url }).execute();
+        });
+      });
+    },
+  };
+})(Drupal);
+```
+
+See [Drupal Behaviors — With Web Components](/drupal-integration/behaviors/web-components) for detailed patterns.
+
+## Form API Integration
+
+HELIX form components participate in native HTML forms. In Drupal, combine with the Form API's `#attributes` key:
+
+```php
+$form['email'] = [
+  '#type' => 'html_tag',
+  '#tag' => 'hx-text-input',
+  '#attributes' => [
+    'name' => 'email',
+    'type' => 'email',
+    'required' => TRUE,
+    'placeholder' => $this->t('Enter your email'),
+  ],
+];
+```
+
+For full Drupal Form API element plugins, see [Form API Integration](/drupal-integration/forms/form-api).
+
+## Per-Component Loading
+
+For performance, load only the components used on each page:
+
+```yaml
+# mytheme.libraries.yml
+helix-button:
+  js:
+    /path/to/hx-button.js: { attributes: { type: module } }
+
+helix-text-input:
+  js:
+    /path/to/hx-text-input.js: { attributes: { type: module } }
+```
+
+See [Per-Component Loading](/drupal-integration/per-component-loading) for the full strategy.
+
+## Full Documentation
+
+This page covers the basics. The complete Drupal integration guide includes:
+
+- [Installation (npm, CDN, Drupal Module)](/drupal-integration/installation/overview)
+- [Twig Templates — Fundamentals](/drupal-integration/twig/fundamentals)
+- [Twig — Properties & Attributes](/drupal-integration/twig/properties)
+- [Drupal Behaviors](/drupal-integration/behaviors/fundamentals)
+- [Library System](/drupal-integration/library-system)
+- [Forms — Form API](/drupal-integration/forms/form-api)
+- [Performance & Lazy Loading](/drupal-integration/performance/overview)
+- [Troubleshooting](/drupal-integration/troubleshooting/common-issues)
+
+## Next Steps
+
+- [Full Drupal Integration Guide](/drupal-integration/overview)
+- [Boolean Attributes reference](/guides/boolean-attributes)
+- [Component Library](/component-library/overview)

--- a/apps/docs/src/content/docs/framework-integration/html.md
+++ b/apps/docs/src/content/docs/framework-integration/html.md
@@ -1,0 +1,213 @@
+---
+title: 'Plain HTML / CDN'
+description: 'Using HELIX web components via CDN or script tag — no build tool required.'
+sidebar:
+  order: 5
+---
+
+# Plain HTML / CDN Integration
+
+HELIX components work in any HTML page with a single `<script>` tag. No build tool, no npm, no bundler required.
+
+## CDN via Script Tag
+
+Load the full library bundle from a CDN:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>My App</title>
+</head>
+<body>
+
+  <hx-button variant="primary" id="my-btn">Click me</hx-button>
+
+  <script type="module">
+    import '@helix/library';
+    // or from a CDN URL:
+    // import 'https://cdn.jsdelivr.net/npm/@helix/library/dist/index.js';
+  </script>
+
+</body>
+</html>
+```
+
+## Loading Individual Components
+
+For performance, load only the components you use:
+
+```html
+<script type="module">
+  import '@helix/library/components/hx-button';
+  import '@helix/library/components/hx-text-input';
+</script>
+```
+
+## Event Handling
+
+Listen for HELIX's `hx-` prefixed custom events with standard `addEventListener`:
+
+```html
+<hx-button id="save-btn" variant="primary">Save</hx-button>
+<hx-text-input id="name-input" name="name" placeholder="Enter name"></hx-text-input>
+
+<script type="module">
+  import '@helix/library';
+
+  const btn = document.getElementById('save-btn');
+  const input = document.getElementById('name-input');
+
+  btn.addEventListener('hx-click', (event) => {
+    console.log('Button clicked', event);
+  });
+
+  input.addEventListener('hx-input', (event) => {
+    console.log('Input value:', event.target.value);
+  });
+
+  input.addEventListener('hx-change', (event) => {
+    console.log('Committed value:', event.target.value);
+  });
+</script>
+```
+
+## Setting Properties
+
+HELIX components expose DOM properties for dynamic values. Set them directly on the element reference:
+
+```html
+<hx-button id="submit-btn" variant="primary">Submit</hx-button>
+
+<script type="module">
+  import '@helix/library';
+
+  const btn = document.getElementById('submit-btn');
+
+  // Set property
+  btn.disabled = true;
+  btn.loading = true;
+
+  // Read property
+  console.log(btn.variant); // 'primary'
+</script>
+```
+
+## Boolean Attributes
+
+Follow HTML's boolean attribute rules — presence means `true`, absence means `false`. See [Boolean Attributes](/guides/boolean-attributes) for details.
+
+```html
+<!-- Disabled: attribute present -->
+<hx-button disabled>Disabled</hx-button>
+
+<!-- Enabled: attribute absent -->
+<hx-button>Enabled</hx-button>
+
+<!-- Wrong: string "false" still disables -->
+<hx-button disabled="false">Still disabled!</hx-button>
+```
+
+Toggle in JavaScript:
+
+```js
+// Disable
+btn.setAttribute('disabled', '');
+// or:
+btn.disabled = true;
+
+// Enable
+btn.removeAttribute('disabled');
+// or:
+btn.disabled = false;
+```
+
+## Form Integration
+
+HELIX form components work with native `<form>` elements and `FormData`:
+
+```html
+<form id="contact-form">
+  <hx-text-input name="email" type="email" required placeholder="you@example.com"></hx-text-input>
+  <hx-select name="subject">
+    <option value="">Choose a subject</option>
+    <option value="support">Support</option>
+    <option value="billing">Billing</option>
+  </hx-select>
+  <hx-button type="submit" variant="primary">Send</hx-button>
+</form>
+
+<script type="module">
+  import '@helix/library';
+
+  const form = document.getElementById('contact-form');
+
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const data = new FormData(form);
+
+    console.log({
+      email: data.get('email'),
+      subject: data.get('subject'),
+    });
+  });
+</script>
+```
+
+## Waiting for Custom Element Registration
+
+If you query an element immediately and it hasn't registered yet, `customElements.whenDefined()` ensures it's ready:
+
+```js
+await customElements.whenDefined('hx-button');
+const btn = document.querySelector('hx-button');
+btn.disabled = false;
+```
+
+Or use `type="module"` scripts — they execute after the document is parsed and deferred, so custom elements registered in the same module will be defined before your listener code runs.
+
+## No-Build Setup Example
+
+A complete, self-contained example:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>HELIX Demo</title>
+</head>
+<body>
+
+  <form id="login-form" style="display: flex; flex-direction: column; gap: 1rem; max-width: 400px; padding: 2rem;">
+    <hx-text-input id="email" name="email" type="email" required placeholder="Email address"></hx-text-input>
+    <hx-text-input id="password" name="password" type="password" required placeholder="Password"></hx-text-input>
+    <hx-button id="login-btn" type="submit" variant="primary">Sign in</hx-button>
+  </form>
+
+  <div id="output"></div>
+
+  <script type="module">
+    import '@helix/library';
+
+    const form = document.getElementById('login-form');
+    const output = document.getElementById('output');
+
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const data = new FormData(form);
+      output.textContent = `Logging in as ${data.get('email')}...`;
+    });
+  </script>
+
+</body>
+</html>
+```
+
+## Next Steps
+
+- [Drupal Integration](/framework-integration/drupal)
+- [React Integration](/framework-integration/react)
+- [Boolean Attributes reference](/guides/boolean-attributes)

--- a/apps/docs/src/content/docs/framework-integration/index.md
+++ b/apps/docs/src/content/docs/framework-integration/index.md
@@ -1,0 +1,40 @@
+---
+title: 'Framework Integration'
+description: 'How to use HELIX web components in React, Vue, Angular, plain HTML, and Drupal.'
+sidebar:
+  order: 1
+---
+
+# Framework Integration
+
+HELIX components are standard custom elements — they work in any framework or no framework at all. This section covers the specific patterns and gotchas for each environment.
+
+## Why Framework-Specific Guides?
+
+Web components are framework-agnostic by design, but frameworks differ in:
+
+- **Event binding** — React uses synthetic events; Vue/Angular have their own binding syntax
+- **Boolean attributes** — Frameworks handle `disabled`, `required`, etc. differently
+- **Form integration** — React Controlled Components don't interop with `ElementInternals` the same way
+- **TypeScript types** — JSX type declarations differ from Angular template types
+- **SSR** — Custom element registration is browser-only; each framework handles SSR differently
+
+## Choose Your Guide
+
+| Framework | Use Case |
+|-----------|----------|
+| [React](/framework-integration/react) | React 18+, Next.js |
+| [Vue](/framework-integration/vue) | Vue 3, Nuxt |
+| [Angular](/framework-integration/angular) | Angular 16+ |
+| [Plain HTML](/framework-integration/html) | CDN / no-build setup |
+| [Drupal](/framework-integration/drupal) | Drupal CMS / Twig templates |
+
+## Installation
+
+All guides assume the library is installed via npm:
+
+```bash
+npm install @helix/library
+```
+
+Or loaded via CDN — see the [Plain HTML guide](/framework-integration/html).

--- a/apps/docs/src/content/docs/framework-integration/react.md
+++ b/apps/docs/src/content/docs/framework-integration/react.md
@@ -1,0 +1,221 @@
+---
+title: 'React Integration'
+description: 'Using HELIX web components in React 18+ and Next.js, including event binding, refs, TypeScript types, form integration, and SSR.'
+sidebar:
+  order: 2
+---
+
+# React Integration
+
+HELIX components work in React 18+ with a few important patterns to follow. React 19 introduced native custom element support; React 18 requires `ref`-based event binding.
+
+## Installation
+
+```bash
+npm install @helix/library
+```
+
+## Importing Components
+
+Import components at the root of your app (or in a client-side module):
+
+```tsx
+// app.tsx or a dedicated helix.ts loader
+import '@helix/library/components/hx-button';
+import '@helix/library/components/hx-text-input';
+// Or import all components
+import '@helix/library';
+```
+
+## Basic Usage
+
+```tsx
+export default function MyPage() {
+  return (
+    <div>
+      <hx-button variant="primary">Save</hx-button>
+    </div>
+  );
+}
+```
+
+## Event Binding
+
+React's synthetic event system does not forward custom events from web components. Use a `ref` to attach native DOM event listeners.
+
+```tsx
+import { useRef, useEffect } from 'react';
+
+export function SaveButton() {
+  const buttonRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = buttonRef.current;
+    if (!el) return;
+
+    const handleClick = (e: Event) => {
+      console.log('hx-click fired', e);
+    };
+
+    el.addEventListener('hx-click', handleClick);
+    return () => el.removeEventListener('hx-click', handleClick);
+  }, []);
+
+  return <hx-button ref={buttonRef} variant="primary">Save</hx-button>;
+}
+```
+
+### React 19 Shorthand
+
+React 19 forwards custom events natively using the `on*` prop convention when the event name matches. For HELIX's `hx-` prefixed events, use a ref until official React 19 support is confirmed.
+
+## TypeScript Types
+
+Add JSX type declarations so TypeScript knows about HELIX elements. Create a `helix.d.ts` in your `src/` directory:
+
+```ts
+// src/helix.d.ts
+import type { HxButton, HxTextInput } from '@helix/library';
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'hx-button': React.DetailedHTMLProps<React.HTMLAttributes<HxButton>, HxButton> & {
+        variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+        size?: 'sm' | 'md' | 'lg';
+        disabled?: boolean;
+        loading?: boolean;
+        type?: 'button' | 'submit' | 'reset';
+      };
+      'hx-text-input': React.DetailedHTMLProps<React.HTMLAttributes<HxTextInput>, HxTextInput> & {
+        value?: string;
+        placeholder?: string;
+        disabled?: boolean;
+        required?: boolean;
+        name?: string;
+      };
+      // Add additional components as needed
+    }
+  }
+}
+```
+
+## Boolean Attributes
+
+React renders boolean props as attributes. Follow HELIX's [boolean attribute semantics](/guides/boolean-attributes):
+
+```tsx
+{/* Correct — presence of attribute = true */}
+<hx-button disabled>Disabled</hx-button>
+
+{/* Correct — omit attribute = false */}
+<hx-button>Enabled</hx-button>
+
+{/* Wrong — disabled="false" still disables the button */}
+<hx-button disabled={false}>Not what you think</hx-button>
+```
+
+React automatically omits boolean props when they are `false`, so this pattern works correctly:
+
+```tsx
+<hx-button disabled={isDisabled}>Submit</hx-button>
+```
+
+## Form Integration
+
+HELIX form components use the [ElementInternals API](https://developer.mozilla.org/en-US/docs/Web/API/ElementInternals) for native form participation. They work with HTML `<form>` elements out of the box — no React state required.
+
+### Uncontrolled Forms
+
+```tsx
+function ContactForm() {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.currentTarget);
+    console.log(data.get('email'));
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <hx-text-input name="email" type="email" required />
+      <hx-button type="submit">Send</hx-button>
+    </form>
+  );
+}
+```
+
+### Controlled Pattern via Ref
+
+For controlled inputs, use a ref to read and set the `value` property:
+
+```tsx
+import { useRef, useEffect, useState } from 'react';
+
+function ControlledInput() {
+  const inputRef = useRef<HTMLElement & { value: string }>(null);
+  const [value, setValue] = useState('');
+
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+
+    const handleChange = (e: Event) => {
+      setValue((e.target as HTMLInputElement).value);
+    };
+
+    el.addEventListener('hx-change', handleChange);
+    return () => el.removeEventListener('hx-change', handleChange);
+  }, []);
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.value = value;
+    }
+  }, [value]);
+
+  return <hx-text-input ref={inputRef} name="search" />;
+}
+```
+
+## SSR / Next.js
+
+Custom elements are browser-only APIs. In Next.js (App Router), import HELIX components inside a Client Component:
+
+```tsx
+// components/HelixLoader.tsx
+'use client';
+
+import { useEffect } from 'react';
+
+export function HelixLoader() {
+  useEffect(() => {
+    import('@helix/library');
+  }, []);
+
+  return null;
+}
+```
+
+Place `<HelixLoader />` in your root layout. HELIX elements in Server Components render as unknown elements on the server and hydrate on the client — this is expected behavior for custom elements.
+
+```tsx
+// app/layout.tsx
+import { HelixLoader } from '@/components/HelixLoader';
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <HelixLoader />
+        {children}
+      </body>
+    </html>
+  );
+}
+```
+
+## Next Steps
+
+- [Vue Integration](/framework-integration/vue)
+- [Boolean Attributes reference](/guides/boolean-attributes)
+- [Component Library](/component-library/overview)

--- a/apps/docs/src/content/docs/framework-integration/vue.md
+++ b/apps/docs/src/content/docs/framework-integration/vue.md
@@ -1,0 +1,272 @@
+---
+title: 'Vue Integration'
+description: 'Using HELIX web components in Vue 3 and Nuxt, including v-model patterns, event handling, and SSR.'
+sidebar:
+  order: 3
+---
+
+# Vue Integration
+
+Vue 3 has first-class support for custom elements. With one compiler option, Vue passes unknown element props directly to the DOM instead of treating them as Vue props.
+
+## Installation
+
+```bash
+npm install @helix/library
+```
+
+## Compiler Configuration
+
+Tell Vue's template compiler to treat `hx-*` elements as custom elements. This prevents Vue from warning about unknown components.
+
+### Vite (`vite.config.ts`)
+
+```ts
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [
+    vue({
+      template: {
+        compilerOptions: {
+          // Treat any element starting with hx- as a custom element
+          isCustomElement: (tag) => tag.startsWith('hx-'),
+        },
+      },
+    }),
+  ],
+});
+```
+
+### Nuxt (`nuxt.config.ts`)
+
+```ts
+export default defineNuxtConfig({
+  vue: {
+    compilerOptions: {
+      isCustomElement: (tag) => tag.startsWith('hx-'),
+    },
+  },
+});
+```
+
+## Importing Components
+
+Import once at the app entry point (or in a plugin):
+
+```ts
+// main.ts
+import { createApp } from 'vue';
+import '@helix/library';
+import App from './App.vue';
+
+createApp(App).mount('#app');
+```
+
+### Nuxt Plugin
+
+```ts
+// plugins/helix.client.ts
+export default defineNuxtPlugin(() => {
+  import('@helix/library');
+});
+```
+
+## Basic Usage
+
+```vue
+<template>
+  <hx-button variant="primary" @hx-click="handleSave">
+    Save
+  </hx-button>
+</template>
+
+<script setup lang="ts">
+function handleSave() {
+  console.log('saved');
+}
+</script>
+```
+
+## Event Handling
+
+Vue forwards `@event-name` bindings as native DOM event listeners, so HELIX's `hx-` prefixed events work directly:
+
+```vue
+<template>
+  <hx-text-input
+    name="search"
+    placeholder="Search..."
+    @hx-input="onInput"
+    @hx-change="onChange"
+  />
+</template>
+
+<script setup lang="ts">
+function onInput(e: Event) {
+  const value = (e.target as HTMLInputElement).value;
+  console.log('input:', value);
+}
+
+function onChange(e: Event) {
+  const value = (e.target as HTMLInputElement).value;
+  console.log('change:', value);
+}
+</script>
+```
+
+## v-model Patterns
+
+HELIX components dispatch `hx-change` and `hx-input` events with `event.target.value`. Vue's `v-model` is not directly compatible, but a simple composable bridges the gap:
+
+### Manual Two-Way Binding
+
+```vue
+<template>
+  <hx-text-input
+    :value="searchQuery"
+    name="search"
+    @hx-input="searchQuery = ($event.target as HTMLInputElement).value"
+  />
+  <p>You typed: {{ searchQuery }}</p>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+const searchQuery = ref('');
+</script>
+```
+
+### Reusable v-model Composable
+
+```ts
+// composables/useHxModel.ts
+import { ref, watch, onMounted, onUnmounted, type Ref } from 'vue';
+
+export function useHxModel(
+  elRef: Ref<HTMLElement | null>,
+  initialValue = '',
+) {
+  const value = ref(initialValue);
+
+  function onInput(e: Event) {
+    value.value = (e.target as HTMLInputElement).value;
+  }
+
+  onMounted(() => {
+    elRef.value?.addEventListener('hx-input', onInput);
+  });
+
+  onUnmounted(() => {
+    elRef.value?.removeEventListener('hx-input', onInput);
+  });
+
+  watch(value, (val) => {
+    if (elRef.value) {
+      (elRef.value as HTMLInputElement).value = val;
+    }
+  });
+
+  return value;
+}
+```
+
+```vue
+<template>
+  <hx-text-input ref="inputEl" name="email" />
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useHxModel } from '@/composables/useHxModel';
+
+const inputEl = ref<HTMLElement | null>(null);
+const email = useHxModel(inputEl);
+</script>
+```
+
+## Boolean Attributes
+
+Vue passes `false` booleans by omitting the attribute, which aligns with HELIX's [boolean attribute semantics](/guides/boolean-attributes):
+
+```vue
+<template>
+  <!-- Correct: disabled attribute present when true, absent when false -->
+  <hx-button :disabled="isDisabled">Submit</hx-button>
+</template>
+```
+
+Avoid passing string `"false"`:
+
+```vue
+<!-- Wrong: disabled="false" still disables the button -->
+<hx-button disabled="false">Submit</hx-button>
+```
+
+## Form Integration
+
+HELIX form components participate in native HTML forms via `ElementInternals`. Wrap them in a `<form>` and read with `FormData`:
+
+```vue
+<template>
+  <form @submit.prevent="handleSubmit">
+    <hx-text-input name="username" required />
+    <hx-select name="role">
+      <option value="admin">Admin</option>
+      <option value="viewer">Viewer</option>
+    </hx-select>
+    <hx-button type="submit">Create User</hx-button>
+  </form>
+</template>
+
+<script setup lang="ts">
+function handleSubmit(e: Event) {
+  const form = e.target as HTMLFormElement;
+  const data = new FormData(form);
+  console.log({
+    username: data.get('username'),
+    role: data.get('role'),
+  });
+}
+</script>
+```
+
+## TypeScript Support
+
+Add global type declarations to your `env.d.ts`:
+
+```ts
+// env.d.ts
+declare module 'vue' {
+  interface GlobalComponents {
+    // Vue 3 does not auto-complete custom elements by default.
+    // Add declarations here if you want IDE completion.
+  }
+}
+
+// Extend standard HTML element interface
+declare global {
+  interface HTMLElementTagNameMap {
+    'hx-button': HTMLElement & {
+      variant?: 'primary' | 'secondary' | 'ghost' | 'danger';
+      size?: 'sm' | 'md' | 'lg';
+      disabled?: boolean;
+    };
+  }
+}
+
+export {};
+```
+
+## SSR / Nuxt
+
+In Nuxt, register HELIX as a client-only plugin (see the plugin example above). Components will render as empty custom element shells during SSR and hydrate on the client — this is expected.
+
+To suppress Vue warnings about unknown elements during SSR, configure `isCustomElement` in `nuxt.config.ts`.
+
+## Next Steps
+
+- [Angular Integration](/framework-integration/angular)
+- [Boolean Attributes reference](/guides/boolean-attributes)
+- [Component Library](/component-library/overview)


### PR DESCRIPTION
## Summary

**Source:** Deep Audit P3-01 | **Effort:** 4 hours | **Priority:** LOW

**Problem:** No framework integration documentation exists. While web components are framework-agnostic, consumers need guidance on event binding patterns, form integration, and SSR considerations per framework.

**Fix:** Create doc pages in Astro Starlight:
1. React integration guide — event binding with refs, TypeScript types, form integration
2. Vue integration guide — v-model patterns, event handling
3. Angular integrati...

---
*Recovered automatically by Automaker post-agent hook*