### PR TITLE
chore: limit CodeRabbit reviews to dev-targeted PRs only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -12,9 +12,7 @@ reviews:
     enabled: true
     drafts: false
     base_branches:
-      - main
       - dev
-      - staging
     ignore_title_keywords:
       - 'AUDIT'
       - 'audit'


### PR DESCRIPTION
## Summary
- Remove `staging` and `main` from CodeRabbit `base_branches`
- CodeRabbit now only reviews PRs targeting `dev` (feature work)
- Promotion PRs (`dev→staging`, `staging→main`) have already been reviewed when they landed on `dev` — no value in re-reviewing them

## Why
Promotion PRs are merge commits of already-reviewed code. CodeRabbit re-reviewing them burns API budget, adds noise, and blocks the pipeline on a redundant gate.