### PR TITLE
promote: dev → staging (review feedback fixes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,11 +303,11 @@ Code flows through three branches: `feature/* → dev → staging → main`.
 **Branch protection:**
 - `dev`: Required status checks: `Quality Gates` + `CodeRabbit`. All feature PRs get CodeRabbit review.
 - `staging`: Required status checks: `Quality Gates` only. CodeRabbit does not auto-review staging-targeted PRs (`.coderabbit.yaml` scopes auto-review to `base_branches: [dev]`).
-- `main`: Receives from staging only.
+- `main`: Required status checks: `Quality Gates` + `CodeRabbit`. Receives from staging only.
 
 **Promotion flow:**
-1. `dev → staging`: Ava-autonomous. Create PR, enable auto-merge, CI must pass `Quality Gates`.
-2. `staging → main`: Create PR, enable auto-merge, CI must pass. Internal code review (3-tier agent review) recommended for large batches since CodeRabbit doesn't cover this leg.
+1. `dev → staging`: Autonomous. Create PR, enable auto-merge, CI must pass `Quality Gates`.
+2. `staging → main`: Create PR, enable auto-merge, CI must pass. Internal code review (3-tier agent review) required since CodeRabbit does not auto-review dev-targeted PRs that have already been promoted.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix: address CodeRabbit and Tier 2 review feedback on promotion pipeline docs
  - Changed "Ava-autonomous" → "Autonomous"
  - Changed "recommended" → "required" for 3-tier review
  - Added required status checks for `main` branch in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)