### PR TITLE
fix(typescript): type safety findings for hx-spinner, hx-steps, hx-textarea, hx-toast, hx-alert

### DIFF
--- a/.changeset/typescript-hx-spinner-hx-steps-hx-textarea.md
+++ b/.changeset/typescript-hx-spinner-hx-steps-hx-textarea.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+Fix TypeScript type safety findings for hx-spinner, hx-steps, hx-textarea, hx-toast, and hx-alert. Exports SpinnerSize type from hx-spinner, improves JSDoc on hx-step internal orientation/size properties, adds readonly property to hx-textarea, and confirms hx-toast animation direction and CSS placement fallback fixes along with hx-alert AlertVariant type export.

--- a/packages/hx-library/src/components/hx-alert/AUDIT.md
+++ b/packages/hx-library/src/components/hx-alert/AUDIT.md
@@ -130,17 +130,11 @@ The component exposes 6 parts: `alert`, `title`, `icon`, `message`, `close-butto
 
 **Fix:** The JSDoc at the top of `CSSParts` story already says "6 CSS `::part()` targets" (correct). Updated the body text in the alert's inner content from "5 CSS parts" to "6 CSS parts" and added `::part(title)` to the enumerated list.
 
-### P2-06: `AlertVariant` type not exported
+### ~~P2-06: `AlertVariant` type not exported~~ FIXED
 
 **File:** `hx-alert.ts:8`, `index.ts:1`
 
-The `AlertVariant` type (`'info' | 'success' | 'warning' | 'error'`) is defined locally but not exported from the component or the barrel file. Consumers who want to type-check variant values in their TypeScript code cannot import this type.
-
-**Fix direction:** Export `AlertVariant` from `hx-alert.ts` and re-export from `index.ts`:
-
-```ts
-export type { AlertVariant } from './hx-alert.js';
-```
+**Resolution:** `AlertVariant` is exported from `hx-alert.ts` and re-exported from `index.ts` as `export type { AlertVariant }`. Consumers can import the type for type-safe variant checks.
 
 ### P2-07: Live region re-announcement reliability on `open` toggle
 

--- a/packages/hx-library/src/components/hx-spinner/AUDIT.md
+++ b/packages/hx-library/src/components/hx-spinner/AUDIT.md
@@ -131,18 +131,11 @@ The test only asserts the `.spinner__sr-text` element exists — it does not ver
 
 ## P2 — Medium (tech debt / DX gap)
 
-### P2-1: `size` TypeScript union collapses to `string` — no runtime narrowing
+### ~~P2-1: `size` TypeScript union collapses to `string` — no runtime narrowing~~ FIXED
 
-**File:** `hx-spinner.ts:31`
+**File:** `hx-spinner.ts`
 
-```typescript
-size: 'sm' | 'md' | 'lg' | string = 'md';
-```
-
-`'sm' | 'md' | 'lg' | string` resolves to `string` at the TypeScript level — the string literal members add no type safety. TypeScript will not flag `size="xxl"` as an error. Consider:
-
-- `type SpinnerSize = 'sm' | 'md' | 'lg'` for the token sizes, combined with a separate `customSize?: string` property.
-- Or keep the union but document that it intentionally degrades to `string` for custom CSS values (add a comment explaining the design choice).
+**Resolution:** Added a named `SpinnerSize = 'sm' | 'md' | 'lg'` type, exported from both `hx-spinner.ts` and `index.ts`. The `size` property is typed as `SpinnerSize | string` with clear JSDoc documentation explaining the intentional widening to `string` for custom CSS size values. Consumers can import `SpinnerSize` for type-safe usage with token values.
 
 ---
 
@@ -225,7 +218,7 @@ Every other T1 component audited so far (hx-tag, hx-switch, hx-textarea) also la
 | P1-3 | CSS           | P1       | `color-mix()` without fallback — broken in older browsers |
 | P1-4 | Tests         | P1       | No reduced-motion behavior test                           |
 | P1-5 | Tests         | P1       | sr-text content and reactive label update untested        |
-| P2-1 | TypeScript    | P2       | `size` union collapses to `string`                        |
+| P2-1 | TypeScript    | P2       | `size` union collapses to `string` — **FIXED**            |
 | P2-2 | Drupal/DX     | P2       | `label` not reflected — asymmetric vs `size`/`variant`    |
 | P2-3 | DX            | P2       | Hardcoded `...` appended to all sr-text labels            |
 | P2-4 | Storybook     | P2       | `size` argType `select`-only, custom sizes not explorable |

--- a/packages/hx-library/src/components/hx-spinner/hx-spinner.ts
+++ b/packages/hx-library/src/components/hx-spinner/hx-spinner.ts
@@ -6,6 +6,13 @@ import { tokenStyles } from '@helixui/tokens/lit';
 import { helixSpinnerStyles } from './hx-spinner.styles.js';
 
 /**
+ * Token size values for the spinner. Use these for standard sizing.
+ * The `size` property also accepts any valid CSS size string (e.g. "3rem", "48px")
+ * for custom sizes — the type widens to `string` in that usage.
+ */
+export type SpinnerSize = 'sm' | 'md' | 'lg';
+
+/**
  * A circular loading indicator for inline and overlay loading states.
  * Purely visual — no slots. Announces loading state to screen readers via
  * `role="status"` and an `aria-label` (customizable via the `label` prop).
@@ -28,16 +35,16 @@ export class HelixSpinner extends LitElement {
   static override styles = [tokenStyles, helixSpinnerStyles];
 
   /**
-   * Size of the spinner. Accepts 'sm' | 'md' | 'lg' token values, or any
-   * valid CSS size string (e.g. "3rem", "48px").
+   * Size of the spinner. Accepts `SpinnerSize` token values ('sm' | 'md' | 'lg'),
+   * or any valid CSS size string (e.g. "3rem", "48px") for custom dimensions.
    *
-   * Note: `'sm' | 'md' | 'lg' | string` intentionally degrades to `string`
-   * at the TypeScript level to allow CSS size values as a convenience override.
-   * This is a deliberate design choice — use token values for standard sizing.
+   * The type is `SpinnerSize | string` which widens to `string` at the TypeScript
+   * level — this is intentional to support CSS size overrides. Use `SpinnerSize`
+   * values for standard sizing; custom strings bypass token-based scaling.
    * @attr size
    */
   @property({ type: String, reflect: true })
-  size: 'sm' | 'md' | 'lg' | string = 'md';
+  size: SpinnerSize | string = 'md';
 
   /**
    * Visual variant of the spinner.
@@ -63,7 +70,7 @@ export class HelixSpinner extends LitElement {
   @property({ type: Boolean, reflect: true })
   decorative = false;
 
-  private _isTokenSize(): boolean {
+  private _isTokenSize(): this is { size: SpinnerSize } {
     return this.size === 'sm' || this.size === 'md' || this.size === 'lg';
   }
 

--- a/packages/hx-library/src/components/hx-spinner/index.ts
+++ b/packages/hx-library/src/components/hx-spinner/index.ts
@@ -1,1 +1,2 @@
 export { HelixSpinner } from './hx-spinner.js';
+export type { SpinnerSize } from './hx-spinner.js';

--- a/packages/hx-library/src/components/hx-steps/AUDIT.md
+++ b/packages/hx-library/src/components/hx-steps/AUDIT.md
@@ -389,7 +389,7 @@ The `label`, `description`, `status` attributes map to Drupal field values. With
 | # | Finding | Status |
 |---|---------|--------|
 | 1 | Status vocabulary mismatch | Documented — current vocabulary (`pending/active/complete/error`) is more expressive than spec. |
-| 2 | Internal props reflected on hx-step | Documented — requires architectural change to child sync pattern. |
+| 2 | Internal props reflected on hx-step | **IMPROVED** — JSDoc updated to explicitly document that `orientation` and `size` are CSS-styling-required reflected attributes, should not be set externally on `<hx-step>`, and are managed exclusively by the parent `<hx-steps>` container via `_syncChildren()`. Full removal of `reflect: true` blocked by CSS dependency on `[orientation='vertical']` selector. |
 | 5 | Complete/error not announced to SR | Documented — needs visually hidden status text. |
 | 10 | Active/complete visually identical | Documented — needs distinct indicator styles. |
 | 14-16 | Test gaps (slot change, coverage) | Documented. |

--- a/packages/hx-library/src/components/hx-steps/hx-step.ts
+++ b/packages/hx-library/src/components/hx-steps/hx-step.ts
@@ -70,6 +70,10 @@ export class HelixStep extends LitElement {
 
   /**
    * Layout orientation. Set by the parent `<hx-steps>` container.
+   * Reflected as an attribute for CSS styling (`[orientation='vertical']` selector).
+   * Do not set this attribute directly on `<hx-step>` — use the `orientation`
+   * property on the parent `<hx-steps>` container instead. The parent will
+   * propagate the value to all child steps via `_syncChildren()`.
    * @internal
    */
   @property({ type: String, reflect: true })
@@ -77,6 +81,10 @@ export class HelixStep extends LitElement {
 
   /**
    * Size variant. Set by the parent `<hx-steps>` container.
+   * Reflected as an attribute for CSS styling. Do not set this attribute
+   * directly on `<hx-step>` — use the `size` property on the parent
+   * `<hx-steps>` container instead. The parent will propagate the value
+   * to all child steps via `_syncChildren()`.
    * @internal
    */
   @property({ type: String, reflect: true })

--- a/packages/hx-library/src/components/hx-textarea/AUDIT.md
+++ b/packages/hx-library/src/components/hx-textarea/AUDIT.md
@@ -180,11 +180,11 @@ IDs generated via `Math.random()` differ between server render and client hydrat
 
 ---
 
-### P2-02: Missing `readonly` property
+### ~~P2-02: Missing `readonly` property~~ FIXED
 
 **File:** `hx-textarea.ts`
 
-The native `<textarea>` element supports `readonly`, a standard HTML attribute. The component does not expose it. Read-only form fields are a common healthcare pattern (displaying non-editable patient data inline with editable fields). Consumers must currently work around this with CSS or by intercepting input events.
+**Resolution:** Added `readonly` boolean property with `reflect: true` (attribute: `readonly`). The native `<textarea>` receives `?readonly=${this.readonly}` via Lit's boolean attribute binding. Common healthcare pattern for displaying non-editable patient data inline with editable fields.
 
 **Severity:** P2
 

--- a/packages/hx-library/src/components/hx-textarea/hx-textarea.ts
+++ b/packages/hx-library/src/components/hx-textarea/hx-textarea.ts
@@ -145,6 +145,15 @@ export class HelixTextarea extends LitElement {
   maxlength: number | undefined;
 
   /**
+   * Whether the textarea is read-only. Read-only fields are visible but
+   * cannot be edited by the user. Common in healthcare for displaying
+   * non-editable patient data inline with editable fields.
+   * @attr readonly
+   */
+  @property({ type: Boolean, reflect: true })
+  readonly = false;
+
+  /**
    * Controls how the textarea can be resized. Use 'auto' for auto-grow behavior.
    * @attr resize
    */
@@ -432,6 +441,7 @@ export class HelixTextarea extends LitElement {
             placeholder=${ifDefined(this.placeholder || undefined)}
             ?required=${this.required}
             ?disabled=${this.disabled}
+            ?readonly=${this.readonly}
             rows=${this.rows}
             minlength=${ifDefined(this.minlength)}
             maxlength=${ifDefined(this.maxlength)}

--- a/packages/hx-library/src/components/hx-toast/AUDIT.md
+++ b/packages/hx-library/src/components/hx-toast/AUDIT.md
@@ -143,13 +143,11 @@ This is the primary behavioral contract of `hx-toast-stack` and it has no test c
 
 ---
 
-### P2-04: Slide animation direction does not vary by placement
+### ~~P2-04: Slide animation direction does not vary by placement~~ FIXED
 
-**File:** `hx-toast.styles.ts:34–46`
+**File:** `hx-toast.styles.ts`
 
-The enter animation always slides from `translateY(0.5rem)` (upward from below). For toasts in a `bottom-*` placement stack, this means they slide up to their final position, which is semantically correct. However for `top-*` placements, toasts should ideally slide downward from above (`translateY(-0.5rem)`) to feel natural. Currently all placements use the same upward slide.
-
-**Impact:** Minor visual inconsistency for `top-start`, `top-center`, `top-end` placements.
+**Resolution:** The `hx-toast-stack` styles now set `--hx-toast-enter-translate` to `calc(var(--hx-space-2, 0.5rem) * -1)` for `top-*` placements via the `::slotted(hx-toast)` selector. Toasts in top-positioned stacks slide downward from above; toasts in bottom-positioned stacks slide upward from below. The `--hx-toast-enter-translate` CSS custom property in `hx-toast.styles.ts` uses the parent-set value as its default.
 
 ---
 
@@ -194,23 +192,11 @@ The story is misleading to developers evaluating the component.
 
 ---
 
-### P2-08: CSS `:host(:not([placement]))` maps to `bottom-start`, conflicting with JS default `bottom-end`
+### ~~P2-08: CSS `:host(:not([placement]))` maps to `bottom-start`, conflicting with JS default `bottom-end`~~ FIXED
 
-**File:** `hx-toast.styles.ts:177–183`, `hx-toast.ts:273`
+**File:** `hx-toast.styles.ts`
 
-The CSS fallback for when no `placement` attribute is present maps to the `bottom-start` position:
-
-```css
-:host([placement='bottom-start']),
-:host(:not([placement])) {
-  bottom: 0;
-  left: 0;
-  right: auto;
-  top: auto;
-}
-```
-
-But the JS property default is `'bottom-end'` (bottom-right). Because `placement` has `reflect: true`, the attribute will be set on first render, so this mismatch only manifests if the attribute is programmatically removed after render (`el.removeAttribute('placement')`). However it creates a confusing inconsistency: the "no placement" CSS state and the JS default disagree on which corner is the fallback. The CSS should either be removed (the reflect will always set the attribute) or changed to match `bottom-end`.
+**Resolution:** The `:host(:not([placement]))` fallback CSS rule has been removed. The styles only contain explicit `:host([placement='...'])` selectors. Because `placement` has `reflect: true` on `HelixToastStack`, the attribute is always present after first render. The JS default `'bottom-end'` and the CSS placement rules are now consistent.
 
 ---
 
@@ -218,7 +204,7 @@ But the JS property default is `'bottom-end'` (bottom-right). Because `placement
 
 | Area                           | Status  | Findings                                   |
 | ------------------------------ | ------- | ------------------------------------------ |
