### PR TITLE
fix: MCP server file: deps breaking changeset publish

### DIFF
--- a/apps/mcp-servers/cem-analyzer/package.json
+++ b/apps/mcp-servers/cem-analyzer/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0",
-    "@helixui/mcp-shared": "file:../shared",
+    "@helixui/mcp-shared": "*",
     "zod": "^3.22.0"
   },
   "devDependencies": {

--- a/apps/mcp-servers/health-scorer/package.json
+++ b/apps/mcp-servers/health-scorer/package.json
@@ -13,7 +13,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@helixui/mcp-shared": "file:../shared",
+    "@helixui/mcp-shared": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^3.22.0"
   },

--- a/apps/mcp-servers/typescript-diagnostics/package.json
+++ b/apps/mcp-servers/typescript-diagnostics/package.json
@@ -13,7 +13,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@helixui/mcp-shared": "file:../shared",
+    "@helixui/mcp-shared": "*",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "ts-morph": "^27.0.2",
     "typescript": "^5.7.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,7 @@
       "name": "@helixui/mcp-cem-analyzer",
       "version": "0.1.0",
       "dependencies": {
-        "@helixui/mcp-shared": "file:../shared",
+        "@helixui/mcp-shared": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "zod": "^3.22.0"
       },
@@ -167,7 +167,7 @@
       "name": "@helixui/mcp-health-scorer",
       "version": "0.1.0",
       "dependencies": {
-        "@helixui/mcp-shared": "file:../shared",
+        "@helixui/mcp-shared": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "zod": "^3.22.0"
       },
@@ -314,7 +314,7 @@
       "name": "@helixui/mcp-typescript-diagnostics",
       "version": "0.1.0",
       "dependencies": {
-        "@helixui/mcp-shared": "file:../shared",
+        "@helixui/mcp-shared": "*",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "ts-morph": "^27.0.2",
         "typescript": "^5.7.2",


### PR DESCRIPTION
## Summary
- Replace `file:../shared` with `*` (workspace protocol) in 3 MCP server packages
- `changeset version` errors on `file:` protocol even for ignored packages
- Tested locally: `changeset version` now succeeds cleanly

## What failed
Publish runs 22937932250 and 22938119270 both failed at "Version packages" with:
```
Package "@helixui/mcp-cem-analyzer" must depend on current version of "@helixui/mcp-shared": "0.1.0" vs "file:../shared"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution strategy across multiple server modules, changing from local workspace references to registry-based versioning. This ensures consistent dependency management and improves build consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->