### PR TITLE
chore(cem): mark internal fields with @internal in hx-menu, hx-accordion, hx-dropdown

### DIFF
--- a/.changeset/healthba-hx-menu-hx-accordion-hx.md
+++ b/.changeset/healthba-hx-menu-hx-accordion-hx.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+mark internal fields with @internal in hx-menu, hx-accordion, and hx-dropdown to improve helixir health scores to 90+

--- a/packages/hx-library/src/components/hx-accordion/hx-accordion.ts
+++ b/packages/hx-library/src/components/hx-accordion/hx-accordion.ts
@@ -77,6 +77,7 @@ export class HelixAccordion extends LitElement {
     });
   }
 
+  /** @internal */
   private _handleChildExpand = (e: Event): void => {
     if (this.mode !== 'single') return;
 
@@ -93,6 +94,7 @@ export class HelixAccordion extends LitElement {
 
   // ─── Arrow key navigation (ARIA APG Accordion pattern) ───
 
+  /** @internal */
   private _handleKeyDown = (e: KeyboardEvent): void => {
     const triggers = this._getTriggers();
     if (triggers.length === 0) return;

--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
@@ -92,13 +92,18 @@ export class HelixDropdown extends LitElement {
 
   // ─── Internal State ───
 
+  /** @internal */
   @state() private _panelVisible = false;
 
   // P1-02: Unique panel ID for aria-controls.
+  /** @internal */
   private static _instanceCounter = 0;
+  /** @internal */
   private _panelId = `hx-dropdown-panel-${++HelixDropdown._instanceCounter}`;
 
+  /** @internal */
   @query('[part="panel"]') private _panel: HTMLElement | undefined;
+  /** @internal */
   @query('[part="trigger"]') private _triggerWrapper: HTMLElement | undefined;
 
   // ─── Lifecycle ───

--- a/packages/hx-library/src/components/hx-menu/hx-menu.ts
+++ b/packages/hx-library/src/components/hx-menu/hx-menu.ts
@@ -37,10 +37,13 @@ export class HelixMenu extends LitElement {
   @property({ type: String, reflect: true })
   label = '';
 
+  /** @internal */
   private _focusedIndex = -1;
 
+  /** @internal */
   private _typeaheadBuffer = '';
 
+  /** @internal */
   private _typeaheadTimeout: ReturnType<typeof setTimeout> | undefined;
 
   private _getItems(): HelixMenuItem[] {


### PR DESCRIPTION
## Summary
- Add `@internal` JSDoc tags to `_focusedIndex`, `_typeaheadBuffer`, `_typeaheadTimeout` in `hx-menu`
- Add `@internal` JSDoc tags to `_handleChildExpand`, `_handleKeyDown` in `hx-accordion`
- Add `@internal` JSDoc tags to `_panelVisible`, `_instanceCounter`, `_panelId`, `_panel`, `_triggerWrapper` in `hx-dropdown`

These undocumented private fields were lowering HELiXiR health scores. Marking them `@internal` excludes them from the public API surface, targeting 90+ scores (A grade) for all three components.

## Test plan
- [x] `npm run cem` — CEM generated successfully
- [x] `npm run verify` — 0 errors (lint + format:check + type-check)
- [x] `npm run test:smart` — skipped (JSDoc-only changes, no component logic modified)
- [x] `git diff --stat` — only the 3 component files + changeset modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)