### PR TITLE
fix(drupal): fix Drupal integration findings for hx-field, hx-link, hx-number-input, hx-prose, hx-radio-group

### DIFF
--- a/.changeset/drupal-hx-field-hx-link-hx-number-input.md
+++ b/.changeset/drupal-hx-field-hx-link-hx-number-input.md
@@ -1,0 +1,13 @@
+---
+"@helixui/library": patch
+---
+
+fix(drupal): fix Drupal integration findings for hx-field, hx-link, hx-number-input, hx-prose, and hx-radio-group
+
+Closes #795, #800, #802, #808, #809
+
+- hx-field: add DrupalIntegration Storybook story with Twig template, Behaviors, and asset loading examples (P2-15)
+- hx-link: add DrupalIntegration Storybook story with Twig template and Behaviors patterns (P2-8)
+- hx-number-input: WithLabelSlot and DrupalFormAPI stories already present; confirmed @slot JSDoc fixed, formResetCallback restores _defaultValue, step attribute always rendered (P0-02, P1-15, P1-16, P2-08, P2-09)
+- hx-prose: fix clear: none → clear: both in _drupal.css and prose.scoped.css so block-level content starts below floated images rather than wrapping beside them (P2-03); deprecated align attribute selectors documented as Drupal CKEditor compatibility shims (P2-05)
+- hx-radio-group: confirmed monotonic counter replaces Math.random() for IDs (P2-2); confirmed _individualDisabledStates map restores per-radio disabled state on group re-enable (P1-1)

--- a/packages/hx-library/src/components/hx-field/hx-field.stories.ts
+++ b/packages/hx-library/src/components/hx-field/hx-field.stories.ts
@@ -926,6 +926,145 @@ export const MedicationDosageField: Story = {
 };
 
 // ─────────────────────────────────────────────────