-| TypeScript (strict, types)     | PASS    | None                                       |
+| TypeScript (strict, types)     | PASS    | P2-04, P2-08 fixed                         |
 | Accessibility (ARIA/axe)       | PARTIAL | P1-01, P1-02                               |
 | Tests (coverage/completeness)  | FAIL    | P1-03, P2-02, P2-03                        |
 | Storybook (variants/demos)     | PARTIAL | P2-07                                      |

--- a/packages/hx-library/src/index.ts
+++ b/packages/hx-library/src/index.ts
@@ -26,11 +26,7 @@ export { HelixCheckbox } from './components/hx-checkbox/index.js';
 export { HelixCheckboxGroup } from './components/hx-checkbox-group/index.js';
 export { HelixCodeSnippet } from './components/hx-code-snippet/index.js';
 export { HelixColorPicker } from './components/hx-color-picker/index.js';
-export {
-  HelixCombobox,
-  type ComboboxOption,
-  type HxComboboxSize,
-} from './components/hx-combobox/index.js';
+export { HelixCombobox, type ComboboxOption, type HxComboboxSize } from './components/hx-combobox/index.js';
 export { HelixContainer } from './components/hx-container/index.js';
 export type { WcContainer } from './components/hx-container/index.js';
 export { HelixCopyButton } from './components/hx-copy-button/index.js';
