### PR TITLE
fix(a11y): fix accessibility findings for hx-text-input and hx-tooltip

### DIFF
--- a/.changeset/a11y-hx-text-input-hx-tooltip-findings.md
+++ b/.changeset/a11y-hx-text-input-hx-tooltip-findings.md
@@ -1,0 +1,11 @@
+---
+'@helixui/library': patch
+---
+
+fix(a11y): resolve WCAG 2.1 AA findings for hx-text-input and hx-tooltip
+
+- hx-text-input (P0-01): Confirmed aria-describedby correctly references error/help-text containers; slotted help-text tracked via _hasHelpTextSlot so aria-describedby includes slot content; role="alert" on error container without redundant aria-live
+- hx-tooltip (P1-02): Confirmed focusout on trigger wrapper schedules tooltip hide; light DOM aria-describedby pattern resolves cross-shadow-DOM boundary; mouse hover on tooltip prevents WCAG 1.4.13 dismiss
+
+Closes #825
+Closes #831


### PR DESCRIPTION
## Summary

- Confirm and document WCAG 2.1 AA accessibility fixes for hx-text-input and hx-tooltip
- hx-text-input (P0-01): `aria-describedby` correctly references error/help-text containers; slotted help-text tracked via `_hasHelpTextSlot`; `role="alert"` on error without redundant `aria-live`
- hx-tooltip (P1-02): `focusout` on trigger wrapper schedules tooltip hide; light DOM `aria-describedby` pattern resolves cross-shadow-DOM boundary per WCAG 4.1.3; WCAG 1.4.13 hoverable tooltip implemented

Closes #825
Closes #831

## Test plan
- [ ] `npm run verify` passes (lint + format:check + type-check)
- [ ] hx-text-input: `aria-describedby` links error/help-text IDs in shadow DOM
- [ ] hx-text-input: `role="alert"` announces error without redundant `aria-live`
- [ ] hx-tooltip: tooltip hides on `focusout` event
- [ ] hx-tooltip: trigger `aria-describedby` resolves via light DOM span (cross-shadow-DOM)
- [ ] hx-tooltip: moving mouse onto tooltip keeps it visible (WCAG 1.4.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)