### PR TITLE
css: hx-avatar, hx-link, hx-number-input, hx-status-indicator, hx-time-picker (35 findings)

### DIFF
--- a/packages/hx-library/src/components/hx-avatar/hx-avatar.styles.ts
+++ b/packages/hx-library/src/components/hx-avatar/hx-avatar.styles.ts
@@ -108,4 +108,12 @@ export const helixAvatarStyles = css`
   .avatar__badge--hidden {
     display: none;
   }
+
+  /* P1-B: Windows High Contrast Mode — background colors are stripped, so the avatar
+     loses its visual boundary. Add a border so the shape remains perceivable (WCAG 1.4.11). */
+  @media (forced-colors: active) {
+    .avatar {
+      border: 2px solid ButtonText;
+    }
+  }
 `;

--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.styles.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.styles.ts
@@ -59,6 +59,9 @@ export const helixNumberInputStyles = css`
 
   .field__input-wrapper:focus-within {
     border-color: var(--hx-number-input-focus-ring-color, var(--hx-focus-ring-color));
+    /* Fallback for Safari < 16.2 (no color-mix support) */
+    box-shadow: 0 0 0 var(--hx-focus-ring-width)
+      var(--hx-number-input-focus-ring-color, var(--hx-focus-ring-color));
     box-shadow: 0 0 0 var(--hx-focus-ring-width)
       color-mix(
         in srgb,
@@ -76,6 +79,9 @@ export const helixNumberInputStyles = css`
 
   .field--error .field__input-wrapper:focus-within {
     border-color: var(--hx-number-input-error-color, var(--hx-color-error-500, #dc2626));
+    /* Fallback for Safari < 16.2 (no color-mix support) */
+    box-shadow: 0 0 0 var(--hx-focus-ring-width)
+      var(--hx-number-input-error-color, var(--hx-color-error-500, #dc2626));
     box-shadow: 0 0 0 var(--hx-focus-ring-width)
       color-mix(
         in srgb,


### PR DESCRIPTION
## Summary

Fix CSS/styling findings for 5 components. 35 total findings.

**Components & GH Issues:** #783, #800, #802, #818, #828

**Instructions:** Read each component's AUDIT.md, fix all css-category UNFIXED findings. Run `npm run verify` and tests. PR must reference GH issues.

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved avatar display in Windows high-contrast mode, ensuring visibility is maintained when system colors are overridden
  * Fixed focus ring styling for number input fields in Safari versions prior to 16.2

* **Accessibility**
  * Enhanced support for Windows forced-colors accessibility mode with improved component visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->