@@ -79,20 +75,14 @@ export { HelixNavItem } from './components/hx-side-nav/index.js';
 export { HelixSkeleton } from './components/hx-skeleton/index.js';
 export { HelixSlider } from './components/hx-slider/index.js';
 export { HelixSpinner } from './components/hx-spinner/index.js';
+export type { SpinnerSize } from './components/hx-spinner/index.js';
 export { HelixSplitButton } from './components/hx-split-button/index.js';
 export { HelixSplitPanel } from './components/hx-split-panel/index.js';
 export { HelixStack } from './components/hx-stack/index.js';
-export {
-  HelixStatusIndicator,
-  type StatusIndicatorStatus,
-  type StatusIndicatorSize,
-} from './components/hx-status-indicator/index.js';
+export { HelixStatusIndicator, type StatusIndicatorStatus, type StatusIndicatorSize } from './components/hx-status-indicator/index.js';
 export { HelixSteps } from './components/hx-steps/index.js';
 export { HelixStep } from './components/hx-steps/index.js';
-export {
-  HelixStructuredList,
-  HelixStructuredListRow,
-} from './components/hx-structured-list/index.js';
+export { HelixStructuredList, HelixStructuredListRow } from './components/hx-structured-list/index.js';
 export { HelixSwitch } from './components/hx-switch/index.js';
 export type { HxSwitch, WcSwitch } from './components/hx-switch/index.js';
 export { HelixTabs } from './components/hx-tabs/index.js';
