### PR TITLE
fix(tokens): add ./dist/tokens.css export alias

### DIFF
--- a/.changeset/tokens-dist-export-alias.md
+++ b/.changeset/tokens-dist-export-alias.md
@@ -1,0 +1,5 @@
+---
+"@helixui/tokens": patch
+---
+
+add ./dist/tokens.css export alias so both import paths resolve correctly

--- a/packages/hx-tokens/package.json
+++ b/packages/hx-tokens/package.json
@@ -27,6 +27,7 @@
       "default": "./dist/utils.js"
     },
     "./tokens.css": "./dist/tokens.css",
+    "./dist/tokens.css": "./dist/tokens.css",
     "./tokens.json": "./src/tokens.json"
   },
   "files": [


### PR DESCRIPTION
## Summary
- Adds `"./dist/tokens.css": "./dist/tokens.css"` to the `exports` field in `packages/hx-tokens/package.json`
- Consumers can now use either `@helixui/tokens/tokens.css` (canonical) or `@helixui/tokens/dist/tokens.css` (intuitive dist path)
- Fixes `Module not found: Can't resolve '@helixui/tokens/dist/tokens.css'` errors

## Test plan
- [x] `npm run build --workspace=packages/hx-tokens` passes
- [x] `npm run verify` passes (0 errors)
- [x] Changeset included (`patch` bump)
- [x] Only `packages/hx-tokens/package.json` modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added export alias for tokens CSS to ensure both import paths resolve correctly, improving compatibility and stability of the tokens package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->