### PR TITLE
feat(cem): mark internal fields with @internal in hx-drawer and hx-time-picker

### DIFF
--- a/.changeset/hx-drawer-hx-time-picker-internal-tags.md
+++ b/.changeset/hx-drawer-hx-time-picker-internal-tags.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+mark internal fields with @internal jsdoc in hx-drawer and hx-time-picker to improve cem health scores

--- a/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
+++ b/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
@@ -79,33 +79,44 @@ export class HelixDrawer extends LitElement {
 
   // ─── Queries ───
 
+  /** @internal */
   @query('.drawer-overlay')
   private _overlayEl: HTMLElement | null | undefined;
 
+  /** @internal */
   @query('.drawer-panel')
   private _panelEl: HTMLElement | null | undefined;
 
   // ─── Internal state ───
 
+  /** @internal */
   @state()
   private _isOpen = false;
 
+  /** @internal */
   @state()
   private _hasHeaderActionsSlot = false;
 
+  /** @internal */
   @state()
   private _hasFooterSlot = false;
 
+  /** @internal */
   @state()
   private _hasLabelSlot = false;
 
+  /** @internal */
   private _cachedFocusableElements: HTMLElement[] = [];
+  /** @internal */
   private _triggerElement: HTMLElement | null = null;
+  /** @internal */
   private _animationTimeout: ReturnType<typeof setTimeout> | null = null;
   /** Whether this drawer instance currently holds a body-scroll lock. */
   private _hasScrollLock = false;
+  /** @internal */
   private _siblingAriaHiddenElements: Element[] = [];
 
+  /** @internal */
   private readonly _titleId = `hx-drawer-title-${++_hxDrawerIdCounter}`;
 
   // ─── Public Properties ───
@@ -328,6 +339,7 @@ export class HelixDrawer extends LitElement {
 
   // ─── Keyboard Handler ───
 
+  /** @internal */
   private _handleKeyDown = (e: KeyboardEvent): void => {
     if (!this._isOpen) return;
 
@@ -423,6 +435,7 @@ export class HelixDrawer extends LitElement {
 
   // ─── Overlay Click ───
 
+  /** @internal */
   private _handleOverlayClick = (e: MouseEvent): void => {
     // Only close when clicking the overlay itself (backdrop), not the panel
     const target = e.target as HTMLElement;

--- a/packages/hx-library/src/components/hx-time-picker/hx-time-picker.ts
+++ b/packages/hx-library/src/components/hx-time-picker/hx-time-picker.ts
@@ -171,8 +171,10 @@ export class HelixTimePicker extends LitElement {
 
   // ─── Form Association ───
 
+  /** @internal */
   static formAssociated = true;
 
+  /** @internal */
   private readonly _internals: ElementInternals;
 
   constructor() {
@@ -254,36 +256,52 @@ export class HelixTimePicker extends LitElement {
 
   // ─── Internal State ───
 
+  /** @internal */
   @state() private _open = false;
+  /** @internal */
   @state() private _activeIndex = -1;
+  /** @internal */
   @state() private _inputDisplayValue = '';
+  /** @internal */
   @state() private _hasLabelSlot = false;
+  /** @internal */
   @state() private _hasErrorSlot = false;
   @state() private _hasHelpSlot = false;
+  /** @internal */
   @state() private _slottedLabelId = '';
 
   // ─── Stable IDs (monotonically incrementing counter for SSR safety) ───
 
+  /** @internal */
   private static _instanceCount = 0;
 
+  /** @internal */
   private readonly _id = `hx-time-picker-${++HelixTimePicker._instanceCount}`;
+  /** @internal */
   private readonly _listboxId = `${this._id}-listbox`;
+  /** @internal */
   private readonly _errorId = `${this._id}-error`;
+  /** @internal */
   private readonly _helpId = `${this._id}-help`;
 
   // ─── Query References ───
 
+  /** @internal */
   @query('.field__input')
   private _inputEl: HTMLInputElement | undefined;
 
+  /** @internal */
   @query('.field__listbox')
   private _listboxEl: HTMLUListElement | undefined;
 
   // ─── Memoized slot generation (avoids regenerating on every render call) ───
 
+  /** @internal */
   private _cachedSlots: TimeSlot[] | null = null;
+  /** @internal */
   private _slotsKey = '';
 
+  /** @internal */
   private get _slots(): TimeSlot[] {
     const key = `${this.min}|${this.max}|${this.step}|${this.format}`;
     if (this._cachedSlots === null || key !== this._slotsKey) {
@@ -295,6 +313,7 @@ export class HelixTimePicker extends LitElement {
 
   // ─── Outside-click handler (bound reference for add/removeEventListener) ───
 
+  /** @internal */
   private readonly _handleOutsideClick = (e: MouseEvent): void => {
     if (!this.contains(e.target as Node) && !this.shadowRoot?.contains(e.target as Node)) {
       this._closeListbox();


### PR DESCRIPTION
## Summary
- Add `@internal` JSDoc tags to 14 private fields in `hx-drawer` to remove them from CEM public API surface
- Add `@internal` JSDoc tags to 19 private fields in `hx-time-picker` for the same reason
- Both components target 90+ HELiXiR health scores (up from 83 and 85 respectively)

## Changes
- `hx-drawer`: `_overlayEl`, `_panelEl`, `_isOpen`, `_hasHeaderActionsSlot`, `_hasFooterSlot`, `_hasLabelSlot`, `_cachedFocusableElements`, `_triggerElement`, `_animationTimeout`, `_siblingAriaHiddenElements`, `_titleId`, `_handleKeyDown`, `_handleOverlayClick`
- `hx-time-picker`: `formAssociated`, `_internals`, `_open`, `_activeIndex`, `_inputDisplayValue`, `_hasLabelSlot`, `_hasErrorSlot`, `_slottedLabelId`, `_instanceCount`, `_id`, `_listboxId`, `_errorId`, `_helpId`, `_inputEl`, `_listboxEl`, `_cachedSlots`, `_slotsKey`, `_slots`, `_handleOutsideClick`

## Test plan
- [x] `npm run cem` generates clean manifest
- [x] `npm run verify` — zero errors (lint + format:check + type-check)
- [x] No functional code changes — JSDoc annotations only

🤖 Generated with [Claude Code](https://claude.com/claude-code)