@@ -105,20 +95,11 @@ export { HelixText } from './components/hx-text/index.js';
 export { HelixTextInput } from './components/hx-text-input/index.js';
 export { HelixTextarea } from './components/hx-textarea/index.js';
 export { HelixTheme } from './components/hx-theme/index.js';
-export type {
-  ThemeName,
-  TokenDefinition,
-  TokenEntry,
-  HxTheme,
-} from './components/hx-theme/index.js';
+export type { ThemeName, TokenDefinition, TokenEntry, HxTheme } from './components/hx-theme/index.js';
 export type { WcTheme } from './components/hx-theme/index.js';
 export { HelixTimePicker } from './components/hx-time-picker/index.js';
 export { HelixToast, HelixToastStack, toast } from './components/hx-toast/index.js';
-export type {
-  ToastVariant,
-  ToastStackPlacement,
-  ToastOptions,
-} from './components/hx-toast/index.js';
+export type { ToastVariant, ToastStackPlacement, ToastOptions } from './components/hx-toast/index.js';
 export { HelixToggleButton } from './components/hx-toggle-button/index.js';
 export { HelixTooltip } from './components/hx-tooltip/index.js';
 export { HelixTopNav } from './components/hx-top-nav/index.js';


### PR DESCRIPTION
## Summary

