### PR TITLE
docs: add jsdoc descriptions to @internal members in hx-carousel, hx-menu, hx-accordion, hx-drawer

### DIFF
--- a/.changeset/jsdoc-internal-descriptions.md
+++ b/.changeset/jsdoc-internal-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+add jsdoc descriptions to @internal members in hx-carousel, hx-menu, hx-accordion, and hx-drawer to improve helixir scores

--- a/packages/hx-library/src/components/hx-accordion/hx-accordion.ts
+++ b/packages/hx-library/src/components/hx-accordion/hx-accordion.ts
@@ -78,7 +78,10 @@ export class HelixAccordion extends LitElement {
     });
   }
 
-  /** @internal */
+  /**
+   * Handles expand events from child accordion items to enforce single-expand mode.
+   * @internal
+   */
   private _handleChildExpand = (e: Event): void => {
     if (this.mode !== 'single') return;
 
@@ -95,7 +98,10 @@ export class HelixAccordion extends LitElement {
 
   // ─── Arrow key navigation (ARIA APG Accordion pattern) ───
 
-  /** @internal */
+  /**
+   * Handles keyboard navigation between accordion triggers using arrow, Home, and End keys.
+   * @internal
+   */
   private _handleKeyDown = (e: KeyboardEvent): void => {
     const triggers = this._getTriggers();
     if (triggers.length === 0) return;

--- a/packages/hx-library/src/components/hx-carousel/hx-carousel.ts
+++ b/packages/hx-library/src/components/hx-carousel/hx-carousel.ts
@@ -199,37 +199,79 @@ export class HelixCarousel extends LitElement {
   @property({ type: String, attribute: 'label-play-autoplay' })
   labelPlayAutoplay = 'Play autoplay';
 
-  /** @internal */
+  /**
+   * Index of the currently visible slide.
+   * @internal
+   */
   @state() private _currentIndex = 0;
-  /** @internal */
+  /**
+   * Array of carousel item elements assigned to the default slot.
+   * @internal
+   */
   @state() private _slides: HelixCarouselItem[] = [];
-  /** @internal */
+  /**
+   * Whether the autoplay is currently active and advancing slides.
+   * @internal
+   */
   @state() private _isPlaying = false;
-  /** @internal */
+  /**
+   * Text content for the ARIA live region announcing slide changes.
+   * @internal
+   */
   @state() private _liveText = '';
   @state() private _livePolite = true;
 
-  /** @internal */
+  /**
+   * Reference to the active autoplay interval timer, or null when stopped.
+   * @internal
+   */
   private _autoplayTimer: ReturnType<typeof setInterval> | null = null;
-  /** @internal */
+  /**
+   * Whether the user has requested reduced motion via the OS media preference.
+   * @internal
+   */
   private _reducedMotion = false;
-  /** @internal */
+  /**
+   * MediaQueryList instance for monitoring the prefers-reduced-motion media feature.
+   * @internal
+   */
   private _mql: MediaQueryList | null = null;
-  /** @internal */
+  /**
+   * Whether the carousel is currently being hovered, used to pause autoplay on hover.
+   * @internal
+   */
   private _isHovered = false;
-  /** @internal */
+  /**
+   * Whether a descendant of the carousel currently has focus, used to pause autoplay on focus.
+   * @internal
+   */
   private _isFocused = false;
 
   // ─── Drag state ───
-  /** @internal */
+  /**
+   * Pointer coordinate at the start of a mouse drag gesture.
+   * @internal
+   */
   private _dragStartCoord = 0;
-  /** @internal */
+  /**
+   * Whether a mouse drag gesture is currently in progress.
+   * @internal
+   */
   private _isDragging = false;
-  /** @internal */
+  /**
+   * Whether the pointer has moved beyond the drag threshold during the current drag gesture.
+   * @internal
+   */
   private _dragMoved = false;
-  /** @internal */
+  /**
+   * Touch coordinate at the start of a touch swipe gesture.
+   * @internal
+   */
   private _touchStartCoord = 0;
-  /** @internal */
+  /**
+   * Whether the touch has moved beyond the swipe threshold during the current touch gesture.
+   * @internal
+   */
   private _touchMoved = false;
 
   // ─── Lifecycle ───
@@ -298,7 +340,10 @@ export class HelixCarousel extends LitElement {
 
   // ─── Navigation ───
 
-  /** @internal */
+  /**
+   * Maximum valid slide index accounting for the number of slides visible per page.
+   * @internal
+   */
   private get _maxIndex(): number {
     return Math.max(0, this._slides.length - this.slidesPerPage);
   }
@@ -346,7 +391,10 @@ export class HelixCarousel extends LitElement {
 
   // ─── Autoplay ───
 
-  /** @internal */
+  /**
+   * Callback invoked on each autoplay interval tick to advance to the next slide.
+   * @internal
+   */
   private _autoplayTick = (): void => {
     this._livePolite = false;
     if (this.loop) {
@@ -394,7 +442,10 @@ export class HelixCarousel extends LitElement {
 
   // ─── Event Handlers ───
 
-  /** @internal */
+  /**
+   * Handles changes to the prefers-reduced-motion media query, stopping or resuming autoplay accordingly.
+   * @internal
+   */
   private _handleMotionChange = (e: MediaQueryListEvent): void => {
     this._reducedMotion = e.matches;
     if (this._reducedMotion) {
@@ -404,13 +455,19 @@ export class HelixCarousel extends LitElement {
     }
   };
 
-  /** @internal */
+  /**
+   * Handles the mouseenter event to pause autoplay while the user hovers over the carousel.
+   * @internal
+   */
   private _handleMouseEnter = (): void => {
     this._isHovered = true;
     this._pauseAutoplay();
   };
 
-  /** @internal */
+  /**
+   * Handles the mouseleave event to resume autoplay when the user stops hovering.
+   * @internal
+   */
   private _handleMouseLeave = (): void => {
     this._isHovered = false;
     if (!this._isFocused) {
@@ -418,13 +475,19 @@ export class HelixCarousel extends LitElement {
     }
   };
 
-  /** @internal */
+  /**
+   * Handles the focusin event to pause autoplay while a descendant has focus.
+   * @internal
+   */
   private _handleFocusIn = (): void => {
     this._isFocused = true;
     this._pauseAutoplay();
   };
 
-  /** @internal */
+  /**
+   * Handles the focusout event to resume autoplay when focus leaves the carousel.
+   * @internal
+   */
   private _handleFocusOut = (): void => {
     this._isFocused = false;
     if (!this._isHovered) {
@@ -432,7 +495,10 @@ export class HelixCarousel extends LitElement {
     }
   };
 
-  /** @internal */
+  /**
+   * Handles keyboard navigation to move between slides using arrow, Home, and End keys.
+   * @internal
+   */
   private _handleKeydown = (e: KeyboardEvent): void => {
     if (this.orientation === 'horizontal') {
       if (e.key === 'ArrowLeft') {
@@ -545,7 +611,10 @@ export class HelixCarousel extends LitElement {
 
   // ─── Computed ───
 
-  /** @internal */
+  /**
+   * CSS transform value applied to the slide track to scroll to the current index.
+   * @internal
+   */
   private get _trackTransform(): string {
     const slideSize = 100 / this.slidesPerPage;
     const offset = this._currentIndex * slideSize;
@@ -554,12 +623,18 @@ export class HelixCarousel extends LitElement {
       : `translateY(-${offset}%)`;
   }
 
-  /** @internal */
+  /**
+   * Whether the previous navigation button should be enabled.
+   * @internal
+   */
   private get _canGoPrev(): boolean {
     return this.loop || this._currentIndex > 0;
   }
 
-  /** @internal */
+  /**
+   * Whether the next navigation button should be enabled.
+   * @internal
+   */
   private get _canGoNext(): boolean {
     return this.loop || this._currentIndex < this._maxIndex;
   }

--- a/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
+++ b/packages/hx-library/src/components/hx-drawer/hx-drawer.ts
@@ -79,44 +79,77 @@ export class HelixDrawer extends LitElement {
 
   // ─── Queries ───
 
-  /** @internal */
+  /**
+   * Reference to the overlay element that wraps the backdrop and panel.
+   * @internal
+   */
   @query('.drawer-overlay')
   private _overlayEl: HTMLElement | null | undefined;
 
-  /** @internal */
+  /**
+   * Reference to the drawer panel element used for focus management.
+   * @internal
+   */
   @query('.drawer-panel')
   private _panelEl: HTMLElement | null | undefined;
 
   // ─── Internal state ───
 
-  /** @internal */
+  /**
+   * Whether the drawer is in the open state and visible to the user.
+   * @internal
+   */
   @state()
   private _isOpen = false;
 
-  /** @internal */
+  /**
+   * Whether the header-actions slot has any assigned content.
+   * @internal
+   */
   @state()
   private _hasHeaderActionsSlot = false;
 
-  /** @internal */
+  /**
+   * Whether the footer slot has any assigned content.
+   * @internal
+   */
   @state()
   private _hasFooterSlot = false;
 
-  /** @internal */
+  /**
+   * Whether the label slot has any assigned content.
+   * @internal
+   */
   @state()
   private _hasLabelSlot = false;
 
-  /** @internal */
+  /**
+   * Cached list of focusable elements within the drawer, used for focus trapping.
+   * @internal
+   */
   private _cachedFocusableElements: HTMLElement[] = [];
-  /** @internal */
+  /**
+   * The element that triggered the drawer to open, restored focus when the drawer closes.
+   * @internal
+   */
   private _triggerElement: HTMLElement | null = null;
-  /** @internal */
+  /**
+   * Handle for the pending animation end timeout, cleared when the drawer opens or closes again.
+   * @internal
+   */
   private _animationTimeout: ReturnType<typeof setTimeout> | null = null;
   /** Whether this drawer instance currently holds a body-scroll lock. */
   private _hasScrollLock = false;
-  /** @internal */
+  /**
+   * Elements outside the drawer that were given aria-hidden during open, restored on close.
+   * @internal
+   */
   private _siblingAriaHiddenElements: Element[] = [];
 
-  /** @internal */
+  /**
+   * Unique ID for the title element, used by aria-labelledby to link the dialog to its label.
+   * @internal
+   */
   private readonly _titleId = `hx-drawer-title-${++_hxDrawerIdCounter}`;
 
   // ─── Public Properties ───
@@ -339,7 +372,10 @@ export class HelixDrawer extends LitElement {
 
   // ─── Keyboard Handler ───
 
-  /** @internal */
+  /**
+   * Handles keyboard events on the document to trap focus and close the drawer on Escape.
+   * @internal
+   */
   private _handleKeyDown = (e: KeyboardEvent): void => {
     if (!this._isOpen) return;
 
@@ -435,7 +471,10 @@ export class HelixDrawer extends LitElement {
 
   // ─── Overlay Click ───
 
-  /** @internal */
+  /**
+   * Handles clicks on the overlay backdrop to close the drawer when the user clicks outside the panel.
+   * @internal
+   */
   private _handleOverlayClick = (e: MouseEvent): void => {
     // Only close when clicking the overlay itself (backdrop), not the panel
     const target = e.target as HTMLElement;

--- a/packages/hx-library/src/components/hx-menu/hx-menu.ts
+++ b/packages/hx-library/src/components/hx-menu/hx-menu.ts
@@ -38,13 +38,22 @@ export class HelixMenu extends LitElement {
   @property({ type: String, reflect: true })
   label = '';
 
-  /** @internal */
+  /**
+   * Index of the currently focused menu item within the list of enabled items.
+   * @internal
+   */
   private _focusedIndex = -1;
 
-  /** @internal */
+  /**
+   * Accumulated character buffer for typeahead search within menu items.
+   * @internal
+   */
   private _typeaheadBuffer = '';
 
-  /** @internal */
+  /**
+   * Timer handle that clears the typeahead buffer after a period of inactivity.
+   * @internal
+   */
   private _typeaheadTimeout: ReturnType<typeof setTimeout> | undefined;
 
   private _getItems(): HelixMenuItem[] {


### PR DESCRIPTION
## Summary
- Added multi-line JSDoc descriptions before `@internal` tags on all private properties and methods in `hx-carousel` (25 members), `hx-menu` (3), `hx-accordion` (2), and `hx-drawer` (14)
- Improves HELiXiR component scores toward 90+ target by resolving missing description issues

## Test plan
- [ ] TypeScript strict check passes (zero errors)
- [ ] ESLint passes (zero errors)
- [ ] Prettier formatting passes (no changes needed)
- [ ] No functional changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)