### PR TITLE
fix(a11y): replace hardcoded shadow DOM IDs with instance-scoped monotonic counter IDs

### DIFF
--- a/.changeset/fix-hardcoded-ids.md
+++ b/.changeset/fix-hardcoded-ids.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+fix(a11y): replace hardcoded ids in hx-accordion-item, hx-meter, and hx-progress-bar with instance-scoped monotonic counter ids to prevent wcag 1.3.1 id collision failures when multiple instances appear on the same page; also fix conflicting aria-label + aria-labelledby on hx-progress-bar

--- a/packages/hx-library/src/components/hx-accordion/hx-accordion-item.ts
+++ b/packages/hx-library/src/components/hx-accordion/hx-accordion-item.ts
@@ -52,6 +52,9 @@ const chevronIcon = svg`
 export class HelixAccordionItem extends LitElement {
   static override styles = [tokenStyles, helixAccordionItemStyles];
 
+  private static _counter = 0;
+  private _uid = `hx-accordion-item-${++HelixAccordionItem._counter}`;
+
   /**
    * Whether this item is expanded.
    * @attr expanded
@@ -114,13 +117,13 @@ export class HelixAccordionItem extends LitElement {
     return html`
       <details part="item" class=${classMap(itemClasses)} ?open=${this.expanded}>
         <summary
-          id="trigger"
+          id=${`${this._uid}-trigger`}
           part="trigger"
           class="trigger"
           tabindex=${this.disabled ? '-1' : '0'}
           aria-expanded=${this.expanded ? 'true' : 'false'}
           aria-disabled=${this.disabled ? 'true' : 'false'}
-          aria-controls="content"
+          aria-controls=${`${this._uid}-content`}
           @click=${this._handleSummaryClick}
           @keydown=${this._handleKeyDown}
         >
