### PR TITLE
NPM PUBLISH P0: CI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+# ============================================================================
+# Publish Pipeline — wc-2026 Enterprise Healthcare Web Component Library
+# ============================================================================
+# Triggers on push to main. Uses changesets/action@v1 to:
+#   - Open a "Version Packages" PR when unreleased changesets exist
+#   - Publish to npm when that PR is merged (changesets consumed)
+#
+# Required secrets:
+#   GITHUB_TOKEN  — auto-provided by Actions (needs contents:write + pull-requests:write)
+#   NPM_TOKEN     — npm automation token (must be added to repo settings by repo admin)
+# ============================================================================
+
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Version or Publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx turbo run type-check --filter='!docs'
+
+      - name: Build
+        run: npx turbo run build --filter='!docs'
+
+      - name: Test
+        run: |
+          npx playwright install --with-deps chromium
+          npm run test:library
+
+      - name: Version or Publish via Changesets
+        uses: changesets/action@v1
+        with:
+          publish: npm run changeset:publish
+          version: npm run changeset:version
+          commit: 'chore: version packages'
+          title: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'


### PR DESCRIPTION
## Summary

Create the GitHub Actions workflow for automated npm publishing via changesets.

## Tasks

1. **Create `.github/workflows/publish.yml`** with:
   - Trigger: push to `main`
   - Steps: checkout, setup Node 20, npm ci, build, type-check, test
   - Use `changesets/action@v1` for version PR creation and publish
   - Requires `GITHUB_TOKEN` and `NPM_TOKEN` secrets
   - Enable npm provenance (`--provenance` flag) via `id-token: write` permission
   - Only publish when changesets exist (action handles ...

---
*Recovered automatically by Automaker post-agent hook*