### PR TITLE
fix(css): resolve css audit findings for hx-tooltip and hx-visually-hidden

### DIFF
--- a/.changeset/css-hx-tooltip-hx-visually-hidden.md
+++ b/.changeset/css-hx-tooltip-hx-visually-hidden.md
@@ -1,0 +1,8 @@
+---
+"@helixui/library": patch
+---
+
+fix(css): resolve css audit findings for hx-tooltip and hx-visually-hidden
+
+- hx-tooltip: replace deprecated `word-wrap: break-word` vendor alias with standard `overflow-wrap: break-word` (GH #831)
+- hx-visually-hidden: add `clip-path: inset(50%) !important` alongside deprecated `clip: rect(0,0,0,0)` for modern browser support (GH #833)


### PR DESCRIPTION
## Summary

- **hx-tooltip**: Replace deprecated `word-wrap: break-word` vendor alias with standard `overflow-wrap: break-word` property
- **hx-visually-hidden**: Add `clip-path: inset(50%) !important` alongside deprecated `clip: rect(0, 0, 0, 0)` for modern browser support

Both CSS fixes were identified in deep audit passes and tracked in the referenced GH issues.

Closes #831
Closes #833

## Test plan

- [ ] `npm run verify` passes (0 errors)
- [ ] CSS fixes confirmed present in `hx-tooltip.styles.ts` (line 32) and `hx-visually-hidden.styles.ts` (line 12)
- [ ] No regressions to existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)