@@ -130,11 +133,11 @@ export class HelixAccordionItem extends LitElement {
         <div class="content-wrapper">
           <div class="content-inner">
             <div
-              id="content"
+              id=${`${this._uid}-content`}
               part="content"
               class="content"
               role="region"
-              aria-labelledby="trigger"
+              aria-labelledby=${`${this._uid}-trigger`}
               aria-hidden=${this.expanded ? nothing : 'true'}
             >
               <slot></slot>

--- a/packages/hx-library/src/components/hx-accordion/hx-accordion.test.ts
+++ b/packages/hx-library/src/components/hx-accordion/hx-accordion.test.ts
@@ -602,7 +602,7 @@ describe('hx-accordion-item', () => {
       `);
       const content = shadowQuery(el, '[role="region"]')!;
       const triggerId = content.getAttribute('aria-labelledby');
-      expect(triggerId).toBe('trigger');
+      expect(triggerId).toMatch(/^hx-accordion-item-\d+-trigger$/);
 
       // Verify the referenced element exists
       const trigger = shadowQuery(el, `#${triggerId}`);
@@ -640,7 +640,7 @@ describe('hx-accordion-item', () => {
       `);
       const summary = shadowQuery<HTMLElement>(el, 'summary')!;
       const controlsId = summary.getAttribute('aria-controls');
-      expect(controlsId).toBe('content');
+      expect(controlsId).toMatch(/^hx-accordion-item-\d+-content$/);
 
       const panel = shadowQuery(el, `#${controlsId}`);
       expect(panel).toBeTruthy();

--- a/packages/hx-library/src/components/hx-meter/hx-meter.test.ts
+++ b/packages/hx-library/src/components/hx-meter/hx-meter.test.ts
@@ -96,8 +96,10 @@ describe('hx-meter', () => {
       const el = await fixture<HelixMeter>('<hx-meter label="Battery" value="80"></hx-meter>');
       await el.updateComplete;
       const base = shadowQuery(el, '[part="base"]');
-      expect(base?.getAttribute('aria-labelledby')).toBe('__hx-meter-label');
-      const labelSpan = shadowQuery(el, '#__hx-meter-label');
+      const labelledById = base?.getAttribute('aria-labelledby');
+      expect(labelledById).toBeTruthy();
+      expect(labelledById).toMatch(/^hx-meter-\d+-label$/);
+      const labelSpan = shadowQuery(el, `#${labelledById}`);
       expect(labelSpan?.textContent?.trim()).toBe('Battery');
     });
 
@@ -123,7 +125,9 @@ describe('hx-meter', () => {
       await el.updateComplete;
       await el.updateComplete;
       const base = shadowQuery(el, '[part="base"]');
-      expect(base?.getAttribute('aria-labelledby')).toBe('__hx-meter-label');
+      const labelledById = base?.getAttribute('aria-labelledby');
+      expect(labelledById).toBeTruthy();
+      expect(labelledById).toMatch(/^hx-meter-\d+-label$/);
     });
   });
 

--- a/packages/hx-library/src/components/hx-meter/hx-meter.ts
+++ b/packages/hx-library/src/components/hx-meter/hx-meter.ts
@@ -40,6 +40,9 @@ type MeterState = 'optimum' | 'warning' | 'danger' | 'default';
 export class HelixMeter extends LitElement {
   static override styles = [tokenStyles, helixMeterStyles];
 
+  private static _counter = 0;
+  private _uid = `hx-meter-${++HelixMeter._counter}`;
+
   /**
    * Current value of the meter.
    * @attr value
@@ -170,9 +173,14 @@ export class HelixMeter extends LitElement {
         aria-valuemax=${this.max}
         aria-valuetext=${ariaValuetext}
         aria-label=${ifDefined(!hasVisibleLabel ? `${clampedValue} of ${this.max}` : undefined)}
-        aria-labelledby=${ifDefined(hasVisibleLabel ? '__hx-meter-label' : undefined)}
+        aria-labelledby=${ifDefined(hasVisibleLabel ? `${this._uid}-label` : undefined)}
       >
-        <span id="__hx-meter-label" part="label" class="meter__label" ?hidden=${!hasVisibleLabel}>
+        <span
+          id=${`${this._uid}-label`}
+          part="label"
+          class="meter__label"
+          ?hidden=${!hasVisibleLabel}
+        >
           <slot name="label" @slotchange=${this._onLabelSlotChange}>${this.label ?? ''}</slot>
         </span>
         <div class="meter__track" part="track">

--- a/packages/hx-library/src/components/hx-progress-bar/hx-progress-bar.ts
+++ b/packages/hx-library/src/components/hx-progress-bar/hx-progress-bar.ts
@@ -90,6 +90,10 @@ export class HelixProgressBar extends LitElement {
   variant: 'default' | 'success' | 'warning' | 'danger' = 'default';
 
   @state() private _liveMessage = '';
+  @state() private _hasLabelSlotContent = false;
+
+  private static _counter = 0;
+  private _uid = `hx-pb-${++HelixProgressBar._counter}`;
 
   private get _isIndeterminate(): boolean {
     return this.indeterminate || this.value === null;
@@ -122,9 +126,15 @@ export class HelixProgressBar extends LitElement {
     }
   }
 
+  private _onLabelSlotChange(e: Event): void {
+    const slot = e.target as HTMLSlotElement;
+    this._hasLabelSlotContent = slot.assignedNodes({ flatten: true }).length > 0;
+  }
+
   override render() {
-    const labelId = `${this.id || 'hx-pb'}-label`;
-    const descId = this.description ? `${this.id || 'hx-pb'}-desc` : undefined;
+    const labelId = `${this._uid}-label`;
+    const descId = this.description ? `${this._uid}-desc` : undefined;
+    const hasVisibleLabel = this._hasLabelSlotContent;
 
     const classes = {
       'progress-bar': true,
@@ -139,7 +149,7 @@ export class HelixProgressBar extends LitElement {
     return html`
       <div class=${classMap(classes)}>
         <span id=${labelId} part="label" class="progress-bar__label">
-          <slot name="label"></slot>
+          <slot name="label" @slotchange=${this._onLabelSlotChange}></slot>
         </span>
         ${this.description
           ? html`<span id=${descId} class="sr-only">${this.description}</span>`
@@ -151,8 +161,8 @@ export class HelixProgressBar extends LitElement {
           aria-valuenow=${ifDefined(ariaValueNow)}
           aria-valuemin=${this.min}
           aria-valuemax=${this.max}
-          aria-label=${this.label || nothing}
-          aria-labelledby=${labelId}
+          aria-label=${ifDefined(!hasVisibleLabel && this.label ? this.label : undefined)}
+          aria-labelledby=${ifDefined(hasVisibleLabel ? labelId : undefined)}
           aria-describedby=${ifDefined(descId)}
         >
           <div part="fill" class="progress-bar__fill" style=${indicatorStyle || nothing}></div>


### PR DESCRIPTION
## Summary

- **hx-accordion-item**: Replaced hardcoded `id=\"trigger\"` and `id=\"content\"` with instance-scoped IDs (`hx-accordion-item-N-trigger`, `hx-accordion-item-N-content`) — multiple items on same page caused duplicate IDs, breaking `aria-controls`/`aria-labelledby` relationships (WCAG 1.3.1)
- **hx-meter**: Replaced hardcoded `id=\"__hx-meter-label\"` with `hx-meter-N-label` — two meters on same page broke `aria-labelledby`
- **hx-progress-bar**: Replaced `this.id`-dependent fallback IDs (`hx-pb-label`) with monotonic counter IDs; also fixed conflicting `aria-label` + `aria-labelledby` being set simultaneously (now uses one based on visible label slot content)

All three components use a `private static _counter` + `private _uid` pattern identical to how hx-meter already handled `_hasSlotContent`.

## Test plan
- [ ] All 94 affected tests pass (accordion: 38, meter: 38+, progress-bar: 18)
- [ ] `pnpm run verify` passes (lint + format:check + type-check)
- [ ] No axe-core violations in determinate, indeterminate, and variant states
- [ ] Multiple instances on same page produce unique IDs
- [ ] `aria-controls` on accordion summary correctly references its own content panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)