### PR TITLE
fix: update LICENSE copyright to legal entity name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Booked Solid Tech
+Copyright (c) 2025-2026 Clarity House LLC d/b/a Booked Solid Technology
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
- Update LICENSE copyright holder from informal "Booked Solid Tech" to legal entity name "Clarity House LLC d/b/a Booked Solid Technology"
- Correct year range to 2025-2026
- P0 fix per CLO/CTO report P0-002

## Acceptance Criteria
- [x] LICENSE copyright holder reads "Clarity House LLC d/b/a Booked Solid Technology"
- [x] Year range is "2025-2026"
- [x] No other references to the informal name as copyright holder exist in the repo

## Test plan
- [x] `npm run verify` passes (zero errors)
- [x] `git diff --stat` confirms only LICENSE modified
- [x] Grep confirms no remaining informal copyright references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated copyright information in the LICENSE file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->