### PR TITLE
fix(type-safety): eliminate as EventListener casts across 5 components

### DIFF
--- a/.changeset/eliminate-as-eventlistener-casts.md
+++ b/.changeset/eliminate-as-eventlistener-casts.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+fix(type-safety): eliminate `as EventListener` casts in hx-radio-group, hx-tabs, hx-tooltip, hx-steps, and hx-breadcrumb by typing handlers to accept `Event` and narrowing with proper type guards; replace `as HelixTab[]`/`as HelixTabPanel[]` casts with type guard filters; guard `e.target` slot handler casts with `instanceof HTMLSlotElement` checks

--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb.ts
@@ -95,7 +95,7 @@ export class HelixBreadcrumb extends LitElement {
   /** @internal */
   private _boundEllipsisClick: (e: Event) => void = () => undefined;
   /** @internal */
-  private _boundEllipsisKeydown: (e: KeyboardEvent) => void = () => undefined;
+  private _boundEllipsisKeydown: (e: Event) => void = () => undefined;
 
   /**
    * Tracks which items had their `current` attribute set by this component
@@ -181,8 +181,8 @@ export class HelixBreadcrumb extends LitElement {
   // ─── Slot Handling ───
 
   private _handleSlotChange(e: Event): void {
-    const slot = e.target as HTMLSlotElement;
-    const items = this._getBreadcrumbItems(slot);
+    if (!(e.target instanceof HTMLSlotElement)) return;
+    const items = this._getBreadcrumbItems(e.target);
 
     // Handle collapse behaviour
     if (this.maxItems > 0 && items.length > this.maxItems) {
@@ -199,8 +199,8 @@ export class HelixBreadcrumb extends LitElement {
   }
 
   private _handleSeparatorSlotChange(e: Event): void {
-    const slot = e.target as HTMLSlotElement;
-    const assigned = slot.assignedElements({ flatten: true });
+    if (!(e.target instanceof HTMLSlotElement)) return;
+    const assigned = e.target.assignedElements({ flatten: true });
     if (assigned.length > 0) {
       const text = (assigned[0] as HTMLElement).textContent?.trim() ?? '';
       this.style.setProperty('--hx-breadcrumb-separator-content', JSON.stringify(text));
@@ -260,7 +260,8 @@ export class HelixBreadcrumb extends LitElement {
     }
   }
 
-  private _handleEllipsisKeydown(e: KeyboardEvent): void {
+  private _handleEllipsisKeydown(e: Event): void {
+    if (!(e instanceof KeyboardEvent)) return;
     if (e.key === 'Enter' || e.key === ' ') {
       if ((e.target as Element)?.closest?.('.hx-bc-ellipsis')) {
         e.preventDefault();
@@ -331,13 +332,13 @@ export class HelixBreadcrumb extends LitElement {
     this._boundEllipsisClick = this._handleEllipsisClick.bind(this);
     this._boundEllipsisKeydown = this._handleEllipsisKeydown.bind(this);
     this.addEventListener('click', this._boundEllipsisClick);
-    this.addEventListener('keydown', this._boundEllipsisKeydown as EventListener);
+    this.addEventListener('keydown', this._boundEllipsisKeydown);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     this.removeEventListener('click', this._boundEllipsisClick);
-    this.removeEventListener('keydown', this._boundEllipsisKeydown as EventListener);
+    this.removeEventListener('keydown', this._boundEllipsisKeydown);
     this._removeJsonLd();
   }
 

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio-group.ts
@@ -127,21 +127,21 @@ export class HelixRadioGroup extends LitElement {
   // ─── Slot Handlers ───
 
   private _handleErrorSlotChange(e: Event): void {
-    const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    if (!(e.target instanceof HTMLSlotElement)) return;
+    this._hasErrorSlot = e.target.assignedNodes({ flatten: true }).length > 0;
   }
 
   // ─── Lifecycle ───
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener('hx-radio-select', this._handleRadioSelect as EventListener);
+    this.addEventListener('hx-radio-select', this._handleRadioSelect);
     this.addEventListener('keydown', this._handleKeydown);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.removeEventListener('hx-radio-select', this._handleRadioSelect as EventListener);
+    this.removeEventListener('hx-radio-select', this._handleRadioSelect);
     this.removeEventListener('keydown', this._handleKeydown);
   }
 
@@ -224,10 +224,11 @@ export class HelixRadioGroup extends LitElement {
   // ─── Event Handling ───
 
   /** @internal */
-  private _handleRadioSelect = (e: CustomEvent<{ value: string }>): void => {
+  private _handleRadioSelect = (e: Event): void => {
+    if (!(e instanceof CustomEvent)) return;
     e.stopPropagation();
 
-    const newValue = e.detail.value;
+    const newValue = (e.detail as { value: string }).value;
     if (newValue === this.value) {
       return;
     }

--- a/packages/hx-library/src/components/hx-steps/hx-steps.ts
+++ b/packages/hx-library/src/components/hx-steps/hx-steps.ts
@@ -54,15 +54,12 @@ export class HelixSteps extends LitElement {
     if (!this.hasAttribute('role')) {
       this.setAttribute('role', 'list');
     }
-    this.addEventListener('hx-step-click-internal', this._handleStepClickInternal as EventListener);
+    this.addEventListener('hx-step-click-internal', this._handleStepClickInternal);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.removeEventListener(
-      'hx-step-click-internal',
-      this._handleStepClickInternal as EventListener,
-    );
+    this.removeEventListener('hx-step-click-internal', this._handleStepClickInternal);
   }
 
   override firstUpdated(): void {

--- a/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
@@ -112,16 +112,18 @@ export class HelixTabs extends LitElement {
 
   private _getTabs(): HelixTab[] {
     if (!this._cachedTabs) {
-      this._cachedTabs = Array.from(this.querySelectorAll(':scope > hx-tab')) as HelixTab[];
+      this._cachedTabs = Array.from(this.querySelectorAll(':scope > hx-tab')).filter(
+        (el): el is HelixTab => el.tagName.toLowerCase() === 'hx-tab',
+      );
     }
     return this._cachedTabs;
   }
 
   private _getPanels(): HelixTabPanel[] {
     if (!this._cachedPanels) {
-      this._cachedPanels = Array.from(
-        this.querySelectorAll(':scope > hx-tab-panel'),
-      ) as HelixTabPanel[];
+      this._cachedPanels = Array.from(this.querySelectorAll(':scope > hx-tab-panel')).filter(
+        (el): el is HelixTabPanel => el.tagName.toLowerCase() === 'hx-tab-panel',
+      );
     }
     return this._cachedPanels;
   }
@@ -134,7 +136,7 @@ export class HelixTabs extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener('hx-tab-select', this._handleTabSelect as EventListener);
+    this.addEventListener('hx-tab-select', this._handleTabSelect);
     this.addEventListener('keydown', this._handleKeydown);
     // Watch for panel/name attribute changes on child tabs and panels
     this._observer = new MutationObserver(() => {
@@ -150,7 +152,7 @@ export class HelixTabs extends LitElement {
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.removeEventListener('hx-tab-select', this._handleTabSelect as EventListener);
+    this.removeEventListener('hx-tab-select', this._handleTabSelect);
     this.removeEventListener('keydown', this._handleKeydown);
     this._observer?.disconnect();
     this._observer = null;
@@ -254,7 +256,8 @@ export class HelixTabs extends LitElement {
   // ─── Event Handling ───
 
   /** @internal */
-  private _handleTabSelect = (e: CustomEvent<{ panel: string }>): void => {
+  private _handleTabSelect = (e: Event): void => {
+    if (!(e instanceof CustomEvent)) return;
     e.stopPropagation();
     const tab = e
       .composedPath()

--- a/packages/hx-library/src/components/hx-tooltip/hx-tooltip.ts
+++ b/packages/hx-library/src/components/hx-tooltip/hx-tooltip.ts
@@ -97,12 +97,12 @@ export class HelixTooltip extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.addEventListener('keydown', this._handleKeydown as EventListener);
+    this.addEventListener('keydown', this._handleKeydown);
   }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this.removeEventListener('keydown', this._handleKeydown as EventListener);
+    this.removeEventListener('keydown', this._handleKeydown);
     this._clearTimers();
     this._lightDomDescription?.remove();
     this._lightDomDescription = null;
@@ -225,7 +225,8 @@ export class HelixTooltip extends LitElement {
   // ─── Events ───
 
   /** @internal */
-  private _handleKeydown = (e: KeyboardEvent): void => {
+  private _handleKeydown = (e: Event): void => {
+    if (!(e instanceof KeyboardEvent)) return;
     if (e.key === 'Escape' && this._visible) {
       this._clearTimers();
       this._hide();


### PR DESCRIPTION
## Summary
- Type all custom event handlers to accept `Event` and narrow with `instanceof` guards, removing all `as EventListener` silencing casts
- Replace `Array.from(...) as HelixTab[]` / `as HelixTabPanel[]` array casts in `hx-tabs` with type guard `.filter()` predicates
- Guard `e.target as HTMLSlotElement` in slot handlers with `if (!(e.target instanceof HTMLSlotElement)) return` checks

## Files Modified
- `hx-tabs.ts` — `_handleTabSelect`, `_getTabs`, `_getPanels`
- `hx-radio-group.ts` — `_handleRadioSelect`, `_handleErrorSlotChange`
- `hx-tooltip.ts` — `_handleKeydown`
- `hx-steps.ts` — `_handleStepClickInternal` (cast was redundant; handler already accepted `Event`)
- `hx-breadcrumb.ts` — `_handleEllipsisKeydown`, `_boundEllipsisKeydown`, `_handleSlotChange`, `_handleSeparatorSlotChange`

## Test plan
- [x] `tsc --noEmit` — zero errors
- [x] 276 tests pass across all 5 affected components
- [x] ESLint clean, Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)