### PR TITLE
fix: publish pipeline — let changesets/action handle both phases

### DIFF
--- a/.changeset/fix-publish-pipeline.md
+++ b/.changeset/fix-publish-pipeline.md
@@ -1,0 +1,6 @@
+---
+'@helixui/library': patch
+'@helixui/tokens': patch
+---
+
+fix: remove manual changeset gating from publish pipeline — let changesets/action handle both version PR creation and npm publish internally

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,17 +49,7 @@ jobs:
       - name: Build
         run: npx turbo run build --filter='!docs'
 
-      - name: Check for unreleased changesets
-        id: changesets
-        run: |
-          if ls .changeset/*.md 1>/dev/null 2>&1 && [ "$(ls .changeset/*.md 2>/dev/null | grep -v README.md)" ]; then
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Version and Publish
-        if: steps.changesets.outputs.has_changesets == 'true'
         uses: changesets/action@v1
         with:
           publish: npm run changeset:publish
@@ -70,7 +60,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
-
-      - name: No changesets found
-        if: steps.changesets.outputs.has_changesets == 'false'
-        run: echo "No unreleased changesets — nothing to publish."


### PR DESCRIPTION
## Summary
- Remove manual `has_changesets` gating from publish.yml
- `changesets/action@v1` handles both phases internally: creates Version PR when changesets exist, publishes to npm when they don't
- The manual check was preventing the publish phase from running after Version Packages PR consumed changesets
- Includes patch changeset to test the full pipeline end-to-end

## What was broken
1. Push to main with changesets → action creates "Version Packages" PR (Phase 1) ✅
2. Version PR merged → push to main → manual check says "no changesets" → **skips publish** ❌

## Fix
Remove the manual check. `changesets/action` knows when to version vs publish.

## Test plan
- [ ] Merge this PR to main
- [ ] Publish workflow fires → changesets/action creates Version Packages PR
- [ ] Merge Version Packages PR → Publish fires again → npm publish executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Patch updates for library and tokens packages to address reported issues.

* **Chores**
  * Streamlined the release pipeline by simplifying the publish workflow process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->