### PR TITLE
fix: correct GitHub URLs in Astro docs site

### DIFF
--- a/apps/docs/src/components/CTASection.astro
+++ b/apps/docs/src/components/CTASection.astro
@@ -34,7 +34,7 @@
       <a href="/architecture/overview/" class="cta-link">Architecture Overview</a>
       <a href="/design-tokens/overview/" class="cta-link">Design Tokens</a>
       <a href="/drupal-integration/overview/" class="cta-link">Drupal Integration</a>
-      <a href="https://github.com/himerus/helix" class="cta-link">GitHub</a>
+      <a href="https://github.com/bookedsolidtech/helix" class="cta-link">GitHub</a>
     </div>
   </div>
 </section>

--- a/apps/docs/src/components/SiteNavbar.astro
+++ b/apps/docs/src/components/SiteNavbar.astro
@@ -328,7 +328,7 @@ const currentPath = Astro.url.pathname;
         <span class="sn-nav-link-text">Docs</span>
       </a>
       <a
-        href="https://github.com/himerus/wc-2026"
+        href="https://github.com/bookedsolidtech/helix"
         class="sn-nav-link"
         target="_blank"
         rel="noopener noreferrer"

--- a/apps/docs/src/content/docs/components/advanced/controllers.md
+++ b/apps/docs/src/content/docs/components/advanced/controllers.md
@@ -1399,4 +1399,4 @@ With Reactive Controllers, you can build a library of reusable behaviors that co
 
 - Explore [Component Lifecycle](/components/fundamentals/lifecycle) for detailed lifecycle documentation
 - Learn about [Reactive Properties](/components/fundamentals/reactive-properties) for property system internals
-- Study the [AdoptedStylesheetsController source](https://github.com/your-repo/packages/hx-library/src/controllers/adopted-stylesheets.ts) for a production example
+- Study the [AdoptedStylesheetsController source](https://github.com/bookedsolidtech/helix/blob/main/packages/hx-library/src/controllers/adopted-stylesheets.ts) for a production example

--- a/apps/docs/src/content/docs/components/documentation/jsdoc.md
+++ b/apps/docs/src/content/docs/components/documentation/jsdoc.md
@@ -1158,7 +1158,7 @@ When deprecating or removing features:
 ```typescript
 /**
  * @deprecated Use `variant="outlined"` instead. This property will be removed in v2.0.0.
- * @see https://github.com/org/repo/issues/123 for migration guide
+ * @see https://github.com/bookedsolidtech/helix/issues for migration guide
  */
 @property({ type: Boolean })
 outline = false;

--- a/apps/docs/src/content/docs/components/typescript/typing-components.md
+++ b/apps/docs/src/content/docs/components/typescript/typing-components.md
@@ -1181,7 +1181,7 @@ Consumers import this and get full type safety.
 - [Lit TypeScript Guide](https://lit.dev/docs/components/typescript/)
 - [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
 - [Custom Elements Manifest](https://custom-elements-manifest.open-wc.org/)
-- [hx-library source code](https://github.com/your-org/hx-library) (internal)
+- [hx-library source code](https://github.com/bookedsolidtech/helix) (internal)
 
 ---
 

--- a/apps/docs/src/content/docs/drupal-integration/installation/module.md
+++ b/apps/docs/src/content/docs/drupal-integration/installation/module.md
@@ -1264,7 +1264,7 @@ drush cr
 
 ## Support
 
-For issues, see: https://github.com/your-org/hx-library/issues
+For issues, see: https://github.com/bookedsolidtech/helix/issues
 
 ````
 

--- a/apps/docs/src/content/docs/drupal-integration/overview.md
+++ b/apps/docs/src/content/docs/drupal-integration/overview.md
@@ -778,7 +778,7 @@ Ready to integrate HELIX with your Drupal site?
 
 ## Support and Community
 
-- **GitHub Issues:** [github.com/your-org/helix/issues](https://github.com)
+- **GitHub Issues:** [github.com/bookedsolidtech/helix/issues](https://github.com/bookedsolidtech/helix/issues)
 - **Documentation:** [helix-docs.example.com](https://example.com)
 - **Drupal Slack:** #helix channel in [Drupal Slack](https://drupal.org/slack)
 - **Stack Overflow:** Tag questions with `helix-web-components` and `drupal`

--- a/apps/docs/src/content/docs/drupal-integration/troubleshooting/common-issues.md
+++ b/apps/docs/src/content/docs/drupal-integration/troubleshooting/common-issues.md
@@ -1511,7 +1511,7 @@ If you've worked through this guide and still have issues:
 
 ### 2. Search Existing Issues
 
-[GitHub Issues](https://github.com/your-org/helix/issues) - Search for your error message or symptom.
+[GitHub Issues](https://github.com/bookedsolidtech/helix/issues) - Search for your error message or symptom.
 
 ### 3. File a Bug Report
 
@@ -1591,4 +1591,4 @@ drush cr && \
 
 ---
 
-**Have a troubleshooting tip not covered here?** [Contribute to this guide](https://github.com/your-org/helix/edit/main/apps/docs/src/content/docs/drupal-integration/troubleshooting/common-issues.md)
+**Have a troubleshooting tip not covered here?** [Contribute to this guide](https://github.com/bookedsolidtech/helix/edit/main/apps/docs/src/content/docs/drupal-integration/troubleshooting/common-issues.md)


### PR DESCRIPTION
## Summary

## Problem

The Astro docs site contains incorrect GitHub URLs — some pointing to the old personal repo (`himerus`) and others using placeholder values (`your-org`, `org`, `your-repo`). All references should point to `https://github.com/bookedsolidtech/helix`.

## Validated Issues

### Component files (user-facing, priority):
1. `apps/docs/src/components/SiteNavbar.astro:331`
   - Current: `https://github.com/himerus/wc-2026`
   - Fix: `https://github.com/bookedsolidtech/helix`

2. `apps/docs/sr...

Closes https://github.com/org/repo/issues/123

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-13T02:03:04.193Z -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated GitHub repository links throughout documentation pages and user interface components to reference the correct project repository for issues, contributions, and reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->