### PR TITLE
fix(css): overflow-wrap and clip-path fixes for hx-tooltip and hx-visually-hidden

### DIFF
--- a/packages/hx-library/src/components/hx-tooltip/AUDIT.md
+++ b/packages/hx-library/src/components/hx-tooltip/AUDIT.md
@@ -77,6 +77,8 @@ All 13 findings from the T1-22 antagonistic quality review have been resolved. T
 
 ### P2-4: RESOLVED — `overflow-wrap: break-word` (standard property)
 
+**Fix:** Replaced `word-wrap: break-word` vendor alias with the standard `overflow-wrap: break-word` property in `hx-tooltip.styles.ts`. Tracked in GH #831.
+
 ### P2-5: RESOLVED — SSR-safe IDs via `crypto.randomUUID()`
 
 ### P2-6: RESOLVED — Twig usage example in JSDoc

--- a/packages/hx-library/src/components/hx-visually-hidden/AUDIT.md
+++ b/packages/hx-library/src/components/hx-visually-hidden/AUDIT.md
@@ -23,9 +23,9 @@
 - Added 4 tests for focusable behavior (default, reflection, removal, keyboard accessibility)
 - Added `SkipLink` story demonstrating the focusable variant
 
-### P1 — Deprecated `clip` without modern `clip-path` (F-05)
+### P1 — Deprecated `clip` without modern `clip-path` (F-05) — GH #833
 
-- Added `clip-path: inset(50%) !important` alongside existing `clip: rect(0, 0, 0, 0)`
+- Added `clip-path: inset(50%) !important` alongside existing `clip: rect(0, 0, 0, 0)` for modern browser support
 
 ### P1 — No guard against display:none / visibility:hidden (F-06)
 


### PR DESCRIPTION
## Summary

- **hx-tooltip**: Uses standard `overflow-wrap: break-word` property (replaces vendor alias `word-wrap`) — closes #831
- **hx-visually-hidden**: Adds modern `clip-path: inset(50%) !important` alongside deprecated `clip: rect(0,0,0,0)` — closes #833

Both CSS fixes were implemented as part of the deep audit resolutions. This PR documents and closes the tracking issues.

## Files Changed

- `packages/hx-library/src/components/hx-tooltip/AUDIT.md` — add GH #831 reference to P2-04 resolution
- `packages/hx-library/src/components/hx-visually-hidden/AUDIT.md` — add GH #833 reference to P1-01 resolution

## Verification

- `npm run verify` passes (lint + format:check + type-check — 0 errors)
- CSS fixes confirmed in source files:
  - `hx-tooltip.styles.ts` line 32: `overflow-wrap: break-word`
  - `hx-visually-hidden.styles.ts` lines 11–12: `clip` + `clip-path` both present
- No component source (.ts) files modified — SKIP_CHANGESET applied (docs-only change)

Closes #831
Closes #833

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping behavior in the tooltip component with updated CSS standards support.

* **Documentation**
  * Enhanced documentation to clarify browser support details for accessibility components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->