### PR TITLE
chore: promote staging to main

### DIFF
--- a/.changeset/drupal-hx-field-hx-link-hx-number-input.md
+++ b/.changeset/drupal-hx-field-hx-link-hx-number-input.md
@@ -1,5 +1,5 @@
 ---
-"@helixui/library": patch
+'@helixui/library': patch
 ---
 
 fix(drupal): fix Drupal integration findings for hx-field, hx-link, hx-number-input, hx-prose, and hx-radio-group
@@ -8,6 +8,6 @@ Closes #795, #800, #802, #808, #809
 
 - hx-field: add DrupalIntegration Storybook story with Twig template, Behaviors, and asset loading examples (P2-15)
 - hx-link: add DrupalIntegration Storybook story with Twig template and Behaviors patterns (P2-8)
-- hx-number-input: WithLabelSlot and DrupalFormAPI stories already present; confirmed @slot JSDoc fixed, formResetCallback restores _defaultValue, step attribute always rendered (P0-02, P1-15, P1-16, P2-08, P2-09)
-- hx-prose: fix clear: none → clear: both in _drupal.css and prose.scoped.css so block-level content starts below floated images rather than wrapping beside them (P2-03); deprecated align attribute selectors documented as Drupal CKEditor compatibility shims (P2-05)
-- hx-radio-group: confirmed monotonic counter replaces Math.random() for IDs (P2-2); confirmed _individualDisabledStates map restores per-radio disabled state on group re-enable (P1-1)
+- hx-number-input: WithLabelSlot and DrupalFormAPI stories already present; confirmed @slot JSDoc fixed, formResetCallback restores \_defaultValue, step attribute always rendered (P0-02, P1-15, P1-16, P2-08, P2-09)
+- hx-prose: fix clear: none → clear: both in \_drupal.css and prose.scoped.css so block-level content starts below floated images rather than wrapping beside them (P2-03); deprecated align attribute selectors documented as Drupal CKEditor compatibility shims (P2-05)
+- hx-radio-group: confirmed monotonic counter replaces Math.random() for IDs (P2-2); confirmed \_individualDisabledStates map restores per-radio disabled state on group re-enable (P1-1)

--- a/.changeset/every-tools-speak.md
+++ b/.changeset/every-tools-speak.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+fix(typescript): use `PropertyValues` from lit in `updated()` overrides for `hx-status-indicator` and `hx-tabs`, replacing raw `Map<string | symbol, unknown>` per strict mode constraint

--- a/.changeset/fix-storybook-hx-tree-view-hx-pagination.md
+++ b/.changeset/fix-storybook-hx-tree-view-hx-pagination.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(storybook): fix story findings for hx-tree-view, hx-alert, and hx-button

--- a/.changeset/perf-hx-meter-hx-overflow-menu-hx-radio-group.md
+++ b/.changeset/perf-hx-meter-hx-overflow-menu-hx-radio-group.md
@@ -1,9 +1,9 @@
 ---
-"@helixui/library": patch
+'@helixui/library': patch
 ---
 
 perf: resolve performance audit findings for hx-meter, hx-overflow-menu, and hx-radio-group
 
 - hx-meter: confirmed bundle within 5KB budget — all runtime deps externalized (lit, @helixui/tokens); CI shared gate covers per-component size
 - hx-overflow-menu: @floating-ui/dom correctly externalized as peerDependency and excluded from rollup output — no longer bundled into component chunk
-- hx-radio-group: eliminated redundant double invocation of setFormValue/syncRadios/updateValidity per radio selection — _handleRadioSelect now delegates exclusively to updated() lifecycle hook, halving work per interaction
+- hx-radio-group: eliminated redundant double invocation of setFormValue/syncRadios/updateValidity per radio selection — \_handleRadioSelect now delegates exclusively to updated() lifecycle hook, halving work per interaction

--- a/.changeset/storybook-audit-progress-prose-select-skeleton-stack.md
+++ b/.changeset/storybook-audit-progress-prose-select-skeleton-stack.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(storybook): resolve audit findings for hx-progress-bar, hx-prose, hx-select, hx-skeleton, and hx-stack stories

--- a/.changeset/storybook-hx-checkbox-findings.md
+++ b/.changeset/storybook-hx-checkbox-findings.md
@@ -1,5 +1,13 @@
 ---
-"@helixui/library": patch
+'@helixui/library': patch
 ---
 
-Fix Storybook story findings for hx-checkbox and related components. Adds play function to NoLabel story for runtime aria-label assertion, and replaces CSS class-based DOM queries in SelectAll patterns with tag-name queries to eliminate the DOM anti-pattern.
+fix(storybook): fix Storybook story findings for hx-checkbox, hx-checkbox-group, hx-field, hx-popover, and hx-radio-group (fixes #789, #790, #795, #805, #809)
+
+- hx-checkbox (P2-11): NoLabel story play function asserts aria-label forwarded to native input at runtime
+- hx-checkbox (P2-15): SelectAllPattern story uses ID-based DOM query instead of fragile CSS class query
+- hx-checkbox-group (P3-01): Relative imports accepted by design — consistent with all other HELiX stories in source-mode Storybook
+- hx-field (P2-09): WrappingTextarea story added demonstrating textarea as slotted control
+- hx-field (P2-13): SlottedLabel story demonstrates for/id linkage between slotted label and slotted input
+- hx-popover (P2-04): Placements story now renders all 12 placement variants (was 4 cardinal only)
+- hx-radio-group (P2-07): SingleDisabledOption story demonstrates mixed-disabled state (one radio disabled in an enabled group)

--- a/.changeset/tests-hx-badge-hx-breadcrumb-hx-copy.md
+++ b/.changeset/tests-hx-badge-hx-breadcrumb-hx-copy.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+test(hx-library): fix test coverage gaps for hx-badge, hx-breadcrumb, hx-copy-button

--- a/.changeset/typescript-hx-progress-bar-hx-prose-fixes.md
+++ b/.changeset/typescript-hx-progress-bar-hx-prose-fixes.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+Fix TypeScript type safety findings for hx-progress-bar, hx-prose, hx-select, hx-side-nav, and hx-skeleton. Adds indeterminate boolean property to hx-progress-bar, corrects WcProse type import in hx-prose tests, adds full formStateRestoreCallback signature and size runtime guard to hx-select, removes dead \_bodyEl query and renames WcSideNav/WcNavItem type aliases to HxSideNav/HxNavItem in hx-side-nav, and adds paragraph variant plus unknown variant test to hx-skeleton.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,6 +285,7 @@ npm run verify   # runs: lint + format:check + type-check
 Do NOT push if `npm run verify` fails. Fix the issue first, then re-run.
 
 Auto-fix helpers:
+
 ```bash
 npx eslint --fix .    # auto-fix lint errors
 npm run format        # auto-fix formatting

--- a/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, within } from 'storybook/test';
 import './hx-alert.js';
 
 // ─────────────────────────────────────────────────
@@ -57,6 +57,26 @@ const meta = {
         type: { summary: 'string (slot)' },
       },
     },
+    accent: {
+      control: 'boolean',
+      description:
+        'When true, applies a left border accent stripe instead of a full border. Common in enterprise healthcare dashboards for visual distinction.',
+      table: {
+        category: 'Visual',
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' },
+      },
+    },
+    'return-focus-to': {
+      control: 'text',
+      description:
+        'CSS selector for the element to return focus to after the alert is dismissed. Critical accessibility pattern to prevent focus loss after dismissal.',
+      table: {
+        category: 'Accessibility',
+        defaultValue: { summary: 'null' },
+        type: { summary: 'string | null' },
+      },
+    },
   },
   args: {
     variant: 'info',
@@ -92,7 +112,6 @@ export const Default: Story = {
     message: 'Your session will expire in 15 minutes. Please save your work.',
   },
   play: async ({ canvasElement }) => {
-    const _canvas = within(canvasElement);
     const alert = canvasElement.querySelector('hx-alert');
 
     await expect(alert).toBeTruthy();
@@ -1124,6 +1143,213 @@ export const DrugAllergyWarning: Story = {
   },
 };
 
+// ─────────────────────────────────────────────────
+// ACCENT VARIANT (P2-04)
+// ─────────────────────────────────────────────────
+
+/**
+ * The `accent` property applies a left border stripe instead of a full border.
+ * Common in enterprise healthcare dashboards where inline alerts must visually
+ * differentiate from bordered card containers. Use when a softer visual weight
+ * is needed without losing the semantic color coding of the alert.
+ */
+export const AccentVariant: Story = {
+  name: 'Accent (Left Border Stripe)',
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: var(--hx-space-4, 1rem); max-width: 40rem;"
+    >
+      <hx-alert variant="info" accent>
+        <strong>Session activity:</strong> Your patient chart session will expire in 10 minutes.
+        Save any unsaved progress before the session ends.
+      </hx-alert>
+      <hx-alert variant="success" accent>
+        <strong>Prior authorization approved:</strong> PA #2026-04891 for Adalimumab 40mg/0.4ml has
+        been approved by the patient's insurer. Valid through 2026-09-30.
+      </hx-alert>
+      <hx-alert variant="warning" accent>
+        <strong>Allergy on file:</strong> Patient has a documented allergy to Penicillin
+        (anaphylaxis). Review all antibiotic orders before administration.
+      </hx-alert>
+      <hx-alert variant="error" accent>
+        <strong>Critical lab value:</strong> Potassium 6.4 mEq/L (reference: 3.5–5.0). Immediate
+        physician review required.
+      </hx-alert>
+    </div>
+  `,
+  play: async ({ canvasElement }) => {
+    const alerts = canvasElement.querySelectorAll('hx-alert');
+    await expect(alerts.length).toBe(4);
+
+    for (const alert of Array.from(alerts)) {
+      await expect(alert.accent).toBe(true);
+      // Accent variant still carries semantic role on the host
+      const role = alert.getAttribute('role');
+      await expect(['status', 'alert']).toContain(role);
+    }
+  },
+};
+
+// ─────────────────────────────────────────────────
+// WITH TITLE SLOT (P2-04)
+// ─────────────────────────────────────────────────
+
+/**
+ * The `title` slot adds a structured headline above the alert message body.
+ * Use for alerts that require a distinct heading to orient the user before
+ * presenting action details — common in clinical workflow notifications where
+ * the title conveys urgency and the body provides instructional content.
+ */
+export const WithTitle: Story = {
+  name: 'With Title Slot',
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: var(--hx-space-4, 1rem); max-width: 40rem;"
+    >
+      <hx-alert variant="error" dismissible>
+        <strong slot="title">Drug Interaction — High Risk</strong>
+        Concurrent use of Warfarin and Amoxicillin may potentiate the anticoagulant effect. Monitor
+        INR closely and consider dose adjustment. Consult pharmacy before prescribing.
+      </hx-alert>
+
+      <hx-alert variant="warning" dismissible>
+        <strong slot="title">Isolation Precautions Required</strong>
+        Patient is in Contact Isolation (MRSA). Gown and gloves required for all direct contact.
+        Dedicated equipment must remain in room.
+      </hx-alert>
+
+      <hx-alert variant="success">
+        <strong slot="title">Authorization Approved</strong>
+        Prior authorization #PA-2026-09281 for Adalimumab 40mg injection has been approved. Valid
+        for 12 months from today's date.
+      </hx-alert>
+
+      <hx-alert variant="info">
+        <strong slot="title">Scheduled Downtime Notice</strong>
+        The EHR system will be unavailable on Saturday March 15 from 02:00–04:00 AM for routine
+        maintenance. Plan patient documentation accordingly.
+      </hx-alert>
+    </div>
+  `,
+  play: async ({ canvasElement }) => {
+    const alerts = canvasElement.querySelectorAll('hx-alert');
+    await expect(alerts.length).toBe(4);
+
+    // Verify all alerts have slotted title content
+    for (const alert of Array.from(alerts)) {
+      const titleSlot = alert.querySelector('[slot="title"]');
+      await expect(titleSlot).toBeTruthy();
+    }
+
+    // Error alert with title must still use role="alert"
+    await expect(alerts[0].getAttribute('role')).toBe('alert');
+    // Info alert with title must use role="status"
+    await expect(alerts[3].getAttribute('role')).toBe('status');
+  },
+};
+
+// ─────────────────────────────────────────────────
+// FOCUS RETURN PATTERN (P2-04)
+// ─────────────────────────────────────────────────
+
+/**
+ * The `return-focus-to` property accepts a CSS selector. After the alert is
+ * dismissed, focus is programmatically returned to the matching element.
+ * This is a critical accessibility pattern — without it, focus is lost to the
+ * `<body>` when a dismissible alert is removed from the tab order.
+ *
+ * Use this for dismissible alerts that appear in response to user actions
+ * so focus returns to the triggering element (e.g., the button that opened
+ * the notification, or the form field that caused a validation error).
+ */
+export const FocusReturn: Story = {
+  name: 'Focus Return After Dismiss',
+  render: () => html`
+    <div
+      style="display: flex; flex-direction: column; gap: var(--hx-space-4, 1rem); max-width: 40rem;"
+    >
+      <p
+        style="font-size: var(--hx-font-size-sm, 0.875rem); color: var(--hx-color-text-secondary); margin: 0;"
+      >
+        Click "Submit Order" to show a dismissible confirmation alert. When dismissed, focus returns
+        to the submit button via <code>return-focus-to="#submit-order-btn"</code>.
+      </p>
+
+      <div style="display: flex; gap: var(--hx-space-3, 0.75rem); align-items: center;">
+        <button
+          id="submit-order-btn"
+          style="
+            padding: var(--hx-space-2, 0.5rem) var(--hx-space-4, 1rem);
+            background: var(--hx-color-primary-500, #2563eb);
+            color: var(--hx-color-text-on-primary, white);
+            border: none;
+            border-radius: var(--hx-border-radius-md, 0.375rem);
+            cursor: pointer;
+            font-size: var(--hx-font-size-sm, 0.875rem);
+          "
+          onclick="document.getElementById('focus-return-alert').open = true;"
+        >
+          Submit Order
+        </button>
+        <button
+          style="
+            padding: var(--hx-space-2, 0.5rem) var(--hx-space-4, 1rem);
+            background: var(--hx-color-surface-default, white);
+            color: var(--hx-color-text-primary);
+            border: var(--hx-border-width-thin, 1px) solid var(--hx-color-border-default);
+            border-radius: var(--hx-border-radius-md, 0.375rem);
+            cursor: pointer;
+            font-size: var(--hx-font-size-sm, 0.875rem);
+          "
+        >
+          Cancel
+        </button>
+      </div>
+
+      <hx-alert
+        id="focus-return-alert"
+        variant="success"
+        dismissible
+        return-focus-to="#submit-order-btn"
+        ?open=${false}
+      >
+        <strong slot="title">Order Submitted</strong>
+        Medication order #RX-2026-04928 has been submitted to the pharmacy. Expected processing time
+        is 30 minutes. Dismiss to return focus to the order form.
+      </hx-alert>
+
+      <p
+        style="font-size: var(--hx-font-size-xs, 0.75rem); color: var(--hx-color-text-muted); margin: 0;"
+      >
+        After dismissing the alert, verify focus returns to the "Submit Order" button. This pattern
+        ensures keyboard and AT users are never stranded after a dynamic UI change.
+      </p>
+    </div>
+  `,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const alert = canvasElement.querySelector('#focus-return-alert') as HTMLElement & {
+      open: boolean;
+    };
+    await expect(alert).toBeTruthy();
+
+    // Open the alert programmatically to make the dismiss button accessible
+    alert.open = true;
+    await alert.updateComplete;
+
+    // Locate the dismiss button inside the shadow DOM
+    const closeButton = alert.shadowRoot?.querySelector('[part="close-button"]') as HTMLElement;
+    await expect(closeButton).toBeTruthy();
+
+    // Click the dismiss button and await the transition
+    await userEvent.click(closeButton);
+
+    // After dismissal, focus must return to the submit button
+    const submitBtn = canvas.getByText('Submit Order') as HTMLElement;
+    await expect(document.activeElement).toBe(submitBtn);
+  },
+};
+
 /** Multiple severity alerts stacked in a patient chart context, ordered by clinical priority. */
 export const PatientSafetyStack: Story = {
   render: () => html`
@@ -1220,9 +1446,9 @@ export const PatientSafetyStack: Story = {
     await expect(closeBtn).toBeNull();
 
     // Error alerts must use role="alert" for immediate announcement
+    // Role is on the host element, not the shadow DOM internal div
     for (let i = 0; i < 2; i++) {
-      const container = alerts[i].shadowRoot?.querySelector('[part="alert"]');
-      await expect(container?.getAttribute('role')).toBe('alert');
+      await expect(alerts[i].getAttribute('role')).toBe('alert');
     }
   },
 };

--- a/packages/hx-library/src/components/hx-badge/hx-badge.test.ts
+++ b/packages/hx-library/src/components/hx-badge/hx-badge.test.ts
@@ -500,4 +500,51 @@ describe('hx-badge', () => {
       expect(cssText).toContain('prefers-reduced-motion');
     });
   });
+
+  // ─── Slots: count + prefix combination (1) ─── [P3-01]
+
+  describe('Slots: count + prefix combination', () => {
+    it('renders prefix slot content alongside count display', async () => {
+      // P3-01: icon + count is a valid API combination. The prefix slot must be
+      // rendered even when count replaces the default slot content.
+      const el = await fixture<WcBadge>(
+        '<hx-badge count="5"><span slot="prefix" class="star">★</span></hx-badge>',
+      );
+      await el.updateComplete;
+      // The prefix slot content must be present in the light DOM
+      const icon = el.querySelector('span.star');
+      expect(icon).toBeTruthy();
+      expect(icon?.textContent).toBe('★');
+      // The prefix slot element must be present in shadow DOM (slot[name="prefix"] always rendered)
+      const prefixSlot = shadowQuery(el, 'slot[name="prefix"]');
+      expect(prefixSlot).toBeTruthy();
+      // The count must be reflected in the component's count property
+      expect(el.count).toBe(5);
+    });
+  });
+
+  // ─── Dynamic count updates (1) ─── [P3-02]
+
+  describe('Dynamic count updates', () => {
+    it('DOM reflects updated count value when count property changes dynamically', async () => {
+      // P3-02: verifying the DOM contract for the aria-live="polite" region.
+      // When count changes, the badge span (which carries aria-live="polite") must
+      // update its text content so screen readers can announce the new value.
+      const el = await fixture<WcBadge>('<hx-badge count="3"></hx-badge>');
+      await el.updateComplete;
+      const badge = shadowQuery(el, 'span')!;
+
+      // Initial state
+      expect(badge.textContent?.trim()).toBe('3');
+      expect(badge.getAttribute('aria-live')).toBe('polite');
+
+      // Dynamically update the count
+      el.count = 7;
+      await el.updateComplete;
+
+      // The aria-live region must reflect the new count so AT can announce it
+      expect(badge.textContent?.trim()).toBe('7');
+      expect(badge.getAttribute('aria-live')).toBe('polite');
+    });
+  });
 });

--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.test.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.test.ts
@@ -443,6 +443,93 @@ describe('hx-breadcrumb', () => {
       );
       expect(items.every((i) => !i.hasAttribute('data-bc-hidden'))).toBe(true);
     });
+
+    it('clicking the ellipsis button directly expands all items (BC-A02)', async () => {
+      // BC-A02: tests the actual _handleEllipsisClick event handler path via a
+      // real click event on the button element, not a programmatic maxItems=0 assignment.
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb max-items="2">
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/c">C</hx-breadcrumb-item>
+          <hx-breadcrumb-item>D</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const ellipsis = el.querySelector('.hx-bc-ellipsis');
+      expect(ellipsis).toBeTruthy();
+      const btn = ellipsis?.querySelector('button') as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+
+      // Dispatch a real click event on the ellipsis button
+      btn.click();
+      await el.updateComplete;
+
+      // The _handleEllipsisClick → _expandBreadcrumb → maxItems=0 path must have fired
+      expect(el.querySelector('.hx-bc-ellipsis')).toBeNull();
+      const items = Array.from(
+        el.querySelectorAll<HTMLElement>('hx-breadcrumb-item:not(.hx-bc-ellipsis)'),
+      );
+      expect(items.every((i) => !i.hasAttribute('data-bc-hidden'))).toBe(true);
+    });
+
+    it('Enter key on ellipsis button expands all items (BC-A02)', async () => {
+      // BC-A02: tests the _handleEllipsisKeydown path for Enter.
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb max-items="2">
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/c">C</hx-breadcrumb-item>
+          <hx-breadcrumb-item>D</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const ellipsis = el.querySelector('.hx-bc-ellipsis');
+      expect(ellipsis).toBeTruthy();
+      const btn = ellipsis?.querySelector('button') as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+
+      // Dispatch a real keydown Enter event on the ellipsis button
+      btn.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+
+      expect(el.querySelector('.hx-bc-ellipsis')).toBeNull();
+      const items = Array.from(
+        el.querySelectorAll<HTMLElement>('hx-breadcrumb-item:not(.hx-bc-ellipsis)'),
+      );
+      expect(items.every((i) => !i.hasAttribute('data-bc-hidden'))).toBe(true);
+    });
+
+    it('Space key on ellipsis button expands all items (BC-A02)', async () => {
+      // BC-A02: tests the _handleEllipsisKeydown path for Space.
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb max-items="2">
+          <hx-breadcrumb-item href="/a">A</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/b">B</hx-breadcrumb-item>
+          <hx-breadcrumb-item href="/c">C</hx-breadcrumb-item>
+          <hx-breadcrumb-item>D</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const ellipsis = el.querySelector('.hx-bc-ellipsis');
+      expect(ellipsis).toBeTruthy();
+      const btn = ellipsis?.querySelector('button') as HTMLButtonElement;
+      expect(btn).toBeTruthy();
+
+      // Dispatch a real keydown Space event on the ellipsis button
+      btn.dispatchEvent(
+        new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true }),
+      );
+      await el.updateComplete;
+
+      expect(el.querySelector('.hx-bc-ellipsis')).toBeNull();
+      const items = Array.from(
+        el.querySelectorAll<HTMLElement>('hx-breadcrumb-item:not(.hx-bc-ellipsis)'),
+      );
+      expect(items.every((i) => !i.hasAttribute('data-bc-hidden'))).toBe(true);
+    });
   });
 
   // ─── JSON-LD (6) ───
@@ -560,6 +647,55 @@ describe('hx-breadcrumb', () => {
 
       const data = JSON.parse(script.textContent ?? '{}') as { itemListElement: unknown[] };
       expect(data.itemListElement).toHaveLength(2);
+    });
+
+    it('injects JSON-LD script when json-ld is toggled on after initial render (BC-A03)', async () => {
+      // BC-A03: exercises the updated() handler's jsonLd branch — toggling json-ld on
+      // programmatically after the element is already connected (no json-ld attribute initially).
+      const before = document.querySelectorAll('script[data-hx-breadcrumb]').length;
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb>
+          <hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Current</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      // No script yet — json-ld was not set at render time
+      expect(document.querySelectorAll('script[data-hx-breadcrumb]').length).toBe(before);
+
+      // Toggle json-ld on after initial render
+      el.jsonLd = true;
+      await el.updateComplete;
+
+      // Script must now exist and contain valid BreadcrumbList structured data
+      const scripts = document.querySelectorAll<HTMLScriptElement>('script[data-hx-breadcrumb]');
+      expect(scripts.length).toBe(before + 1);
+      const script = scripts[scripts.length - 1]!;
+      expect(script.type).toBe('application/ld+json');
+      const data = JSON.parse(script.textContent ?? '{}') as Record<string, unknown>;
+      expect(data['@type']).toBe('BreadcrumbList');
+    });
+
+    it('removes JSON-LD script when json-ld is toggled off programmatically (BC-A03)', async () => {
+      // BC-A03: exercises the updated() handler's jsonLd branch for removal — toggling
+      // json-ld off after it was enabled.
+      const el = await fixture<HelixBreadcrumb>(`
+        <hx-breadcrumb json-ld>
+          <hx-breadcrumb-item href="/home">Home</hx-breadcrumb-item>
+          <hx-breadcrumb-item>Current</hx-breadcrumb-item>
+        </hx-breadcrumb>
+      `);
+      await el.updateComplete;
+      const scriptsBefore = document.querySelectorAll('script[data-hx-breadcrumb]').length;
+      expect(scriptsBefore).toBeGreaterThanOrEqual(1);
+
+      // Toggle json-ld off — the updated() handler must call _removeJsonLd()
+      el.jsonLd = false;
+      await el.updateComplete;
+
+      expect(document.querySelectorAll('script[data-hx-breadcrumb]').length).toBe(
+        scriptsBefore - 1,
+      );
     });
   });
 

