### PR TITLE
fix(infra): replace blanket .automaker/ gitignore with granular rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,8 +65,35 @@ apps/mcp-servers/*/coverage/
 # Library registry (per-install, not shared)
 apps/admin/src/data/library-registry.json
 
-# protoLabs Studio (entire directory — runtime state, settings, features, archives)
-.automaker/
+# protoLabs Studio — operational state (never committed)
+# context/, memory/, skills/, spec.md are TRACKED (project knowledge)
+.automaker/archive/
+.automaker/authority/
+.automaker/checkpoints/
+.automaker/events/
+.automaker/features/
+.automaker/images/
+.automaker/ledger/
+.automaker/notes/
+.automaker/projects/
+.automaker/quarantine/
+.automaker/recovery/
+.automaker/todos/
+.automaker/trajectory/
+.automaker/worktrees/
+.automaker/.backups/
+.automaker/agents/
+.automaker/self-review/
+.automaker/active-branches.json
+.automaker/actionable-items.json
+.automaker/calendar.json
+.automaker/categories.json
+.automaker/execution-state.json
+.automaker/notifications.json
+.automaker/settings.json
+.automaker/settings.json.bak*
+.automaker/context/context-metadata.json
+.automaker/knowledge*
 .automaker-lock
 
 # MCP health scorer output (regenerated on demand)


### PR DESCRIPTION
## Summary
- Removes the blanket `.automaker/` rule from `.gitignore`
- Adds granular ignores for all operational/runtime directories (features, events, settings, etc.)
- Leaves `context/`, `memory/`, `skills/`, and `spec.md` unignored so project knowledge is trackable

## Why
The blanket ignore was blocking `git add -A -- ':!.automaker/'` with a pathspec error — observed on the pnpm migration feature ($6.95 of Opus work blocked). It also prevented agent-learned knowledge from ever being committed.

HELiXiR already has the correct granular configuration. This aligns Helix with that gold standard.

## Test plan
- [x] `npm run verify` passes (0 errors)
- [x] `git check-ignore -v .automaker/context/pr-workflow.md` returns exit code 1 (not ignored)
- [x] Operational files (.automaker/settings.json, features/, events/) remain ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)