### PR TITLE
fix: hx-top-nav mobile menu open causes nav bar content to shift vertically

### DIFF
--- a/packages/hx-library/src/components/hx-top-nav/hx-top-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-top-nav/hx-top-nav.styles.ts
@@ -38,7 +38,6 @@ export const helixTopNavStyles = css`
 
   .nav__bar {
     display: flex;
-    flex-wrap: wrap;
     align-items: center;
     min-height: var(--hx-top-nav-height, var(--hx-space-16, 4rem));
     padding-inline: var(--hx-top-nav-padding-x, var(--hx-space-6, 1.5rem));
@@ -123,13 +122,22 @@ export const helixTopNavStyles = css`
   /* NOTE: CSS @media queries do not support custom properties.
      This value corresponds to --hx-breakpoint-md (768px). */
   @media (min-width: 768px) {
-    /* Hide hamburger on desktop */
-    .mobile-toggle {
-      display: none;
+    /* Make nav a flex row so bar and collapsible sit side-by-side */
+    .nav {
+      display: flex;
+      align-items: center;
+      padding-inline: var(--hx-top-nav-padding-x, var(--hx-space-6, 1.5rem));
     }
 
     .nav__bar {
-      flex-wrap: nowrap;
+      flex-shrink: 0;
+      padding-inline: 0;
+      min-height: var(--hx-top-nav-height, var(--hx-space-16, 4rem));
+    }
+
+    /* Hide hamburger on desktop */
+    .mobile-toggle {
+      display: none;
     }
 
     /* Collapsible becomes a standard inline flex row */
@@ -137,7 +145,6 @@ export const helixTopNavStyles = css`
       display: flex;
       flex-direction: row;
       align-items: center;
-      width: auto;
       flex: 1;
       padding-block: 0;
       border-top: none;

--- a/packages/hx-library/src/components/hx-top-nav/hx-top-nav.ts
+++ b/packages/hx-library/src/components/hx-top-nav/hx-top-nav.ts
@@ -172,15 +172,15 @@ export class HelixTopNav extends LitElement {
             >
               ${this._renderHamburgerIcon()}
             </button>
+          </div>
 
-            <div id="nav-menu" class=${classMap(menuClasses)}>
-              <div part="menu" class="nav__menu">
-                <slot></slot>
-              </div>
+          <div id="nav-menu" class=${classMap(menuClasses)}>
+            <div part="menu" class="nav__menu">
+              <slot></slot>
+            </div>
 
-              <div part="actions" class="nav__actions">
-                <slot name="actions"></slot>
-              </div>
+            <div part="actions" class="nav__actions">
+              <slot name="actions"></slot>
             </div>
           </div>
         </nav>


### PR DESCRIPTION
## Summary

## Bug

When the mobile collapsible menu opens in `hx-top-nav`, the logo and hamburger toggle button shift upward by ~8px. This creates a jarring visual jump.

## Root Cause

The `.nav__bar` container uses `display: flex; flex-wrap: wrap; align-items: center; min-height: var(--hx-top-nav-height)`.

- **Menu closed (1 flex line):** The single line stretches to fill `min-height: 4rem`. Items center vertically in 4rem = nice spacing.
- **Menu open (2 flex lines):** The collapsible div (`width: 100%...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Restructured top navigation layout for improved desktop display with items arranged horizontally without wrapping.
  * Enhanced navigation bar spacing and alignment on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->