+// DRUPAL INTEGRATION
+// ─────────────────────────────────────────────────
+
+export const DrupalIntegration: Story = {
+  name: 'Drupal Integration',
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 2rem; max-width: 520px;">
+      <div>
+        <p
+          style="margin: 0 0 0.75rem; font-size: 0.75rem; font-weight: 600; color: var(--hx-color-neutral-500, #6c757d); text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 1: Native input from Drupal Form API
+        </p>
+        <hx-field label="Patient Name" required help-text="Enter legal name as it appears on ID.">
+          <input
+            type="text"
+            name="patient_name"
+            placeholder="First Last"
+            required
+            style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--hx-color-neutral-300, #dee2e6); border-radius: 0.375rem; font-size: 0.875rem; line-height: 1.5;"
+          />
+        </hx-field>
+      </div>
+
+      <div>
+        <p
+          style="margin: 0 0 0.75rem; font-size: 0.75rem; font-weight: 600; color: var(--hx-color-neutral-500, #6c757d); text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 2: Select field from Drupal Form API
+        </p>
+        <hx-field label="Department" required>
+          <select
+            name="department"
+            required
+            style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--hx-color-neutral-300, #dee2e6); border-radius: 0.375rem; font-size: 0.875rem; background: white;"
+          >
+            <option value="">Select a department...</option>
+            <option value="cardiology">Cardiology</option>
+            <option value="emergency">Emergency Medicine</option>
+            <option value="oncology">Oncology</option>
+          </select>
+        </hx-field>
+      </div>
+
+      <div>
+        <p
+          style="margin: 0 0 0.75rem; font-size: 0.75rem; font-weight: 600; color: var(--hx-color-neutral-500, #6c757d); text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 3: Textarea for clinical notes
+        </p>
+        <hx-field
+          label="Clinical Notes"
+          help-text="Document observations for the attending physician."
+        >
+          <textarea
+            name="clinical_notes"
+            rows="4"
+            style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--hx-color-neutral-300, #dee2e6); border-radius: 0.375rem; font-size: 0.875rem; line-height: 1.5; resize: vertical; font-family: inherit;"
+          ></textarea>
+        </hx-field>
+      </div>
+
+      <div>
+        <p
+          style="margin: 0 0 0.75rem; font-size: 0.75rem; font-weight: 600; color: var(--hx-color-neutral-500, #6c757d); text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 4: Error state from Drupal validation
+        </p>
+        <hx-field
+          label="Insurance ID"
+          required
+          error="Insurance ID must be 9–12 digits. Please verify and re-enter."
+        >
+          <input
+            type="text"
+            name="insurance_id"
+            value="ABC"
+            style="width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--hx-color-error-500, #dc3545); border-radius: 0.375rem; font-size: 0.875rem; line-height: 1.5;"
+          />
+        </hx-field>
+      </div>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Demonstrates the primary Drupal Form API integration patterns for \`hx-field\`.
+
+**Twig template example:**
+\`\`\`twig
+{# Basic labeled field from Drupal field data #}
+<hx-field
+  label="{{ field_label|t }}"
+  {% if field_required %}required{% endif %}
+  {% if field_help_text %}help-text="{{ field_help_text|t }}"{% endif %}
+  {% if field_error %}error="{{ field_error|t }}"{% endif %}
+>
+  <input
+    type="{{ field_type|default('text') }}"
+    name="{{ field_name }}"
+    id="{{ field_id }}"
+    value="{{ field_value|default('') }}"
+  />
+</hx-field>
+\`\`\`
+
+**Drupal Behaviors (AJAX validation):**
+\`\`\`js
+(function (Drupal, once) {
+  Drupal.behaviors.helixFieldValidation = {
+    attach(context) {
+      once('hx-field-validation', 'hx-field[data-drupal-field]', context).forEach((field) => {
+        field.closest('form').addEventListener('submit', (e) => {
+          const input = field.querySelector('input, textarea, select');
+          if (input && !input.value.trim()) {
+            e.preventDefault();
+            field.error = Drupal.t('This field is required.');
+          }
+        });
+      });
+    },
+  };
+})(Drupal, once);
+\`\`\`
+
+**Asset loading (mytheme.libraries.yml):**
+\`\`\`yaml
+helix-components:
+  js:
+    /libraries/helix/helix.min.js: { minified: true }
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
+// ─────────────────────────────────────────────────
 // INTERACTION TESTS
 // ─────────────────────────────────────────────────
 

--- a/packages/hx-library/src/components/hx-link/AUDIT.md
+++ b/packages/hx-library/src/components/hx-link/AUDIT.md
@@ -55,7 +55,7 @@ All 14 issues from the T1-05 audit have been addressed:
 | P2-5 | Redundant `cursor: not-allowed`              | **Fixed** (removed from `.link--disabled`, kept on `:host([disabled])`) |
 | P2-6 | `LinkVariant` type not exported              | **Fixed** (exported from `index.ts`)                                    |
 | P2-7 | Missing `outline: 0` on `.link`              | **Fixed** (present on `.link` base)                                     |
-| P2-8 | No Drupal Twig usage example                 | **Fixed** (full Twig + behaviors in docs)                               |
+| P2-8 | No Drupal Twig usage example                 | **Fixed** (full Twig + behaviors in docs and `DrupalIntegration` story) |
 
 ---
 

--- a/packages/hx-library/src/components/hx-link/hx-link.stories.ts
+++ b/packages/hx-library/src/components/hx-link/hx-link.stories.ts
@@ -242,6 +242,119 @@ export const InlineContext: Story = {
   `,
 };
 
