### PR TITLE
chore: update merge strategy docs and config — squash disabled

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -259,7 +259,7 @@ All PRs must pass:
 
 ### After Approval
 
-PRs are merged by maintainers using **squash and merge** strategy.
+PRs are merged by maintainers using **merge commits** strategy (squash merging is disabled to preserve conventional commit messages for semantic-release).
 
 ## Component Development
 

--- a/docs/pre-pr-quality-gates.md
+++ b/docs/pre-pr-quality-gates.md
@@ -22,7 +22,7 @@ A three-layer quality gate system that catches errors at progressively wider sco
    - [Code Review (CodeRabbit)](#code-review-coderabbit)
 4. [Layer 3: Branch Protection & Deploy Gates](#layer-3-branch-protection--deploy-gates)
    - [Required Status Checks](#required-status-checks)
-   - [Squash-Only Merges](#squash-only-merges)
+   - [Merge Commit Strategy](#merge-commit-strategy)
    - [Deploy Verification](#deploy-verification)
 5. [Tool-by-Tool Setup](#tool-by-tool-setup)
    - [ESLint v9 (Flat Config)](#eslint-v9-flat-config)
@@ -588,12 +588,12 @@ Configure via GitHub Settings > Branches > Branch protection rules, or use the G
 #!/usr/bin/env bash
 REPO="your-org/your-repo"
 
-# Set squash-only merges
+# Set merge commit strategy (squash disabled to preserve conventional commits for semantic-release)
 gh api "repos/${REPO}" \
   --method PATCH \
-  --field allow_squash_merge=true \
-  --field allow_merge_commit=false \
-  --field allow_rebase_merge=false
+  --field allow_squash_merge=false \
+  --field allow_merge_commit=true \
+  --field allow_rebase_merge=true
 
 # Create ruleset with required checks
 gh api "repos/${REPO}/rulesets" \
@@ -639,11 +639,11 @@ gh api "repos/${REPO}/rulesets" \
 EOF
 ```
 
-### Squash-Only Merges
+### Merge Commit Strategy
 
-Squash merges keep the main branch history clean — one commit per PR. Configure at the repo level:
+Merge commits are used to preserve conventional commit messages through the branch pipeline, which is required for semantic-release to correctly determine version bumps. Squash merging is disabled. Configure at the repo level:
 
-- GitHub Settings > General > Pull Requests > Allow squash merging (only)
+- GitHub Settings > General > Pull Requests > Allow merge commits (enabled), Allow squash merging (disabled)
 - Or via API as shown above
 
 ### Deploy Verification


### PR DESCRIPTION
## Summary

## Summary
Squash merges have been disabled on the `bookedsolidtech/helix` GitHub repo. The merge strategy is now **merge commits only** (rebase also enabled as fallback).

This change was made to preserve conventional commit messages through the branch pipeline, which is required for semantic-release to correctly determine version bumps.

## Requirements
1. Update any CONTRIBUTING.md or docs that reference 'squash-only' merge strategy to reflect the new 'merge commits' strategy
2. Update `.auto...

---
*Recovered automatically by Automaker post-agent hook*