- **hx-spinner (#814):** Export `SpinnerSize = 'sm' | 'md' | 'lg'` type from `hx-spinner.ts` and `index.ts`. Type the `size` property as `SpinnerSize | string` (with JSDoc explaining the intentional widening for CSS size values). Add type guard `_isTokenSize()` returning `this is { size: SpinnerSize }`.
- **hx-steps (#819):** Improve JSDoc on `hx-step`'s `orientation` and `size` internal properties to explicitly document the CSS-styling dependency (`:host([orientation='vertical'])` selector) and that these are managed exclusively by the parent `<hx-steps>` container via `_syncChildren()`. `reflect: true` retained for CSS selector functionality; `@internal` tags already present.
- **hx-textarea (#826):** Add `readonly` boolean property with `reflect: true`, wired to the native `<textarea>` via Lit's `?readonly` binding. Common healthcare pattern for non-editable patient data fields.
- **hx-toast (#829):** Confirm P2-04 (slide animation direction varies by placement via `--hx-toast-enter-translate`) and P2-08 (`:host(:not([placement]))` CSS fallback mismatch) are already resolved in current styles. AUDIT.md updated.
- **hx-alert (#782):** Confirm P2-06 (`AlertVariant` type export) is already resolved in `index.ts`. AUDIT.md updated.

## Test plan

- [ ] `npm run verify` passes — zero lint, format, and type-check errors
- [ ] `npm run cem` generates valid Custom Elements Manifest
- [ ] `SpinnerSize` type importable from `@helixui/library`
- [ ] `hx-textarea` accepts `readonly` attribute and reflects it to the native `<textarea>`
- [ ] `hx-step` internal properties documented with correct `@internal` JSDoc

Closes #814
Closes #819
Closes #826
Closes #829
Closes #782

🤖 Generated with [Claude Code](https://claude.com/claude-code)