### PR TITLE
fix: changesets/action for branch-protection-compatible publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,13 +2,13 @@
 # Publish Pipeline — wc-2026 Enterprise Healthcare Web Component Library
 # ============================================================================
 # Triggers on push to main. If unreleased changesets exist, bumps versions
-# and publishes directly to npm in a single step. No intermediate PR.
+# and publishes to npm directly. Version bump is pushed back via a PR.
 #
 # Tests are NOT re-run here — CI (ci.yml + ci-matrix.yml) already validates
 # all code before it reaches main via the staging→main promotion flow.
 #
 # Required secrets:
-#   GITHUB_TOKEN  — auto-provided by Actions (needs contents:write)
+#   GITHUB_TOKEN  — auto-provided by Actions (needs contents:write + pull-requests:write)
 #   NPM_TOKEN     — npm automation token (must be added to repo settings by repo admin)
 # ============================================================================
 
@@ -24,6 +24,7 @@ concurrency:
 
 permissions:
   contents: write
+  pull-requests: write
   id-token: write
 
 jobs:
@@ -35,7 +36,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:
@@ -58,20 +58,16 @@ jobs:
             echo "has_changesets=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Version packages
+      - name: Version and Publish
         if: steps.changesets.outputs.has_changesets == 'true'
-        run: |
-          npm run changeset:version
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore: version packages" || echo "No version changes to commit"
-          git push
-
-      - name: Publish to npm
-        if: steps.changesets.outputs.has_changesets == 'true'
-        run: npm run changeset:publish
+        uses: changesets/action@v1
+        with:
+          publish: npm run changeset:publish
+          version: npm run changeset:version
+          commit: 'chore: version packages'
+          title: 'chore: version packages'
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 


### PR DESCRIPTION
## Summary
- Switches back to `changesets/action@v1` which creates a PR for version bumps instead of pushing directly to main
- Direct push was blocked by branch protection (GH006) and `github-actions[bot]` can't be added as bypass actor
- Still wrapped in `has_changesets` check so empty runs are fast no-ops

## Flow
1. Push to main with changesets → action creates "Version Packages" PR
2. Merge that PR → changesets consumed, next run publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package release workflow to use an automated action for more reliable and consistent version management and npm publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->