### PR TITLE
NPM PUBLISH P1: package README files

### DIFF
--- a/packages/hx-library/README.md
+++ b/packages/hx-library/README.md
@@ -1,0 +1,174 @@
+# @helix/library
+
+**Enterprise Web Component Library** built with [Lit 3.x](https://lit.dev/), TypeScript, and Shadow DOM — designed for healthcare applications where accessibility and reliability are non-negotiable.
+
+[![npm version](https://img.shields.io/npm/v/@helix/library)](https://www.npmjs.com/package/@helix/library)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+---
+
+## Installation
+
+```bash
+npm install @helix/library
+```
+
+Design tokens are included automatically as a dependency via `@helix/tokens`.
+
+---
+
+## Usage
+
+### Barrel import (all components)
+
+```js
+import '@helix/library';
+```
+
+### Per-component import (recommended for tree-shaking)
+
+```js
+import '@helix/library/components/hx-button';
+import '@helix/library/components/hx-card';
+import '@helix/library/components/hx-text-input';
+```
+
+### HTML / Twig (after script load)
+
+```html
+<hx-button variant="primary">Save</hx-button>
+
+<hx-text-input label="Patient Name" required></hx-text-input>
+
+<hx-alert variant="warning">Please review before submitting.</hx-alert>
+```
+
+### CDN (placeholder — coming soon)
+
+```html
+<script type="module" src="https://cdn.example.com/@helix/library/dist/index.js"></script>
+```
+
+---
+
+## Components
+
+73 component directories, 85 custom elements total.
+
+| Component | Tag |
+|---|---|
+| Accordion | `<hx-accordion>` |
+| Action Bar | `<hx-action-bar>` |
+| Alert | `<hx-alert>` |
+| Avatar | `<hx-avatar>` |
+| Badge | `<hx-badge>` |
+| Breadcrumb | `<hx-breadcrumb>` |
+| Button | `<hx-button>` |
+| Button Group | `<hx-button-group>` |
+| Card | `<hx-card>` |
+| Carousel | `<hx-carousel>` |
+| Checkbox | `<hx-checkbox>` |
+| Checkbox Group | `<hx-checkbox-group>` |
+| Code Snippet | `<hx-code-snippet>` |
+| Color Picker | `<hx-color-picker>` |
+| Combobox | `<hx-combobox>` |
+| Container | `<hx-container>` |
+| Copy Button | `<hx-copy-button>` |
+| Data Table | `<hx-data-table>` |
+| Date Picker | `<hx-date-picker>` |
+| Dialog | `<hx-dialog>` |
+| Divider | `<hx-divider>` |
+| Drawer | `<hx-drawer>` |
+| Dropdown | `<hx-dropdown>` |
+| Field | `<hx-field>` |
+| Field Label | `<hx-field-label>` |
+| File Upload | `<hx-file-upload>` |
+| Form | `<hx-form>` |
+| Format Date | `<hx-format-date>` |
+| Grid | `<hx-grid>` |
+| Help Text | `<hx-help-text>` |
+| Icon | `<hx-icon>` |
+| Image | `<hx-image>` |
+| Link | `<hx-link>` |
+| List | `<hx-list>` |
+| Menu | `<hx-menu>` |
+| Meter | `<hx-meter>` |
+| Nav | `<hx-nav>` |
+| Number Input | `<hx-number-input>` |
+| Overflow Menu | `<hx-overflow-menu>` |
+| Pagination | `<hx-pagination>` |
+| Popover | `<hx-popover>` |
+| Popup | `<hx-popup>` |
+| Progress Bar | `<hx-progress-bar>` |
+| Progress Ring | `<hx-progress-ring>` |
+| Prose | `<hx-prose>` |
+| Radio Group | `<hx-radio-group>` |
+| Rating | `<hx-rating>` |
+| Select | `<hx-select>` |
+| Side Nav | `<hx-side-nav>` |
+| Skeleton | `<hx-skeleton>` |
+| Slider | `<hx-slider>` |
+| Spinner | `<hx-spinner>` |
+| Split Button | `<hx-split-button>` |
+| Split Panel | `<hx-split-panel>` |
+| Stack | `<hx-stack>` |
+| Status Indicator | `<hx-status-indicator>` |
+| Steps | `<hx-steps>` |
+| Structured List | `<hx-structured-list>` |
+| Switch | `<hx-switch>` |
+| Tabs | `<hx-tabs>` |
+| Tag | `<hx-tag>` |
+| Text | `<hx-text>` |
+| Text Input | `<hx-text-input>` |
+| Textarea | `<hx-textarea>` |
+| Theme | `<hx-theme>` |
+| Time Picker | `<hx-time-picker>` |
+| Toast | `<hx-toast>` |
+| Toggle Button | `<hx-toggle-button>` |
+| Tooltip | `<hx-tooltip>` |
+| Top Nav | `<hx-top-nav>` |
+| Tree View | `<hx-tree-view>` |
+| Visually Hidden | `<hx-visually-hidden>` |
+
+---
+
+## Design Tokens
+
+All components consume design tokens from `@helix/tokens` via CSS custom properties. Override at the semantic level to theme your application:
+
+```css
+:root {
+  --hx-color-primary: #0057b8;
+  --hx-color-primary-hover: #004a9e;
+  --hx-spacing-md: 1rem;
+  --hx-font-family-base: 'Inter', sans-serif;
+}
+```
+
+See the [@helix/tokens](../hx-tokens/README.md) package for the full token reference.
+
+---
+
+## Framework Support
+
+Components are standard Custom Elements and work in any framework:
+
+- **Vanilla HTML / Twig** — drop in `<script type="module">` and use tags directly
+- **React** — use via `@lit/react` wrappers or directly in JSX
+- **Vue** — works out of the box with `compilerOptions.isCustomElement`
+- **Angular** — add `CUSTOM_ELEMENTS_SCHEMA` to your module
+- **Drupal** — attach via Drupal behaviors; compatible with Twig templates
+
+---
+
+## Documentation
+
+Full component docs, API reference, and Storybook playground:
+
+> **Docs site coming soon**
+
+---
+
+## License
+
+MIT

--- a/packages/hx-tokens/README.md
+++ b/packages/hx-tokens/README.md
@@ -1,0 +1,130 @@
+# @helix/tokens
+
+**Design tokens for the HELiX component library** — a structured set of CSS custom properties, JavaScript constants, and Lit CSS utilities that power the `@helix/library` components.
+
+[![npm version](https://img.shields.io/npm/v/@helix/tokens)](https://www.npmjs.com/package/@helix/tokens)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+
+---
+
+## Installation
+
+```bash
+npm install @helix/tokens
+```
+
+> **Note:** This package is automatically installed as a dependency of `@helix/library`. You only need to install it directly if you are consuming tokens without the component library.
+
+---
+
+## Usage
+
+### JavaScript / TypeScript (token constants)
+
+```js
+import { tokens } from '@helix/tokens';
+
+console.log(tokens.colorPrimary); // '#0057b8'
+```
+
+### Lit CSS utilities (for Lit component authors)
+
+```ts
+import { css } from 'lit';
+import { colorPrimary, spacingMd } from '@helix/tokens/lit';
+
+const styles = css`
+  :host {
+    color: ${colorPrimary};
+    padding: ${spacingMd};
+  }
+`;
+```
+
+### CSS custom properties (global stylesheet)
+
+```js
+import '@helix/tokens/css';
+```
+
+Or in CSS:
+
+```css
+@import '@helix/tokens/tokens.css';
+
+.my-element {
+  color: var(--hx-color-primary);
+  padding: var(--hx-spacing-md);
+}
+```
+
+### JSON token source
+
+```js
+import tokens from '@helix/tokens/tokens.json';
+```
+
+Useful for build tooling, style dictionaries, or design tool integrations.
+
+### Utility helpers
+
+```js
+import { toCssVar, resolveToken } from '@helix/tokens/utils';
+
+toCssVar('color-primary'); // 'var(--hx-color-primary)'
+```
+
+---
+
+## Export Paths
+
+| Import path | Contents |
+|---|---|
+| `@helix/tokens` | JavaScript token constants (default export) |
+| `@helix/tokens/lit` | Lit CSS tagged template values |
+| `@helix/tokens/css` | Side-effect import — injects CSS custom properties |
+| `@helix/tokens/tokens.css` | Raw CSS file with all `--hx-*` custom properties |
+| `@helix/tokens/tokens.json` | Source token definitions as JSON |
+| `@helix/tokens/utils` | Helper utilities (`toCssVar`, etc.) |
+
+---
+
+## Token Categories
+
+All CSS custom properties use the `--hx-` prefix:
+
+- **Color** — `--hx-color-primary`, `--hx-color-neutral-*`, `--hx-color-error`, etc.
+- **Spacing** — `--hx-spacing-xs` through `--hx-spacing-2xl`
+- **Typography** — `--hx-font-family-base`, `--hx-font-size-*`, `--hx-font-weight-*`
+- **Border** — `--hx-border-radius-*`, `--hx-border-width-*`
+- **Shadow** — `--hx-shadow-sm`, `--hx-shadow-md`, `--hx-shadow-lg`
+- **Motion** — `--hx-duration-fast`, `--hx-easing-standard`
+- **Z-index** — `--hx-z-dropdown`, `--hx-z-modal`, `--hx-z-toast`
+
+---
+
+## Theming
+
+Override semantic tokens at the `:root` level to apply a custom theme across all HELiX components:
+
+```css
+:root {
+  --hx-color-primary: #005eb8;
+  --hx-color-primary-hover: #004f9f;
+  --hx-font-family-base: 'Roboto', sans-serif;
+}
+```
+
+---
+
+## Documentation
+
+Full token reference and theming guide:
+
+> **Docs site coming soon**
+
+---
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Create README.md files for both npm packages. These are displayed on the npm registry page and are the first thing developers see.

## Tasks

1. **Create `packages/hx-library/README.md`** with:
   - HELiX branding and description
   - Quick install: `npm install @helix/library`
   - Usage examples (barrel import, per-component import, CDN placeholder)
   - Component list (85 custom elements, 73 directories)
   - Design token integration mention
   - Link to full docs site
   - License badge, npm...

---
*Recovered automatically by Automaker post-agent hook*