### PR TITLE
fix(a11y): LOW findings — hx-switch label element, hx-tabs tabindex docs, hx-toggle-button label warning

### DIFF
--- a/.changeset/a11y-low-switch-tabs-toggle.md
+++ b/.changeset/a11y-low-switch-tabs-toggle.md
@@ -1,0 +1,9 @@
+---
+'@helixui/library': patch
+---
+
+fix(a11y): hx-switch label element, hx-tabs tabindex comment, hx-toggle-button missing label warning
+
+- hx-switch: change label from span to native label element with for attribute for proper HTML association
+- hx-tabs: document dual tabindex pattern with explicit WCAG 2.4.3 reference
+- hx-toggle-button: add dev console.warn when no accessible label or slot text is present

--- a/packages/hx-library/src/components/hx-switch/hx-switch.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.ts
@@ -293,6 +293,7 @@ export class HelixSwitch extends LitElement {
           <button
             part="track"
             class="switch__track"
+            id=${this._switchId}
             type="button"
             role="switch"
             aria-checked=${this.checked ? 'true' : 'false'}
@@ -307,11 +308,11 @@ export class HelixSwitch extends LitElement {
             <span part="thumb" class="switch__thumb"></span>
           </button>
 
-          <span part="label" class="switch__label" id=${this._labelId} @click=${this._handleClick}>
+          <label part="label" class="switch__label" id=${this._labelId} for=${this._switchId}>
             <slot @slotchange=${this._handleDefaultSlotChange}>${this.label}</slot>${this.required
               ? html`<span class="switch__required-marker" aria-hidden="true">*</span>`
               : nothing}
-          </span>
+          </label>
         </div>
 
         <slot name="error" @slotchange=${this._handleErrorSlotChange}>

--- a/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
@@ -208,9 +208,11 @@ export class HelixTabs extends LitElement {
     tabs.forEach((tab) => {
       const isSelected = tab.panel === this._activePanel;
       tab.selected = isSelected;
-      // Tabindex is managed by the inner button in hx-tab via the `selected` property.
-      // We also set it on the host for the roving tabindex pattern so document.activeElement
-      // comparisons work correctly when the inner button is focused.
+      // Dual tabindex is intentional: the inner button in hx-tab manages its own tabindex
+      // via the `selected` property. We also set it on the host element for the roving
+      // tabindex pattern so document.activeElement comparisons work correctly when the
+      // inner button is focused. This is safe because the inner button is the only
+      // focusable element in hx-tab's shadow DOM (WCAG 2.4.3).
       tab.tabIndex = isSelected ? 0 : -1;
     });
 

--- a/packages/hx-library/src/components/hx-toggle-button/hx-toggle-button.ts
+++ b/packages/hx-library/src/components/hx-toggle-button/hx-toggle-button.ts
@@ -113,6 +113,22 @@ export class HelixToggleButton extends LitElement {
 
   // ─── Lifecycle ───
 
+  override firstUpdated(changedProperties: PropertyValues<this>): void {
+    super.firstUpdated(changedProperties);
+
+    if (!this.label) {
+      const slot = this.shadowRoot?.querySelector<HTMLSlotElement>('slot:not([name])');
+      const hasSlotText = slot
+        ? slot.assignedNodes({ flatten: true }).some((n) => n.textContent?.trim())
+        : false;
+      if (!hasSlotText) {
+        console.warn(
+          '[hx-toggle-button] No accessible label found. Set the `label` attribute or provide slot text content for WCAG 4.1.2 compliance.',
+        );
+      }
+    }
+  }
+
   override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
 


### PR DESCRIPTION
## Summary

- **hx-switch**: Change label from `<span>` to native `<label>` element with `for` attribute pointing to the button ID, establishing proper HTML label association. Removes redundant `@click` handler (native label behavior handles it).
- **hx-tabs**: Document the dual tabindex pattern with an explicit comment noting it is intentional, safe (inner button is the only focusable element in hx-tab's shadow DOM), and WCAG 2.4.3 compliant.
- **hx-toggle-button**: Add `firstUpdated` lifecycle hook that emits `console.warn` when the button has neither a `label` attribute nor slot text content, guiding developers toward WCAG 4.1.2 compliance.

## WCAG References

- WCAG 4.1.2 — Name, Role, Value (hx-switch, hx-toggle-button)
- WCAG 2.4.3 — Focus Order (hx-tabs)

## Test plan

- [ ] CI Quality Gates pass
- [ ] hx-switch: clicking the label text activates the switch via native `<label for>` association
- [ ] hx-switch: `aria-labelledby` still references the label element ID
- [ ] hx-toggle-button: `console.warn` fires in dev when no label or slot text; silent when either is present
- [ ] hx-tabs: no functional change — comment-only documentation fix