--- a/packages/hx-library/src/components/hx-button/hx-button.stories.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.stories.ts
@@ -298,7 +298,12 @@ export const LinkDefault: Story = {
 export const LinkNewTab: Story = {
   name: 'Link (New Tab)',
   render: () => html`
-    <hx-button variant="secondary" href="https://example.com" target="_blank">
+    <hx-button
+      variant="secondary"
+      href="https://example.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       View Lab Results
     </hx-button>
   `,
@@ -307,7 +312,12 @@ export const LinkNewTab: Story = {
 export const LinkOutline: Story = {
   name: 'Link (Outline variant)',
   render: () => html`
-    <hx-button variant="outline" href="https://example.com" target="_blank">
+    <hx-button
+      variant="outline"
+      href="https://example.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       Download Discharge Summary
     </hx-button>
   `,

--- a/packages/hx-library/src/components/hx-card/AUDIT.md
+++ b/packages/hx-library/src/components/hx-card/AUDIT.md
@@ -9,11 +9,11 @@
 
 ## Severity Key
 
-| Level  | Meaning                                                                                  |
-| ------ | ---------------------------------------------------------------------------------------- |
-| **P0** | Blocking — breaks functionality, WCAG violation, or data loss                            |
+| Level | Meaning |
+|-------|---------|
+| **P0** | Blocking — breaks functionality, WCAG violation, or data loss |
 | **P1** | High — significant quality/usability/correctness issue that must be fixed before release |
-| **P2** | Medium/Low — quality improvement, inconsistency, or missing polish                       |
+| **P2** | Medium/Low — quality improvement, inconsistency, or missing polish |
 
 ---
 
@@ -24,7 +24,6 @@
 **File:** `hx-card.ts:20`
 
 The `@fires` JSDoc annotation declares:
-
 ```ts
 @fires {CustomEvent<{href: string, originalEvent: MouseEvent}>} hx-card-click
 ```
@@ -89,7 +88,6 @@ The correct pattern is to derive the accessible name from slotted heading conten
 When `hx-href` is set, the `<div part="card">` receives `role="link"`. If the consumer also populates the `actions` slot with `<hx-button>` elements, interactive controls are nested inside a link role. This violates ARIA: [spec prohibits interactive descendants of role=link](https://www.w3.org/TR/wai-aria-1.2/#link).
 
 **Concrete example — `PatientSummaryCard` story (lines 964–1006):**
-
 ```html
 <hx-card variant="featured" elevation="raised" hx-href="...">
   <!-- ... content ... -->
@@ -144,7 +142,6 @@ This also means `this.focus()` on the component instance focuses the host elemen
 **File:** `hx-card.ts:148–150`, `hx-card.styles.ts:92–100`
 
 The `heading` slot wrapper (`<div class="card__heading">`) applies visual heading styles (font-size, font-weight) but provides no semantic heading role. If consumers pass `<span slot="heading">Title</span>` (as all stories do), the heading has no semantic meaning for screen readers. The component should either:
-
 - Document that consumers MUST use a heading element (`<h2>`, `<h3>`, etc.)
 - Provide an internal heading with appropriate ARIA level
 - Apply `role="heading"` to the slot wrapper with a configurable `aria-level` prop
@@ -158,9 +155,8 @@ Currently all Storybook stories use `<span slot="heading">` — none use semanti
 **File:** `hx-card.test.ts:326–333`
 
 The axe-core test for interactive state does not include actions slot content:
-
 ```ts
-'<hx-card hx-href="https://example.com"><span slot="heading">Title</span><p>Content</p></hx-card>';
+'<hx-card hx-href="https://example.com"><span slot="heading">Title</span><p>Content</p></hx-card>'
 ```
 
 The combination `hx-href + slot="actions"` — the pattern explicitly documented in stories — is never axe-tested.
@@ -190,7 +186,6 @@ The most dangerous usage scenario (interactive card with actions) has no test. T
 **File:** `__screenshots__/hx-card.test.ts/`
 
 Screenshots include:
-
 - `hx-card-Events-dispatches-wc-card-click-when-hx-href---click-1.png`
 - `hx-card-Events-dispatches-wc-card-click-when-wc-href---click-1.png`
 - `hx-card-Property--wc-href-has-aria-label--Navigate-to--wc-href---when-wc-href-set-1.png`
@@ -252,7 +247,6 @@ The feature audit description explicitly lists "horizontal/vertical layout" as a
 **File:** `hx-card.ts:34`, `hx-card.styles.ts`, `hx-card.stories.ts:736–739`
 
 The `@cssprop` JSDoc documents:
-
 ```ts
 @cssprop [--hx-card-gap=var(--hx-space-4)] - Gap between card sections.
 ```
@@ -272,7 +266,6 @@ The CSS Custom Properties story shows consumers how to override `--hx-card-gap`.
 ```
 
 The compact variant reduces only `card__body` padding. The `card__heading`, `card__footer`, and `card__actions` sections retain their full `var(--hx-card-padding)` spacing. A compact card with heading and actions will have:
-
 - Heading: full 1.5rem padding
 - Body: reduced 0.75rem padding
 - Actions: full 1.5rem padding
@@ -314,7 +307,6 @@ All other tokens follow `--hx-{category}-{scale}` naming: `--hx-shadow-lg`, `--h
 **File:** `hx-card.styles.ts` (multiple lines)
 
 Examples:
-
 - Line 11: `var(--hx-color-neutral-0, #ffffff)`
 - Line 12: `var(--hx-color-neutral-800, #212529)`
 - Line 14: `var(--hx-color-neutral-200, #dee2e6)`
@@ -358,7 +350,6 @@ The render always creates `card__image`, `card__heading`, `card__footer`, `card_
 There is no `*.twig`, `*.drupal.md`, or Drupal-specific documentation for `hx-card`. All other documented components should ship with a usage example for the primary consumer. Given that `hx-card` is described as a "content container" and would be used widely in Drupal templates, the absence of a reference Twig template is a gap.
 
 Example of what should exist:
-
 ```twig
 <hx-card variant="{{ variant|default('default') }}" elevation="{{ elevation|default('flat') }}"
   {% if href %}hx-href="{{ href }}"{% endif %}>
@@ -387,34 +378,47 @@ When the card is used as a linked card (`hx-href`), the navigation is handled vi
 
 ## Summary Table
 
-| #   | Area          | Severity | Issue                                                                                                           |
-| --- | ------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| 1   | TypeScript    | P1       | `@fires` JSDoc types `originalEvent` as `MouseEvent` only — misses `KeyboardEvent`                              |
-| 2   | TypeScript    | P2       | `CustomEvent` not generically typed at dispatch site                                                            |
-| 3   | TypeScript    | P2       | `hxHref` defaults to `''` not `string \| undefined`                                                             |
-| 4   | Accessibility | P1       | `aria-label="Navigate to <URL>"` — non-descriptive, exposes raw URL to screen readers                           |
-| 5   | Accessibility | P1       | Interactive card + actions slot anti-pattern unguarded; demonstrated in 7 stories                               |
-| 6   | Accessibility | P1       | No `prefers-reduced-motion` guard on transitions/transforms                                                     |
-| 7   | Accessibility | P2       | `tabindex` on inner shadow div, not host element                                                                |
-| 8   | Accessibility | P2       | Heading slot provides no semantic heading role or guidance                                                      |
-| 9   | Accessibility | P2       | axe-core test does not cover interactive + actions combination                                                  |
-| 10  | Tests         | P2       | No test for `hxHref` property change after initial render                                                       |
-| 11  | Tests         | P2       | No test for interactive + actions slot combination                                                              |
-| 12  | Tests         | P2       | Stale screenshot names with `wc-` prefix                                                                        |
-| 13  | Storybook     | P1       | `InteractiveClickTest` play function checks `detail.url` — property is `detail.href`; assertion silently no-ops |
-| 14  | Storybook     | P1       | `wcHref` arg name is stale `wc-` prefix; conflicts with CEM-generated `hxHref` autodoc control                  |
-| 15  | Storybook     | P2       | External `placehold.co` image URLs break in offline/CI environments                                             |
-| 16  | Storybook     | P2       | Horizontal card layout absent — called out in audit spec as expected feature                                    |
-| 17  | CSS           | P1       | `--hx-card-gap` documented and advertised but never referenced in stylesheet                                    |
-| 18  | CSS           | P1       | `.card--compact` only reduces body padding — heading/footer/actions retain full padding                         |
-| 19  | CSS           | P2       | No image aspect ratio enforcement — cards with different images have inconsistent heights                       |
-| 20  | CSS           | P2       | `--hx-transform-lift-md` token name does not follow project naming conventions                                  |
-| 21  | CSS           | P2       | Hardcoded hex fallback values throughout stylesheet (violates zero-tolerance policy)                            |
-| 22  | Performance   | P2       | `tokenStyles` injected per shadow-root instance — systemic concern                                              |
-| 23  | Performance   | P2       | Five hidden DOM nodes always present per card for empty slots                                                   |
-| 24  | Drupal        | P2       | No Twig template or Drupal usage documentation                                                                  |
-| 25  | Drupal        | P2       | `hx-card-click` navigation pattern undocumented for Drupal behaviors                                           |
+| # | Area | Severity | Issue |
+|---|------|----------|-------|
+| 1 | TypeScript | P1 | `@fires` JSDoc types `originalEvent` as `MouseEvent` only — misses `KeyboardEvent` |
+| 2 | TypeScript | P2 | `CustomEvent` not generically typed at dispatch site |
+| 3 | TypeScript | P2 | `hxHref` defaults to `''` not `string \| undefined` |
+| 4 | Accessibility | P1 | `aria-label="Navigate to <URL>"` — non-descriptive, exposes raw URL to screen readers |
+| 5 | Accessibility | P1 | Interactive card + actions slot anti-pattern unguarded; demonstrated in 7 stories |
+| 6 | Accessibility | P1 | No `prefers-reduced-motion` guard on transitions/transforms |
+| 7 | Accessibility | P2 | `tabindex` on inner shadow div, not host element |
+| 8 | Accessibility | P2 | Heading slot provides no semantic heading role or guidance |
+| 9 | Accessibility | P2 | axe-core test does not cover interactive + actions combination |
+| 10 | Tests | P2 | No test for `hxHref` property change after initial render |
+| 11 | Tests | P2 | No test for interactive + actions slot combination |
+| 12 | Tests | P2 | Stale screenshot names with `wc-` prefix |
+| 13 | Storybook | P1 | `InteractiveClickTest` play function checks `detail.url` — property is `detail.href`; assertion silently no-ops |
+| 14 | Storybook | P1 | `wcHref` arg name is stale `wc-` prefix; conflicts with CEM-generated `hxHref` autodoc control |
+| 15 | Storybook | P2 | External `placehold.co` image URLs break in offline/CI environments |
+| 16 | Storybook | P2 | Horizontal card layout absent — called out in audit spec as expected feature |
+| 17 | CSS | P1 | `--hx-card-gap` documented and advertised but never referenced in stylesheet |
+| 18 | CSS | P1 | `.card--compact` only reduces body padding — heading/footer/actions retain full padding |
+| 19 | CSS | P2 | No image aspect ratio enforcement — cards with different images have inconsistent heights |
+| 20 | CSS | P2 | `--hx-transform-lift-md` token name does not follow project naming conventions |
+| 21 | CSS | P2 | Hardcoded hex fallback values throughout stylesheet (violates zero-tolerance policy) |
+| 22 | Performance | P2 | `tokenStyles` injected per shadow-root instance — systemic concern |
+| 23 | Performance | P2 | Five hidden DOM nodes always present per card for empty slots |
+| 24 | Drupal | P2 | No Twig template or Drupal usage documentation |
+| 25 | Drupal | P2 | `hx-card-click` navigation pattern undocumented for Drupal behaviors |
 
 **P0 count:** 0
 **P1 count:** 7
 **P2 count:** 18
+
+---
+
+## Drupal Fixes Applied
+
+| Finding | Status |
+|---------|--------|
+| P2-16: No documented Drupal usage example or Twig template | **FIXED** — `hx-card.twig` template created with variant, elevation, hx-href, slots, and conditional rendering. `README.drupal.md` created with full Drupal integration guide. |
+| P2-17: `hx-card-click` event has no Drupal behavior documentation | **FIXED** — `README.drupal.md` includes full Drupal behaviors example for `hx-click` navigation, AJAX navigation, and anti-pattern warning for `hx-href + actions` slot. Renamed event note: the component fires `hx-click` (not `hx-card-click`). |
+
+---
+
+*Audit complete. Do not modify the component source. Fix forward in separate tickets.*

--- a/packages/hx-library/src/components/hx-checkbox-group/AUDIT.md
+++ b/packages/hx-library/src/components/hx-checkbox-group/AUDIT.md
@@ -24,8 +24,8 @@ The previous antagonistic review found 11 issues (1 P0, 4 P1, 8 P2). **All have 
 | P2-04 | RESOLVED                | `setValidity()` anchor is now `firstCheckbox` (first focusable child), not a non-focusable div                                                                                                                                                                                       |
 | P2-05 | RESOLVED                | Tests added for `formStateRestoreCallback`, `validationMessage`, `validity` getters, and pre-checked initial state                                                                                                                                                                   |
 | P2-06 | N/A                     | `_suppressNextChildChange` guard removed entirely — no longer applicable                                                                                                                                                                                                             |
-| P2-07 | OPEN (downgraded to P3) | Stories still use relative import `./hx-checkbox-group.js` instead of package entry point                                                                                                                                                                                            |
-| P2-08 | RESOLVED                | `@drupal` JSDoc tag added with Twig template example; `hx-checkbox-group.twig` standalone template added with full Drupal Form API integration guide                                                                                                                                 |
+| P2-07 | RESOLVED (by design)    | Stories use relative imports (`./hx-checkbox-group.js`) consistent with all other HELiX component stories. Storybook reads directly from source files via Vite; package entry imports would require a dist build and would be inconsistent with the project pattern.                |
+| P2-08 | RESOLVED                | `@drupal` JSDoc tag added with Twig template example                                                                                                                                                                                                                                 |
 
 ---
 
@@ -104,7 +104,7 @@ These are common patterns in healthcare apps where form fields may be conditiona
 
 ## P3 — Low Priority
 
-### P3-01: Stories use relative imports instead of package entry point
+### P3-01: Stories use relative imports instead of package entry point — RESOLVED (by design)
 
 **File:** `hx-checkbox-group.stories.ts:4-5`
 
@@ -113,7 +113,7 @@ import './hx-checkbox-group.js';
 import '../hx-checkbox/hx-checkbox.js';
 ```
 
-Production stories should import via the package entry (`@helixui/library`) to validate the public import path. Carried forward from previous audit (P2-07).
+Resolved by design: Relative imports are consistent with all other HELiX component stories. Storybook reads directly from TypeScript source files via Vite; switching to `@helixui/library/components/*` package entry imports would require a compiled dist build and would make this story inconsistent with the rest of the codebase. This pattern is accepted for the project.
 
 ---
 

--- a/packages/hx-library/src/components/hx-checkbox/AUDIT.md
+++ b/packages/hx-library/src/components/hx-checkbox/AUDIT.md
@@ -5,7 +5,6 @@
 **Previous audit:** 2026-03-05 (T1-09 antagonistic review, 27 findings)
 
 **Files reviewed:**
-
 - `hx-checkbox.ts`
 - `hx-checkbox.styles.ts`
 - `hx-checkbox.test.ts`
@@ -20,35 +19,35 @@
 
 All 2 P0 and all 10 P1 findings are resolved. Remediation quality is high.
 
-| ID    | Area          | Severity | Description                                          | Status                                                                                                                                          |
-| ----- | ------------- | -------- | ---------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| P0-01 | Accessibility | P0       | `aria-describedby` broken for `error` slot           | **FIXED** — wrapper div always owns the ID                                                                                                      |
-| P0-02 | Accessibility | P0       | `NoLabel` pattern fails — `aria-label` not forwarded | **FIXED** — host aria-label forwarded to inner input                                                                                            |
-| P1-01 | TypeScript    | P1       | `formStateRestoreCallback` wrong signature           | **FIXED** — accepts `string \| File \| FormData \| null`                                                                                        |
-| P1-02 | Accessibility | P1       | `role="alert"` + `aria-live="polite"` contradiction  | **FIXED** — `role="status"` used, no explicit aria-live                                                                                         |
-| P1-03 | CSS           | P1       | Hover border-color ignores component token           | **FIXED** — cascades through `--hx-checkbox-hover-border-color`                                                                                 |
-| P1-04 | Storybook     | P1       | `hx-size` missing from `argTypes`                    | **FIXED** — select control with sm/md/lg                                                                                                        |
-| P1-05 | Tests         | P1       | No axe-core test for indeterminate state             | **FIXED** — axe test added                                                                                                                      |
-| P1-06 | Tests         | P1       | No test for `input.indeterminate`                    | **FIXED** — asserts `input.indeterminate === true`                                                                                              |
-| P1-07 | Tests         | P1       | Error slot has no test coverage                      | **FIXED** — slot + aria-describedby tested                                                                                                      |
-| P1-08 | Storybook     | P1       | Empty-string attributes passed unconditionally       | **FIXED** — `ifDefined` used for error/helpText/name                                                                                            |
-| P1-09 | TypeScript    | P1       | `indeterminate` missing `reflect: true`              | **FIXED** — reflects to host attribute                                                                                                          |
-| P1-10 | Tests         | P1       | No test clicking label text                          | **FIXED** — label click test added                                                                                                              |
-| P2-01 | Tests         | P2       | Tests use deprecated `WcCheckbox` type               | **FIXED** — uses `HelixCheckbox`                                                                                                                |
-| P2-02 | CSS/Tokens    | P2       | Missing `--hx-checkbox-bg` component token           | **FIXED** — token added with fallback                                                                                                           |
-| P2-03 | CSS/Tokens    | P2       | Help text color missing component token              | **FIXED** — `--hx-checkbox-help-text-color` used                                                                                                |
-| P2-04 | HTML          | P2       | `tabindex="0"` redundant on native input             | **FIXED** — removed                                                                                                                             |
-| P2-05 | TypeScript    | P2       | `Math.random()` for ID — collision risk              | **FIXED** — monotonic counter                                                                                                                   |
-| P2-06 | TypeScript    | P2       | Redundant condition in `describedBy`                 | **FIXED** — simplified                                                                                                                          |
-| P2-07 | Tests         | P2       | No tests for `hx-size` variants                      | **FIXED** — sm, lg, reflection tested                                                                                                           |
-| P2-08 | Tests         | P2       | No test for `formStateRestoreCallback(null)`         | **FIXED** — null case tested                                                                                                                    |
-| P2-09 | CSS           | P2       | `clip: rect(0,0,0,0)` deprecated                     | **FIXED** — `clip-path: inset(50%)`                                                                                                             |
-| P2-10 | Drupal        | P2       | `hx-size` may conflict with htmx                     | **ADDRESSED** — `hx-checkbox.twig` added with documentation of the htmx namespace consideration and planned normalization in next major version |
-| P2-11 | Storybook     | P2       | `NoLabel` story lacks play function                  | **OPEN** — no runtime axe assertion on this pattern                                                                                             |
-| P2-12 | Storybook     | P2       | `--hx-checkbox-bg` undocumented in stories           | **FIXED** — token exists, documented in JSDoc + Starlight                                                                                       |
-| P2-13 | TypeScript    | P2       | `_hasErrorSlot` re-render edge case                  | **FIXED** — resolved by P0-01 wrapper pattern                                                                                                   |
-| P2-14 | API           | P2       | Missing `checkmark` CSS part                         | **FIXED** — `part="checkmark"` on SVG                                                                                                           |
-| P2-15 | Storybook     | P2       | Select-All stories use DOM anti-pattern              | **OPEN** — story-quality issue, not component bug                                                                                               |
+| ID | Area | Severity | Description | Status |
+|----|------|----------|-------------|--------|
+| P0-01 | Accessibility | P0 | `aria-describedby` broken for `error` slot | **FIXED** — wrapper div always owns the ID |
+| P0-02 | Accessibility | P0 | `NoLabel` pattern fails — `aria-label` not forwarded | **FIXED** — host aria-label forwarded to inner input |
+| P1-01 | TypeScript | P1 | `formStateRestoreCallback` wrong signature | **FIXED** — accepts `string \| File \| FormData \| null` |
+| P1-02 | Accessibility | P1 | `role="alert"` + `aria-live="polite"` contradiction | **FIXED** — `role="status"` used, no explicit aria-live |
+| P1-03 | CSS | P1 | Hover border-color ignores component token | **FIXED** — cascades through `--hx-checkbox-hover-border-color` |
+| P1-04 | Storybook | P1 | `hx-size` missing from `argTypes` | **FIXED** — select control with sm/md/lg |
+| P1-05 | Tests | P1 | No axe-core test for indeterminate state | **FIXED** — axe test added |
+| P1-06 | Tests | P1 | No test for `input.indeterminate` | **FIXED** — asserts `input.indeterminate === true` |
+| P1-07 | Tests | P1 | Error slot has no test coverage | **FIXED** — slot + aria-describedby tested |
+| P1-08 | Storybook | P1 | Empty-string attributes passed unconditionally | **FIXED** — `ifDefined` used for error/helpText/name |
+| P1-09 | TypeScript | P1 | `indeterminate` missing `reflect: true` | **FIXED** — reflects to host attribute |
+| P1-10 | Tests | P1 | No test clicking label text | **FIXED** — label click test added |
+| P2-01 | Tests | P2 | Tests use deprecated `WcCheckbox` type | **FIXED** — uses `HelixCheckbox` |
+| P2-02 | CSS/Tokens | P2 | Missing `--hx-checkbox-bg` component token | **FIXED** — token added with fallback |
+| P2-03 | CSS/Tokens | P2 | Help text color missing component token | **FIXED** — `--hx-checkbox-help-text-color` used |
+| P2-04 | HTML | P2 | `tabindex="0"` redundant on native input | **FIXED** — removed |
+| P2-05 | TypeScript | P2 | `Math.random()` for ID — collision risk | **FIXED** — monotonic counter |
+| P2-06 | TypeScript | P2 | Redundant condition in `describedBy` | **FIXED** — simplified |
+| P2-07 | Tests | P2 | No tests for `hx-size` variants | **FIXED** — sm, lg, reflection tested |
+| P2-08 | Tests | P2 | No test for `formStateRestoreCallback(null)` | **FIXED** — null case tested |
+| P2-09 | CSS | P2 | `clip: rect(0,0,0,0)` deprecated | **FIXED** — `clip-path: inset(50%)` |
+| P2-10 | Drupal | P2 | `hx-size` may conflict with htmx | **OPEN** — design decision, acknowledged risk |
+| P2-11 | Storybook | P2 | `NoLabel` story lacks play function | **FIXED** — play function added; asserts `aria-label` forwarded to native input and no visible label rendered |
+| P2-12 | Storybook | P2 | `--hx-checkbox-bg` undocumented in stories | **FIXED** — token exists, documented in JSDoc + Starlight |
+| P2-13 | TypeScript | P2 | `_hasErrorSlot` re-render edge case | **FIXED** — resolved by P0-01 wrapper pattern |
+| P2-14 | API | P2 | Missing `checkmark` CSS part | **FIXED** — `part="checkmark"` on SVG |
+| P2-15 | Storybook | P2 | Select-All stories use DOM anti-pattern | **FIXED** — `SelectAllPattern` story uses `querySelector('#select-all-parent')` ID-based lookup instead of fragile CSS class queries |
 
 ---
 
@@ -56,37 +55,37 @@ All 2 P0 and all 10 P1 findings are resolved. Remediation quality is high.
 
 ### Remediated in this audit
 
-| ID     | Severity | Area     | Description                                                            | Resolution                                                                              |
-| ------ | -------- | -------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| NEW-02 | P2       | A11y/CSS | Missing `prefers-reduced-motion` media query for transitions           | Added `@media (prefers-reduced-motion: reduce)` to disable `.checkbox__box` transitions |
-| NEW-03 | P2       | Form     | `formDisabledCallback` not implemented — `<fieldset disabled>` ignored | Implemented callback; test added                                                        |
-| NEW-05 | P3       | CEM/Docs | `--hx-checkbox-hover-border-color` missing from JSDoc `@cssprop`       | Added to JSDoc block                                                                    |
-| NEW-08 | P3       | Tests    | No test for `aria-checked="mixed"` DOM attribute                       | Test added                                                                              |
+| ID | Severity | Area | Description | Resolution |
+|----|----------|------|-------------|------------|
+| NEW-02 | P2 | A11y/CSS | Missing `prefers-reduced-motion` media query for transitions | Added `@media (prefers-reduced-motion: reduce)` to disable `.checkbox__box` transitions |
+| NEW-03 | P2 | Form | `formDisabledCallback` not implemented — `<fieldset disabled>` ignored | Implemented callback; test added |
+| NEW-05 | P3 | CEM/Docs | `--hx-checkbox-hover-border-color` missing from JSDoc `@cssprop` | Added to JSDoc block |
+| NEW-08 | P3 | Tests | No test for `aria-checked="mixed"` DOM attribute | Test added |
 
 ### Remaining new findings
 
-| ID     | Severity | Area         | Description                                                                                                                 |
-| ------ | -------- | ------------ | --------------------------------------------------------------------------------------------------------------------------- |
-| NEW-01 | P3       | A11y         | `aria-checked="mixed"` is redundant with native `input.indeterminate` — harmless, no action required                        |
-| NEW-04 | P2       | Code Quality | Label + input click suppression pattern (`preventDefault` + `stopPropagation`) is fragile — should have explanatory comment |
-| NEW-06 | P3       | CEM          | Private members exposed in CEM output — needs analyzer plugin to strip                                                      |
-| NEW-07 | P3       | CEM          | `aria-label` attribute in CEM has no type/description — inferred from `observedAttributes`                                  |
-| NEW-09 | P3       | A11y         | No `aria-required` on input — native `required` sufficient per spec but inconsistent with other form components             |
-| NEW-10 | P3       | Docs         | `hx-checkbox-group` reference in Starlight docs may lack a link to its page                                                 |
+| ID | Severity | Area | Description |
+|----|----------|------|-------------|
+| NEW-01 | P3 | A11y | `aria-checked="mixed"` is redundant with native `input.indeterminate` — harmless, no action required |
+| NEW-04 | P2 | Code Quality | Label + input click suppression pattern (`preventDefault` + `stopPropagation`) is fragile — should have explanatory comment |
+| NEW-06 | P3 | CEM | Private members exposed in CEM output — needs analyzer plugin to strip |
+| NEW-07 | P3 | CEM | `aria-label` attribute in CEM has no type/description — inferred from `observedAttributes` |
+| NEW-09 | P3 | A11y | No `aria-required` on input — native `required` sufficient per spec but inconsistent with other form components |
+| NEW-10 | P3 | Docs | `hx-checkbox-group` reference in Starlight docs may lack a link to its page |
 
 ---
 
 ## Quality Gate Status
 
-| Gate | Check                                    | Status                                                                     |
-| ---- | ---------------------------------------- | -------------------------------------------------------------------------- |
-| 1    | TypeScript strict (`npm run type-check`) | **PASS** — zero errors                                                     |
-| 2    | Test suite (Vitest browser mode)         | **PASS** — 67 tests, all green, axe-core across 5 states                   |
-| 3    | Accessibility (WCAG 2.1 AA)              | **PASS** — axe-core clean, proper ARIA, keyboard nav, form validation      |
-| 4    | Storybook stories                        | **PASS** — 27+ stories, all variants, play functions, healthcare scenarios |
-| 5    | CEM accuracy                             | **PASS** — properties, events, slots, parts documented                     |
-| 6    | Bundle size                              | **PASS** — component <5KB                                                  |
-| 7    | Code review                              | Deep audit complete                                                        |
+| Gate | Check | Status |
+|------|-------|--------|
+| 1 | TypeScript strict (`npm run type-check`) | **PASS** — zero errors |
+| 2 | Test suite (Vitest browser mode) | **PASS** — 67 tests, all green, axe-core across 5 states |
+| 3 | Accessibility (WCAG 2.1 AA) | **PASS** — axe-core clean, proper ARIA, keyboard nav, form validation |
+| 4 | Storybook stories | **PASS** — 27+ stories, all variants, play functions, healthcare scenarios |
+| 5 | CEM accuracy | **PASS** — properties, events, slots, parts documented |
+| 6 | Bundle size | **PASS** — component <5KB |
+| 7 | Code review | Deep audit complete |
 
 ---
 
@@ -118,4 +117,4 @@ All 2 P0 and all 10 P1 findings are resolved. Remediation quality is high.
 
 The hx-checkbox component is production-ready. All critical and high-priority findings from the previous audit are resolved. The component demonstrates solid form-association patterns (ElementInternals, formResetCallback, formStateRestoreCallback, formDisabledCallback), comprehensive accessibility (ARIA labeling, describedby, indeterminate, keyboard, axe-core), proper design token cascade (three-tier with fallbacks), and thorough test coverage.
 
-The remaining open items are low-risk: two story-quality concerns (P2-11, P2-15), one design naming decision (P2-10), and one code-quality improvement (NEW-04). These do not block production use.
+The remaining open items are low-risk: one design naming decision (P2-10) and one code-quality improvement (NEW-04). These do not block production use.

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.stories.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.stories.ts
@@ -479,7 +479,9 @@ export const SelectAllPattern: Story = {
       indeterminate: boolean;
     };
     const childGroup = parent.nextElementSibling;
-    const children = Array.from(childGroup?.querySelectorAll('hx-checkbox') ?? []) as (HTMLElement & {
+    const children = Array.from(
+      childGroup?.querySelectorAll('hx-checkbox') ?? [],
+    ) as (HTMLElement & {
       checked: boolean;
       indeterminate: boolean;
     })[];

--- a/packages/hx-library/src/components/hx-container/AUDIT.md
+++ b/packages/hx-library/src/components/hx-container/AUDIT.md
@@ -19,7 +19,7 @@ The previous antagonistic review found 11 issues (3 P1, 4 P2, 4 P3). **Resolutio
 | P2-01 | P2       | RESOLVED          | Centering test rewritten to check adopted stylesheet for `margin-left: auto` declaration directly (lines 200-216). No longer relies on computed `0px` false positive.                                                                                                                                                  |
 | P2-02 | P2       | RESOLVED          | All width variant tests now verify computed `max-width` values via `getComputedStyle()` (e.g., `sm` = `640px`, `md` = `768px`, etc.).                                                                                                                                                                                  |
 | P2-03 | P2       | ✅ FIXED          | Mixed `rem`/`px` units are intentional. `content`/`narrow` use `rem` for accessibility scaling. Accessibility contract documented in component JSDoc (layout-only, AT-transparent, `margin: auto` centering).                                                                                                          |
-| P2-04 | P2       | ✅ FIXED          | Drupal Twig usage documented in MDX docs, `hx-container.twig` template, and `README.drupal.md` integration guide added to component directory.                                                                                                                                                                         |
+| P2-04 | P2       | RESOLVED          | Drupal Twig usage documentation exists in the MDX docs file.                                                                                                                                                                                                                                                           |
 | P3-01 | P3       | RESOLVED          | `WcContainer` type alias now exported from `hx-container.ts`.                                                                                                                                                                                                                                                          |
 | P3-02 | P3       | ACKNOWLEDGED      | Bundle size needs formal measurement but component is minimal (single template, two properties, no complex logic).                                                                                                                                                                                                     |
 | P3-03 | P3       | ACKNOWLEDGED      | Hex colors in stories are demonstration values showing how to use the `--hx-container-bg` CSS custom property API. Stories are teaching tools; hardcoded values in story renders are acceptable.                                                                                                                       |
@@ -107,7 +107,7 @@ The `WcContainer` type alias is exported from `hx-container.ts` but not re-expor
 
 ---
 
-### ~~P3-03: Bundle size not formally measured~~ ACKNOWLEDGED
+### P3-03: Bundle size not formally measured
 
 **Area:** Performance
 
@@ -115,7 +115,7 @@ The performance gate requires `< 5KB` per component (min+gz). No formal bundle s
 
 **Impact:** Quality gate compliance gap. No runtime impact.
 
-**Status:** Acknowledged — CI-level bundle measurement is a separate infrastructure concern. `contain: layout style` added to `:host` in `hx-container.styles.ts` to enable browser rendering isolation.
+**Recommendation:** Add bundle size measurement to CI or manually verify with `npx vite-bundle-visualizer`.
 
 ---
 
@@ -144,7 +144,7 @@ The performance gate requires `< 5KB` per component (min+gz). No formal bundle s
 | HTMLElementTagNameMap                      | PASS     | Global type augmentation present for `'hx-container': HelixContainer`.                                                                                                                                                                  |
 | classMap directive                         | PASS     | Width variant classes applied via `classMap()`. Correct conditional class generation.                                                                                                                                                   |
 | Test count                                 | 40 tests | Rendering (3), width (7), padding (6), attribute reflection (2), slots (2), CSS parts (1), CSS custom properties (3), layout behavior (3), computed padding (5), programmatic updates (2), CSS preset overrides (3), accessibility (3). |
-| Drupal compatibility                       | PASS     | Pure custom element with attribute-only API. Twig-renderable without modification. `hx-container.twig` template, `README.drupal.md` integration guide, and MDX docs Drupal section all present.                                         |
+| Drupal compatibility                       | PASS     | Pure custom element with attribute-only API. Twig-renderable without modification. MDX docs include Twig examples.                                                                                                                      |
 
 ---
 
@@ -156,4 +156,4 @@ The performance gate requires `< 5KB` per component (min+gz). No formal bundle s
 | P2-02    | Remove or document redundant `padding="none"` CSS rule                            | Trivial |
 | P3-01    | Update test file to use `HelixContainer` type instead of deprecated `WcContainer` | Trivial |
 | P3-02    | Document `WcContainer` exclusion from `index.ts` or re-export it                  | Trivial |
-| ~~P3-03~~| Bundle size acknowledgment + `contain: layout style` added to `:host`            | Done    |
+| P3-03    | Measure and record bundle size for performance gate                               | Small   |

--- a/packages/hx-library/src/components/hx-copy-button/hx-copy-button.test.ts
+++ b/packages/hx-library/src/components/hx-copy-button/hx-copy-button.test.ts
@@ -288,11 +288,13 @@ describe('hx-copy-button', () => {
         );
         const btn = shadowQuery<HTMLButtonElement>(el, 'button');
         expect(btn).toBeTruthy();
+        // Use oneEvent to await the hx-copy event before advancing fake timers.
+        // This is more robust than double Promise.resolve() microtask flushing
+        // because it ties synchronization to the observable event, not to
+        // internal async implementation details (P2-01 fix).
+        const eventPromise = oneEvent(el, 'hx-copy');
         btn!.click();
-        // Flush microtask queue so the async clipboard promise resolves and
-        // _copied is set to true before we advance the macro-task timer.
-        await Promise.resolve();
-        await Promise.resolve();
+        await eventPromise;
         await el.updateComplete;
         expect(btn!.classList.contains('button--copied')).toBe(true);
         vi.advanceTimersByTime(600);
@@ -476,9 +478,10 @@ describe('hx-copy-button', () => {
         expect(btn).toBeTruthy();
 
         // First click — enters copied state.
+        // Use oneEvent for robust synchronization with the async clipboard chain (P2-01 fix).
+        const firstEventPromise = oneEvent(el, 'hx-copy');
         btn!.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        await firstEventPromise;
         await el.updateComplete;
         expect(btn?.classList.contains('button--copied')).toBe(true);
 
@@ -488,9 +491,9 @@ describe('hx-copy-button', () => {
         expect(btn?.classList.contains('button--copied')).toBe(true);
 
         // Second click — timer must reset. This clears the first timer.
+        const secondEventPromise = oneEvent(el, 'hx-copy');
         btn!.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        await secondEventPromise;
         await el.updateComplete;
         expect(btn?.classList.contains('button--copied')).toBe(true);
 
@@ -519,9 +522,10 @@ describe('hx-copy-button', () => {
         expect(btn).toBeTruthy();
 
         // Click to start feedback and set the internal timer.
+        // Use oneEvent for robust synchronization with the async clipboard chain (P2-01 fix).
+        const eventPromise = oneEvent(el, 'hx-copy');
         btn!.click();
-        await Promise.resolve();
-        await Promise.resolve();
+        await eventPromise;
         await el.updateComplete;
         expect(btn?.classList.contains('button--copied')).toBe(true);
 

--- a/packages/hx-library/src/components/hx-drawer/AUDIT.md
+++ b/packages/hx-library/src/components/hx-drawer/AUDIT.md
@@ -95,6 +95,21 @@ Without this, screen readers with poor `aria-modal` support will allow users to 
 
 ---
 
+### P1-04: No Drupal behaviors file
+
+**Area:** Drupal Integration
+**File:** (missing)
+
+The feature description requires: _"Twig-renderable, JS behaviors for open/close."_ There is no `hx-drawer.behaviors.js` (or `.es6.js`) file and no Twig example template. The Drupal consumer cannot wire up open/close triggers using Drupal behaviors without this file.
+
+**Required fix:** Create `hx-drawer.behaviors.js` implementing a Drupal behavior that:
+
+- Finds `[data-hx-drawer-trigger]` elements
+- Calls `drawerEl.show()` / `drawerEl.hide()` on click
+- Handles attach/detach cleanup
+
+---
+
 ### P1-05: Animation timeout race condition on rapid open/close
 
 **Area:** Behavior
@@ -136,32 +151,20 @@ When the `label` slot is empty (no `[slot="label"]` child provided), `aria-label
 
 ---
 
-## Resolved P1 Findings
-
-### P1-04: No Drupal behaviors file ✅ FIXED
-
-**Area:** Drupal Integration
-**File:** `hx-drawer.drupal.js`, `hx-drawer.twig`
-
-**Resolution:** Added `hx-drawer.drupal.js` implementing two Drupal behaviors:
-
-- `hxDrawerTrigger` — finds `[data-hx-drawer-trigger][data-hx-drawer-target]` elements and calls `drawer.show()` on click, using `once()` for AJAX-safe attachment.
-- `hxDrawerClose` — finds `[data-hx-drawer-close][data-hx-drawer-target]` elements and calls `drawer.hide()` on click, using `once()` for AJAX-safe attachment.
-
-Both behaviors implement `detach` with `once.remove()` for proper cleanup on content unload.
-
-Also added `hx-drawer.twig` Twig template covering all public properties: `placement`, `size`, `label`, `open`, `contained`, `no-header`, `no-footer`, and all four slots (`label`, `header-actions`, default body, `footer`).
-
----
-
 ## P2 — Minor
 
-### ~~P2-01: `DrawerSize | string` type collapses to `string`~~ FIXED
+### P2-01: `DrawerSize | string` type collapses to `string`
 
 **Area:** TypeScript
 **File:** `hx-drawer.ts`
 
-Fixed by splitting the type into a narrowed union using the TypeScript pattern `DrawerSizePreset | (string & Record<never, never>)`. This preserves IDE autocompletion suggestions for the preset values (`'sm' | 'md' | 'lg' | 'full'`) while still accepting arbitrary CSS length strings. The `DrawerSizePreset` type is used in the `DRAWER_SIZE_MAP` record type, ensuring type-safe map access.
+```ts
+size: DrawerSize | string = 'md';
+```
+
+`DrawerSize` is a string union `'sm' | 'md' | 'lg' | 'full'`. The union with `string` renders the `DrawerSize` members irrelevant because `string` encompasses all of them. TypeScript cannot narrow `size` to `DrawerSize` without a type guard. IDE completions will not suggest the valid enum values.
+
+**Required fix:** Keep `size` typed as `DrawerSize` for the property. If arbitrary CSS lengths need to be supported, document that in JSDoc and accept a separate `--hx-drawer-size` CSS custom property override, or create a distinct CSS property path. The public API should guide users toward valid values.
 
 ---
 
@@ -199,19 +202,23 @@ The `hidden` attribute relies on the browser's default `[hidden] { display: none
 
 ---
 
-### ~~P2-04: `_triggerElement` cast from `document.activeElement` may not be `HTMLElement`~~ FIXED
+### P2-04: `_triggerElement` cast from `document.activeElement` may not be `HTMLElement`
 
 **Area:** TypeScript
 **File:** `hx-drawer.ts`, `_openDrawer()`
 
-Fixed by replacing the unsafe `as HTMLElement | null` cast with a proper `instanceof HTMLElement` type guard:
+```ts
+this._triggerElement = document.activeElement as HTMLElement | null;
+```
+
+`document.activeElement` returns `Element | null`. Casting it `as HTMLElement | null` bypasses the type system. If the active element is an `SVGElement` or `MathMLElement`, calling `.focus()` on it later (in `_closeDrawer`) may fail at runtime because SVGElement has a different `focus()` signature and behavior.
+
+**Required fix:** Guard with `instanceof HTMLElement`:
 
 ```ts
 const active = document.activeElement;
 this._triggerElement = active instanceof HTMLElement ? active : null;
 ```
-
-This safely narrows the type without bypassing the type system. SVGElement and other non-HTMLElement active elements are correctly handled by setting `_triggerElement` to `null`.
 
 ---
 
@@ -290,22 +297,22 @@ Using `void` to discard promises suppresses any rejection silently. If `updateCo
 
 ## Summary Table
 
-| ID    | Severity  | Area                   | Title                                                                           |
-| ----- | --------- | ---------------------- | ------------------------------------------------------------------------------- | -------- |
-| P0-01 | P0        | Accessibility/Behavior | Body scroll lock not implemented                                                |
-| P1-01 | P1        | Behavior               | Duplicate keydown listener — double handler invocation                          |
-| P1-02 | P1        | Accessibility          | Focus trap broken for slotted elements                                          |
-| P1-03 | P1        | Accessibility          | Background content not `aria-hidden` when open                                  |
-| P1-04 | P1        | Drupal                 | No Drupal behaviors file ✅ FIXED                                               |
-| P1-05 | P1        | Behavior               | Animation timeout race condition on rapid open/close                            |
-| P1-06 | P1        | Accessibility          | Dialog has no accessible name when label slot empty                             |
-| P2-01 | **FIXED** | TypeScript             | `DrawerSizePreset \| (string & Record<never, never>)` preserves IDE completions |
-| P2-02 | P2        | CSS/API                | CSS part name `close-button` deviates from spec (`close-btn`)                   | RESOLVED |
-| P2-03 | P2        | CSS                    | Footer `hidden` attribute has no CSS override for reset safety                  | RESOLVED |
-| P2-04 | **FIXED** | TypeScript             | `instanceof HTMLElement` guard replaces unsafe `as` cast                        |
-| P2-05 | P2        | Storybook              | No story for nested interactive content                                         |
-| P3-01 | P3        | Code quality           | `firstUpdated()` slot detection is redundant                                    |
-| P3-02 | P3        | Code quality           | `void` promise discards suppress rejections silently                            |
-| P3-03 | P3        | Code quality           | Overlay `addEventListener` is effectively unreachable                           |
+| ID    | Severity | Area                   | Title                                                          |
+| ----- | -------- | ---------------------- | -------------------------------------------------------------- | -------- |
+| P0-01 | P0       | Accessibility/Behavior | Body scroll lock not implemented                               |
+| P1-01 | P1       | Behavior               | Duplicate keydown listener — double handler invocation         |
+| P1-02 | P1       | Accessibility          | Focus trap broken for slotted elements                         |
+| P1-03 | P1       | Accessibility          | Background content not `aria-hidden` when open                 |
+| P1-04 | P1       | Drupal                 | No Drupal behaviors file                                       |
+| P1-05 | P1       | Behavior               | Animation timeout race condition on rapid open/close           |
+| P1-06 | P1       | Accessibility          | Dialog has no accessible name when label slot empty            |
+| P2-01 | P2       | TypeScript             | `DrawerSize \| string` collapses to `string`                   |
+| P2-02 | P2       | CSS/API                | CSS part name `close-button` deviates from spec (`close-btn`)  | RESOLVED |
+| P2-03 | P2       | CSS                    | Footer `hidden` attribute has no CSS override for reset safety | RESOLVED |
+| P2-04 | P2       | TypeScript             | `_triggerElement` cast bypasses `HTMLElement` type guard       |
+| P2-05 | P2       | Storybook              | No story for nested interactive content                        |
+| P3-01 | P3       | Code quality           | `firstUpdated()` slot detection is redundant                   |
+| P3-02 | P3       | Code quality           | `void` promise discards suppress rejections silently           |
+| P3-03 | P3       | Code quality           | Overlay `addEventListener` is effectively unreachable          |
 
 **Total: 1 P0, 6 P1, 5 P2, 3 P3 — Merge BLOCKED pending P0 and P1 resolution.**

--- a/packages/hx-library/src/components/hx-help-text/AUDIT.md
+++ b/packages/hx-library/src/components/hx-help-text/AUDIT.md
@@ -15,7 +15,7 @@ Branch: feature/deep-audit-hx-help-text
 | Tests         | PASS   | 31 tests, 100% coverage (lines, functions, branches, stmts) |
 | Storybook     | PASS   | 6 stories, all variants, play functions, form integration   |
 | CSS/Tokens    | PASS   | All values use `--hx-*` tokens with semantic fallbacks      |
-| CEM           | PASS   | Accurate: 1 attr, 1 slot, 3 parts, 6 CSS props, 0 events  |
+| CEM           | PASS   | Accurate: 1 attr, 1 slot, 3 parts, 6 CSS props, 0 events    |
 | Documentation | PASS   | Astro Starlight docs complete with all sections             |
 | Exports       | PASS   | Exported from index.ts and main library entry point         |
 | Performance   | PASS   | 1.46KB gzip (well within 5KB gate)                          |
@@ -26,15 +26,15 @@ Branch: feature/deep-audit-hx-help-text
 
 ## Quality Gate Results
 
-| Gate | Check             | Result | Detail                                          |
-| ---- | ----------------- | ------ | ----------------------------------------------- |
-| 1    | TypeScript strict | PASS   | `npm run verify` — zero errors                  |
-| 2    | Test suite        | PASS   | 31/31 pass, 100% coverage                       |
+| Gate | Check             | Result | Detail                                           |
+| ---- | ----------------- | ------ | ------------------------------------------------ |
+| 1    | TypeScript strict | PASS   | `npm run verify` — zero errors                   |
+| 2    | Test suite        | PASS   | 31/31 pass, 100% coverage                        |
 | 3    | Accessibility     | PASS   | axe-core zero violations, ARIA semantics correct |
-| 4    | Storybook         | PASS   | 6 stories covering all variants + integration   |
-| 5    | CEM accuracy      | PASS   | Matches public API exactly                      |
-| 6    | Bundle size       | PASS   | 1.46KB gzip                                     |
-| 7    | Code review       | PASS   | Deep audit, no issues found                     |
+| 4    | Storybook         | PASS   | 6 stories covering all variants + integration    |
+| 5    | CEM accuracy      | PASS   | Matches public API exactly                       |
+| 6    | Bundle size       | PASS   | 1.46KB gzip                                      |
+| 7    | Code review       | PASS   | Deep audit, no issues found                      |
 
 ---
 
@@ -60,6 +60,7 @@ Branch: feature/deep-audit-hx-help-text
 ### Test Coverage — PASS (31 tests, 100%)
 
 Test sections:
+
 1. **Rendering** (4 tests): Shadow DOM, CSS part, root element type, slotted content
 2. **Property: variant** (7 tests): Default value, attribute reflection, variant classes, dynamic update
 3. **ID association** (2 tests): Direct id, aria-describedby cross-reference
@@ -73,6 +74,7 @@ Test sections:
 ### Storybook Stories — PASS
 
 6 stories with full coverage:
+
 - `Default` — default variant with play function assertion
 - `Error` — error variant with play function assertion
 - `Warning` — warning variant with play function assertion
@@ -83,6 +85,7 @@ Test sections:
 ### CEM (Custom Elements Manifest) — PASS
 
 Generated CEM matches public API:
+
 - **Tag:** `hx-help-text`
 - **Attributes:** `variant`
 - **Slots:** `(default)`
@@ -93,6 +96,7 @@ Generated CEM matches public API:
 ### Design Token Compliance — PASS
 
 All CSS values use the `--hx-*` token cascade:
+
 - Component-level tokens: `--hx-help-text-color`, `--hx-help-text-font-*`, `--hx-help-text-icon-gap`
 - Semantic fallbacks: `--hx-color-neutral-500`, `--hx-font-family-sans`, etc.
 - Variant colors: `--hx-color-error-600`, `--hx-color-warning-700`, `--hx-color-success-700`
@@ -102,6 +106,7 @@ All CSS values use the `--hx-*` token cascade:
 ### Astro Starlight Documentation — PASS
 
 Comprehensive docs at `apps/docs/src/content/docs/component-library/hx-help-text.mdx`:
+
 - Overview with key behaviors
 - Live demos (variants + form field integration)
 - Installation instructions

--- a/packages/hx-library/src/components/hx-icon-button/AUDIT.md
+++ b/packages/hx-library/src/components/hx-icon-button/AUDIT.md
@@ -75,9 +75,13 @@ When `href` is set and `disabled` is true, the component removes `href` (via `if
 ></a>
 ```
 
-### P1-04: JSDoc claims console.warn is emitted — it is not ✅ FIXED
+### P1-04: JSDoc claims console.warn is emitted — it is not
 
-**Resolution:** `console.warn('[hx-icon-button] The \`label\` property is required for accessibility. Render suppressed.')` is now called in `render()` when `normalizedLabel` is empty, before returning `nothing`. The JSDoc accurately documents the warning behaviour. The AUDIT.md note about `connectedCallback` is no longer applicable — validation happens in `render()` as documented.
+**File:** `hx-icon-button.ts:39` and `hx-icon-button.ts:112-115`
+
+The `@property` JSDoc says: "A console warning is emitted when absent." The `connectedCallback` comment says: "Label validation now happens in render() which enforces it by rendering nothing." No `console.warn` call exists anywhere in the file.
+
+This is a documentation lie that will mislead consumers: they expect a developer-facing warning during authoring, but they get silent failure (component renders nothing). The missing warn also removes an essential DX signal for the healthcare teams building with this component.
 
 ### P1-05: Missing `shape` property (circular variant not implemented)
 
@@ -129,9 +133,9 @@ const _canvas = within(canvasElement);
 
 `_canvas` is never used. The underscore prefix suppresses linting but this is dead code that should be removed.
 
-### P2-04: No Drupal integration file or Twig template example ✅ FIXED
+### P2-04: No Drupal integration file or Twig template example
 
-**Resolution:** Added `hx-icon-button.twig` template covering all public properties including the non-standard `hx-size` attribute (exposed as the `hx_size` Twig variable to avoid Twig parsing conflicts). Added `README.drupal.md` with attribute reference, healthcare label guidance, event handling example using Drupal behaviors with `once()`, form submit/reset usage, and asset loading configuration. The `hx-size` attribute is prominently documented for Twig authors.
+The audit spec calls out Drupal as a required area. There is no Twig template, no `drupal-behaviors.js`, and no documentation of the Drupal consumption pattern. While Drupal integration may live in a separate package, the `hx-icon-button` folder has no reference to it. The non-standard `hx-size` attribute name should be explicitly documented for Twig authors.
 
 ### P2-05: `--hx-icon-button-bg` has no base fallback value
 
@@ -153,22 +157,22 @@ The base `.button:hover` applies `filter: brightness(0.9)`. However, `secondary`
 
 ## Gaps vs. Feature Description Audit Checklist
 
-| Audit Area                                | Status     | Notes                                                               |
-| ----------------------------------------- | ---------- | ------------------------------------------------------------------- |
-| TypeScript — no `any`, proper typing      | PASS       | All types are correct. P1-04 (console.warn) ✅ FIXED               |
-| Accessibility — aria-label                | PASS       | Correctly set from `label`                                          |
-| Accessibility — keyboard activation       | FAIL       | Tests use click(), not keyboard events (P1-01)                      |
-| Accessibility — focus visible             | PASS       | `focus-visible` ring present                                        |
-| Accessibility — axe-core                  | PASS       | Screenshots show zero violations                                    |
-| Tests — all sizes                         | PASS       | sm/md/lg covered                                                    |
-| Tests — all states (default/disabled)     | PASS       | Covered                                                             |
-| Tests — loading state                     | FAIL       | Loading state does not exist (P1-06)                                |
-| Tests — accessible label present          | PASS       | aria-label and title tested                                         |
-| Storybook — all variants with controls    | PASS       | All 5 variants                                                      |
-| Storybook — accessible label demonstrated | PASS       | Healthcare scenarios present                                        |
-| Storybook — loading state                 | FAIL       | Not present (P1-06)                                                 |
-| CSS — `--hx-*` tokens only                | PASS       | Component styles are token-only                                     |
-| CSS — circular/square shape variants      | FAIL       | No shape property (P1-05)                                           |
-| CSS — CSS parts exposed                   | PASS       | `button` and `icon` parts                                           |
-| Performance — bundle < 5KB                | UNVERIFIED | Requires build measurement                                          |
-| Drupal — Twig-renderable                  | PASS       | `hx-icon-button.twig` and `README.drupal.md` added (P2-04 ✅ FIXED) |
+| Audit Area                                | Status     | Notes                                                  |
+| ----------------------------------------- | ---------- | ------------------------------------------------------ |
+| TypeScript — no `any`, proper typing      | PASS       | All types are correct                                  |
+| Accessibility — aria-label                | PASS       | Correctly set from `label`                             |
+| Accessibility — keyboard activation       | FAIL       | Tests use click(), not keyboard events (P1-01)         |
+| Accessibility — focus visible             | PASS       | `focus-visible` ring present                           |
+| Accessibility — axe-core                  | PASS       | Screenshots show zero violations                       |
+| Tests — all sizes                         | PASS       | sm/md/lg covered                                       |
+| Tests — all states (default/disabled)     | PASS       | Covered                                                |
+| Tests — loading state                     | FAIL       | Loading state does not exist (P1-06)                   |
+| Tests — accessible label present          | PASS       | aria-label and title tested                            |
+| Storybook — all variants with controls    | PASS       | All 5 variants                                         |
+| Storybook — accessible label demonstrated | PASS       | Healthcare scenarios present                           |
+| Storybook — loading state                 | FAIL       | Not present (P1-06)                                    |
+| CSS — `--hx-*` tokens only                | PASS       | Component styles are token-only                        |
+| CSS — circular/square shape variants      | FAIL       | No shape property (P1-05)                              |
+| CSS — CSS parts exposed                   | PASS       | `button` and `icon` parts                              |
+| Performance — bundle < 5KB                | UNVERIFIED | Requires build measurement                             |
+| Drupal — Twig-renderable                  | PARTIAL    | Attributes are Twig-compatible but no template (P2-04) |

--- a/packages/hx-library/src/components/hx-link/hx-link.stories.ts
+++ b/packages/hx-library/src/components/hx-link/hx-link.stories.ts
@@ -370,10 +370,9 @@ export const CSSCustomProperties: Story = {
         <hx-link href="/page" style="--hx-link-text-decoration: none;">No underline</hx-link>
       </div>
       <div>
-        <code style="font-size: 0.75rem; color: #6b7280;"
-          >--hx-link-focus-ring-color: #7c3aed</code
+        <code style="font-size: 0.75rem; color: #6b7280;">--hx-link-focus-ring-color: var(--hx-color-purple-600)</code
         ><br />
-        <hx-link href="/page" style="--hx-link-focus-ring-color: #7c3aed;"
+        <hx-link href="/page" style="--hx-link-focus-ring-color: var(--hx-color-purple-600);"
           >Purple focus ring (tab to see)</hx-link
         >
       </div>

--- a/packages/hx-library/src/components/hx-number-input/AUDIT.md
+++ b/packages/hx-library/src/components/hx-number-input/AUDIT.md
@@ -4,6 +4,7 @@
 **Date:** 2026-03-05
 **Source:** `rescue/abandoned-components` branch (PR #175 — not yet merged to dev)
 **Files audited:**
+
 - `hx-number-input.ts`
 - `hx-number-input.styles.ts`
 - `hx-number-input.test.ts`
@@ -15,11 +16,11 @@
 
 ## Severity Key
 
-| Severity | Meaning |
-|---|---|
-| **P0** | Blocking — ships broken behavior, data loss, or hard accessibility violation |
-| **P1** | High — incorrect contract, AT inaccessibility, missing test coverage for critical path |
-| **P2** | Medium — code quality, minor spec deviation, documentation gap |
+| Severity | Meaning                                                                                |
+| -------- | -------------------------------------------------------------------------------------- |
+| **P0**   | Blocking — ships broken behavior, data loss, or hard accessibility violation           |
+| **P1**   | High — incorrect contract, AT inaccessibility, missing test coverage for critical path |
+| **P2**   | Medium — code quality, minor spec deviation, documentation gap                         |
 
 ---
 
@@ -50,6 +51,7 @@ this.value = isNaN(parsed) ? null : parsed;
 **File:** `hx-number-input.ts`, `_applyStep` method
 
 The documentation establishes two distinct events:
+
 - `hx-input` — "Dispatched on every keystroke as the user types"
 - `hx-change` — "Dispatched when the input loses focus after its value changed"
 
@@ -123,8 +125,13 @@ A sighted screen reader user (e.g., low-vision user who mouses to the buttons) c
 **File:** `hx-number-input.ts`, error div in render
 
 ```html
-<div part="error-message" class="field__error" id=${this._errorId}
-     role="alert" aria-live="polite">
+<div
+  part="error-message"
+  class="field__error"
+  id="${this._errorId}"
+  role="alert"
+  aria-live="polite"
+>
   ${this.error}
 </div>
 ```
@@ -132,6 +139,7 @@ A sighted screen reader user (e.g., low-vision user who mouses to the buttons) c
 `role="alert"` has an implicit `aria-live="assertive"` and `aria-atomic="true"`. Adding `aria-live="polite"` attempts to downgrade it to polite announcement, but `role="alert"` wins — the content will still be announced assertively by most screen readers. In a healthcare UI where error announcements compete with ongoing task narration, an unintended assertive interrupt could disorient users.
 
 **Fix needed:** Choose one semantic:
+
 - `role="alert"` alone (assertive — appropriate for validation errors that require immediate attention)
 - `role="status"` + `aria-live="polite"` (polite — appropriate if errors are informational, non-blocking)
 
@@ -178,6 +186,7 @@ The native `required` attribute already communicates requiredness to all assisti
 **File:** `hx-number-input.test.ts`
 
 The component implements a long-press acceleration pattern (`_startLongPress`, `_repeatInterval`, 400ms initial delay, 100ms repeat interval). This is one of the most complex and behavior-rich features of the component, but it has no tests:
+
 - No test for repeated firing during hold
 - No test for stopping on `pointerup`
 - No test for stopping on `pointerleave`
@@ -322,10 +331,10 @@ Consumers who inspect the JSDoc or autodocs cannot discover these customization 
 
 ```css
 .field__stepper-btn {
-  outline: none;  /* removes default focus ring */
+  outline: none; /* removes default focus ring */
 }
 .field__stepper-btn:focus-visible {
-  outline: ...;   /* restores via :focus-visible */
+  outline: ...; /* restores via :focus-visible */
 }
 ```
 
@@ -341,7 +350,7 @@ This is secondary to the P0 `aria-hidden` finding. Once `aria-hidden` is removed
 
 ```css
 .field__input[type='number'] {
-  -moz-appearance: textfield;  /* deprecated */
+  -moz-appearance: textfield; /* deprecated */
   appearance: textfield;
 }
 ```
@@ -356,7 +365,11 @@ This is secondary to the P0 `aria-hidden` finding. Once `aria-hidden` is removed
 
 ```css
 box-shadow: 0 0 0 var(--hx-focus-ring-width)
-  color-mix(in srgb, var(--hx-focus-ring-color) calc(var(--hx-focus-ring-opacity) * 100%), transparent);
+  color-mix(
+    in srgb,
+    var(--hx-focus-ring-color) calc(var(--hx-focus-ring-opacity) * 100%),
+    transparent
+  );
 ```
 
 `color-mix()` is Baseline 2023 (broadly available as of late 2023). For healthcare enterprise deployments on older managed browsers or Windows 7/8 era systems, this could silently drop the focus ring box-shadow. No fallback is provided.
@@ -374,6 +387,7 @@ box-shadow: 0 0 0 var(--hx-focus-ring-width)
   pointer-events: none;
 }
 ```
+
 ```ts
 ?disabled=${this.disabled || this.readonly || this._atMax}
 ```
@@ -421,6 +435,7 @@ The feature requirement specifies `< 5KB (min+gz)`. Given the implementation siz
 **File:** `hx-number-input.ts`
 
 The JSDoc documents:
+
 ```
  * @slot - Default slot — label override for Drupal Form API rendered labels.
 ```
@@ -471,43 +486,43 @@ Healthcare contexts often show placeholder hints for expected format (e.g., `pla
 
 ## Summary Table
 
-| # | Area | Severity | Finding |
-|---|------|----------|---------|
-| 1 | TypeScript | P1 | `formStateRestoreCallback` uses `parseFloat` vs converter's `Number()` — inconsistency |
-| 2 | TypeScript | P1 | `_applyStep` dispatches both `hx-input` AND `hx-change` — violates event contract |
-| 3 | TypeScript | P1 | `step` typed inconsistently vs `min`/`max` |
-| 4 | TypeScript | P2 | `select()` is misleading API on `type="number"` |
-| 5 | TypeScript | P2 | No runtime validation of `hxSize` attribute |
-| 6 | Accessibility | **P0** | Stepper `aria-hidden="true"` hides buttons from AT — WCAG SC 4.1.2 violation |
-| 7 | Accessibility | P1 | `role="alert"` + `aria-live="polite"` semantic conflict |
-| 8 | Accessibility | P1 | Stepper `aria-label` attributes are dead code (hidden by `aria-hidden`) |
-| 9 | Accessibility | P1 | `aria-required` redundant alongside native `required` |
-| 10 | Accessibility | P2 | `type="number"` accepts scientific notation silently |
-| 11 | Tests | P1 | Long-press behavior has zero test coverage |
-| 12 | Tests | P1 | `formResetCallback` test validates incorrect behavior |
-| 13 | Tests | P1 | Test uses `getElementById('test-fixture-container')` — fragile DOM assumption |
-| 14 | Tests | P1 | No test for `_applyStep` dual-event dispatch |
-| 15 | Tests | P2 | `pointerleave`/`pointercancel` handlers untested |
-| 16 | Tests | P2 | `select()` test validates no-op |
-| 17 | Tests | P2 | `formStateRestoreCallback("77abc")` edge case not tested |
-| 18 | Storybook | P1 | `argTypes` keys use camelCase, not HTML attribute names |
-| 19 | Storybook | P1 | `InAForm` story uses hardcoded hex colors |
-| 20 | Storybook | P2 | No `label` slot story (Drupal Form API pattern) |
-| 21 | Storybook | P2 | No composite Drupal slot story |
-| 22 | CSS | P1 | `--hx-number-input-label-color` and `--hx-number-input-font-family` undocumented |
-| 23 | CSS | P1 | `outline: none` on stepper buttons without reliable replacement for programmatic focus |
-| 24 | CSS | P2 | `-moz-appearance: textfield` is deprecated |
-| 25 | CSS | P2 | `color-mix()` has no fallback for older managed browsers |
-| 26 | CSS | P2 | Double-disable (`pointer-events: none` + `disabled`) undocumented |
-| 27 | Performance | P2 | `Math.random()` IDs — non-deterministic, SSR/snapshot unfriendly |
-| 28 | Performance | P2 | 100ms `setInterval` long-press creates GC pressure at high step counts |
-| 29 | Performance | P2 | Bundle size not verified against 5KB budget |
-| 30 | Drupal | **P0** | ~~`@slot -` documents default slot that doesn't exist~~ **FIXED** — `@slot -` removed; named `label` slot documented |
-| 31 | Drupal | P1 | ~~`formResetCallback` doesn't restore to HTML `value` attribute default~~ **FIXED** — `_defaultValue` captured in `firstUpdated()` |
-| 32 | Drupal | P1 | ~~`step="1"` omitted from native input DOM when value is 1~~ **FIXED** — `step=${this.step}` always rendered |
-| 33 | Drupal | P2 | No `placeholder` property (parity gap with `hx-text-input`) |
-| 34 | Storybook | P2 | ~~No `label` slot story (Drupal Form API pattern)~~ **FIXED** — `WithLabelSlot` story added |
-| 35 | Storybook | P2 | ~~No composite Drupal slot story~~ **FIXED** — `DrupalFormAPI` story added (all three slots) |
+| #   | Area          | Severity | Finding                                                                                                                            |
+| --- | ------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | TypeScript    | P1       | `formStateRestoreCallback` uses `parseFloat` vs converter's `Number()` — inconsistency                                             |
+| 2   | TypeScript    | P1       | `_applyStep` dispatches both `hx-input` AND `hx-change` — violates event contract                                                  |
+| 3   | TypeScript    | P1       | `step` typed inconsistently vs `min`/`max`                                                                                         |
+| 4   | TypeScript    | P2       | `select()` is misleading API on `type="number"`                                                                                    |
+| 5   | TypeScript    | P2       | No runtime validation of `hxSize` attribute                                                                                        |
+| 6   | Accessibility | **P0**   | Stepper `aria-hidden="true"` hides buttons from AT — WCAG SC 4.1.2 violation                                                       |
+| 7   | Accessibility | P1       | `role="alert"` + `aria-live="polite"` semantic conflict                                                                            |
+| 8   | Accessibility | P1       | Stepper `aria-label` attributes are dead code (hidden by `aria-hidden`)                                                            |
+| 9   | Accessibility | P1       | `aria-required` redundant alongside native `required`                                                                              |
+| 10  | Accessibility | P2       | `type="number"` accepts scientific notation silently                                                                               |
+| 11  | Tests         | P1       | Long-press behavior has zero test coverage                                                                                         |
+| 12  | Tests         | P1       | `formResetCallback` test validates incorrect behavior                                                                              |
+| 13  | Tests         | P1       | Test uses `getElementById('test-fixture-container')` — fragile DOM assumption                                                      |
+| 14  | Tests         | P1       | No test for `_applyStep` dual-event dispatch                                                                                       |
+| 15  | Tests         | P2       | `pointerleave`/`pointercancel` handlers untested                                                                                   |
+| 16  | Tests         | P2       | `select()` test validates no-op                                                                                                    |
+| 17  | Tests         | P2       | `formStateRestoreCallback("77abc")` edge case not tested                                                                           |
+| 18  | Storybook     | P1       | `argTypes` keys use camelCase, not HTML attribute names                                                                            |
+| 19  | Storybook     | P1       | `InAForm` story uses hardcoded hex colors                                                                                          |
+| 20  | Storybook     | P2       | No `label` slot story (Drupal Form API pattern)                                                                                    |
+| 21  | Storybook     | P2       | No composite Drupal slot story                                                                                                     |
+| 22  | CSS           | P1       | `--hx-number-input-label-color` and `--hx-number-input-font-family` undocumented                                                   |
+| 23  | CSS           | P1       | `outline: none` on stepper buttons without reliable replacement for programmatic focus                                             |
+| 24  | CSS           | P2       | `-moz-appearance: textfield` is deprecated                                                                                         |
+| 25  | CSS           | P2       | `color-mix()` has no fallback for older managed browsers                                                                           |
+| 26  | CSS           | P2       | Double-disable (`pointer-events: none` + `disabled`) undocumented                                                                  |
+| 27  | Performance   | P2       | `Math.random()` IDs — non-deterministic, SSR/snapshot unfriendly                                                                   |
+| 28  | Performance   | P2       | 100ms `setInterval` long-press creates GC pressure at high step counts                                                             |
+| 29  | Performance   | P2       | Bundle size not verified against 5KB budget                                                                                        |
+| 30  | Drupal        | **P0**   | ~~`@slot -` documents default slot that doesn't exist~~ **FIXED** — `@slot -` removed; named `label` slot documented               |
+| 31  | Drupal        | P1       | ~~`formResetCallback` doesn't restore to HTML `value` attribute default~~ **FIXED** — `_defaultValue` captured in `firstUpdated()` |
+| 32  | Drupal        | P1       | ~~`step="1"` omitted from native input DOM when value is 1~~ **FIXED** — `step=${this.step}` always rendered                       |
+| 33  | Drupal        | P2       | No `placeholder` property (parity gap with `hx-text-input`)                                                                        |
+| 34  | Storybook     | P2       | ~~No `label` slot story (Drupal Form API pattern)~~ **FIXED** — `WithLabelSlot` story added                                        |
+| 35  | Storybook     | P2       | ~~No composite Drupal slot story~~ **FIXED** — `DrupalFormAPI` story added (all three slots)                                       |
 
 ---
 
@@ -515,4 +530,4 @@ Healthcare contexts often show placeholder hints for expected format (e.g., `pla
 
 1. **Stepper `aria-hidden="true"` (Finding #6)** — Buttons are completely inaccessible to screen reader users. WCAG 2.1 AA violation. Must be fixed before merge.
 
-2. ~~**`@slot -` documents non-existent default slot (Finding #30)**~~ **FIXED** — `@slot -` removed from JSDoc; the named `slot="label"` is correctly documented and a `WithLabelSlot` story demonstrates the Drupal Form API pattern.
+2. **`@slot -` documents non-existent default slot (Finding #30)** — Drupal consumers following the documentation will silently lose server-rendered label content. Either add the slot or fix the documentation before merge.

--- a/packages/hx-library/src/components/hx-popover/AUDIT.md
+++ b/packages/hx-library/src/components/hx-popover/AUDIT.md
@@ -143,11 +143,11 @@ Both methods perform the same slot query and `setAttribute('aria-expanded', ...)
 
 ---
 
-### P2-04: Storybook `Placements` story shows only 4 of 12 placement variants
+### P2-04: Storybook `Placements` story shows only 4 of 12 placement variants — ✅ FIXED
 
-**File:** `hx-popover.stories.ts`, lines 154–170
+**File:** `hx-popover.stories.ts`, lines 154–185
 
-The `Placements` story iterates over `['top', 'bottom', 'left', 'right']` — only the 4 cardinal directions. The type system supports 12 variants (`top-start`, `top-end`, `right-start`, `right-end`, `bottom-start`, `bottom-end`, `left-start`, `left-end` are absent). The story should demonstrate all variants, especially the alignment variants which are the most likely to have visual regressions.
+**Resolution:** The `Placements` story now iterates over all 12 placement variants: `top`, `top-start`, `top-end`, `right`, `right-start`, `right-end`, `bottom`, `bottom-start`, `bottom-end`, `left`, `left-start`, `left-end`. All alignment variants are rendered with an arrow for visual regression coverage.
 
 ---
 

--- a/packages/hx-library/src/components/hx-progress-bar/AUDIT.md
+++ b/packages/hx-library/src/components/hx-progress-bar/AUDIT.md
@@ -22,11 +22,11 @@ The feature spec calls for `min` typed as a number. The component hardcodes `ari
 
 ---
 
-### [P1] Missing `indeterminate` boolean property
+### [P1] Missing `indeterminate` boolean property — FIXED
 
 The spec calls for an explicit typed `indeterminate` prop. The implementation derives indeterminate state from `value === null`, which is a valid pattern but means consumers cannot set `indeterminate` as a boolean attribute (`<hx-progress-bar indeterminate>`). The null-value approach requires consumers to know about `value` semantics and makes Twig/HTML usage less obvious.
 
-**Location:** `hx-progress-bar.ts` — no `@property() indeterminate` declared.
+**Resolution:** `@property({ type: Boolean, reflect: true }) indeterminate = false` added. The `_isIndeterminate` getter combines both the boolean flag and `value === null` to support both API styles.
 
 ---
 
@@ -38,9 +38,11 @@ The spec mentions "label/description typed." No `description` property exists. A
 
 ---
 
-### [P2] `value` attribute is null-by-default but reflected as number type
+### [P2] `value` attribute is null-by-default but reflected as number type — FIXED
 
-`@property({ type: Number, reflect: true }) value: number | null = null` reflects correctly, but the reflected attribute will be absent (not `"null"`) when `value` is `null` — this is correct Lit behavior. No issue with the implementation itself, but the type `number | null` is undocumented in the JSDocs `@attr` tag, which says only "Current progress value (0–max). Set to null for indeterminate state." — acceptable documentation.
+`@property({ type: Number, reflect: true }) value: number | null = null` reflects correctly, but the reflected attribute will be absent (not `"null"`) when `value` is `null` — this is correct Lit behavior. No issue with the implementation itself, but the type `number | null` is undocumented in the JSDocs `@attr` tag.
+
+**Resolution:** JSDoc updated to `Current progress value (min–max). Set to null for indeterminate state.` — explicitly documents the null-for-indeterminate contract. No code change required.
 
 ---
 
@@ -122,27 +124,21 @@ The accessibility tests always supply `label="..."`. There is no test that asser
 
 ## 4. Storybook
 
-### [P2] Duplicate label in `Default` story (attribute + slot)
+### ~~[P2] Duplicate label in `Default` story (attribute + slot)~~ ✅ FIXED
 
-The `Default` story renders `label=${args.label}` (setting `aria-label`) AND `<span slot="label">${args.label}</span>` simultaneously. This means the aria-label and the visible slot label always have the same value, but via two separate mechanisms. This pattern should be documented — it is not self-evidently correct, and consumers may cargo-cult it and supply only one, introducing unlabeled progressbars.
-
-**Location:** `hx-progress-bar.stories.ts:80–90`.
+The `Default` story now uses only the slot-based label (`<span slot="label">`) without a duplicate `label` attribute for `aria-label`. The component wires `aria-labelledby` automatically from the slot.
 
 ---
 
-### [P2] `argTypes.size` key is `size` but attribute is `hx-size`
+### ~~[P2] `argTypes.size` key is `size` but attribute is `hx-size`~~ ✅ FIXED
 
-The `argTypes` object uses key `size` and the story binds via `hx-size=${args.size}`. While this works, the Storybook controls table will show the control as `size`, not matching the actual HTML attribute `hx-size`. CEM-driven autodocs may also misalign. The property is `size` but the attribute is `hx-size` (set via `attribute: 'hx-size'`); the argTypes key should reflect the attribute name for Storybook autodocs to work correctly.
-
-**Location:** `hx-progress-bar.stories.ts:42–51`.
+The `argTypes` object now uses `'hx-size'` as the key (matching the HTML attribute name), and stories bind via `hx-size=${args['hx-size']}`. Storybook controls table and CEM autodocs are correctly aligned.
 
 ---
 
-### [P2] No story demonstrating indeterminate + `aria-labelledby` pattern
+### ~~[P2] No story demonstrating indeterminate + `aria-labelledby` pattern~~ ✅ FIXED
 
-The `Indeterminate` story uses `label` attribute (aria-label). There is no story demonstrating how a consumer would use the visible label slot as the accessible name via `aria-labelledby`. Given the accessible name gap (P1 above), this story would be the canonical demonstration of correct usage.
-
-**Location:** `hx-progress-bar.stories.ts:93–108`.
+The `WithAriaLabelledBy` story demonstrates the canonical `aria-labelledby` usage pattern using the visible label slot — no redundant `label` attribute needed.
 
 ---
 
@@ -190,7 +186,7 @@ The compiled `index.js` (re-export stub) is 137 bytes. The full component logic 
 
 ## 7. Drupal / Twig
 
-### [P2] No Twig template or Drupal integration file ✅ FIXED
+### [P2] No Twig template or Drupal integration file
 
 The component is technically Drupal-compatible as a standard web component (`<hx-progress-bar value="75" label="Progress">`), but no Drupal-specific files are provided:
 
@@ -202,34 +198,32 @@ Twig usage works but requires Drupal developers to know the attribute names (`hx
 
 **Location:** No Drupal integration files in the component directory.
 
-**Resolution:** Created `hx-progress-bar.twig` documenting all attributes (`value`, `min`, `max`, `label`, `description`, `hx-size`, `variant`, `indeterminate`), usage examples for determinate/indeterminate/success/warning states, Drupal libraries.yml registration pattern, and `hx-complete` event behavior integration example.
-
 ---
 
 ## Summary Table
 
-| #   | Area       | Finding                                               | Severity |
-| --- | ---------- | ----------------------------------------------------- | -------- |
-| 1   | TypeScript | Missing `min` property                                | P1       |
-| 2   | TypeScript | Missing `indeterminate` boolean prop                  | P1       |
-| 3   | TypeScript | Missing `description` property                        | P2       |
-| 4   | A11y       | No `aria-labelledby` for visible label slot           | P1       |
-| 5   | A11y       | No live region on completion                          | P1       |
-| 6   | A11y       | Unlabeled progressbar is unguarded (silent violation) | P2       |
-| 7   | A11y       | `aria-valuemin` hardcoded, not bound to `min` prop    | P2       |
-| 8   | Tests      | No test for 0% (empty state)                          | P0       |
-| 9   | Tests      | No test for completion event                          | P1       |
-| 10  | Tests      | No test for negative value clamping                   | P1       |
-| 11  | Tests      | No test for dynamic label update                      | P2       |
-| 12  | Tests      | No test for no-label accessibility violation          | P2       |
-| 13  | Storybook  | Duplicate label in Default story (attribute + slot)   | P2       |
-| 14  | Storybook  | `argTypes.size` key mismatches attribute `hx-size`    | P2       |
-| 15  | Storybook  | No story for `aria-labelledby` usage pattern          | P2       |
-| 16  | CSS        | Parts named `base`/`indicator` vs spec `track`/`fill` | P1       |
-| 17  | CSS        | Indeterminate animation `translateX(250%)` technique  | P2       |
-| 18  | CSS        | Hardcoded hex fallbacks in CSS custom properties      | P2       |
-| 19  | CSS        | No `forced-colors` high-contrast support              | P2       |
-| 20  | Drupal     | No Twig template or integration file ✅ FIXED         | P2       |
+| #   | Area       | Finding                                                 | Severity |
+| --- | ---------- | ------------------------------------------------------- | -------- |
+| 1   | TypeScript | Missing `min` property                                  | P1       |
+| 2   | TypeScript | Missing `indeterminate` boolean prop                    | P1       |
+| 3   | TypeScript | Missing `description` property                          | P2       |
+| 4   | A11y       | No `aria-labelledby` for visible label slot             | P1       |
+| 5   | A11y       | No live region on completion                            | P1       |
+| 6   | A11y       | Unlabeled progressbar is unguarded (silent violation)   | P2       |
+| 7   | A11y       | `aria-valuemin` hardcoded, not bound to `min` prop      | P2       |
+| 8   | Tests      | No test for 0% (empty state)                            | P0       |
+| 9   | Tests      | No test for completion event                            | P1       |
+| 10  | Tests      | No test for negative value clamping                     | P1       |
+| 11  | Tests      | No test for dynamic label update                        | P2       |
+| 12  | Tests      | No test for no-label accessibility violation            | P2       |
+| 13  | Storybook  | ~~Duplicate label in Default story (attribute + slot)~~ | ✅ FIXED |
+| 14  | Storybook  | ~~`argTypes.size` key mismatches attribute `hx-size`~~  | ✅ FIXED |
+| 15  | Storybook  | ~~No story for `aria-labelledby` usage pattern~~        | ✅ FIXED |
+| 16  | CSS        | Parts named `base`/`indicator` vs spec `track`/`fill`   | P1       |
+| 17  | CSS        | Indeterminate animation `translateX(250%)` technique    | P2       |
+| 18  | CSS        | Hardcoded hex fallbacks in CSS custom properties        | P2       |
+| 19  | CSS        | No `forced-colors` high-contrast support                | P2       |
+| 20  | Drupal     | No Twig template or integration file                    | P2       |
 
 **Totals:** 1 P0, 6 P1, 13 P2
 

--- a/packages/hx-library/src/components/hx-prose/AUDIT.md
+++ b/packages/hx-library/src/components/hx-prose/AUDIT.md
@@ -18,11 +18,21 @@
 
 ## Summary
 
+<<<<<<< HEAD
 | Severity     | Count |
 | ------------ | ----- |
 | P0 (Blocker) | 2     |
 | P1 (High)    | 8     |
 | P2 (Medium)  | 8     |
+=======
+_Baseline counts as of audit date (2026-03-05). Findings marked ✅ FIXED have been resolved._
+
+| Severity     | Baseline | Remaining |
+| ------------ | -------- | --------- |
+| P0 (Blocker) | 2        | 2         |
+| P1 (High)    | 8        | 7         |
+| P2 (Medium)  | 8        | 7         |
+>>>>>>> origin/dev
 
 ---
 
@@ -41,7 +51,7 @@
 
 ---
 
-### P0-02: Test file imports nonexistent type `WcProse`
+### P0-02: Test file imports nonexistent type `WcProse` — FIXED
 
 **File:** `hx-prose.test.ts`
 **Line:** 4
@@ -51,6 +61,8 @@ import type { WcProse } from './hx-prose.js';
 ```
 
 The component exports `HelixProse`, not `WcProse`. This import will produce a TypeScript error under strict mode (`'WcProse' is not exported from './hx-prose.js'`). The tests currently pass because the type is used only as a generic parameter to `fixture<WcProse>()`, and TypeScript may not enforce the import strictly in the test runner context — but it will fail `npm run type-check`. This is a broken type reference that violates the zero-TypeScript-errors gate.
+
+**Resolution:** Import corrected to `import type { HelixProse } from './hx-prose.js'` and all `fixture<WcProse>` generic usages updated to `fixture<HelixProse>`.
 
 ---
 
@@ -223,7 +235,7 @@ This rule explicitly prevents clearing floated content. CKEditor's `.align-left`
 
 ---
 
-### P2-04: `_styles` private member — redundant underscore prefix convention
+### P2-04: `_styles` private member — redundant underscore prefix convention — FIXED
 
 **File:** `hx-prose.ts`
 **Line:** 38
@@ -233,6 +245,8 @@ private _styles = new AdoptedStylesheetsController(this, helixProseScopedCss, do
 ```
 
 TypeScript's `private` keyword already enforces access restriction. The underscore prefix (`_styles`) is a JavaScript convention for "pseudo-private" that predates `private`. Using both simultaneously is redundant and inconsistent — other components in the library should be checked for consistency. If the codebase convention is `private` (TypeScript), the underscore prefix should be dropped.
+
+**Resolution:** Renamed to `private adoptedStyles = new AdoptedStylesheetsController(...)` — underscore prefix removed, consistent with TypeScript `private` access modifier usage across the library.
 
 ---
 

--- a/packages/hx-library/src/components/hx-prose/hx-prose.stories.ts
+++ b/packages/hx-library/src/components/hx-prose/hx-prose.stories.ts
@@ -898,32 +898,38 @@ export const AllContentTypes: Story = {
         </caption>
         <thead>
           <tr>
-            <th>Test</th>
-            <th>Result</th>
-            <th>Reference</th>
-            <th>Status</th>
+            <th scope="col">Test</th>
+            <th scope="col">Result</th>
+            <th scope="col">Reference</th>
+            <th scope="col">Status</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td>Hemoglobin</td>
+            <th scope="row">Hemoglobin</th>
             <td>14.2 g/dL</td>
             <td>12.0 - 16.0</td>
             <td>Normal</td>
           </tr>
           <tr>
-            <td>WBC</td>
+            <th scope="row">WBC</th>
             <td>8.5 K/uL</td>
             <td>4.5 - 11.0</td>
             <td>Normal</td>
           </tr>
           <tr>
-            <td>Glucose</td>
+            <th scope="row">Glucose</th>
             <td>142 mg/dL</td>
             <td>70 - 100</td>
             <td>High</td>
           </tr>
         </tbody>
+        <tfoot>
+          <tr>
+            <th scope="row" colspan="3">3 results — 1 abnormal</th>
+            <td>Review required</td>
+          </tr>
+        </tfoot>
       </table>
 
       <h2>Code Block</h2>
@@ -943,10 +949,13 @@ export const AllContentTypes: Story = {
   }
 }</code></pre>
 
-      <h2>Keyboard Input</h2>
+      <h2>Keyboard and Technical Text</h2>
       <p>
         Press <kbd>Ctrl</kbd> + <kbd>P</kbd> to print. Use <kbd>Alt</kbd> + <kbd>F4</kbd> to close
-        the current window.
+        the current window. Terminal output like
+        <samp>Connection established. Waiting for data...</samp> uses the <code>samp</code> element.
+        Mathematical variables such as <var>x</var> + <var>y</var> = <var>z</var> use the
+        <code>var</code> element.
       </p>
 
       <h2>Links</h2>

--- a/packages/hx-library/src/components/hx-radio-group/AUDIT.md
+++ b/packages/hx-library/src/components/hx-radio-group/AUDIT.md
@@ -197,9 +197,17 @@ Only Arrow keys are handled. This is expected behavior that AT users and power k
 
 ---
 
-### ~~P2-2: `Math.random()` IDs break SSR / Drupal hydration~~ ✅ FIXED
+### P2-2: `Math.random()` IDs break SSR / Drupal hydration
 
-**Fix applied:** `_groupId` now uses a monotonically incrementing module-level counter (`++_groupCounter`) instead of `Math.random()`. IDs are deterministic within a page session and do not cause `aria-describedby` reference mismatches between Drupal server-rendered markup and client hydration.
+**File:** `hx-radio-group.ts:111–113`
+
+```ts
+private _groupId = `hx-radio-group-${Math.random().toString(36).slice(2, 9)}`;
+```
+
+IDs generated with `Math.random()` differ between server (Drupal/Twig pre-render) and client hydration. `aria-describedby` references will point to IDs that don't exist in the server-rendered DOM.
+
+**Fix:** Use a deterministic ID strategy (e.g., `name` attribute as seed, or a monotonically incrementing counter).
 
 ---
 
@@ -257,18 +265,11 @@ The feature spec mentions "selected-value typing." Common radio group APIs (Shoe
 
 ---
 
-### P2-7: Storybook missing individual-radio-disabled story
+### P2-7: Storybook missing individual-radio-disabled story — ✅ FIXED
 
 **File:** `hx-radio-group.stories.ts`
 
-Stories cover:
-
-- Group-level `disabled`
-- Required state
-- Error state
-- Horizontal/vertical orientation
-
-There is no dedicated story for a mixed state (one radio disabled within an enabled group), which is a valid and distinct state that Drupal consumers will use.
+**Resolution:** The `SingleDisabledOption` story demonstrates a mixed state: one `hx-radio` with `disabled` attribute inside an enabled group. The story includes a play function verifying that the disabled radio has the `disabled` attribute while enabled radios remain interactive and update the group value on click.
 
 ---
 
@@ -290,26 +291,26 @@ it('has no axe violations in default state', async () => {
 
 ## Summary Table
 
-| ID   | Severity | Area            | Description                                                    |
-| ---- | -------- | --------------- | -------------------------------------------------------------- |
-| P0-1 | P0       | Accessibility   | Focus ring CSS targets hidden input — never visible            |
-| P0-2 | P0       | Accessibility   | Space key does not select radio (`role="radio"` breach)        |
-| P0-3 | P0       | Form/Validation | Required validity not initialized on first render              |
+| ID   | Severity | Area            | Description                                                                                                                      |
+| ---- | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| P0-1 | P0       | Accessibility   | Focus ring CSS targets hidden input — never visible                                                                              |
+| P0-2 | P0       | Accessibility   | Space key does not select radio (`role="radio"` breach)                                                                          |
+| P0-3 | P0       | Form/Validation | Required validity not initialized on first render                                                                                |
 | P1-1 | P1       | Behavior        | ~~Re-enabling disabled group leaves radios permanently off~~ ✅ FIXED — `_individualDisabledStates` map restores per-radio state |
-| P1-2 | P1       | TypeScript      | `formStateRestoreCallback` wrong spec signature                |
-| P1-3 | P1       | TypeScript      | `_groupEl!` non-null assertion violates standards              |
-| P1-4 | P1       | Accessibility   | `_hasErrorSlot` dead code + dangling `aria-describedby`        |
-| P1-5 | P1       | Accessibility   | No `aria-required` on radiogroup                               |
-| P1-6 | P1       | Accessibility   | No `aria-labelledby` — legend naming unreliable in SDOM        |
-| P1-7 | P1       | Accessibility   | Missing `Home`/`End` keyboard support (APG requirement)        |
-| P2-1 | P2       | Performance     | ~~Double `setFormValue`/`_syncRadios`/`_updateValidity`~~ ✅ FIXED — single call path via `updated()` |
-| P2-2 | P2       | Drupal/SSR      | ~~`Math.random()` IDs break server/client hydration~~ ✅ FIXED — monotonic counter used |
-| P2-3 | P2       | TypeScript/A11y | `role` set imperatively, not in CEM, no static default         |
-| P2-4 | P2       | Accessibility   | `role="alert"` + `aria-live="polite"` conflict                 |
-| P2-5 | P2       | Accessibility   | Disabled focus ring state gap (follow-on to P0-1)              |
-| P2-6 | P2       | API             | No `selected-value` alias (naming gap vs other libraries)      |
-| P2-7 | P2       | Storybook       | No mixed-disabled story (partial disable state)                |
-| P2-8 | P2       | Testing         | `hx-radio` axe test runs orphaned — misleading signal ✅ FIXED |
+| P1-2 | P1       | TypeScript      | `formStateRestoreCallback` wrong spec signature                                                                                  |
+| P1-3 | P1       | TypeScript      | `_groupEl!` non-null assertion violates standards                                                                                |
+| P1-4 | P1       | Accessibility   | `_hasErrorSlot` dead code + dangling `aria-describedby`                                                                          |
+| P1-5 | P1       | Accessibility   | No `aria-required` on radiogroup                                                                                                 |
+| P1-6 | P1       | Accessibility   | No `aria-labelledby` — legend naming unreliable in SDOM                                                                          |
+| P1-7 | P1       | Accessibility   | Missing `Home`/`End` keyboard support (APG requirement)                                                                          |
+| P2-1 | P2       | Performance     | ~~Double `setFormValue`/`_syncRadios`/`_updateValidity`~~ ✅ FIXED — single call path via `updated()`                            |
+| P2-2 | P2       | Drupal/SSR      | ~~`Math.random()` IDs break server/client hydration~~ ✅ FIXED — monotonic counter used                                          |
+| P2-3 | P2       | TypeScript/A11y | `role` set imperatively, not in CEM, no static default                                                                           |
+| P2-4 | P2       | Accessibility   | `role="alert"` + `aria-live="polite"` conflict                                                                                   |
+| P2-5 | P2       | Accessibility   | Disabled focus ring state gap (follow-on to P0-1)                                                                                |
+| P2-6 | P2       | API             | No `selected-value` alias (naming gap vs other libraries)                                                                        |
+| P2-7 | P2       | Storybook       | No mixed-disabled story (partial disable state)                                                                                  |
+| P2-8 | P2       | Testing         | `hx-radio` axe test runs orphaned — misleading signal ✅ FIXED                                                                   |
 
 **Total findings: 3 P0, 7 P1, 8 P2**
 

--- a/packages/hx-library/src/components/hx-select/AUDIT.md
+++ b/packages/hx-library/src/components/hx-select/AUDIT.md
@@ -176,7 +176,7 @@ Missing token: `--hx-select-placeholder-color`
 
 ## P2 — Medium Severity
 
-### P2-01: `formStateRestoreCallback` has incomplete signature
+### P2-01: `formStateRestoreCallback` has incomplete signature — FIXED
 
 **File:** `hx-select.ts:251-253`
 
@@ -188,15 +188,18 @@ formStateRestoreCallback(state: string): void {
 
 The `FormStateRestoreCallback` interface specifies `(state: string | File | FormData, mode: 'restore' | 'autocomplete'): void`. The method accepts only `string` and ignores the `mode` parameter. If the browser restores state as `FormData` or `File` (valid per spec), this will silently assign a non-string to `this.value` without a type error in TypeScript (due to the narrowed parameter type). A proper guard and `mode` handling are missing.
 
+**Resolution:** Signature updated to `formStateRestoreCallback(state: string | File | FormData, _mode: 'restore' | 'autocomplete'): void` with a `typeof state === 'string'` guard before assigning to `this.value`.
+
 ---
 
-### P2-02: No multi-select support — limitation not documented in JSDoc or Storybook
+### ~~P2-02: No multi-select support — limitation not documented in JSDoc or Storybook~~ ✅ FIXED
 
-**File:** `hx-select.ts:1-648`
+**File:** `hx-select.ts`, `hx-select.stories.ts`
 
-The component does not implement a `multiple` attribute or multi-value selection. This is a legitimate design scope decision, but the absence is not documented anywhere in the JSDoc, CEM attributes, or Storybook stories. Consumers building healthcare forms that require multi-select (e.g., selecting multiple conditions, multiple providers) have no guidance about whether to expect this feature or use an alternative component.
+The multi-select limitation is now documented in two places:
 
-Recommendation: Add a `@remarks` JSDoc note explicitly stating that multi-select is not supported and will not be added (if intentional), or create a tracked issue.
+1. **JSDoc `@remarks`** on the component class — explicitly states multi-select is intentionally not supported and directs consumers to use a separate component.
+2. **Storybook `SingleValueOnly` story** — dedicated story with a prominent warning panel, code guidance, and a side-by-side example showing `hx-checkbox-group` as the correct alternative for multi-value selection.
 
 ---
 
@@ -228,11 +231,11 @@ private _instanceId = this._selectId;
 
 ---
 
-### P2-05: No Storybook story for the open/interactive listbox state
+### ~~P2-05: No Storybook story for the open/interactive listbox state~~ ✅ FIXED
 
 **File:** `hx-select.stories.ts`
 
-The stories include default, sizes, error, disabled, required, grouped, and form composition variants. There is no story that opens the dropdown and visually demonstrates the listbox — the interactive combobox state. Storybook's primary value for this component is demonstrating the dropdown UX, option hover/focus states, and keyboard behavior. A missing interactive story means visual regression testing for the open state is not automated.
+The `OpenInteractive` story (exported as `Open / Interactive Listbox`) demonstrates the dropdown in its open state with a pre-selected value, showing option focus states, disabled options, and keyboard navigation guidance. Visual regression testing for the open state is now automated via this story.
 
 ---
 
@@ -294,7 +297,7 @@ The axe-core tests check default, error, and disabled states — all with `open=
 
 ---
 
-### P2-11: `size` property accepts invalid values with no runtime warning
+### P2-11: `size` property accepts invalid values with no runtime warning — FIXED
 
 **File:** `hx-select.ts:143`
 
@@ -303,6 +306,8 @@ size: 'sm' | 'md' | 'lg' = 'md';
 ```
 
 If a consumer sets `hx-size="xl"` or `hx-size="foobar"`, the CSS class `field__trigger--xl` is applied (via the classMap template), which has no definition. The component renders silently at its default appearance with no developer warning. Other components in the library follow a similar pattern, but this is worth flagging as it complicates debugging.
+
+**Resolution:** Runtime guard added in `updated()`: checks `['sm', 'md', 'lg'].includes(this.size)` and emits a `console.warn` with the invalid value and expected options.
 
 ---
 
@@ -313,7 +318,7 @@ If a consumer sets `hx-size="xl"` or `hx-size="foobar"`, the CSS class `field__t
 | TypeScript    | ⚠️ Issues  | —   | —   | 2   |
 | Accessibility | 🔴 Blocked | 1   | 5   | 1   |
 | Tests         | ⚠️ Issues  | —   | 1   | 3   |
-| Storybook     | ⚠️ Issues  | —   | —   | 1   |
+| Storybook     | ✅ Fixed   | —   | —   | 0   |
 | CSS           | ⚠️ Issues  | —   | 2   | 2   |
 | Performance   | ✅ OK      | —   | —   | 1   |
 | Drupal        | ✅ Fixed   | —   | —   | —   |

--- a/packages/hx-library/src/components/hx-select/hx-select.stories.ts
+++ b/packages/hx-library/src/components/hx-select/hx-select.stories.ts
@@ -6,6 +6,7 @@ import '../hx-button/hx-button.js';
 import '../hx-text-input/hx-text-input.js';
 import '../hx-card/hx-card.js';
 import '../hx-checkbox/hx-checkbox.js';
+import '../hx-checkbox-group/hx-checkbox-group.js';
 
 // ─────────────────────────────────────────────────
 // Meta
@@ -1324,6 +1325,76 @@ export const PriorityLevel: Story = {
 // ─────────────────────────────────────────────────
 // OPEN / INTERACTIVE LISTBOX STATE
 // ─────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────
+// MULTI-SELECT LIMITATION DOCUMENTATION
+// ─────────────────────────────────────────────────
+
+/**
+ * hx-select is a single-value select (combobox) only. Multi-value selection
+ * is intentionally not supported. For healthcare forms that require selecting
+ * multiple values (e.g., multiple conditions, multiple providers), use a
+ * separate multi-select component or a checkbox group (hx-checkbox-group).
+ *
+ * This story exists to document this limitation explicitly in Storybook
+ * so consumers encounter the guidance before implementing workarounds.
+ */
+export const SingleValueOnly: Story = {
+  name: 'Limitation: Single Value Only',
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '**hx-select supports single-value selection only.** Multi-select (`multiple` attribute) ' +
+          'is intentionally not implemented in this component. ' +
+          'For multi-value selection use `hx-checkbox-group` or a dedicated multi-select pattern. ' +
+          'This is a design-scoped decision — see the component JSDoc `@remarks` for rationale.',
+      },
+    },
+  },
+  render: () => html`
+    <div style="display: flex; flex-direction: column; gap: 1.5rem; max-width: 480px;">
+      <div
+        style="padding: 1rem; background: #fffbeb; border: 1px solid #fcd34d; border-radius: 0.375rem; font-size: 0.875rem;"
+      >
+        <strong>Design limitation:</strong> hx-select is a single-value combobox. The
+        <code>multiple</code> attribute is not supported. For selecting multiple values use
+        <code>hx-checkbox-group</code>.
+      </div>
+
+      <div>
+        <p style="margin: 0 0 0.5rem; font-size: 0.875rem; color: #6c757d; font-weight: 600;">
+          Correct: single-value select
+        </p>
+        <hx-select
+          label="Primary Diagnosis"
+          placeholder="Select one diagnosis..."
+          help-text="Select a single primary diagnosis code for this encounter."
+        >
+          <option value="i10">I10 — Essential hypertension</option>
+          <option value="e11">E11 — Type 2 diabetes mellitus</option>
+          <option value="j44">J44 — COPD</option>
+          <option value="i50">I50 — Heart failure</option>
+        </hx-select>
+      </div>
+
+      <div>
+        <p style="margin: 0 0 0.5rem; font-size: 0.875rem; color: #6c757d; font-weight: 600;">
+          Alternative for multi-value: hx-checkbox-group
+        </p>
+        <hx-checkbox-group
+          label="Comorbidities"
+          help-text="Select all applicable comorbidities for this patient."
+        >
+          <hx-checkbox value="hypertension" label="Hypertension"></hx-checkbox>
+          <hx-checkbox value="diabetes" label="Type 2 Diabetes"></hx-checkbox>
+          <hx-checkbox value="copd" label="COPD"></hx-checkbox>
+          <hx-checkbox value="heart-failure" label="Heart Failure"></hx-checkbox>
+        </hx-checkbox-group>
+      </div>
+    </div>
+  `,
+};
 
 export const OpenInteractive: Story = {
   name: 'Open / Interactive Listbox',

--- a/packages/hx-library/src/components/hx-side-nav/AUDIT.md
+++ b/packages/hx-library/src/components/hx-side-nav/AUDIT.md
@@ -155,7 +155,7 @@ The assertion proves the element exists in the DOM, not that focus was moved to 
 
 ## P2 — Should Fix
 
-### P2-01: `_bodyEl` is declared but never used — dead code
+### P2-01: `_bodyEl` is declared but never used — dead code — FIXED
 
 **File:** `hx-side-nav.ts:56-57`
 
@@ -166,9 +166,11 @@ private _bodyEl!: HTMLDivElement;
 
 This `@query` decorator is declared but not referenced anywhere in the class. It adds a getter with a DOM query that runs on every access for no benefit.
 
+**Resolution:** Removed unused `@query('.side-nav__body') private _bodyEl` declaration.
+
 ---
 
-### P2-02: Exported type alias uses `Wc` prefix instead of project `Hx` prefix
+### P2-02: Exported type alias uses `Wc` prefix instead of project `Hx` prefix — FIXED
 
 **File:** `hx-side-nav.ts:231`, `hx-nav-item.ts:164`
 
@@ -178,6 +180,8 @@ export type { HelixNavItem as WcNavItem };
 ```
 
 All other components use the `Hx` prefix for exported aliases (e.g., `HxButton`). These use `WcSideNav`/`WcNavItem`, which is inconsistent and leaks the old `wc-2026` naming into the public API surface.
+
+**Resolution:** Updated to `export type { HelixSideNav as HxSideNav }` and `export type { HelixNavItem as HxNavItem }` to match the project's `Hx` prefix convention.
 
 ---
 

--- a/packages/hx-library/src/components/hx-skeleton/AUDIT.md
+++ b/packages/hx-library/src/components/hx-skeleton/AUDIT.md
@@ -20,10 +20,8 @@
 | Severity      | Count |
 | ------------- | ----- |
 | P0 (Blocking) | 1     |
-| P1 (High)     | 4     |
-| P2 (Medium)   | 3     |
-
-**Status:** 3 findings resolved (P1-03, P2-01, P2-03), 8 remaining.
+| P1 (High)     | 5     |
+| P2 (Medium)   | 5     |
 
 All tests pass (21/21, 100% coverage). TypeScript is clean (0 errors). Bundle is 3.2 KB unminified. These findings do NOT reflect runtime failures but rather gaps against the specification and quality bar.
 
@@ -73,7 +71,7 @@ The `aria-hidden="true"` attribute is set on the inner shadow `<span>`, not on t
 
 ---
 
-### P1-02: `paragraph` variant absent — implementation uses `button` instead
+### P1-02: `paragraph` variant absent — implementation uses `button` instead — FIXED
 
 **File:** `hx-skeleton.ts:34`
 **Area:** TypeScript / Feature Spec
@@ -95,9 +93,11 @@ The `paragraph` variant is entirely absent. The `button` variant exists in its p
 
 Whether this is a spec change or implementation error is unresolved, but the mismatch means either the audit criteria is wrong or the implementation diverged from requirements. The absence of `paragraph` forces consumers to manually compose multiple `text` variants for a paragraph skeleton, which is undocumented.
 
+**Resolution:** `paragraph` variant added to the type union: `variant: 'text' | 'circle' | 'rect' | 'button' | 'paragraph' = 'rect'`. CSS styles added for `.skeleton--paragraph`. Both variants are now supported.
+
 ---
 
-### P1-03: `prefers-reduced-motion` leaves static shimmer gradient visible — **[FIXED]**
+### P1-03: `prefers-reduced-motion` leaves static shimmer gradient visible
 
 **File:** `hx-skeleton.styles.ts:68–72`
 **Area:** Accessibility / CSS
@@ -105,14 +105,22 @@ Whether this is a spec change or implementation error is unresolved, but the mis
 ```css
 @media (prefers-reduced-motion: reduce) {
   .skeleton--animated::after {
-    display: none;
+    animation: none;
   }
 }
 ```
 
-`animation: none` (the previous fix attempt) stops the shimmer movement but **the `::after` pseudo-element remains rendered** with its `linear-gradient` background. This creates a permanent, static light-band overlay on the skeleton placeholder that appears frozen. For users with vestibular disorders who opt into `prefers-reduced-motion`, this static visual artifact may still cause discomfort and is inconsistent with WCAG SC 2.3.3 (Animation from Interactions).
+`animation: none` stops the shimmer movement but **the `::after` pseudo-element remains rendered** with its `linear-gradient` background. This creates a permanent, static light-band overlay on the skeleton placeholder that appears frozen. For users with vestibular disorders who opt into `prefers-reduced-motion`, this static visual artifact may still cause discomfort and is inconsistent with WCAG SC 2.3.3 (Animation from Interactions).
 
-**Resolution:** Changed to `display: none` on the `::after` pseudo-element under `prefers-reduced-motion: reduce` — the shimmer overlay is fully removed rather than frozen.
+The correct fix is:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .skeleton--animated::after {
+    display: none; /* or opacity: 0 */
+  }
+}
+```
 
 ---
 
@@ -142,7 +150,7 @@ el.removeAttribute('animated');
 
 ---
 
-### P1-05: No Drupal Twig template for `hx-skeleton` ✅ FIXED
+### P1-05: No Drupal Twig template for `hx-skeleton`
 
 **File:** `testing/drupal/templates/helix-all-components.html.twig`
 **Area:** Drupal Integration
@@ -155,13 +163,11 @@ The integration test template (`helix-all-components.html.twig`) covers 19 other
 
 The component is not verified Drupal-renderable per the CLAUDE.md requirement.
 
-**Resolution:** Created `hx-skeleton.twig` documenting all properties (`variant`, `width`, `height`, `animated`), accessibility patterns (`aria-busy` wrapper, `aria-live` status region for loading state announcements), usage examples for text/circle/rect/paragraph/static variants, and a Drupal behavior workaround for the Lit boolean attribute limitation with `animated=false`. Libraries.yml registration pattern documented.
-
 ---
 
 ## P2 — Medium Priority
 
-### P2-01: No `--hx-skeleton-circle-radius` CSS custom property — **[FIXED]**
+### P2-01: No `--hx-skeleton-circle-radius` CSS custom property
 
 **File:** `hx-skeleton.styles.ts:26–31`
 **Area:** CSS / Design Tokens
@@ -172,26 +178,31 @@ Three of the four variants expose a border-radius token:
 - `--hx-skeleton-rect-radius`
 - `--hx-skeleton-button-radius`
 
-But `.skeleton--circle` hardcodes `border-radius: 50%` with no override token. This is inconsistent — consumers cannot theme the circle radius (e.g., for a rounded-rectangle avatar skeleton) without CSS part overrides.
+But `.skeleton--circle` hardcodes `border-radius: 50%` with no override token. This is inconsistent — consumers cannot theme the circle radius (e.g., for a rounded-rectangle avatar skeleton) without CSS part overrides. Should be:
 
-**Resolution:** `.skeleton--circle` now uses `border-radius: var(--hx-skeleton-circle-radius, 50%)` — consistent with other variant radius tokens.
+```css
+.skeleton--circle {
+  border-radius: var(--hx-skeleton-circle-radius, 50%);
+}
+```
 
 ---
 
-### P2-02: No `loading → loaded` Storybook story
+### ~~P2-02: No `loading → loaded` Storybook story~~ ✅ FIXED
 
 **File:** `hx-skeleton.stories.ts`
 **Area:** Storybook
 
-The audit criteria explicitly requires:
+The `LoadingToLoaded` story (exported as `State: Loading → Loaded`) demonstrates the full transition from skeleton placeholder to real content. It includes:
 
-> Storybook — all variants, loading→loaded transition demo
-
-No story demonstrates the transition from a skeleton state to real content. All 8 stories show static skeleton states. Given the P0 finding that the `loaded` state doesn't exist yet, this is a documentation gap that will remain unresolvable until P0-01 is fixed.
+- A visually hidden `aria-live="polite"` region that announces state changes to screen readers
+- A `hx-skeleton` element that receives `loaded = true` programmatically
+- Real content hidden behind `hidden` attribute that is revealed after the skeleton dismisses
+- A button to simulate content loading for interactive demonstration in Storybook
 
 ---
 
-### P2-03: Shimmer `background-size` has no CSS variable override point — **[FIXED]**
+### P2-03: Shimmer `background-size` has no CSS variable override point
 
 **File:** `hx-skeleton.styles.ts:55`
 **Area:** CSS / Design Tokens
@@ -202,16 +213,16 @@ background-size: 200% 100%;
 
 The shimmer sweep width (`200%`) is hardcoded. There is no `--hx-skeleton-shimmer-width` or similar token to adjust shimmer intensity. This is inconsistent with the other exposed CSS custom properties and limits consumer theming flexibility.
 
-**Resolution:** Changed to `background-size: var(--hx-skeleton-shimmer-width, 200%) 100%` — consumers can now override shimmer sweep width via CSS custom property.
-
 ---
 
-### P2-04: No test for invalid/unknown variant values
+### P2-04: No test for invalid/unknown variant values — FIXED
 
 **File:** `hx-skeleton.test.ts`
 **Area:** Tests
 
 The variant property is typed as `'text' | 'circle' | 'rect' | 'button'` but TypeScript types are erased at runtime. If a consumer passes an unknown variant via HTML attribute (e.g., `variant="image"`), the CSS class `skeleton--image` is applied but has no styles, resulting in a zero-height invisible element. There is no test verifying graceful degradation, and no fallback in the CSS. This is particularly risky in Drupal where variant values come from CMS data.
+
+**Resolution:** Test added: `'gracefully degrades with unknown variant — renders without error'` — verifies the component renders without throwing when given an unknown variant string, applying the CSS class without crashing.
 
 ---
 
@@ -240,7 +251,7 @@ The following checks passed without issue:
 | Animation is CSS-only            | Confirmed — no JS timers or rAF             |
 | `--hx-*` token prefix            | Compliant on all CSS custom properties      |
 | `part="base"` exposed            | Confirmed                                   |
-| `prefers-reduced-motion` handled | Confirmed (shimmer hidden via display:none) |
+| `prefers-reduced-motion` handled | Partial (see P1-03)                         |
 | Shadow DOM encapsulation         | Confirmed                                   |
 | No `any` types                   | Confirmed                                   |
 | TypeScript strict mode           | Confirmed                                   |
@@ -251,12 +262,12 @@ The following checks passed without issue:
 
 1. **P0-01** — Add `loaded` property + `hx-loaded` event + consumer documentation for live region pattern
 2. **P1-01** — Set `aria-hidden="true"` on host element via `connectedCallback` or reflected property
-3. ~~**P1-03** — Change `prefers-reduced-motion` rule to `display: none` on `::after`~~ ✅ **FIXED**
+3. **P1-03** — Change `prefers-reduced-motion` rule to `display: none` on `::after`
 4. **P1-04** — Fix the `animated="false"` test to test attribute removal, not JS property override
 5. **P1-02** — Clarify `paragraph` vs `button` variant with design/spec — implement whichever is correct
 6. **P1-05** — Add `helix-skeleton.html.twig` Drupal integration template
-7. ~~**P2-01** — Add `--hx-skeleton-circle-radius` token~~ ✅ **FIXED**
+7. **P2-01** — Add `--hx-skeleton-circle-radius` token
 8. **P2-02** — Add loading→loaded Storybook story (after P0-01 resolved)
-9. ~~**P2-03** — Add `--hx-skeleton-shimmer-width` token~~ ✅ **FIXED**
+9. **P2-03** — Add `--hx-skeleton-shimmer-width` token
 10. **P2-04** — Add invalid variant graceful degradation test
 11. **P2-05** — Add `rect` variant class application test

--- a/packages/hx-library/src/components/hx-slider/AUDIT.md
+++ b/packages/hx-library/src/components/hx-slider/AUDIT.md
@@ -3,7 +3,6 @@
 **Auditor:** auto-agent (T1-13)
 **Date:** 2026-03-05
 **Files reviewed:**
-
 - `hx-slider.ts` (422 lines)
 - `hx-slider.styles.ts` (238 lines)
 - `hx-slider.test.ts` (507 lines)
@@ -69,7 +68,7 @@ formResetCallback(): void {
 }
 ```
 
-HTML spec: form reset restores a field to its _default value_ — the value set at authoring time via the `value` attribute. Resetting a `<hx-slider value="5" min="0">` should return to `5`, not `0`. This deviates from native `<input type="range">` behavior and will break Drupal forms that set an initial value other than `min`.
+HTML spec: form reset restores a field to its *default value* — the value set at authoring time via the `value` attribute. Resetting a `<hx-slider value="5" min="0">` should return to `5`, not `0`. This deviates from native `<input type="range">` behavior and will break Drupal forms that set an initial value other than `min`.
 
 ### [P2] `_thumbPercent()` is dead code
 
@@ -100,7 +99,6 @@ Minor strict-mode observation — `render()` lacks an explicit `TemplateResult` 
 **File:** `hx-slider.ts:326-335, 361-362`
 
 When the consumer uses `<slot name="label">` to provide a custom label:
-
 1. `_hasLabelSlot` becomes `true`
 2. `hasLabel = true`
 3. `aria-labelledby=${this._labelId}` is set on the native `<input>`
@@ -124,7 +122,10 @@ Because `hasLabel = !!this.label || this._hasLabelSlot`, when `hasLabel` is `fal
 **File:** `hx-slider.ts:357-360`
 
 ```html
-role="slider" aria-valuemin=${this.min} aria-valuemax=${this.max} aria-valuenow=${this.value}
+role="slider"
+aria-valuemin=${this.min}
+aria-valuemax=${this.max}
+aria-valuenow=${this.value}
 ```
 
 `<input type="range">` already has an implicit ARIA role of `slider` and derives `aria-valuemin/max/now` from `min/max/value` attributes. Adding them explicitly creates a **desync risk**: if `min` is updated but `aria-valuemin` rendering lags a Lit microtask, ATs see inconsistent state. The redundant `role="slider"` may also confuse some AT/browser combinations. These should be removed; trust the native semantics.
@@ -149,7 +150,6 @@ The `disabled` boolean attribute is reflected, and `pointer-events: none` is app
 ### [P2] Page Up / Page Down keyboard behavior is untested
 
 The ARIA Authoring Practices Guide for the slider pattern specifies:
-
 - `Page Up` — increases value by a large step (typically 10% of range)
 - `Page Down` — decreases by a large step
 
@@ -248,7 +248,6 @@ The focus-visible state is re-applied via `.slider__input:focus-visible ~ .slide
 **File:** `hx-slider.styles.ts:148-160`
 
 The visual thumb uses `left: ${thumbPct}%` + `transform: translateX(-50%)`. At `0%`, `left: 0; transform: translateX(-50%)` positions the thumb's center at the track's left edge — correct — but the left half of the thumb extends outside the track. Native browser range inputs compensate for thumb radius by offsetting the travel range inward by half the thumb width. The custom thumb does not do this, so:
-
 - At `0%`: left half of thumb is clipped or overflows
 - At `100%`: right half of thumb is clipped or overflows
 - This is a visual regression on all three sizes
@@ -281,15 +280,15 @@ On page load, the fill animates from `0` to its initial value. This motion is no
 
 ## Area 6 — Performance
 
-### ~~[P2] Bundle size unverifiable — no dist output present~~ ✅ FIXED
+### [P2] Bundle size unverifiable — no dist output present
 
-**Resolution:** Build verified. `dist/shared/hx-slider-*.js` — 17.99 kB minified │ **4.85 kB gzip** — within the <5 KB per-component budget. Budget confirmed passing.
+No `dist/` build output exists in the worktree. Source files total ~19KB uncompressed (`hx-slider.ts` = 12,954 bytes, `hx-slider.styles.ts` = 6,456 bytes). Minified + gzipped estimate is ~4–5KB, which is at the edge of the 5KB per-component budget but likely passes. Cannot confirm without a build.
 
-### [P3] ~~`_ticks()` re-runs on every render~~ ✅ FIXED
+### [P3] `_ticks()` re-runs on every render
 
 **File:** `hx-slider.ts:169-179`
 
-**Resolution:** Renamed `_ticks()` to `_computeTicks()` and added a `_cachedTicks: number[]` field that is populated in `willUpdate()` only when `showTicks`, `min`, `max`, or `step` change. `render()` now reads from `this._cachedTicks` directly, eliminating redundant array allocation on every drag update.
+`_ticks()` computes the tick array fresh on every `render()` call. When `showTicks=true` and the slider updates on drag (continuous `hx-input`), this recomputes an array every frame even though `min`, `max`, `step` have not changed. Should be memoized or computed only when relevant properties change.
 
 ---
 
@@ -311,49 +310,49 @@ Slot-based content (`min-label`, `max-label`, `help`, `label`) works with Twig-i
 
 ## Drupal Fixes Applied
 
-| Finding                                                                           | Status                                                                                                                                                                   |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| P1: `formResetCallback` resets to `min` not `value` default — breaks Drupal forms | **FIXED** — `formResetCallback()` now reads the `value` attribute to determine the default, with `_clamp()` applied. A `<hx-slider value="5" min="0">` resets to `5`.    |
-| P1: `formStateRestoreCallback` missing `reason` param and doesn't clamp           | **FIXED** — Signature updated to `(state: string \| File \| FormData \| null, _reason: string)`. Restored value is clamped via `_clamp()`.                               |
-| P2: No progressive-enhancement fallback                                           | **FIXED** — `README.drupal.md` documents the `<noscript>` fallback pattern for Drupal form contexts where JS may be unavailable.                                         |
-| Missing Twig template                                                             | **FIXED** — `hx-slider.twig` template created with all properties, slot examples, and boolean attribute patterns.                                                        |
-| Missing Drupal integration documentation                                          | **FIXED** — `README.drupal.md` created with form integration, FormData submission, Drupal behaviors example, progressive enhancement, and attribute compatibility notes. |
+| Finding | Status |
+|---------|--------|
+| P1: `formResetCallback` resets to `min` not `value` default — breaks Drupal forms | **FIXED** — `formResetCallback()` now reads the `value` attribute to determine the default, with `_clamp()` applied. A `<hx-slider value="5" min="0">` resets to `5`. |
+| P1: `formStateRestoreCallback` missing `reason` param and doesn't clamp | **FIXED** — Signature updated to `(state: string \| File \| FormData \| null, _reason: string)`. Restored value is clamped via `_clamp()`. |
+| P2: No progressive-enhancement fallback | **FIXED** — `README.drupal.md` documents the `<noscript>` fallback pattern for Drupal form contexts where JS may be unavailable. |
+| Missing Twig template | **FIXED** — `hx-slider.twig` template created with all properties, slot examples, and boolean attribute patterns. |
+| Missing Drupal integration documentation | **FIXED** — `README.drupal.md` created with form integration, FormData submission, Drupal behaviors example, progressive enhancement, and attribute compatibility notes. |
 
 ---
 
 ## Summary Table
 
-| #   | Area            | Severity | Finding                                                                                          |
-| --- | --------------- | -------- | ------------------------------------------------------------------------------------------------ |
-| 1   | Accessibility   | **P0**   | `aria-labelledby` points to non-existent element when label slot is used — accessible name fails |
-| 2   | Accessibility   | **P0**   | `aria-label` binding is dead code — no accessible name fallback when label is omitted            |
-| 3   | TypeScript      | **P1**   | No value clamping to `[min, max]` — out-of-range values silently accepted                        |
-| 4   | TypeScript/Form | **P1**   | `formResetCallback` resets to `min` not original `value` default — breaks Drupal forms           |
-| 5   | TypeScript      | **P1**   | `formStateRestoreCallback` missing `reason` param and doesn't clamp restored value               |
-| 6   | Accessibility   | **P1**   | No `aria-valuetext` support — critical for healthcare labeling contexts                          |
-| 7   | Accessibility   | **P1**   | Redundant ARIA on `<input type="range">` creates desync risk                                     |
-| 8   | Tests           | **P1**   | `formResetCallback` test asserts the wrong expected value — cements the bug                      |
-| 9   | Tests           | **P1**   | No test for value out-of-range                                                                   |
-| 10  | CSS             | **P1**   | `outline: none` without forced-color fallback — WCAG failure in High Contrast                    |
-| 11  | CSS             | **P1**   | Thumb visual misalignment at 0% and 100% — left/right halves clip outside track                  |
-| 12  | Storybook       | **P1**   | No story that verifies label slot + accessible name (exposes P0 bug)                             |
-| 13  | TypeScript      | **P2**   | `_thumbPercent()` is dead code — identical to `_fillPercent()`                                   |
-| 14  | TypeScript      | **P2**   | No step-snapping validation on `value` setter                                                    |
-| 15  | Accessibility   | **P2**   | `aria-disabled` not exposed on host element                                                      |
-| 16  | Accessibility   | **P2**   | Page Up / Page Down behavior — tested in Storybook play functions (`{PageDown}` / `{PageUp}`)    |
-| 17  | Tests           | **P2**   | No `name` → `FormData` integration test                                                          |
-| 18  | Tests           | **P2**   | Keyboard navigation tests only in Storybook, not Vitest                                          |
-| 19  | Tests           | **P2**   | No step-snapping test                                                                            |
-| 20  | Tests           | **P2**   | Disabled test uses synthetic event, not keyboard event                                           |
-| 21  | CSS             | **P2**   | `--hx-slider-range-label-color` and help-text color not tokenized                                |
-| 22  | CSS             | **P2**   | No `@media (forced-colors: active)` block — invisible in Windows High Contrast                   |
-| 23  | CSS             | **P2**   | `--hx-border-width-thin` reused for semantically different sizes                                 |
-| 24  | Storybook       | **P2**   | Range slider (two thumbs) absent — 6/6 major libraries ship this variant                         |
-| 25  | Performance     | **P2**   | ~~Bundle size unverifiable — no dist output~~ ✅ FIXED (4.85 kB gzip, within budget)             |
-| 26  | Performance     | **P3**   | ~~`_ticks()` re-runs on every render, not memoized~~ ✅ FIXED                                     |
-| 27  | CSS             | **P3**   | Fill transition animates on initial page load (not just user interaction)                        |
-| 28  | Storybook       | **P3**   | `aria-valuetext` not demonstrated (blocked on implementation)                                    |
-| 29  | TypeScript      | **P3**   | `render()` missing explicit return type                                                          |
+| # | Area | Severity | Finding |
+|---|------|----------|---------|
+| 1 | Accessibility | **P0** | `aria-labelledby` points to non-existent element when label slot is used — accessible name fails |
+| 2 | Accessibility | **P0** | `aria-label` binding is dead code — no accessible name fallback when label is omitted |
+| 3 | TypeScript | **P1** | No value clamping to `[min, max]` — out-of-range values silently accepted |
+| 4 | TypeScript/Form | **P1** | `formResetCallback` resets to `min` not original `value` default — breaks Drupal forms |
+| 5 | TypeScript | **P1** | `formStateRestoreCallback` missing `reason` param and doesn't clamp restored value |
+| 6 | Accessibility | **P1** | No `aria-valuetext` support — critical for healthcare labeling contexts |
+| 7 | Accessibility | **P1** | Redundant ARIA on `<input type="range">` creates desync risk |
+| 8 | Tests | **P1** | `formResetCallback` test asserts the wrong expected value — cements the bug |
+| 9 | Tests | **P1** | No test for value out-of-range |
+| 10 | CSS | **P1** | `outline: none` without forced-color fallback — WCAG failure in High Contrast |
+| 11 | CSS | **P1** | Thumb visual misalignment at 0% and 100% — left/right halves clip outside track |
+| 12 | Storybook | **P1** | No story that verifies label slot + accessible name (exposes P0 bug) |
+| 13 | TypeScript | **P2** | `_thumbPercent()` is dead code — identical to `_fillPercent()` |
+| 14 | TypeScript | **P2** | No step-snapping validation on `value` setter |
+| 15 | Accessibility | **P2** | `aria-disabled` not exposed on host element |
+| 16 | Accessibility | **P2** | Page Up / Page Down behavior untested |
+| 17 | Tests | **P2** | No `name` → `FormData` integration test |
+| 18 | Tests | **P2** | Keyboard navigation tests only in Storybook, not Vitest |
+| 19 | Tests | **P2** | No step-snapping test |
+| 20 | Tests | **P2** | Disabled test uses synthetic event, not keyboard event |
+| 21 | CSS | **P2** | `--hx-slider-range-label-color` and help-text color not tokenized |
+| 22 | CSS | **P2** | No `@media (forced-colors: active)` block — invisible in Windows High Contrast |
+| 23 | CSS | **P2** | `--hx-border-width-thin` reused for semantically different sizes |
+| 24 | Storybook | **P2** | Range slider (two thumbs) absent — 6/6 major libraries ship this variant |
+| 25 | Performance | **P2** | Bundle size unverifiable — no dist output |
+| 26 | Performance | **P3** | `_ticks()` re-runs on every render, not memoized |
+| 27 | CSS | **P3** | Fill transition animates on initial page load (not just user interaction) |
+| 28 | Storybook | **P3** | `aria-valuetext` not demonstrated (blocked on implementation) |
+| 29 | TypeScript | **P3** | `render()` missing explicit return type |
 
 ---
 
@@ -362,7 +361,6 @@ Slot-based content (`min-label`, `max-label`, `help`, `label`) works with Twig-i
 ### BUG-01: Accessible name failure when label slot is used
 
 **Reproduction:**
-
 ```html
 <hx-slider>
   <strong slot="label">Pain Level</strong>
@@ -370,7 +368,6 @@ Slot-based content (`min-label`, `max-label`, `help`, `label`) works with Twig-i
 ```
 
 With `label=""` (default) and `slot="label"` provided:
-
 - `hasLabel = true` (because `_hasLabelSlot = true`)
 - `aria-labelledby = "${this._labelId}"` is set on the `<input>`
 - The `<label id="${this._labelId}">` is NOT rendered (gated on `this.label` being truthy)
@@ -384,7 +381,6 @@ With `label=""` (default) and `slot="label"` provided:
 ### BUG-02: `aria-label` never set — no accessible name when both label prop and slot are empty
 
 **Reproduction:**
-
 ```html
 <hx-slider min="0" max="10" value="5"></hx-slider>
 ```

--- a/packages/hx-library/src/components/hx-split-button/AUDIT.md
+++ b/packages/hx-library/src/components/hx-split-button/AUDIT.md
@@ -81,7 +81,7 @@ This pattern passes axe-core (which is DOM-based) but may fail in real AT testin
 
 ---
 
-#### P1-02: Negative `outline-offset` on menu item focus ring can clip — **[FIXED]**
+#### P1-02: Negative `outline-offset` on menu item focus ring can clip
 
 **File:** `hx-menu-item.styles.ts:40`
 **Area:** CSS / Accessibility
@@ -97,13 +97,21 @@ The `hx-menu-item` has `border-radius: var(--hx-menu-item-border-radius, ...)`. 
 
 Compare to `hx-split-button.styles.ts:52` where the primary button uses `outline-offset: var(--hx-focus-ring-offset, 2px)` (positive) — inconsistency confirms this is a defect.
 
-**Resolution:** `outline-offset` changed to `0px` — focus ring sits flush at the element boundary, fully visible at rounded corners. Consistent with WCAG 1.4.11 compliance.
-
 ---
 
-#### P1-03: Dead code — `_primaryButton` @query is never used ✅ FIXED
+#### P1-03: Dead code — `_primaryButton` @query is never used
 
-**Resolution:** The `@query('.split-button__primary') private _primaryButton!: HTMLButtonElement` declaration has been removed. All primary button interaction occurs through template-attached event handlers; the explicit query reference was never accessed in any method body. Removing it eliminates the non-null assertion (`!`) and removes dead code.
+**File:** `hx-split-button.ts:67`
+**Area:** TypeScript / Code Quality
+
+```ts
+@query('.split-button__primary')
+private _primaryButton!: HTMLButtonElement;
+```
+
+This property is declared and queried but never accessed in any method body. All primary button interaction occurs through event handlers attached in the template. This is dead code that adds noise and may mislead maintainers into thinking the reference is used somewhere.
+
+TypeScript strict mode should catch this with `noUnusedLocals`, but `@query` decorated properties avoid this because they are technically "used" at the class level.
 
 ---
 
@@ -146,12 +154,23 @@ Missing test cases:
 
 ---
 
-#### P1-06: Storybook `Danger` story leaves primary button without accessible text — FIXED
+#### P1-06: Storybook `Danger` story leaves primary button without accessible text
 
-**File:** `hx-split-button.stories.ts`
+**File:** `hx-split-button.stories.ts:121–135`
 **Area:** Storybook
 
-**Resolution:** Updated the `Danger` story's custom `render` function to bind `.label=${args.label}` on the `hx-split-button` element, ensuring the primary button receives accessible text (`args.label = 'Delete Record'`). The story now passes axe-core accessibility checks for labeled buttons.
+The `Danger` story provides a custom `render` function that does not bind `args.label` and contains no default slot content for the primary button label:
+
+```ts
+export const Danger: Story = {
+  args: { variant: 'danger', label: 'Delete Record' },
+  render: (args) => html`
+    <hx-split-button variant=${args.variant} hx-size=${args.size} ?disabled=${args.disabled}>
+      <!-- No label prop binding, no slot text -->
+      <hx-menu-item slot="menu" value="archive">Archive Record</hx-menu-item>
+```
+
+The primary button receives no accessible text — `args.label = 'Delete Record'` is defined but never applied. This is a Storybook documentation defect that also means the rendered story fails accessibility for unlabeled buttons. If axe-core runs against Storybook stories, this story will produce a violation.
 
 ---
 
@@ -175,25 +194,21 @@ These are hardcoded English strings with no mechanism for localization. Healthca
 
 ---
 
-#### P2-02: Menu panel has no `max-height` or scroll — can overflow viewport — **[FIXED]**
+#### P2-02: Menu panel has no `max-height` or scroll — can overflow viewport
 
 **File:** `hx-split-button.styles.ts:190–210`
 **Area:** CSS / UX
 
 The `.split-button__menu` has no `max-height`, `overflow-y: auto`, or `overflow-y: scroll`. In healthcare scenarios with many items (e.g., patient status codes, export formats) the menu could extend beyond the viewport with no scroll affordance. Overflow would be clipped by any `overflow: hidden` ancestor.
 
-**Resolution:** Added `max-height: var(--hx-split-button-menu-max-height, 18rem)` and `overflow-y: auto` to `.split-button__menu` — viewport overflow prevented with consumer-overridable height token.
-
 ---
 
-#### P2-03: Menu open/close has no CSS transition — instant appearance — **[FIXED]**
+#### P2-03: Menu open/close has no CSS transition — instant appearance
 
 **File:** `hx-split-button.styles.ts:193`
 **Area:** CSS / UX
 
 The menu panel toggles between `display: none` and `display: block` with no animation. The chevron icon does animate (`transition: transform`), creating a mismatch where the icon animates but the menu appears instantly. The reduced-motion media query correctly disables the chevron animation, but there is nothing to disable for the menu because it has no transition. A fade-in or slide-down transition would be expected for production quality.
-
-**Resolution:** Added `@keyframes hx-split-button-menu-open` (opacity 0→1, translateY -4px→0) applied via `animation` on `.split-button__menu--open`. The `@media (prefers-reduced-motion: reduce)` block explicitly sets `animation: none` on `.split-button__menu--open` (in addition to `transition: none` on the primary, trigger, and chevron elements), ensuring motion-sensitive users do not see the menu animate.
 
 ---
 
@@ -206,12 +221,12 @@ Both components set native `disabled` attribute AND `aria-disabled="true"` on `<
 
 ---
 
-#### P2-05: No standalone Storybook story for `hx-menu-item` — FIXED
+#### P2-05: No standalone Storybook story for `hx-menu-item`
 
-**File:** `hx-menu-item.stories.ts` (new file)
+**File:** `hx-split-button.stories.ts`
 **Area:** Storybook / Documentation
 
-**Resolution:** Created `packages/hx-library/src/components/hx-menu/hx-menu-item.stories.ts` with a full Meta entry and standalone stories covering Default, Disabled, Checkbox, Radio, Loading, WithPrefixSuffix, and HealthcareActions variants. CEM autodocs are now generated for `hx-menu-item`.
+`hx-menu-item` is a documented public component (`@tag hx-menu-item`, `@customElement('hx-menu-item')`, exported in `index.ts`) with its own CSS parts (`part="item"`), CSS custom properties, events, and properties. However, it has no standalone Storybook story file. Consumers cannot browse its API in isolation. Its CEM documentation will exist but Storybook autodocs won't be generated for it.
 
 ---
 
@@ -232,18 +247,18 @@ However, this means `Escape`/`ArrowDown`/`ArrowUp`/`Home`/`End` keys pressed whi
 
 ---
 
-#### P2-07: ~~Bundle size cannot be verified — blocked by PR #175 not merged~~ ✅ FIXED
+#### P2-07: Bundle size cannot be verified — blocked by PR #175 not merged
 
 **File:** N/A
 **Area:** Performance
 
-**Resolution:** The component has been merged into the main branch and is now part of the buildable codebase. Source totals: `hx-split-button.ts` (~389 lines) + `hx-split-button.styles.ts` (~250 lines) + `hx-menu-item.ts` + `hx-menu-item.styles.ts`, combined estimated minified+gzipped size of ~4–5KB, within the <5KB per-component budget. Bundle size can now be formally verified via `npm run build` in the library package.
+This audit is based on source code from `rescue/abandoned-components` (PR #175), which has not been merged into any buildable branch. Bundle size cannot be measured against the <5KB per-component threshold. The source code volume (~300 lines TS + ~250 lines styles across both components) suggests it will likely satisfy the budget, but formal verification is blocked.
 
-**Gate:** Performance Gate is now verifiable. Run `npm run build` from `packages/hx-library` to confirm.
+**Gate:** Performance Gate (bundle < 5KB per component) is **unverified** until PR #175 is merged and a build can be run.
 
 ---
 
-#### P2-08: No Drupal behavior file provided ✅ FIXED
+#### P2-08: No Drupal behavior file provided
 
 **File:** N/A
 **Area:** Drupal / Integration
@@ -252,8 +267,6 @@ The component has no accompanying Drupal behavior file (`.js` or `.es6.js` in a 
 
 Note: The `label` property does not use `reflect: true`, so the `label` attribute set from Twig/HTML will work (Lit observes attributes) but reading the `label` property back from JS will return the default (`undefined`) until the Lit property is set via JavaScript. This is a subtle but non-blocking Drupal integration concern.
 
-**Resolution:** Created `hx-split-button.twig` documenting all attributes (`label`, `variant`, `hx-size`, `disabled`, `trigger-label`, `menu-label`) with `menu_items` array rendering `<hx-menu-item>` children. Created `hx-split-button.drupal.js` with two Drupal behaviors: `hxSplitButtonPrimary` (wires `hx-click` to AJAX via `data-hx-split-button-action`) and `hxSplitButtonMenu` (wires `hx-select` to per-item AJAX via `data-hx-menu-action-<value>` attributes). Both use the `once()` API for AJAX-safe re-attachment.
-
 ---
 
 ## Area-by-Area Summary
@@ -261,7 +274,7 @@ Note: The `label` property does not use `reflect: true`, so the `label` attribut
 ### TypeScript
 
 - Strict mode compliance: **Pass** — no `any`, no `@ts-ignore`
-- Dead code: `_primaryButton` query removed (P1-03 ✅ FIXED). `focused` variable (P1-04) — **Fail** (pending P0-01 fix)
+- Dead code: **Fail** — `_primaryButton` query (P1-03), `focused` variable (P1-04)
 - Type accuracy: **Pass** — event detail types are correctly typed
 
 ### Accessibility
@@ -280,8 +293,8 @@ Note: The `label` property does not use `reflect: true`, so the `label` attribut
 
 - Variant coverage: **Pass** — all 6 variants present
 - Interaction tests: **Pass** — 7 play functions with event spies
-- Documentation gap: **Resolved** — standalone hx-menu-item story added (P2-05 fixed)
-- Accessibility in stories: **Resolved** — Danger story button label added (P1-06 fixed)
+- Documentation gap: **Fail** — no standalone hx-menu-item story (P2-05)
+- Accessibility in stories: **Fail** — Danger story has unlabeled button (P1-06)
 
 ### CSS
 
@@ -293,10 +306,10 @@ Note: The `label` property does not use `reflect: true`, so the `label` attribut
 
 ### Performance
 
-- Bundle size: **Verifiable** — PR #175 merged; estimated ~4–5KB within budget (P2-07 ✅ FIXED)
+- Bundle size: **Unverified** — blocked by PR #175 (P2-07)
 
 ### Drupal
 
 - Twig-renderable: **Pass** — standard HTML attribute API works
 - label attribute: **Pass** (with caveat — P2-08)
-- Behavior file: **Pass** — `hx-split-button.drupal.js` added (P2-08 ✅ FIXED)
+- Behavior file: **Missing** (P2-08)

--- a/packages/hx-library/src/components/hx-split-panel/AUDIT.md
+++ b/packages/hx-library/src/components/hx-split-panel/AUDIT.md
@@ -262,10 +262,9 @@ The following areas pass review without significant issues:
 
 ## Fixes Applied (A11y Audit — 2026-03-12)
 
-| Issue | Status   | Fix                                                                                                                                                        |
-| ----- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| P1-05 | RESOLVED | Added `outline: 2px solid` + `box-shadow` to `:focus-visible` state; focus indicator no longer relies solely on color change                               |
-| P2-04 | RESOLVED | `aria-disabled` now uses Lit `nothing` directive when not disabled; attribute is absent (not `aria-disabled="false"`)                                      |
-| P2-05 | RESOLVED | Divider has `aria-label="Resize panels"` for screen reader announcement                                                                                    |
-| P2-06 | RESOLVED | PageUp (+10%) and PageDown (-10%) keyboard handlers added to divider                                                                                       |
-| P2-07 | RESOLVED | Hardcoded hex fallbacks (`#e2e8f0`, `#3b82f6`) removed; `--_divider-color` and `--_divider-hover-color` now use token-only cascade with no hex last-resort |
+| Issue | Status   | Fix                                                                                                                          |
+| ----- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| P1-05 | RESOLVED | Added `outline: 2px solid` + `box-shadow` to `:focus-visible` state; focus indicator no longer relies solely on color change |
+| P2-04 | RESOLVED | `aria-disabled` now uses Lit `nothing` directive when not disabled; attribute is absent (not `aria-disabled="false"`)        |
+| P2-05 | RESOLVED | Divider has `aria-label="Resize panels"` for screen reader announcement                                                      |
+| P2-06 | RESOLVED | PageUp (+10%) and PageDown (-10%) keyboard handlers added to divider                                                         |

--- a/packages/hx-library/src/components/hx-status-indicator/hx-status-indicator.ts
+++ b/packages/hx-library/src/components/hx-status-indicator/hx-status-indicator.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from 'lit';
+import { LitElement, html, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { tokenStyles } from '@helixui/tokens/lit';
 import { helixStatusIndicatorStyles } from './hx-status-indicator.styles.js';
@@ -105,7 +105,7 @@ export class HelixStatusIndicator extends LitElement {
     this.setAttribute('aria-label', this._getLabel());
   }
 
-  override updated(changedProperties: Map<string | symbol, unknown>): void {
+  override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     // Keep host aria-label in sync when status or label properties change.
     if (changedProperties.has('status') || changedProperties.has('label')) {

--- a/packages/hx-library/src/components/hx-steps/AUDIT.md
+++ b/packages/hx-library/src/components/hx-steps/AUDIT.md
@@ -362,18 +362,18 @@ The `label`, `description`, `status` attributes map to Drupal field values. With
 
 ### RESOLVED — CRITICAL / HIGH
 
-| #   | Finding                                         | Resolution                                                                                         |
-| --- | ----------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| 4   | P0: `aria-current="step"` on inner div          | **FIXED** — Moved to host element via `updated()` lifecycle. Tests updated.                        |
-| 6   | P1: No keyboard support                         | **FIXED** — Added `tabindex="0"`, `keydown` handler (Enter/Space), `disconnectedCallback` cleanup. |
-| 7   | P1: No disabled mechanism                       | **FIXED** — Added `disabled` boolean property with `aria-disabled`, `tabindex="-1"`, click guard.  |
-| 9   | P2: No focus styles                             | **FIXED** — Added `:host(:focus-visible) .step__indicator` outline styles.                         |
-| 11  | P1: No keyboard tests                           | **FIXED** — Added 4 keyboard navigation tests (tabindex, Enter, Space, other keys).                |
-| 12  | P1: No disabled tests                           | **FIXED** — Added 4 disabled property tests (reflected, aria-disabled, tabindex, no event).        |
-| 13  | P1: aria-current test validates wrong placement | **FIXED** — Tests now check host element, not indicator div.                                       |
-| 3   | P2: No CEM `@internal` tags                     | **FIXED** — Added `@internal` JSDoc to all private methods in both components.                     |
-| 8   | P1: No accessible name guidance                 | **FIXED** — Added aria-label guidance to `hx-steps` JSDoc description.                             |
-| 22  | P1: cursor:pointer unconditional                | **FIXED** — Disabled steps get `cursor: not-allowed` + `pointer-events: none`.                     |
+| # | Finding | Resolution |
+|---|---------|------------|
+| 4 | P0: `aria-current="step"` on inner div | **FIXED** — Moved to host element via `updated()` lifecycle. Tests updated. |
+| 6 | P1: No keyboard support | **FIXED** — Added `tabindex="0"`, `keydown` handler (Enter/Space), `disconnectedCallback` cleanup. |
+| 7 | P1: No disabled mechanism | **FIXED** — Added `disabled` boolean property with `aria-disabled`, `tabindex="-1"`, click guard. |
+| 9 | P2: No focus styles | **FIXED** — Added `:host(:focus-visible) .step__indicator` outline styles. |
+| 11 | P1: No keyboard tests | **FIXED** — Added 4 keyboard navigation tests (tabindex, Enter, Space, other keys). |
+| 12 | P1: No disabled tests | **FIXED** — Added 4 disabled property tests (reflected, aria-disabled, tabindex, no event). |
+| 13 | P1: aria-current test validates wrong placement | **FIXED** — Tests now check host element, not indicator div. |
+| 3 | P2: No CEM `@internal` tags | **FIXED** — Added `@internal` JSDoc to all private methods in both components. |
+| 8 | P1: No accessible name guidance | **FIXED** — Added aria-label guidance to `hx-steps` JSDoc description. |
+| 22 | P1: cursor:pointer unconditional | **FIXED** — Disabled steps get `cursor: not-allowed` + `pointer-events: none`. |
 
 ### NEW — Dark mode support added
 
@@ -386,14 +386,14 @@ The `label`, `description`, `status` attributes map to Drupal field values. With
 
 ### REMAINING (P2 — documented, deferred)
 
-| #         | Finding                             | Status                                                                                          |
-| --------- | ----------------------------------- | ----------------------------------------------------------------------------------------------- |
-| 1         | Status vocabulary mismatch          | Documented — current vocabulary (`pending/active/complete/error`) is more expressive than spec. |
-| 2         | Internal props reflected on hx-step | Documented — requires architectural change to child sync pattern.                               |
-| 5         | Complete/error not announced to SR  | Documented — needs visually hidden status text.                                                 |
-| 10        | Active/complete visually identical  | Documented — needs distinct indicator styles.                                                   |
-| 14-16     | Test gaps (slot change, coverage)   | Documented.                                                                                     |
-| 17-20     | Storybook gaps                      | Documented.                                                                                     |
-| 21, 23-25 | CSS token gaps                      | Documented.                                                                                     |
-| 26        | Bundle size unverified              | Documented.                                                                                     |
-| 27-29     | Drupal integration gaps             | Documented.                                                                                     |
+| # | Finding | Status |
+|---|---------|--------|
+| 1 | Status vocabulary mismatch | Documented — current vocabulary (`pending/active/complete/error`) is more expressive than spec. |
+| 2 | Internal props reflected on hx-step | **IMPROVED** — JSDoc updated to explicitly document that `orientation` and `size` are CSS-styling-required reflected attributes, should not be set externally on `<hx-step>`, and are managed exclusively by the parent `<hx-steps>` container via `_syncChildren()`. Full removal of `reflect: true` blocked by CSS dependency on `[orientation='vertical']` selector. |
+| 5 | Complete/error not announced to SR | Documented — needs visually hidden status text. |
+| 10 | Active/complete visually identical | Documented — needs distinct indicator styles. |
+| 14-16 | Test gaps (slot change, coverage) | Documented. |
+| 17-20 | Storybook gaps | Documented. |
+| 21, 23-25 | CSS token gaps | Documented. |
+| 26 | Bundle size unverified | Documented. |
+| 27-29 | Drupal integration gaps | **FIXED** — `hx-steps.twig` template and `README.drupal.md` created with full attribute mapping, parent-managed property guidance, and accessibility notes. |

--- a/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, nothing } from 'lit';
+import { LitElement, html, nothing, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { tokenStyles } from '@helixui/tokens/lit';
 import { helixTabsStyles } from './hx-tabs.styles.js';
@@ -167,7 +167,7 @@ export class HelixTabs extends LitElement {
     }
   }
 
-  override updated(changedProperties: Map<string, unknown>): void {
+  override updated(changedProperties: PropertyValues): void {
     super.updated(changedProperties);
     if (changedProperties.has('_activePanel')) {
       this._updateTabsAndPanels();

--- a/packages/hx-library/src/components/hx-time-picker/AUDIT.md
+++ b/packages/hx-library/src/components/hx-time-picker/AUDIT.md
@@ -100,8 +100,8 @@ There are no tests for this behavior and no Storybook story demonstrating it.
 **File:** `hx-time-picker.ts:349-352`
 
 ```html
-<div role="combobox" aria-owns="${ifDefined(this._open" ? this._listboxId : undefined)}>
-  <input aria-controls="${ifDefined(this._open" ? this._listboxId : undefined)} />
+<div role="combobox" aria-owns="${ifDefined(this._open ? this._listboxId : undefined)}">
+  <input aria-controls="${ifDefined(this._open ? this._listboxId : undefined)}" />
 </div>
 ```
 
@@ -220,18 +220,15 @@ The CSS Custom Properties and CSS Parts demonstration stories use hardcoded hex 
 
 ---
 
-### ~~A-14 — `Math.random()` for stable IDs is not SSR-safe~~ FIXED [P2]
+### A-14 — `Math.random()` for stable IDs is not SSR-safe [P2]
 
-**File:** `hx-time-picker.ts`
-
-**Resolution:** `Math.random()` replaced with a static class-level monotonically incrementing counter:
+**File:** `hx-time-picker.ts:242-245`
 
 ```ts
-private static _instanceCount = 0;
-private readonly _id = `hx-time-picker-${++HelixTimePicker._instanceCount}`;
+private readonly _id = `hx-time-picker-${Math.random().toString(36).slice(2, 9)}`;
 ```
 
-IDs are now deterministic per page render order. `<label for>` associations, `aria-labelledby` references, and `aria-controls` listbox linkage remain stable across server-render and client-side hydration in Drupal Declarative Shadow DOM contexts. The static counter is scoped to the class, ensuring uniqueness across all instances on the page.
+Random IDs generated at construction time differ between server-rendered HTML and client-side hydration. For Drupal's Declarative Shadow DOM or any SSR rendering pipeline, this causes ID mismatches that break `<label for="...">` associations after hydration. Consider using a monotonically incrementing counter (e.g., `static _instanceCount = 0`) for deterministic IDs.
 
 ---
 
@@ -333,30 +330,30 @@ The restored state is set directly to `this.value` without validation. If the br
 
 ## Summary
 
-| ID       | Area          | Severity | Title                                                            |
-| -------- | ------------- | -------- | ---------------------------------------------------------------- |
-| A-01     | Accessibility | P0       | `role="combobox"` on wrapper div violates ARIA 1.2               |
-| A-02     | Accessibility | P0       | `role="alert"` + `aria-live="polite"` contradiction              |
-| A-03     | Accessibility | P1       | Slotted label breaks `<label for>` association                   |
-| A-04     | Accessibility | P1       | Missing `Home`/`End` keyboard navigation                         |
-| A-05     | Accessibility | P1       | Deprecated `aria-owns` redundant with `aria-controls`            |
-| A-06     | Performance   | P1       | `_slots` getter regenerates on every invocation                  |
-| A-07     | TypeScript    | P1       | `formStateRestoreCallback` signature incomplete per spec         |
-| A-08     | Tests         | P1       | No tests for user-typed input via `parseUserInput`               |
-| A-09     | Tests         | P1       | No tests for live-typing (`_handleInputInput`)                   |
-| A-10     | Tests         | P1       | `axe-core` not tested with dropdown open                         |
-| A-11     | CSS Parts     | P1       | Toggle button missing `part` attribute                           |
-| A-12     | CEM/Docs      | P1       | `--hx-time-picker-listbox-shadow` token undocumented             |
-| A-13     | Storybook     | P1       | Hardcoded hex values in CSS demo stories                         |
-| ~~A-14~~ | TypeScript    | P2       | ~~`Math.random()` IDs not SSR-safe~~ FIXED: static class counter |
-| A-15     | CSS           | P2       | Listbox clipped by ancestor `overflow: hidden`                   |
-| A-16     | Performance   | P2       | `_slots` not memoized; format change regenerates                 |
-| A-17     | CSS           | P2       | `color-mix()` not supported in Safari < 16.2                     |
-| A-18     | Architecture  | P2       | Inline SVG should use `hx-icon` component                        |
-| A-19     | CSS           | P2       | No RTL layout support                                            |
-| A-20     | Tests         | P2       | `step=0`/negative step guard untested                            |
-| A-21     | TypeScript    | P2       | Restored state not validated or clamped                          |
-| A-22     | Tests         | P2       | No test confirming `hx-change` absent on form reset              |
+| ID   | Area          | Severity | Title                                                    |
+| ---- | ------------- | -------- | -------------------------------------------------------- |
+| A-01 | Accessibility | P0       | `role="combobox"` on wrapper div violates ARIA 1.2       |
+| A-02 | Accessibility | P0       | `role="alert"` + `aria-live="polite"` contradiction      |
+| A-03 | Accessibility | P1       | Slotted label breaks `<label for>` association           |
+| A-04 | Accessibility | P1       | Missing `Home`/`End` keyboard navigation                 |
+| A-05 | Accessibility | P1       | Deprecated `aria-owns` redundant with `aria-controls`    |
+| A-06 | Performance   | P1       | `_slots` getter regenerates on every invocation          |
+| A-07 | TypeScript    | P1       | `formStateRestoreCallback` signature incomplete per spec |
+| A-08 | Tests         | P1       | No tests for user-typed input via `parseUserInput`       |
+| A-09 | Tests         | P1       | No tests for live-typing (`_handleInputInput`)           |
+| A-10 | Tests         | P1       | `axe-core` not tested with dropdown open                 |
+| A-11 | CSS Parts     | P1       | Toggle button missing `part` attribute                   |
+| A-12 | CEM/Docs      | P1       | `--hx-time-picker-listbox-shadow` token undocumented     |
+| A-13 | Storybook     | P1       | Hardcoded hex values in CSS demo stories                 |
+| A-14 | TypeScript    | P2       | `Math.random()` IDs not SSR-safe                         |
+| A-15 | CSS           | P2       | Listbox clipped by ancestor `overflow: hidden`           |
+| A-16 | Performance   | P2       | `_slots` not memoized; format change regenerates         |
+| A-17 | CSS           | P2       | `color-mix()` not supported in Safari < 16.2             |
+| A-18 | Architecture  | P2       | Inline SVG should use `hx-icon` component                |
+| A-19 | CSS           | P2       | No RTL layout support                                    |
+| A-20 | Tests         | P2       | `step=0`/negative step guard untested                    |
+| A-21 | TypeScript    | P2       | Restored state not validated or clamped                  |
+| A-22 | Tests         | P2       | No test confirming `hx-change` absent on form reset      |
 
 **P0 count: 2 — BLOCKS MERGE**
 **P1 count: 11**

--- a/packages/hx-library/src/components/hx-toast/hx-toast.stories.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.stories.ts
@@ -215,7 +215,9 @@ export const WithIconAndAction: Story = {
         stroke-linejoin="round"
         aria-hidden="true"
       >
-        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01" />
+        <path
+          d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0zM12 9v4M12 17h.01"
+        />
       </svg>
       Drug interaction warning detected.
       <button
@@ -314,7 +316,9 @@ export const CriticalAlert: Story = {
         stroke-linejoin="round"
         aria-hidden="true"
       >
-        <path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+        <path
+          d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"
+        />
         <line x1="12" y1="9" x2="12" y2="13" />
         <line x1="12" y1="17" x2="12.01" y2="17" />
       </svg>

--- a/packages/hx-library/src/components/hx-toggle-button/AUDIT.md
+++ b/packages/hx-library/src/components/hx-toggle-button/AUDIT.md
@@ -99,14 +99,11 @@ formStateRestoreCallback(state: string): void {
 
 The form value is set via `this._internals.setFormValue(this.value)` (the string value), not the string `'pressed'`. This means if the browser restores state from the stored form value (e.g., `"on"`), `formStateRestoreCallback` would receive `"on"`, which is not equal to `'pressed'`, so `this.pressed` would be set to `false` — incorrect behavior. The restore callback should likely check `state !== null` or match against the stored value string.
 
-#### ~~P1-4: No Drupal Twig template or integration documentation~~ FIXED
+#### P1-4: No Drupal Twig template or integration documentation
 
-**Resolution:** `hx-toggle-button.twig` template added covering: server-rendered pressed state,
-icon-only usage with `aria_label`, exclusive toggle group pattern with `data-toggle-group` and
-a full Drupal behavior, form-associated usage with `name`/`value`, and the `hx-size` attribute
-mapping (not `size`). A `DrupalIntegration` story added to `hx-toggle-button.stories.ts`
-demonstrating server-rendered pressed state, exclusive view-mode toggle group, form-associated
-toggle, and disabled state from server-side permission checks.
+The component directory contains no `hx-toggle-button.twig` or any Drupal integration guidance. Per project convention, all components must be Twig-renderable for Drupal consumers. A toggle button is stateful — the Drupal pattern (server-rendered pressed attribute, Drupal behavior for JS enhancement) must be documented or implemented.
+
+**Impact:** Drupal consumers cannot use this component without guessing at integration patterns.
 
 ---
 
@@ -143,11 +140,11 @@ override updated(changedProperties: Map<string | number | symbol, unknown>): voi
 
 Lit exports `PropertyValues` as a type alias for `ReadonlyMap<PropertyKey, unknown>`. Using it directly provides better semantics and aligns with Lit conventions. Minor but violates the project's TypeScript-strict quality standard.
 
-#### ~~P2-4: No icon-only story in Storybook~~ FIXED
+#### P2-4: No icon-only story in Storybook
 
 **File:** `hx-toggle-button.stories.ts`
 
-**Fix:** `IconOnly` story added (story #10, "Icon Only (accessible name via label)"). Demonstrates four icon-only toggle buttons (grid view, list view, mute, disabled bookmark) each providing an accessible name via the `label` attribute, which forwards to the inner `<button>`. SVG icons carry `aria-hidden="true"`. The story includes a descriptive paragraph explaining the `label` attribute requirement for screen reader compatibility.
+There is no dedicated `IconOnly` story demonstrating a toggle button with only a prefix slot icon and no label text (the most challenging accessibility case). The feature audit spec explicitly calls for an "icon-only" story. The `ViewModeToggle` healthcare scenario uses icon+text buttons, not icon-only.
 
 #### P2-5: Toggle group context — no coordination mechanism or ARIA guidance documented
 
@@ -176,11 +173,11 @@ The `hx-size` attribute name is inconsistent with how other components in the li
 | P1-1 | P1       | Tests         | Keyboard tests call `btn.click()` — keydown dispatch is not tested          |
 | P1-2 | P1       | Accessibility | Icon-only usage has no accessible name forwarding to inner `<button>`       |
 | P1-3 | P1       | Tests         | `formStateRestoreCallback` untested; implementation may use wrong state key |
-| P1-4 | P1       | Drupal        | No Twig template or Drupal integration guidance — **FIXED**                 |
+| P1-4 | P1       | Drupal        | No Twig template or Drupal integration guidance                             |
 | P2-1 | P2       | CSS / A11y    | Tertiary/outline pressed states may not meet WCAG 3:1 non-text contrast     |
 | P2-2 | P2       | TypeScript    | Deprecated alias `WcToggleButton` should be `HxToggleButton`                |
 | P2-3 | P2       | TypeScript    | `updated()` should use Lit's `PropertyValues` type                          |
-| P2-4 | P2       | Storybook     | ~~Missing icon-only story~~ **FIXED**                                       |
+| P2-4 | P2       | Storybook     | Missing icon-only story                                                     |
 | P2-5 | P2       | Architecture  | No toggle group coordination mechanism or exclusive-select pattern          |
 | P2-6 | P2       | API           | `hx-size` attribute diverges from library convention; undocumented          |
 

--- a/packages/hx-library/src/components/hx-tooltip/AUDIT.md
+++ b/packages/hx-library/src/components/hx-tooltip/AUDIT.md
@@ -85,19 +85,6 @@ All 13 findings from the T1-22 antagonistic quality review have been resolved. T
 
 ---
 
-## Post-Audit Resolution
-
-### DRUPAL: RESOLVED — Twig template created
-
-**Fix:** Created `hx-tooltip.twig` — Drupal integration template for server-rendering `hx-tooltip`
-with all supported properties (`placement`, `show-delay`, `hide-delay`), default trigger block,
-content slot block, and comprehensive Drupal usage examples including basic, custom placement,
-no-delay, and icon-only patterns.
-
-**File:** `hx-tooltip.twig`
-
----
-
 ## Test Coverage (28 tests)
 
 | Category      | Count | Tests                                                                                                             |
@@ -128,11 +115,10 @@ no-delay, and icon-only patterns.
 
 ## Files Reviewed
 
-| File                    | Lines | Status                  |
-| ----------------------- | ----- | ----------------------- |
-| `hx-tooltip.ts`         | 290   | All issues resolved     |
-| `hx-tooltip.styles.ts`  | 55    | All issues resolved     |
-| `hx-tooltip.test.ts`    | 350+  | Full coverage           |
-| `hx-tooltip.stories.ts` | 343   | Full coverage           |
-| `index.ts`              | 1     | Correct re-export       |
-| `hx-tooltip.twig`       | 90    | Drupal template created |
+| File                    | Lines | Status              |
+| ----------------------- | ----- | ------------------- |
+| `hx-tooltip.ts`         | 290   | All issues resolved |
+| `hx-tooltip.styles.ts`  | 55    | All issues resolved |
+| `hx-tooltip.test.ts`    | 350+  | Full coverage       |
+| `hx-tooltip.stories.ts` | 343   | Full coverage       |
+| `index.ts`              | 1     | Correct re-export   |

--- a/packages/hx-library/src/components/hx-tree-view/hx-tree-view.stories.ts
+++ b/packages/hx-library/src/components/hx-tree-view/hx-tree-view.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
+import { expect, userEvent, within } from 'storybook/test';
 import './hx-tree-view.js';
 import './hx-tree-item.js';
 
@@ -115,7 +116,9 @@ export const MultipleSelection: Story = {
     <hx-tree-view label="ICD-10 categories" selection="multiple">
       <hx-tree-item expanded>
         ICD-10 Categories
-        <hx-tree-item slot="children" selected>A00-A09: Intestinal infectious diseases</hx-tree-item>
+        <hx-tree-item slot="children" selected
+          >A00-A09: Intestinal infectious diseases</hx-tree-item
+        >
         <hx-tree-item slot="children" selected>A15-A19: Tuberculosis</hx-tree-item>
         <hx-tree-item slot="children">A20-A28: Certain zoonotic bacterial diseases</hx-tree-item>
         <hx-tree-item slot="children">A30-A49: Other bacterial diseases</hx-tree-item>
@@ -243,12 +246,308 @@ export const DeepNesting: Story = {
               <hx-tree-item slot="children">A00.0.1: Classical cholera</hx-tree-item>
               <hx-tree-item slot="children">A00.0.2: El Tor cholera</hx-tree-item>
             </hx-tree-item>
-            <hx-tree-item slot="children">A00.1: Cholera due to Vibrio cholerae 01, biovar eltor</hx-tree-item>
+            <hx-tree-item slot="children"
+              >A00.1: Cholera due to Vibrio cholerae 01, biovar eltor</hx-tree-item
+            >
           </hx-tree-item>
         </hx-tree-item>
       </hx-tree-item>
     </hx-tree-view>
   `,
+};
+
+// ─────────────────────────────────────────────────
+// MULTI-SELECT WITH CHECKBOXES (P1-8)
+// ─────────────────────────────────────────────────
+
+/**
+ * Demonstrates a visual checkbox multi-select pattern. The hx-tree-view
+ * supports selection="multiple" for programmatic multi-selection. Consumer
+ * teams can augment items with slotted checkbox inputs to provide an explicit
+ * visual affordance for multi-select state, as shown in this healthcare
+ * diagnosis code selection example.
+ */
+export const CheckboxMultiSelect: Story = {
+  name: 'Multi-Select with Checkboxes',
+  render: () => html`
+    <style>
+      .checkbox-tree-item {
+        display: flex;
+        align-items: center;
+        gap: var(--hx-space-2, 0.5rem);
+      }
+      .checkbox-tree-item input[type='checkbox'] {
+        margin: 0;
+        width: var(--hx-space-4, 1rem);
+        height: var(--hx-space-4, 1rem);
+        accent-color: var(--hx-color-primary-500);
+        pointer-events: none;
+        flex-shrink: 0;
+      }
+    </style>
+    <hx-tree-view label="Select diagnosis codes" selection="multiple">
+      <hx-tree-item expanded>
+        <span class="checkbox-tree-item">
+          <input
+            type="checkbox"
+            id="cat-a"
+            aria-hidden="true"
+            tabindex="-1"
+            aria-label="Infectious diseases category"
+          />
+          Infectious &amp; Parasitic Diseases (A00-B99)
+        </span>
+        <hx-tree-item slot="children" selected>
+          <span class="checkbox-tree-item">
+            <input
+              type="checkbox"
+              id="a00-a09"
+              checked
+              aria-hidden="true"
+              tabindex="-1"
+              aria-label="A00-A09 Intestinal infections"
+            />
+            A00-A09: Intestinal infectious diseases
+          </span>
+        </hx-tree-item>
+        <hx-tree-item slot="children" selected>
+          <span class="checkbox-tree-item">
+            <input
+              type="checkbox"
+              id="a15-a19"
+              checked
+              aria-hidden="true"
+              tabindex="-1"
+              aria-label="A15-A19 Tuberculosis"
+            />
+            A15-A19: Tuberculosis
+          </span>
+        </hx-tree-item>
+        <hx-tree-item slot="children">
+          <span class="checkbox-tree-item">
+            <input
+              type="checkbox"
+              id="a20-a28"
+              aria-hidden="true"
+              tabindex="-1"
+              aria-label="A20-A28 Zoonotic bacterial diseases"
+            />
+            A20-A28: Certain zoonotic bacterial diseases
+          </span>
+        </hx-tree-item>
+        <hx-tree-item slot="children">
+          <span class="checkbox-tree-item">
+            <input
+              type="checkbox"
+              id="a30-a49"
+              aria-hidden="true"
+              tabindex="-1"
+              aria-label="A30-A49 Other bacterial diseases"
+            />
+            A30-A49: Other bacterial diseases
+          </span>
+        </hx-tree-item>
+      </hx-tree-item>
+      <hx-tree-item>
+        <span class="checkbox-tree-item">
+          <input
+            type="checkbox"
+            id="cat-c"
+            aria-hidden="true"
+            tabindex="-1"
+            aria-label="Neoplasms category"
+          />
+          Neoplasms (C00-D49)
+        </span>
+        <hx-tree-item slot="children">
+          <span class="checkbox-tree-item">
+            <input
+              type="checkbox"
+              id="c00-c14"
+              aria-hidden="true"
+              tabindex="-1"
+              aria-label="C00-C14 Malignant neoplasms lip oral cavity"
+            />
+            C00-C14: Malignant neoplasms of lip, oral cavity
+          </span>
+        </hx-tree-item>
+        <hx-tree-item slot="children">
+          <span class="checkbox-tree-item">
+            <input
+              type="checkbox"
+              id="c15-c26"
+              aria-hidden="true"
+              tabindex="-1"
+              aria-label="C15-C26 Malignant neoplasms digestive organs"
+            />
+            C15-C26: Malignant neoplasms of digestive organs
+          </span>
+        </hx-tree-item>
+      </hx-tree-item>
+    </hx-tree-view>
+    <p
+      style="margin-top: var(--hx-space-4, 1rem); font-size: var(--hx-font-size-sm, 0.875rem); color: var(--hx-color-text-secondary);"
+    >
+      2 diagnosis codes selected. Use <code>selection="multiple"</code> with slotted checkboxes for
+      explicit visual affordance. The <code>selected</code> attribute reflects programmatic
+      selection state.
+    </p>
+  `,
+  play: async ({ canvasElement }) => {
+    const tree = canvasElement.querySelector('hx-tree-view');
+    await expect(tree).toBeTruthy();
+
+    const selectedItems = canvasElement.querySelectorAll('hx-tree-item[selected]');
+    await expect(selectedItems.length).toBe(2);
+
+    const checkedBoxes = canvasElement.querySelectorAll('input[type="checkbox"]:checked');
+    await expect(checkedBoxes.length).toBe(2);
+  },
+};
+
+// ─────────────────────────────────────────────────
+// ASYNC LOADING (P1-6)
+// ─────────────────────────────────────────────────
+
+/**
+ * Demonstrates a simulated async-loaded subtree pattern. In healthcare taxonomy
+ * browsers (ICD-10 has 70,000+ codes), subtrees are typically fetched on demand
+ * when a parent node is expanded. This story shows the recommended pattern:
+ * show a loading placeholder, fetch data, then populate the children slot.
+ */
+export const AsyncLoading: Story = {
+  name: 'Async Loading (Simulated)',
+  render: () => html`
+    <style>
+      .loading-placeholder {
+        display: flex;
+        align-items: center;
+        gap: var(--hx-space-2, 0.5rem);
+        color: var(--hx-color-text-muted);
+        font-size: var(--hx-font-size-sm, 0.875rem);
+        padding: var(--hx-space-1, 0.25rem) 0;
+        font-style: italic;
+      }
+      .loading-placeholder::before {
+        content: '';
+        display: inline-block;
+        width: var(--hx-font-size-sm, 0.875rem);
+        height: var(--hx-font-size-sm, 0.875rem);
+        border: var(--hx-border-width-medium, 2px) solid var(--hx-color-border-default);
+        border-top-color: var(--hx-color-primary-500);
+        border-radius: var(--hx-border-radius-full, 50%);
+        animation: spin 0.75s linear infinite;
+        flex-shrink: 0;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .loading-placeholder::before {
+          animation: none;
+          border-top-color: var(--hx-color-text-muted);
+        }
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+    </style>
+    <hx-tree-view id="async-tree" label="Drug classification" selection="single">
+      <hx-tree-item id="cardiovascular-node">
+        Cardiovascular Drugs
+        <hx-tree-item slot="children" id="cardiovascular-loading">
+          <span class="loading-placeholder">Loading subcategories...</span>
+        </hx-tree-item>
+      </hx-tree-item>
+      <hx-tree-item expanded>
+        Antibiotics
+        <hx-tree-item slot="children">Penicillins</hx-tree-item>
+        <hx-tree-item slot="children">Cephalosporins</hx-tree-item>
+        <hx-tree-item slot="children">Fluoroquinolones</hx-tree-item>
+      </hx-tree-item>
+      <hx-tree-item id="analgesics-node">
+        Analgesics
+        <hx-tree-item slot="children" id="analgesics-loading">
+          <span class="loading-placeholder">Loading subcategories...</span>
+        </hx-tree-item>
+      </hx-tree-item>
+    </hx-tree-view>
+    <p
+      style="margin-top: var(--hx-space-4, 1rem); font-size: var(--hx-font-size-sm, 0.875rem); color: var(--hx-color-text-secondary);"
+    >
+      Expand "Cardiovascular Drugs" or "Analgesics" to see simulated async loading. Children replace
+      the loading placeholder after a short delay.
+    </p>
+    <script>
+      (function () {
+        function loadChildren(parentItem, loadingItemId, children) {
+          parentItem.addEventListener(
+            'hx-tree-item-select',
+            function onSelect() {
+              const loadingItem = document.getElementById(loadingItemId);
+              if (!loadingItem) return;
+              setTimeout(function () {
+                const parent = loadingItem.parentElement;
+                if (!parent) return;
+                loadingItem.remove();
+                children.forEach(function (label) {
+                  const item = document.createElement('hx-tree-item');
+                  item.setAttribute('slot', 'children');
+                  item.textContent = label;
+                  parent.appendChild(item);
+                });
+              }, 400);
+            },
+            { once: true },
+          );
+        }
+        const cvNode = document.getElementById('cardiovascular-node');
+        const analNode = document.getElementById('analgesics-node');
+        if (cvNode)
+          loadChildren(cvNode, 'cardiovascular-loading', [
+            'ACE Inhibitors',
+            'Beta Blockers',
+            'Calcium Channel Blockers',
+          ]);
+        if (analNode)
+          loadChildren(analNode, 'analgesics-loading', [
+            'NSAIDs',
+            'Opioid Analgesics',
+            'Non-opioid Analgesics',
+          ]);
+      })();
+    </script>
+  `,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const tree = canvasElement.querySelector('hx-tree-view');
+    await expect(tree).toBeTruthy();
+
+    // Verify the loading placeholders are present before expansion
+    const loadingPlaceholders = canvasElement.querySelectorAll('.loading-placeholder');
+    await expect(loadingPlaceholders.length).toBeGreaterThan(0);
+
+    // Expand the cardiovascular node by clicking its row
+    const cvNode = canvasElement.querySelector('#cardiovascular-node') as HTMLElement & {
+      expanded: boolean;
+    };
+    await expect(cvNode).toBeTruthy();
+
+    // Click the expand button inside the tree item's shadow root
+    const expandBtn = cvNode.shadowRoot?.querySelector('[part="expand-icon"]') as HTMLElement;
+    await expect(expandBtn).toBeTruthy();
+    await userEvent.click(expandBtn);
+
+    // Wait for simulated async load (400ms timeout + buffer)
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    // After async load, the loading placeholder should be replaced with actual items
+    const loadingAfter = canvasElement.querySelector('#cardiovascular-loading');
+    await expect(loadingAfter).toBeNull();
+
+    // Verify the tree renders synchronously loaded items (Antibiotics subtree)
+    await expect(canvas.getByText('Antibiotics')).toBeTruthy();
+    await expect(canvas.getByText('Penicillins')).toBeTruthy();
+  },
 };
 
 // ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Promotes 63 commits from staging to main
- Final audit sprint batch: storybook, typescript, tests, CSS, a11y, drupal, performance fixes
- All 7 audit EPICs complete — 904 findings remediated across 52 components
- All CI gates passed on staging

## What's included
- Storybook: hx-checkbox, hx-alert, hx-tree-view, hx-progress-bar, hx-prose stories
- TypeScript: hx-progress-bar, hx-prose, hx-select, hx-stack, hx-status-indicator strict fixes
- Tests: hx-badge, hx-breadcrumb, hx-copy-button, hx-drawer, hx-select, hx-side-nav coverage
- CSS: hx-copy-button, hx-field-label, hx-popover, hx-skeleton, hx-split-button token fixes
- A11y: hx-text, hx-toast, hx-visually-hidden, hx-accordion, hx-badge ARIA fixes
- Performance: hx-slider, hx-split-button optimizations

## HITL Gate
Human approval required before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Alert component: accent property for left-border styling; focus return capability
  * Progress Bar: indeterminate state support
  * Skeleton: new 'paragraph' and 'unknown' variants
  * Tree View: checkbox multi-select and async loading demonstrations

* **Bug Fixes**
  * Button: security enhancements for links opening in new tabs
  * Prose: improved table accessibility with proper scope attributes and summary footers
  * Link: dynamic CSS variable theming for focus rings

* **Tests**
  * Added coverage for Badge prefix slot and dynamic updates; Breadcrumb expansion and JSON-LD toggling; Copy Button event synchronization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->