### PR TITLE
fix: standardize CSS parts naming, dialog docs, slot detection

### DIFF
--- a/packages/hx-library/src/components/hx-alert/hx-alert.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.ts
@@ -155,7 +155,7 @@ export class HelixAlert extends LitElement {
     const actionsSlot = this.renderRoot.querySelector<HTMLSlotElement>('slot[name="actions"]');
     if (actionsSlot) {
       this._actionsSlotChangeHandler = () => {
-        this._hasActions = actionsSlot.assignedNodes({ flatten: true }).length > 0;
+        this._hasActions = actionsSlot.assignedElements({ flatten: true }).length > 0;
       };
       actionsSlot.addEventListener('slotchange', this._actionsSlotChangeHandler);
     }
@@ -164,7 +164,7 @@ export class HelixAlert extends LitElement {
     const titleSlot = this.renderRoot.querySelector<HTMLSlotElement>('slot[name="title"]');
     if (titleSlot) {
       this._titleSlotChangeHandler = () => {
-        this._hasTitle = titleSlot.assignedNodes({ flatten: true }).length > 0;
+        this._hasTitle = titleSlot.assignedElements({ flatten: true }).length > 0;
       };
       titleSlot.addEventListener('slotchange', this._titleSlotChangeHandler);
     }

--- a/packages/hx-library/src/components/hx-card/hx-card.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.ts
@@ -79,22 +79,22 @@ export class HelixCard extends LitElement {
 
   private _onImageSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasImage = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasImage = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _onHeadingSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasHeading = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasHeading = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _onFooterSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasFooter = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasFooter = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _onActionsSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasActions = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasActions = slot.assignedElements({ flatten: true }).length > 0;
     if (this._hasActions && this.hxHref) {
       console.warn(
         '[hx-card] Using hx-href (interactive card) together with the actions slot is an ARIA anti-pattern: ' +

--- a/packages/hx-library/src/components/hx-checkbox-group/hx-checkbox-group.ts
+++ b/packages/hx-library/src/components/hx-checkbox-group/hx-checkbox-group.ts
@@ -114,12 +114,12 @@ export class HelixCheckboxGroup extends LitElement {
 
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasErrorSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleHelpSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasHelpSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasHelpSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Lifecycle ───

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
@@ -22,7 +22,8 @@ let _checkboxCounter = 0;
  *
  * @fires {CustomEvent<{checked: boolean, value: string}>} hx-change - Dispatched when the checkbox is toggled.
  *
- * @csspart checkbox - The visual checkbox element.
+ * @csspart checkbox - The outer checkbox wrapper container.
+ * @csspart box - The visual checkbox element.
  * @csspart checkmark - The SVG checkmark icon inside the checkbox.
  * @csspart label - The label element.
  * @csspart help-text - The help text container.
@@ -147,7 +148,7 @@ export class HelixCheckbox extends LitElement {
 
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasErrorSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Lifecycle ───
@@ -286,7 +287,7 @@ export class HelixCheckbox extends LitElement {
     const hostAriaLabel = this.getAttribute('aria-label') ?? undefined;
 
     return html`
-      <div class=${classMap(containerClasses)}>
+      <div part="checkbox" class=${classMap(containerClasses)}>
         <label part="control" class="checkbox__control" @click=${this._handleChange}>
           <input
             class="checkbox__input"
@@ -310,7 +311,7 @@ export class HelixCheckbox extends LitElement {
             @change=${(e: Event) => e.stopPropagation()}
           />
 
-          <span part="checkbox" class="checkbox__box">
+          <span part="box" class="checkbox__box">
             <svg
               part="checkmark"
               class="checkbox__icon checkbox__icon--check"

--- a/packages/hx-library/src/components/hx-combobox/hx-combobox.ts
+++ b/packages/hx-library/src/components/hx-combobox/hx-combobox.ts
@@ -334,7 +334,7 @@ export class HelixCombobox extends LitElement {
 
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasErrorSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Dropdown Control ───

--- a/packages/hx-library/src/components/hx-dialog/hx-dialog.ts
+++ b/packages/hx-library/src/components/hx-dialog/hx-dialog.ts
@@ -118,6 +118,12 @@ export class HelixDialog extends LitElement {
   /**
    * When true, renders as a modal dialog with a backdrop and focus trap.
    * When false, renders as a non-modal dialog.
+   *
+   * **Note:** Because this uses standard boolean attribute semantics, setting
+   * `modal="false"` in HTML still results in `modal = true` (attribute presence
+   * = true). To disable modal mode from HTML, remove the `modal` attribute entirely.
+   * From JavaScript: `dialog.modal = false`.
+   *
    * @attr modal
    */
   @property({ type: Boolean, reflect: true })
@@ -125,6 +131,12 @@ export class HelixDialog extends LitElement {
 
   /**
    * When true, clicking the backdrop closes the dialog.
+   *
+   * **Note:** Unlike standard boolean attributes, this property uses a custom converter so
+   * `close-on-backdrop="false"` in HTML correctly sets `closeOnBackdrop = false`. This is
+   * intentional — it diverges from standard boolean attribute semantics to allow HTML-only
+   * opt-out without JavaScript.
+   *
    * @attr close-on-backdrop
    */
   @property({
@@ -145,9 +157,15 @@ export class HelixDialog extends LitElement {
   heading = '';
 
   /**
-   * ARIA role variant. Use `'alertdialog'` for urgent dialogs requiring immediate attention
-   * (e.g., drug interaction warnings, critical lab alerts). Defaults to `'dialog'`.
+   * ARIA role for the dialog. Use `'alertdialog'` for urgent dialogs requiring immediate
+   * attention (e.g., drug interaction warnings, critical lab alerts). Defaults to `'dialog'`.
+   *
+   * **Important:** This property controls the ARIA `role` attribute — not visual appearance.
+   * Unlike `variant` on other components, this does not change the dialog's visual style.
+   * Use `'alertdialog'` only for dialogs that interrupt workflow and require an explicit response.
+   *
    * @attr variant
+   * @default 'dialog'
    */
   @property({ type: String, reflect: true })
   variant: 'dialog' | 'alertdialog' = 'dialog';
@@ -459,12 +477,12 @@ export class HelixDialog extends LitElement {
 
   private _handleHeaderSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasHeaderSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasHeaderSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleFooterSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasFooterSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasFooterSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Render Helpers ───

--- a/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
+++ b/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
@@ -429,17 +429,17 @@ export class HelixDrawer extends LitElement {
 
   private _handleHeaderActionsSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasHeaderActionsSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasHeaderActionsSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleFooterSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasFooterSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasFooterSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleLabelSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasLabelSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasLabelSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Render Helpers ───

--- a/packages/hx-library/src/components/hx-image/hx-image.ts
+++ b/packages/hx-library/src/components/hx-image/hx-image.ts
@@ -159,7 +159,7 @@ export class HelixImage extends LitElement {
 
   private _onCaptionSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasCaptionSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasCaptionSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _computeBorderRadius(): string | undefined {

--- a/packages/hx-library/src/components/hx-meter/hx-meter.ts
+++ b/packages/hx-library/src/components/hx-meter/hx-meter.ts
@@ -143,7 +143,7 @@ export class HelixMeter extends LitElement {
 
   private _onLabelSlotChange(e: Event) {
     const slot = e.target as HTMLSlotElement;
-    this._hasSlotContent = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasSlotContent = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   override updated() {

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
@@ -118,7 +118,7 @@ export class HelixRadioGroup extends LitElement {
 
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasErrorSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Lifecycle ───

--- a/packages/hx-library/src/components/hx-select/hx-select.ts
+++ b/packages/hx-library/src/components/hx-select/hx-select.ts
@@ -347,7 +347,7 @@ export class HelixSelect extends LitElement {
 
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasErrorSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Dropdown Control ───

--- a/packages/hx-library/src/components/hx-side-nav/hx-nav-item.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-nav-item.ts
@@ -89,7 +89,7 @@ export class HelixNavItem extends LitElement {
 
   private _onChildrenSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasChildren = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasChildren = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Private Helpers ───

--- a/packages/hx-library/src/components/hx-slider/hx-slider.ts
+++ b/packages/hx-library/src/components/hx-slider/hx-slider.ts
@@ -296,22 +296,22 @@ export class HelixSlider extends LitElement {
 
   private _handleLabelSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasLabelSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasLabelSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleHelpSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasHelpSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasHelpSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleMinLabelSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasMinLabelSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasMinLabelSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleMaxLabelSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasMaxLabelSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasMaxLabelSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Event Handling ───

--- a/packages/hx-library/src/components/hx-switch/hx-switch.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.ts
@@ -205,13 +205,13 @@ export class HelixSwitch extends LitElement {
   /** Updates _hasErrorSlot when error slot content changes. */
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasErrorSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   /** Updates _hasDefaultSlot when default slot content changes. */
   private _handleDefaultSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasDefaultSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasDefaultSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Event Handling ───

--- a/packages/hx-library/src/components/hx-tabs/hx-tab.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tab.ts
@@ -97,12 +97,12 @@ export class HelixTab extends LitElement {
 
   private _handlePrefixSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasPrefixSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasPrefixSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   private _handleSuffixSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasSuffixSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasSuffixSlot = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Render ───

--- a/packages/hx-library/src/components/hx-tag/hx-tag.ts
+++ b/packages/hx-library/src/components/hx-tag/hx-tag.ts
@@ -125,13 +125,13 @@ export class HelixTag extends LitElement {
   /** @internal */
   private _onPrefixSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasPrefix = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasPrefix = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   /** @internal */
   private _onSuffixSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
-    this._hasSuffix = slot.assignedNodes({ flatten: true }).length > 0;
+    this._hasSuffix = slot.assignedElements({ flatten: true }).length > 0;
   }
 
   // ─── Render ───

--- a/packages/hx-library/src/components/hx-toast/hx-toast.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.ts
@@ -30,7 +30,7 @@ export type ToastStackPlacement =
  * @fires {CustomEvent} hx-hide - Dispatched when the toast begins hiding.
  * @fires {CustomEvent} hx-after-hide - Dispatched after the hide animation completes.
  *
- * @csspart base - The inner toast container div.
+ * @csspart toast - The inner toast container div.
  * @csspart icon - The icon slot wrapper.
  * @csspart message - The message slot wrapper.
  * @csspart close-button - The dismiss button (only when closable).
@@ -248,7 +248,7 @@ export class HelixToast extends LitElement {
   override render() {
     return html`
       <div
-        part="base"
+        part="toast"
         class=${classMap({
           toast: true,
           [`toast--${this.variant}`]: true,
@@ -309,7 +309,7 @@ export class HelixToast extends LitElement {
  *
  * @slot - Accepts `hx-toast` elements.
  *
- * @csspart base - The inner stack container div.
+ * @csspart toast-stack - The inner stack container div.
  *
  * @cssprop [--hx-z-index-toast=9000] - Z-index for the fixed stack.
  */
@@ -334,7 +334,7 @@ export class HelixToastStack extends LitElement {
   override render() {
     return html`
       <div
-        part="base"
+        part="toast-stack"
         class=${classMap({
           'toast-stack': true,
           [`toast-stack--${this.placement}`]: true,


### PR DESCRIPTION
## Summary
- **P2-01:** CSS parts naming standardized — `hx-toast::part(base)` → `::part(toast)`, `hx-checkbox::part(checkbox)` → outer container, new `::part(box)` for visual element
- **P2-02:** Dialog `variant` property documented with healthcare `alertdialog` guidance
- **P2-07:** Boolean attribute gotcha documented on `hx-dialog` modal/closeOnBackdrop
- **P2-09:** Slot change detection standardized from `assignedNodes()` to `assignedElements({ flatten: true })` across 14 components

## Breaking Changes
- `hx-checkbox::part(checkbox)` now targets outer container; use `::part(box)` for visual checkbox
- `hx-toast::part(base)` → `::part(toast)`; `hx-toast-stack::part(base)` → `::part(toast-stack)`

## Test plan
- [ ] `npm run verify` passes
- [ ] CSS parts updated in all affected components
- [ ] Slot detection standardized across 14 components

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-10T11:56:00Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slot content detection across form and layout components for more reliable error message and help text handling.

* **Style**
  * Updated CSS part naming in checkbox and toast components for consistency and customization.

* **Documentation**
  * Enhanced dialog component documentation with improved guidance on modal behavior, backdrop interactions, and ARIA semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->