### PR TITLE
chore: promote dev to staging

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -28,6 +28,21 @@ reviews:
     docstrings:
       enabled: false
 
+  path_instructions:
+    - path: 'packages/hx-library/src/**/*.styles.ts'
+      instructions: |
+        CSS fallbacks in `var()` expressions (e.g. `var(--hx-space-4, 1rem)`) are ALLOWED and
+        intentional. This is a defensive pattern for enterprise consumers (Drupal CMS) where the
+        token stylesheet may not always load. The "no hardcoded values" rule applies to raw literals
+        like `padding: 1rem` or `color: #ff0000`, NOT to fallback values inside `var()` token
+        references. Do NOT flag `var(--hx-*, <fallback>)` as a hardcoded value violation.
+    - path: 'packages/hx-library/src/**/*.stories.ts'
+      instructions: |
+        CSS fallbacks in `var()` expressions (e.g. `var(--hx-space-4, 1rem)`) are ALLOWED and
+        intentional. This is a defensive pattern for enterprise consumers (Drupal CMS) where the
+        token stylesheet may not always load. Do NOT flag `var(--hx-*, <fallback>)` as a hardcoded
+        value violation.
+
 chat:
   auto_reply: true
 

--- a/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { expect, userEvent, within } from 'storybook/test';
 import './hx-alert.js';
 
@@ -94,7 +95,7 @@ const meta = {
       ?open=${args.open}
       ?show-icon=${args.icon}
       ?accent=${args.accent}
-      return-focus-to=${args['return-focus-to'] || ''}
+      return-focus-to=${ifDefined(args['return-focus-to'] || undefined)}
     >
       ${args.message}
     </hx-alert>

--- a/packages/hx-library/src/components/hx-tree-view/hx-tree-view.stories.ts
+++ b/packages/hx-library/src/components/hx-tree-view/hx-tree-view.stories.ts
@@ -393,7 +393,7 @@ export const CheckboxMultiSelect: Story = {
         // Sync visual checkboxes with hx-tree-item selection state.
         // The hx-tree-view emits 'hx-select' when an item is selected/deselected.
         // This listener updates the decorative checkbox inputs to match.
-        const tree = document.querySelector('hx-tree-view[label="Select diagnosis codes"]');
+        const tree = document.querySelector('hx-tree-view[selection="multiple"]');
         if (tree) {
           tree.addEventListener('hx-select', function (e) {
             const detail = /** @type {CustomEvent} */ (e).detail;


### PR DESCRIPTION
## Summary
- ifDefined for return-focus-to in hx-alert stories
- Decouple checkbox sync selector from fixed label value
- Update .coderabbit.yaml: CSS var() fallbacks are intentional, not violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)