### PR TITLE
fix(hx-alert,hx-code-snippet): correct boolean property defaults to false

### DIFF
--- a/.changeset/fix-boolean-property-defaults.md
+++ b/.changeset/fix-boolean-property-defaults.md
@@ -1,0 +1,13 @@
+---
+"@helixui/library": minor
+---
+
+fix: correct boolean property defaults for hx-alert and hx-code-snippet
+
+HTML boolean attributes follow presence=true, absence=false semantics. Properties that defaulted to `true` were impossible to set to `false` via HTML attributes — `open="false"` still evaluates to truthy because the attribute is present.
+
+**Breaking changes:**
+
+- `hx-alert`: `open` now defaults to `false`. Use `<hx-alert open>` to show the alert.
+- `hx-alert`: `showIcon` now defaults to `false`. Use `<hx-alert show-icon>` to display the icon.
+- `hx-code-snippet`: `copyable` now defaults to `false`. Use `<hx-code-snippet copyable>` to enable the copy button.

--- a/packages/hx-library/src/components/hx-alert/hx-alert.test.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.test.ts
@@ -26,10 +26,10 @@ describe('hx-alert', () => {
       expect(el.textContent?.trim()).toContain('Hello world');
     });
 
-    it('is visible by default (open=true)', async () => {
+    it('is hidden by default (open=false)', async () => {
       const el = await fixture<HxAlert>('<hx-alert>Visible</hx-alert>');
-      expect(el.open).toBe(true);
-      expect(el.hasAttribute('open')).toBe(true);
+      expect(el.open).toBe(false);
+      expect(el.hasAttribute('open')).toBe(false);
     });
   });
 
