### PR TITLE
NPM PUBLISH P0: package metadata, access, and LICENSE

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,7 +4,7 @@
   "commit": false,
   "fixed": [],
   "linked": [["@helix/library", "@helix/tokens"]],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 wc-2026 Contributors
+Copyright (c) 2026 Booked Solid Tech
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -48,6 +48,21 @@
   "peerDependencies": {
     "@floating-ui/dom": "^1.7.6"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bookedsolidtech/helix.git",
+    "directory": "packages/hx-library"
+  },
+  "license": "MIT",
+  "homepage": "https://helix.bookedsolid.com",
+  "bugs": "https://github.com/bookedsolidtech/helix/issues",
+  "keywords": [
+    "web-components",
+    "lit",
+    "healthcare",
+    "design-system",
+    "custom-elements"
+  ],
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.11.0",
     "@vitest/browser": "^3.0.0",

--- a/packages/hx-tokens/package.json
+++ b/packages/hx-tokens/package.json
@@ -41,6 +41,21 @@
   "dependencies": {
     "lit": "^3.3.2"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bookedsolidtech/helix.git",
+    "directory": "packages/hx-tokens"
+  },
+  "license": "MIT",
+  "homepage": "https://helix.bookedsolid.com",
+  "bugs": "https://github.com/bookedsolidtech/helix/issues",
+  "keywords": [
+    "web-components",
+    "lit",
+    "healthcare",
+    "design-system",
+    "custom-elements"
+  ],
   "devDependencies": {
     "tsx": "^4.19.0",
     "typescript": "^5.7.2"


### PR DESCRIPTION
## Summary

Implement the P0 blockers from docs/RELEASE-STRATEGY.md for npm publish readiness.

## Tasks

1. **Change changeset access** — Edit `.changeset/config.json`: change `'access': 'restricted'` to `'access': 'public'`

2. **Add package metadata to @helix/library** — Edit `packages/hx-library/package.json`, add:
```json
{
  'repository': {
    'type': 'git',
    'url': 'https://github.com/bookedsolidtech/helix.git',
    'directory': 'packages/hx-library'
  },
  'license': 'MIT',
  'homepage': 'https:...

---
*Recovered automatically by Automaker post-agent hook*