+// --- Drupal Integration ---
+
+export const DrupalIntegration: Story = {
+  name: 'Drupal Integration',
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 1.5rem; max-width: 600px;">
+      <div>
+        <p
+          style="margin: 0 0 0.5rem; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 1: Internal navigation link
+        </p>
+        <hx-link href="/patient/123">View Patient Record</hx-link>
+      </div>
+
+      <div>
+        <p
+          style="margin: 0 0 0.5rem; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 2: External reference link (opens in new tab)
+        </p>
+        <hx-link href="https://example.com/clinical-guidelines" target="_blank"
+          >Clinical Guidelines</hx-link
+        >
+      </div>
+
+      <div>
+        <p
+          style="margin: 0 0 0.5rem; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 3: Document download link
+        </p>
+        <hx-link href="/reports/discharge-summary.pdf" download="discharge-summary.pdf"
+          >Download Discharge Summary</hx-link
+        >
+      </div>
+
+      <div>
+        <p
+          style="margin: 0 0 0.5rem; font-size: 0.75rem; font-weight: 600; color: #6b7280; text-transform: uppercase; letter-spacing: 0.05em;"
+        >
+          Pattern 4: Inline within prose content
+        </p>
+        <p style="line-height: 1.6; color: #374151;">
+          Review the patient's
+          <hx-link href="/records/lab-results">lab results</hx-link>
+          and consult the
+          <hx-link href="https://example.com/formulary" target="_blank">formulary</hx-link>
+          before updating the medication order.
+        </p>
+      </div>
+    </div>
+  `,
+  parameters: {
+    docs: {
+      description: {
+        story: `
+Demonstrates \`hx-link\` usage patterns for Drupal Twig templates.
+
+**Twig template example:**
+\`\`\`twig
+{# Internal navigation link #}
+<hx-link href="{{ path('entity.node.canonical', {'node': node.id}) }}">
+  {{ node.label }}
+</hx-link>
+
+{# External reference link opening in new tab #}
+<hx-link
+  href="{{ url }}"
+  target="_blank"
+  {% if variant %}variant="{{ variant }}"{% endif %}
+>
+  {{ link_text }}
+</hx-link>
+
+{# Document download #}
+<hx-link
+  href="{{ file.url }}"
+  download="{{ file.filename }}"
+>
+  {{ 'Download'|t }} {{ file.filename }}
+</hx-link>
+
+{# Conditionally disabled based on access #}
+<hx-link
+  href="{{ path }}"
+  {% if not access %}disabled{% endif %}
+>
+  {{ label }}
+</hx-link>
+\`\`\`
+
+**Drupal Behaviors (AJAX navigation):**
+\`\`\`js
+(function (Drupal, once) {
+  Drupal.behaviors.helixLink = {
+    attach(context) {
+      once('hx-link-init', 'hx-link[href]', context).forEach((link) => {
+        link.addEventListener('hx-click', (e) => {
+          // Handle AJAX navigation or analytics tracking
+          console.log('hx-link clicked:', e.detail);
+        });
+      });
+    },
+  };
+})(Drupal, once);
+\`\`\`
+        `,
+      },
+    },
+  },
+};
+
 // --- CSS Custom Properties ---
 
 export const CSSCustomProperties: Story = {

--- a/packages/hx-library/src/components/hx-number-input/AUDIT.md
+++ b/packages/hx-library/src/components/hx-number-input/AUDIT.md
@@ -502,10 +502,12 @@ Healthcare contexts often show placeholder hints for expected format (e.g., `pla
 | 27 | Performance | P2 | `Math.random()` IDs — non-deterministic, SSR/snapshot unfriendly |
 | 28 | Performance | P2 | 100ms `setInterval` long-press creates GC pressure at high step counts |
 | 29 | Performance | P2 | Bundle size not verified against 5KB budget |
-| 30 | Drupal | **P0** | `@slot -` documents default slot that doesn't exist — Drupal label content silently lost |
-| 31 | Drupal | P1 | `formResetCallback` doesn't restore to HTML `value` attribute default |
-| 32 | Drupal | P1 | `step="1"` omitted from native input DOM when value is 1 |
+| 30 | Drupal | **P0** | ~~`@slot -` documents default slot that doesn't exist~~ **FIXED** — `@slot -` removed; named `label` slot documented |
+| 31 | Drupal | P1 | ~~`formResetCallback` doesn't restore to HTML `value` attribute default~~ **FIXED** — `_defaultValue` captured in `firstUpdated()` |
+| 32 | Drupal | P1 | ~~`step="1"` omitted from native input DOM when value is 1~~ **FIXED** — `step=${this.step}` always rendered |
 | 33 | Drupal | P2 | No `placeholder` property (parity gap with `hx-text-input`) |
+| 34 | Storybook | P2 | ~~No `label` slot story (Drupal Form API pattern)~~ **FIXED** — `WithLabelSlot` story added |
+| 35 | Storybook | P2 | ~~No composite Drupal slot story~~ **FIXED** — `DrupalFormAPI` story added (all three slots) |
 
 ---
 
@@ -513,4 +515,4 @@ Healthcare contexts often show placeholder hints for expected format (e.g., `pla
 
 1. **Stepper `aria-hidden="true"` (Finding #6)** — Buttons are completely inaccessible to screen reader users. WCAG 2.1 AA violation. Must be fixed before merge.
 
-2. **`@slot -` documents non-existent default slot (Finding #30)** — Drupal consumers following the documentation will silently lose server-rendered label content. Either add the slot or fix the documentation before merge.
+2. ~~**`@slot -` documents non-existent default slot (Finding #30)**~~ **FIXED** — `@slot -` removed from JSDoc; the named `slot="label"` is correctly documented and a `WithLabelSlot` story demonstrates the Drupal Form API pattern.

--- a/packages/hx-library/src/components/hx-prose/AUDIT.md
+++ b/packages/hx-library/src/components/hx-prose/AUDIT.md
@@ -24,7 +24,7 @@ _Baseline counts as of audit date (2026-03-05). Findings marked ✅ FIXED have b
 | ------------ | -------- | --------- |
 | P0 (Blocker) | 2        | 2         |
 | P1 (High)    | 8        | 7         |
-| P2 (Medium)  | 8        | 7         |
+| P2 (Medium)  | 8        | 6         |
 
 ---
 
@@ -202,19 +202,9 @@ The comment block uses `--wc-prose-*` (old namespace) while the actual CSS custo
 
 ---
 
-### P2-03: `align-left + *` / `align-right + *` sets `clear: none` — float not cleared
+### ~~P2-03: `align-left + *` / `align-right + *` sets `clear: none` — float not cleared~~ ✅ FIXED
 
-**File:** `styles/prose/prose.scoped.css`
-**Lines:** ~730–733
-
-```css
-hx-prose .align-left + *,
-hx-prose .align-right + * {
-  clear: none;
-}
-```
-
-This rule explicitly prevents clearing floated content. CKEditor's `.align-left` and `.align-right` classes create floated elements. Setting `clear: none` on the following sibling means subsequent content will wrap around the float — which may be the intended visual behavior. However, if two consecutive floated images appear, or if a heading follows an aligned image, the heading may render adjacent to the floated image rather than below it. This is a layout bug waiting to happen in complex WYSIWYG content. The `clearfix` utility class exists (line ~795) but is opt-in. Most Drupal authors will not add it.
+**Fix:** Changed `clear: none` to `clear: both` in both `styles/prose/_drupal.css` and `styles/prose/prose.scoped.css`. Block-level content (headings, paragraphs) now starts below floated images rather than wrapping beside them. Updated comment explains the behavior and notes consumers can override with `clear: none` if wrap-around is intentional for their layout.
 
 ---
 

--- a/packages/hx-library/src/components/hx-radio-group/AUDIT.md
+++ b/packages/hx-library/src/components/hx-radio-group/AUDIT.md
@@ -206,17 +206,9 @@ After `this.value = newValue`, the Lit reactive system queues an update. `update
 
 ---
 
-### P2-2: `Math.random()` IDs break SSR / Drupal hydration
+### ~~P2-2: `Math.random()` IDs break SSR / Drupal hydration~~ ✅ FIXED
 
-**File:** `hx-radio-group.ts:111–113`
-
-```ts
-private _groupId = `hx-radio-group-${Math.random().toString(36).slice(2, 9)}`;
-```
-
-IDs generated with `Math.random()` differ between server (Drupal/Twig pre-render) and client hydration. `aria-describedby` references will point to IDs that don't exist in the server-rendered DOM.
-
-**Fix:** Use a deterministic ID strategy (e.g., `name` attribute as seed, or a monotonically incrementing counter).
+**Fix applied:** `_groupId` now uses a monotonically incrementing module-level counter (`++_groupCounter`) instead of `Math.random()`. IDs are deterministic within a page session and do not cause `aria-describedby` reference mismatches between Drupal server-rendered markup and client hydration.
 
 ---
 
@@ -312,7 +304,7 @@ it('has no axe violations in default state', async () => {
 | P0-1 | P0       | Accessibility   | Focus ring CSS targets hidden input — never visible            |
 | P0-2 | P0       | Accessibility   | Space key does not select radio (`role="radio"` breach)        |
 | P0-3 | P0       | Form/Validation | Required validity not initialized on first render              |
-| P1-1 | P1       | Behavior        | Re-enabling disabled group leaves radios permanently off       |
+| P1-1 | P1       | Behavior        | ~~Re-enabling disabled group leaves radios permanently off~~ ✅ FIXED — `_individualDisabledStates` map restores per-radio state |
 | P1-2 | P1       | TypeScript      | `formStateRestoreCallback` wrong spec signature                |
 | P1-3 | P1       | TypeScript      | `_groupEl!` non-null assertion violates standards              |
 | P1-4 | P1       | Accessibility   | `_hasErrorSlot` dead code + dangling `aria-describedby`        |
@@ -320,7 +312,7 @@ it('has no axe violations in default state', async () => {
 | P1-6 | P1       | Accessibility   | No `aria-labelledby` — legend naming unreliable in SDOM        |
 | P1-7 | P1       | Accessibility   | Missing `Home`/`End` keyboard support (APG requirement)        |
 | P2-1 | P2       | Performance     | Double `setFormValue`/`_syncRadios`/`_updateValidity`          |
-| P2-2 | P2       | Drupal/SSR      | `Math.random()` IDs break server/client hydration              |
+| P2-2 | P2       | Drupal/SSR      | ~~`Math.random()` IDs break server/client hydration~~ ✅ FIXED — monotonic counter used |
 | P2-3 | P2       | TypeScript/A11y | `role` set imperatively, not in CEM, no static default         |
 | P2-4 | P2       | Accessibility   | `role="alert"` + `aria-live="polite"` conflict                 |
 | P2-5 | P2       | Accessibility   | Disabled focus ring state gap (follow-on to P0-1)              |

--- a/packages/hx-library/src/styles/prose/_drupal.css
+++ b/packages/hx-library/src/styles/prose/_drupal.css
@@ -95,10 +95,12 @@
   display: block;
 }
 
-/* Clearfix after floated elements */
+/* Clear floats after aligned elements so block-level content (headings,
+   paragraphs) starts below floated images rather than wrapping beside them.
+   Consumers who want wrap-around behavior can override with clear: none. */
 .align-left + *,
 .align-right + * {
-  clear: none;
+  clear: both;
 }
 
 /* ─── CKEditor Caption ─── */

--- a/packages/hx-library/src/styles/prose/prose.scoped.css
+++ b/packages/hx-library/src/styles/prose/prose.scoped.css
@@ -747,10 +747,13 @@ hx-prose .align-right img {
   display: block;
 }
 
-/* Float siblings — allow content to wrap around aligned images (intentional).
-   Removed explicit clear:none; the default is already no-clear and setting it
-   explicitly prevented consumers from overriding it when clearfix is needed.
-   Use the .clearfix utility class on the parent container when floats must be cleared. */
+/* Clear floats after aligned elements so block-level content (headings,
+   paragraphs) starts below floated images rather than wrapping beside them.
+   Consumers who want wrap-around behavior can override with clear: none. */
+hx-prose .align-left + *,
+hx-prose .align-right + * {
+  clear: both;
+}
 
 /* CKEditor Caption */
 hx-prose .caption {


### PR DESCRIPTION
## Summary

- Add `DrupalIntegration` Storybook story to `hx-field` with Twig template examples, Drupal Behaviors AJAX validation, and `mytheme.libraries.yml` snippet
- Add `DrupalIntegration` Storybook story to `hx-link` covering internal navigation, external links, downloads, and inline prose patterns
- Fix `clear: none` → `clear: both` in `hx-prose` Drupal CSS to ensure block content starts below floated CKEditor images
- Update AUDIT.md files to mark all resolved drupal findings as FIXED

Fixes #795, #800, #802, #808, #809

## Test plan
- [ ] `npm run verify` passes (lint + format:check + type-check)
- [ ] `hx-field` DrupalIntegration story renders 4 field patterns correctly in Storybook
- [ ] `hx-link` DrupalIntegration story renders 4 link patterns correctly in Storybook
- [ ] `hx-prose` floated images (CKEditor) render below subsequent block content
- [ ] All referenced AUDIT.md drupal findings show FIXED status

🤖 Generated with [Claude Code](https://claude.com/claude-code)