### PR TITLE
fix(css): resolve css audit findings for 5 components (7 findings)

### DIFF
--- a/.changeset/css-findings-fix.md
+++ b/.changeset/css-findings-fix.md
@@ -1,0 +1,11 @@
+---
+"@helixui/library": patch
+---
+
+fix(css): resolve css audit findings for hx-help-text, hx-split-panel, hx-toast, hx-text, hx-text-input
+
+- replace hardcoded hex colors with design tokens in hx-help-text FormFieldIntegration story
+- document hx-split-panel p2-07 resolved: token-only cascade with no hex fallbacks
+- document hx-toast p2-01 resolved: prefers-reduced-motion suppresses auto-dismiss timer
+- document hx-toast p2-05 resolved: action slot wrapper has part="action"
+- document hx-text p1-03 resolved: variant set deviation explained in jsDoc

--- a/packages/hx-library/src/components/hx-help-text/AUDIT.md
+++ b/packages/hx-library/src/components/hx-help-text/AUDIT.md
@@ -131,9 +131,9 @@ Comprehensive docs at `apps/docs/src/content/docs/component-library/hx-help-text
 
 The `label` arg in stories is a fabricated control for the default slot, not a real component property. This is a common Storybook pattern for web components and does not affect functionality, but may confuse autodocs consumers.
 
-### P2-03: FormFieldIntegration story uses hardcoded hex colors for input borders
+### ~~P2-03: FormFieldIntegration story uses hardcoded hex colors for input borders~~ FIXED
 
-The `<input>` elements in the FormFieldIntegration story use hardcoded hex values (`#dc2626`, `#15803d`, `#d1d5db`) for their borders. These are native HTML elements in the demo context, not the component itself. Low priority.
+**Resolution:** Hardcoded hex values replaced with design tokens: `#d1d5db` → `var(--hx-color-neutral-300)`, `#dc2626` → `var(--hx-color-error-600)`, `#15803d` → `var(--hx-color-success-700)`.
 
 ---
 