@@ -86,9 +86,9 @@ describe('hx-alert', () => {
   // ─── Property: open (3) ───
 
   describe('Property: open', () => {
-    it('defaults to true', async () => {
+    it('defaults to false', async () => {
       const el = await fixture<HxAlert>('<hx-alert>Open</hx-alert>');
-      expect(el.open).toBe(true);
+      expect(el.open).toBe(false);
     });
 
     it('hides alert when open is false', async () => {
@@ -100,7 +100,7 @@ describe('hx-alert', () => {
     });
 
     it('reflects open attribute', async () => {
-      const el = await fixture<HxAlert>('<hx-alert>Open</hx-alert>');
+      const el = await fixture<HxAlert>('<hx-alert open>Open</hx-alert>');
       expect(el.hasAttribute('open')).toBe(true);
       el.open = false;
       await el.updateComplete;
@@ -111,15 +111,15 @@ describe('hx-alert', () => {
   // ─── Property: showIcon (4) ───
 
   describe('Property: showIcon', () => {
-    it('defaults to true', async () => {
+    it('defaults to false', async () => {
       const el = await fixture<HxAlert>('<hx-alert>Test</hx-alert>');
-      expect(el.showIcon).toBe(true);
+      expect(el.showIcon).toBe(false);
     });
 
-    it('renders icon container by default', async () => {
+    it('does not render icon container by default (show-icon is opt-in)', async () => {
       const el = await fixture<HxAlert>('<hx-alert>Test</hx-alert>');
       const iconPart = shadowQuery(el, '[part="icon"]');
-      expect(iconPart).toBeTruthy();
+      expect(iconPart).toBeNull();
     });
 
     it('hides icon container when showIcon is false', async () => {
@@ -211,7 +211,7 @@ describe('hx-alert', () => {
     });
 
     it('removes open attribute when closed', async () => {
-      const el = await fixture<HxAlert>('<hx-alert dismissible>Dismissible</hx-alert>');
+      const el = await fixture<HxAlert>('<hx-alert dismissible open>Dismissible</hx-alert>');
       expect(el.hasAttribute('open')).toBe(true);
       const closeBtn = shadowQuery<HTMLButtonElement>(el, '.alert__close-button')!;
       closeBtn.click();
@@ -239,7 +239,7 @@ describe('hx-alert', () => {
     });
 
     it('does not dismiss alert when Escape is pressed on close button', async () => {
-      const el = await fixture<HxAlert>('<hx-alert dismissible>Dismissible</hx-alert>');
+      const el = await fixture<HxAlert>('<hx-alert dismissible open>Dismissible</hx-alert>');
       const closeBtn = shadowQuery<HTMLButtonElement>(el, '.alert__close-button')!;
       closeBtn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
       await el.updateComplete;
@@ -354,8 +354,8 @@ describe('hx-alert', () => {
       expect(part).toBeTruthy();
     });
 
-    it('exposes "icon" part', async () => {
-      const el = await fixture<HxAlert>('<hx-alert>Test</hx-alert>');
+    it('exposes "icon" part when show-icon is set', async () => {
+      const el = await fixture<HxAlert>('<hx-alert show-icon>Test</hx-alert>');
       const part = shadowQuery(el, '[part="icon"]');
       expect(part).toBeTruthy();
     });
@@ -450,7 +450,7 @@ describe('hx-alert', () => {
     it('renders a default SVG icon per variant', async () => {
       const variants = ['info', 'success', 'warning', 'error'] as const;
       for (const variant of variants) {
-        const el = await fixture<HxAlert>(`<hx-alert variant="${variant}">Test</hx-alert>`);
+        const el = await fixture<HxAlert>(`<hx-alert variant="${variant}" show-icon>Test</hx-alert>`);
         const iconContainer = shadowQuery(el, '[part="icon"]')!;
         const svg = iconContainer.querySelector('svg');
         expect(svg).toBeTruthy();

--- a/packages/hx-library/src/components/hx-alert/hx-alert.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.ts
@@ -63,21 +63,18 @@ export class HelixAlert extends LitElement {
   dismissible = false;
 
   /**
-   * Whether the alert is visible. Set to false to hide the alert.
+   * Whether the alert is visible. Add the `open` attribute to show the alert.
    * @attr open
    */
   @property({ type: Boolean, reflect: true })
-  open = true;
+  open = false;
 
   /**
-   * Whether to show the default variant icon. Set to false to hide the icon container entirely.
-   * Note: Boolean attribute semantics apply — the attribute must be absent (not set to "false")
-   * to hide the icon. `<hx-alert show-icon="false">` still shows the icon because the attribute
-   * is present; use `<hx-alert>` (attribute absent) or `el.showIcon = false` to hide it.
+   * Whether to show the default variant icon. Add `show-icon` attribute to display the icon.
    * @attr show-icon
    */
   @property({ type: Boolean, reflect: true, attribute: 'show-icon' })
-  showIcon = true;
+  showIcon = false;
 
   /**
    * When true, applies a left border accent stripe instead of a full border.

--- a/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.test.ts
+++ b/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.test.ts
@@ -32,8 +32,8 @@ describe('hx-code-snippet', () => {
       expect(code).toBeTruthy();
     });
 
-    it('exposes "copy-button" CSS part by default', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+    it('exposes "copy-button" CSS part when copyable is set', async () => {
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery(el, '[part~="copy-button"]');
       expect(btn).toBeTruthy();
     });
@@ -98,10 +98,10 @@ describe('hx-code-snippet', () => {
   // ─── Property: copyable (4) ───
 
   describe('Property: copyable', () => {
-    it('shows copy button by default (copyable=true)', async () => {
+    it('does not show copy button by default (copyable is opt-in)', async () => {
       const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery(el, '[part~="copy-button"]');
-      expect(btn).toBeTruthy();
+      expect(btn).toBeNull();
     });
 
     it('copyable="false" as HTML attribute shows copy button (boolean trap)', async () => {
@@ -123,8 +123,8 @@ describe('hx-code-snippet', () => {
       expect(btn).toBeNull();
     });
 
-    it('copy button has aria-label="Copy code" initially', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+    it('copy button has aria-label="Copy code" when copyable', async () => {
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery(el, '[part~="copy-button"]');
       expect(btn?.getAttribute('aria-label')).toBe('Copy code');
     });
@@ -134,7 +134,7 @@ describe('hx-code-snippet', () => {
 
   describe('Copy Action', () => {
     it('dispatches hx-copy event on copy button click', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery<HTMLButtonElement>(el, '[part~="copy-button"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-copy');
       btn.click();
@@ -145,7 +145,7 @@ describe('hx-code-snippet', () => {
     });
 
     it('hx-copy event detail has text property', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery<HTMLButtonElement>(el, '[part~="copy-button"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-copy');
       btn.click();
@@ -154,7 +154,7 @@ describe('hx-code-snippet', () => {
     });
 
     it('copy button aria-label changes to "Copied!" after click', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery<HTMLButtonElement>(el, '[part~="copy-button"]')!;
       btn.click();
       await el.updateComplete;
@@ -162,7 +162,7 @@ describe('hx-code-snippet', () => {
     });
 
     it('copy button text changes to "Copied!" after click', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery<HTMLButtonElement>(el, '[part~="copy-button"]')!;
       btn.click();
       await el.updateComplete;
@@ -346,9 +346,9 @@ describe('hx-code-snippet', () => {
   // ─── Defaults (3) ───
 
   describe('Defaults', () => {
-    it('copyable defaults to true', async () => {
+    it('copyable defaults to false', async () => {
       const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
-      expect(el.copyable).toBe(true);
+      expect(el.copyable).toBe(false);
     });
 
     it('inline defaults to false', async () => {
@@ -378,7 +378,7 @@ describe('hx-code-snippet', () => {
 
   describe('Keyboard Interaction', () => {
     it('copy button is activatable via Enter key', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery<HTMLButtonElement>(el, '[part~="copy-button"]')!;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-copy');
       btn.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
@@ -457,7 +457,7 @@ describe('hx-code-snippet', () => {
       });
 
       const el = await fixture<HelixCodeSnippet>(
-        '<hx-code-snippet>npm install @helixui/library</hx-code-snippet>',
+        '<hx-code-snippet copyable>npm install @helixui/library</hx-code-snippet>',
       );
       await el.updateComplete;
       const btn = shadowQuery<HTMLButtonElement>(el, '[part~="copy-button"]')!;
@@ -468,7 +468,7 @@ describe('hx-code-snippet', () => {
     });
 
     it('clears copy timer on disconnect without post-disconnect mutation', async () => {
-      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet>const x = 1;</hx-code-snippet>');
+      const el = await fixture<HelixCodeSnippet>('<hx-code-snippet copyable>const x = 1;</hx-code-snippet>');
       const btn = shadowQuery<HTMLButtonElement>(el, '[part~="copy-button"]')!;
       btn.click();
       await el.updateComplete;

--- a/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.ts
+++ b/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.ts
@@ -62,16 +62,11 @@ export class HelixCodeSnippet extends LitElement {
   wrap: boolean = false;
 
   /**
-   * When true, shows a copy-to-clipboard button.
+   * When true, shows a copy-to-clipboard button. Add the `copyable` attribute to enable it.
    * @attr copyable
-   *
-   * IMPORTANT: This is a standard boolean attribute. Setting `copyable="false"` in HTML
-   * will NOT disable the copy button — the attribute presence alone signals `true`.
-   * To disable programmatically, set `el.copyable = false` via JavaScript.
-   * In Lit/HTML templates, use `?copyable=${false}` (Lit boolean binding) to remove the attribute.
    */
   @property({ type: Boolean, reflect: true })
-  copyable: boolean = true;
+  copyable: boolean = false;
 
   /**
    * Maximum number of lines to display before showing a "Show more" button.

--- a/packages/hx-library/src/index.ts
+++ b/packages/hx-library/src/index.ts
@@ -27,11 +27,7 @@ export { HelixCheckbox } from './components/hx-checkbox/index.js';
 export { HelixCheckboxGroup } from './components/hx-checkbox-group/index.js';
 export { HelixCodeSnippet } from './components/hx-code-snippet/index.js';
 export { HelixColorPicker } from './components/hx-color-picker/index.js';
-export {
-  HelixCombobox,
-  type ComboboxOption,
-  type HxComboboxSize,
-} from './components/hx-combobox/index.js';
+export { HelixCombobox, type ComboboxOption, type HxComboboxSize } from './components/hx-combobox/index.js';
 export { HelixContainer } from './components/hx-container/index.js';
 export type { WcContainer } from './components/hx-container/index.js';
 export { HelixCopyButton } from './components/hx-copy-button/index.js';
@@ -84,17 +80,10 @@ export type { SpinnerSize } from './components/hx-spinner/index.js';
 export { HelixSplitButton } from './components/hx-split-button/index.js';
 export { HelixSplitPanel } from './components/hx-split-panel/index.js';
 export { HelixStack } from './components/hx-stack/index.js';
-export {
-  HelixStatusIndicator,
-  type StatusIndicatorStatus,
-  type StatusIndicatorSize,
-} from './components/hx-status-indicator/index.js';
+export { HelixStatusIndicator, type StatusIndicatorStatus, type StatusIndicatorSize } from './components/hx-status-indicator/index.js';
 export { HelixSteps } from './components/hx-steps/index.js';
 export { HelixStep } from './components/hx-steps/index.js';
-export {
-  HelixStructuredList,
-  HelixStructuredListRow,
-} from './components/hx-structured-list/index.js';
+export { HelixStructuredList, HelixStructuredListRow } from './components/hx-structured-list/index.js';
 export { HelixSwitch } from './components/hx-switch/index.js';
 export type { HxSwitch, WcSwitch } from './components/hx-switch/index.js';
 export { HelixTabs } from './components/hx-tabs/index.js';
@@ -107,12 +96,7 @@ export { HelixText } from './components/hx-text/index.js';
 export { HelixTextInput } from './components/hx-text-input/index.js';
 export { HelixTextarea } from './components/hx-textarea/index.js';
 export { HelixTheme } from './components/hx-theme/index.js';
-export type {
-  ThemeName,
-  TokenDefinition,
-  TokenEntry,
-  HxTheme,
-} from './components/hx-theme/index.js';
+export type { ThemeName, TokenDefinition, TokenEntry, HxTheme } from './components/hx-theme/index.js';
 export type { WcTheme } from './components/hx-theme/index.js';
 export { HelixTimePicker } from './components/hx-time-picker/index.js';
 export { HelixToast } from './components/hx-toast/index.js';


### PR DESCRIPTION
## Summary

- `hx-alert.open` changed from `true` → `false`: use `<hx-alert open>` to show the alert
- `hx-alert.showIcon` changed from `true` → `false`: use `<hx-alert show-icon>` for the icon
- `hx-code-snippet.copyable` changed from `true` → `false`: use `<hx-code-snippet copyable>` for the copy button

HTML boolean attributes follow presence=true, absence=false semantics. Defaulting to `true` made it impossible to express `false` via HTML — `open="false"` still evaluates to truthy because the attribute is present. JSDoc warnings documenting this footgun are removed since the defaults are now correct.

All 108 tests pass. Minor changeset included.

## Test plan

- [x] `pnpm run verify` — zero lint/format/type-check errors
- [x] `hx-alert` tests: 54/54 pass
- [x] `hx-code-snippet` tests: 54/54 pass
- [x] Updated test fixtures to use `open`, `show-icon`, `copyable` attributes where previously assumed as defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)