### PR TITLE
release: staging → main (promotion pipeline docs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,11 +303,11 @@ Code flows through three branches: `feature/* → dev → staging → main`.
 **Branch protection:**
 - `dev`: Required status checks: `Quality Gates` + `CodeRabbit`. All feature PRs get CodeRabbit review.
 - `staging`: Required status checks: `Quality Gates` only. CodeRabbit does not auto-review staging-targeted PRs (`.coderabbit.yaml` scopes auto-review to `base_branches: [dev]`).
-- `main`: Receives from staging only.
+- `main`: Required status checks: `Quality Gates` + `CodeRabbit`. Receives from staging only.
 
 **Promotion flow:**
-1. `dev → staging`: Ava-autonomous. Create PR, enable auto-merge, CI must pass `Quality Gates`.
-2. `staging → main`: Create PR, enable auto-merge, CI must pass. Internal code review (3-tier agent review) recommended for large batches since CodeRabbit doesn't cover this leg.
+1. `dev → staging`: Autonomous. Create PR, enable auto-merge, CI must pass `Quality Gates`.
+2. `staging → main`: Create PR, enable auto-merge, CI must pass. Internal code review (3-tier agent review) required since CodeRabbit does not auto-review dev-targeted PRs that have already been promoted.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix: correct promotion pipeline docs — CodeRabbit only reviews dev-targeted PRs
- ci: add changeset-release branches to CI push triggers
- chore: version packages (changeset release)

Carries forward the corrected CLAUDE.md documentation that accurately describes branch protection and CodeRabbit's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Promotion Pipeline section describing the three-branch flow (feature → dev → staging → main), branch protections, and the promotion steps.
  * Expanded Git Rules with guidance on avoiding force pushes, commit message style, verification usage, and version bump practices.
  * Introduced a Key Files section mapping important repository paths and their roles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->