### PR TITLE
fix: rename hx-drawer CSS part close-button → close-btn (CSS audit P2-02)

### DIFF
--- a/.changeset/fix-hx-drawer-close-btn-part.md
+++ b/.changeset/fix-hx-drawer-close-btn-part.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix: rename hx-drawer CSS part from `close-button` to `close-btn` to match feature specification

--- a/packages/hx-library/src/components/hx-drawer/AUDIT.md
+++ b/packages/hx-library/src/components/hx-drawer/AUDIT.md
@@ -307,8 +307,8 @@ Using `void` to discard promises suppresses any rejection silently. If `updateCo
 | P1-05 | P1       | Behavior               | Animation timeout race condition on rapid open/close           |
 | P1-06 | P1       | Accessibility          | Dialog has no accessible name when label slot empty            |
 | P2-01 | P2       | TypeScript             | `DrawerSize \| string` collapses to `string`                   |
-| P2-02 | P2       | CSS/API                | CSS part name `close-button` deviates from spec (`close-btn`)  |
-| P2-03 | P2       | CSS                    | Footer `hidden` attribute has no CSS override for reset safety |
+| P2-02 | P2       | CSS/API                | CSS part name `close-button` deviates from spec (`close-btn`)  | RESOLVED |
+| P2-03 | P2       | CSS                    | Footer `hidden` attribute has no CSS override for reset safety | RESOLVED |
 | P2-04 | P2       | TypeScript             | `_triggerElement` cast bypasses `HTMLElement` type guard       |
 | P2-05 | P2       | Storybook              | No story for nested interactive content                        |
 | P3-01 | P3       | Code quality           | `firstUpdated()` slot detection is redundant                   |

--- a/packages/hx-library/src/components/hx-drawer/hx-drawer.test.ts
+++ b/packages/hx-library/src/components/hx-drawer/hx-drawer.test.ts
@@ -234,12 +234,12 @@ describe('hx-drawer', () => {
       expect(part?.getAttribute('part')).toBe('body');
     });
 
-    it('exposes "close-button" part on the close button', async () => {
+    it('exposes "close-btn" part on the close button', async () => {
       const el = await fixture<HelixDrawer>('<hx-drawer></hx-drawer>');
       await el.updateComplete;
-      const part = shadowQuery(el, '[part="close-button"]');
+      const part = shadowQuery(el, '[part="close-btn"]');
       expect(part).toBeTruthy();
-      expect(part?.getAttribute('part')).toBe('close-button');
+      expect(part?.getAttribute('part')).toBe('close-btn');
     });
 
     it('exposes "title" part on the title element', async () => {
@@ -330,7 +330,7 @@ describe('hx-drawer', () => {
     it('close button has aria-label="Close drawer"', async () => {
       const el = await fixture<HelixDrawer>('<hx-drawer></hx-drawer>');
       await el.updateComplete;
-      const closeBtn = shadowQuery(el, '[part="close-button"]');
+      const closeBtn = shadowQuery(el, '[part="close-btn"]');
       expect(closeBtn?.getAttribute('aria-label')).toBe('Close drawer');
     });
   });
@@ -374,7 +374,7 @@ describe('hx-drawer', () => {
       await new Promise((r) => setTimeout(r, 50));
 
       expect(el.open).toBe(true);
-      const closeBtn = shadowQuery<HTMLButtonElement>(el, '[part="close-button"]');
+      const closeBtn = shadowQuery<HTMLButtonElement>(el, '[part="close-btn"]');
       expect(closeBtn).toBeTruthy();
 
       const hidePromise = oneEvent<CustomEvent>(el, 'hx-hide');
@@ -419,7 +419,7 @@ describe('hx-drawer', () => {
       await new Promise((r) => setTimeout(r, 100));
 
       // Focus the close button (first shadow DOM focusable)
-      const closeBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('[part="close-button"]');
+      const closeBtn = el.shadowRoot?.querySelector<HTMLButtonElement>('[part="close-btn"]');
       expect(closeBtn).toBeTruthy();
       closeBtn!.focus();
 

--- a/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
+++ b/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
@@ -54,7 +54,7 @@ const FOCUSABLE_SELECTORS = [
  * @csspart panel - The drawer panel itself.
  * @csspart header - The header region containing the title and actions.
  * @csspart title - The drawer title element.
- * @csspart close-button - The built-in close button.
+ * @csspart close-btn - The built-in close button.
  * @csspart body - The scrollable body region.
  * @csspart footer - The footer region.
  *
@@ -465,7 +465,7 @@ export class HelixDrawer extends LitElement {
                 style="display:none"
               ></slot>`}
           <button
-            part="close-button"
+            part="close-btn"
             class="drawer-close-button"
             aria-label="Close drawer"
             @click=${() => {


### PR DESCRIPTION
## Summary

- Renames CSS part `close-button` to `close-btn` on the hx-drawer component to match the feature specification (CSS audit finding P2-02)
- Updates `@csspart` JSDoc annotation from `close-button` to `close-btn`
- Updates all test selectors to use the corrected part name `[part="close-btn"]`
- Marks P2-02 and P2-03 as RESOLVED in AUDIT.md (P2-03 was already fixed in styles)

**Note on other components:**
- hx-icon-button: Component was consolidated into hx-button in a prior commit — CSS findings are moot
- hx-action-bar (P2-07): Already marked RESOLVED in AUDIT.md
- hx-container (P2-02): Already marked RESOLVED in AUDIT.md
- hx-checkbox-group (P2-01): Already resolved — styles now use `--hx-color-error-500, #dc3545` consistently with JSDoc

Closes #794

## Test plan

- [x] `npm run verify` — zero errors
- [x] All 49 hx-drawer tests pass
- [x] Full test suite passes (all ✓)
- [x] Changeset included: `patch` bump for `@helixui/library`

🤖 Generated with [Claude Code](https://claude.com/claude-code)