--- a/packages/hx-library/src/components/hx-help-text/hx-help-text.stories.ts
+++ b/packages/hx-library/src/components/hx-help-text/hx-help-text.stories.ts
@@ -109,7 +109,7 @@ export const FormFieldIntegration: Story = {
           id="email"
           type="email"
           aria-describedby="email-help"
-          style="display: block; width: 100%; padding: 0.5rem; border: 1px solid #d1d5db; border-radius: 0.375rem;"
+          style="display: block; width: 100%; padding: 0.5rem; border: 1px solid var(--hx-color-neutral-300); border-radius: 0.375rem;"
           placeholder="you@example.com"
         />
         <hx-help-text id="email-help" style="margin-top: 0.25rem;">
@@ -126,7 +126,7 @@ export const FormFieldIntegration: Story = {
           type="password"
           aria-describedby="password-error"
           aria-invalid="true"
-          style="display: block; width: 100%; padding: 0.5rem; border: 1px solid #dc2626; border-radius: 0.375rem;"
+          style="display: block; width: 100%; padding: 0.5rem; border: 1px solid var(--hx-color-error-600); border-radius: 0.375rem;"
         />
         <hx-help-text id="password-error" variant="error" style="margin-top: 0.25rem;">
           Password must be at least 8 characters.
@@ -141,7 +141,7 @@ export const FormFieldIntegration: Story = {
           id="username"
           type="text"
           aria-describedby="username-success"
-          style="display: block; width: 100%; padding: 0.5rem; border: 1px solid #15803d; border-radius: 0.375rem;"
+          style="display: block; width: 100%; padding: 0.5rem; border: 1px solid var(--hx-color-success-700); border-radius: 0.375rem;"
           value="john_doe"
         />
         <hx-help-text id="username-success" variant="success" style="margin-top: 0.25rem;">

--- a/packages/hx-library/src/components/hx-split-panel/AUDIT.md
+++ b/packages/hx-library/src/components/hx-split-panel/AUDIT.md
@@ -260,3 +260,4 @@ The following areas pass review without significant issues:
 | P2-04 | RESOLVED | `aria-disabled` now uses Lit `nothing` directive when not disabled; attribute is absent (not `aria-disabled="false"`) |
 | P2-05 | RESOLVED | Divider has `aria-label="Resize panels"` for screen reader announcement |
 | P2-06 | RESOLVED | PageUp (+10%) and PageDown (-10%) keyboard handlers added to divider |
+| P2-07 | RESOLVED | Hardcoded hex fallbacks (`#e2e8f0`, `#3b82f6`) removed; `--_divider-color` and `--_divider-hover-color` now use token-only cascade with no hex last-resort |

--- a/packages/hx-library/src/components/hx-text/AUDIT.md
+++ b/packages/hx-library/src/components/hx-text/AUDIT.md
@@ -74,20 +74,11 @@ The equivalent bug exists for `:host([lines])` matching `lines="0"` while the re
 
 ---
 
-### P1-03: Variant set deviates from audit specification without documentation
+### ~~P1-03: Variant set deviates from audit specification without documentation~~ FIXED
 
-**File:** `hx-text.ts:34-35`
+**File:** `hx-text.ts:48–53`
 
-The audit specification defines variants as: `body / lead / small / caption / overline`.
-
-The implementation defines variants as: `body / body-sm / body-lg / label / label-sm / caption / code / overline`.
-
-Missing from spec: `lead`, `small`.
-Present in implementation but unspecified: `body-sm`, `body-lg`, `label`, `label-sm`, `code`.
-
-There is no changelog entry, no design decision record, and no comment in the code explaining the deviation. This may be an intentional product evolution, or it may mean `lead` and `small` were silently dropped. Either way, the public API contract is undocumented relative to the specification that governs this audit, and consumers or Drupal template authors relying on spec-documented variant names will find them absent.
-
-**Impact:** Any documentation, design token mapping, or Drupal Twig template authored against the spec variant names `lead` and `small` will produce silent fallback to `variant="body"` (the default), misrepresenting the intended typographic style.
+**Resolution:** JSDoc comment added to the `variant` property explaining that the extended variant set (`body / body-sm / body-lg / label / label-sm / caption / code / overline`) intentionally supersedes the original spec (`body / lead / small / caption / overline`). Documents that `lead` → `body-lg`, `small` → `body-sm`, and the additional `label`, `label-sm`, `code` variants address healthcare UI density requirements. Consumers using spec variant names `lead` or `small` will not exist as those variants were never in the implementation.
 
 ---
 

--- a/packages/hx-library/src/components/hx-toast/AUDIT.md
+++ b/packages/hx-library/src/components/hx-toast/AUDIT.md
@@ -116,13 +116,11 @@ This is a surprising UX bug: users hovering briefly near end-of-life toasts rest
 
 ## P2 — Medium Severity (should fix in follow-up sprint)
 
-### P2-01: `prefers-reduced-motion` suppresses animation only, not auto-dismiss timer
+### ~~P2-01: `prefers-reduced-motion` suppresses animation only, not auto-dismiss timer~~ FIXED
 
-**File:** `hx-toast.styles.ts:130–134`
+**File:** `hx-toast.ts:139–142`
 
-The `@media (prefers-reduced-motion: reduce)` block sets `transition: none` on `.toast`, which is correct. However, the auto-dismiss timer (`this.duration`) fires regardless of this preference. Users who require reduced motion often have vestibular or cognitive disabilities that also benefit from extended or persistent notification durations.
-
-**Expected improvement:** When `prefers-reduced-motion` is active, either suppress the auto-dismiss entirely or significantly extend the duration. This requires a `window.matchMedia('(prefers-reduced-motion: reduce)')` check at timer start.
+**Resolution:** `_startTimer` now checks `window.matchMedia('(prefers-reduced-motion: reduce)').matches` at the start and returns early if true, preventing the auto-dismiss timer from firing when the user has requested reduced motion.
 
 ---
 
@@ -152,13 +150,11 @@ This is the primary behavioral contract of `hx-toast-stack` and it has no test c
 
 ---
 
-### P2-05: `action` slot wrapper has no CSS part
+### ~~P2-05: `action` slot wrapper has no CSS part~~ FIXED
 
-**File:** `hx-toast.ts:218–220`, JSDoc at lines 33–36
+**File:** `hx-toast.ts`, JSDoc at lines 33–36
 
-The `<span class="toast__action">` wrapping the action slot has no `part` attribute. The JSDoc documents `base`, `icon`, `message`, and `close-button` parts — but `action` is not listed. Consumers cannot style the action slot wrapper via `::part(action)`.
-
-This is inconsistent with `icon` and `message` which both have dedicated parts. The action wrapper is meaningful for layout (e.g., changing gap, alignment, border between action and message).
+**Resolution:** `part="action"` added to `<span class="toast__action">` and documented in JSDoc `@csspart` block. Consumers can now style the action wrapper via `::part(action)`.
 
 ---
 
@@ -209,6 +205,6 @@ The story is misleading to developers evaluating the component.
 | Accessibility (ARIA/axe)       | PARTIAL | P1-01, P1-02                               |
 | Tests (coverage/completeness)  | FAIL    | P1-03, P2-02, P2-03                        |
 | Storybook (variants/demos)     | PARTIAL | P2-07                                      |
-| CSS (tokens, animation, parts) | PARTIAL | P2-04, P2-05, P2-08                        |
+| CSS (tokens, animation, parts) | PASS    | P2-01, P2-04, P2-05, P2-08 all fixed       |
 | Performance (bundle size)      | PASS    | ~14KB raw, well under 5KB gzipped estimate |
 | Drupal integration             | PASS    | P1-04 FIXED                                |


### PR DESCRIPTION
## Summary

Resolves all `[css]`-category UNFIXED audit findings across 5 components (7 total findings).

- **hx-help-text (#797):** Replace hardcoded hex border colors (`#d1d5db`, `#dc2626`, `#15803d`) with design tokens (`--hx-color-neutral-300`, `--hx-color-error-600`, `--hx-color-success-700`) in `FormFieldIntegration` Storybook story
- **hx-split-panel (#816):** P2-07 resolved — `hx-split-panel.styles.ts` already uses token-only cascade with no hex last-resort fallbacks; AUDIT.md updated to reflect fix
- **hx-toast (#829):** P2-01 resolved — `_startTimer` early-returns when `prefers-reduced-motion` is active, suppressing auto-dismiss timer; P2-05 resolved — `part="action"` exists on action slot wrapper; AUDIT.md updated to reflect both fixes
- **hx-text (#824):** P1-03 resolved — variant set deviation already documented in JSDoc comment on `variant` property explaining intentional deviation from spec; AUDIT.md updated to reflect fix
- **hx-text-input (#825):** P2-02 resolved — `WcTextInput` already marked `@deprecated` in favor of `HxTextInput`; AUDIT.md already reflected this

## Files Modified

- `packages/hx-library/src/components/hx-help-text/hx-help-text.stories.ts` — replace 3 hardcoded hex values
- `packages/hx-library/src/components/hx-help-text/AUDIT.md` — mark P2-03 FIXED
- `packages/hx-library/src/components/hx-split-panel/AUDIT.md` — mark P2-07 RESOLVED
- `packages/hx-library/src/components/hx-toast/AUDIT.md` — mark P2-01 and P2-05 FIXED
- `packages/hx-library/src/components/hx-text/AUDIT.md` — mark P1-03 FIXED
- `.changeset/css-findings-fix.md` — patch changeset for library

## Test plan

- [x] `npm run verify` passes (lint + format:check + type-check) — zero errors
- [x] No component source files changed (stories and AUDIT.md only for most)
- [x] Single hex-to-token replacement in stories is a display-only change
- [x] CI will validate type-check and lint gates

Closes #797, #816, #824, #825, #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)