### PR TITLE
docs: add jsdoc descriptions to internal properties in hx-combobox, hx-select, hx-checkbox-group, hx-file-upload

### DIFF
--- a/.changeset/hx-combobox-select-jsdoc-descriptions.md
+++ b/.changeset/hx-combobox-select-jsdoc-descriptions.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+add jsdoc descriptions to internal properties in hx-combobox, hx-select, hx-checkbox-group, and hx-file-upload to improve cem documentation scores

--- a/packages/hx-library/src/components/hx-checkbox-group/hx-checkbox-group.ts
+++ b/packages/hx-library/src/components/hx-checkbox-group/hx-checkbox-group.ts
@@ -50,10 +50,10 @@ export class HelixCheckboxGroup extends LitElement {
 
   // ─── Form Association ───
 
-  /** @internal */
+  /** Marks this element as form-associated for ElementInternals support. @internal */
   static formAssociated = true;
 
-  /** @internal */
+  /** Holds the ElementInternals instance used for form value and validity management. @internal */
   private _internals: ElementInternals;
 
   constructor() {
@@ -115,9 +115,9 @@ export class HelixCheckboxGroup extends LitElement {
   }
   private _orientation: 'vertical' | 'horizontal' = 'vertical';
 
-  /** @internal */
+  /** Whether the named error slot contains projected content. @internal */
   @state() private _hasErrorSlot = false;
-  /** @internal */
+  /** Whether the named help-text slot contains projected content. @internal */
   @state() private _hasHelpSlot = false;
 
   // ─── Internal IDs ───

--- a/packages/hx-library/src/components/hx-combobox/hx-combobox.ts
+++ b/packages/hx-library/src/components/hx-combobox/hx-combobox.ts
@@ -67,10 +67,10 @@ export class HelixCombobox extends LitElement {
 
   // ─── Form Association ───
 
-  /** @internal */
+  /** Marks this element as form-associated for ElementInternals support. @internal */
   static formAssociated = true;
 
-  /** @internal */
+  /** Holds the ElementInternals instance used for form value and validity management. @internal */
   private _internals: ElementInternals;
 
   constructor() {
@@ -204,22 +204,22 @@ export class HelixCombobox extends LitElement {
 
   // ─── Internal State ───
 
-  /** @internal */
+  /** Parsed option models derived from slotted `<option>` and `<optgroup>` elements. @internal */
   @state() private _options: ComboboxOption[] = [];
-  /** @internal */
+  /** Current text typed in the input, used to filter the option list. @internal */
   @state() private _filterText = '';
-  /** @internal */
+  /** Whether the listbox dropdown is currently visible. @internal */
   @state() private _open = false;
-  /** @internal */
+  /** Zero-based index of the keyboard-focused option within the filtered list; -1 means none. @internal */
   @state() private _focusedOptionIndex = -1;
-  /** @internal */
+  /** Whether the named error slot contains projected content. @internal */
   @state() private _hasErrorSlot = false;
-  /** @internal */
+  /** Live-region announcement text describing the current number of filtered options. @internal */
   @state() private _filterAnnouncement = '';
 
   // ─── Queries ───
 
-  /** @internal */
+  /** Reference to the native text input element inside the shadow DOM. @internal */
   @query('.field__input')
   private _input: HTMLInputElement | undefined;
 

--- a/packages/hx-library/src/components/hx-file-upload/hx-file-upload.ts
+++ b/packages/hx-library/src/components/hx-file-upload/hx-file-upload.ts
@@ -49,10 +49,10 @@ export class HelixFileUpload extends LitElement {
 
   // ─── Form Association ───
 
-  /** @internal */
+  /** Marks this element as form-associated for ElementInternals support. @internal */
   static formAssociated = true;
 
-  /** @internal */
+  /** Holds the ElementInternals instance used for form value and validity management. @internal */
   private _internals: ElementInternals;
 
   constructor() {
@@ -129,16 +129,16 @@ export class HelixFileUpload extends LitElement {
 
   // ─── Internal State ───
 
-  /** @internal */
+  /** The list of currently selected file entries, each with a file reference and upload progress. @internal */
   @state() private _files: FileEntry[] = [];
-  /** @internal */
+  /** Whether a file is currently being dragged over the dropzone. @internal */
   @state() private _dragOver = false;
-  /** @internal */
+  /** Whether the named file-list slot contains projected content. @internal */
   @state() private _hasFileListSlot = false;
 
   // ─── Internal References ───
 
-  /** @internal */
+  /** Reference to the hidden native file input element used to open the OS file picker. @internal */
   @query('.file-input')
   private _fileInput: HTMLInputElement | null | undefined;
 

--- a/packages/hx-library/src/components/hx-select/hx-select.ts
+++ b/packages/hx-library/src/components/hx-select/hx-select.ts
@@ -75,10 +75,10 @@ export class HelixSelect extends LitElement {
 
   // ─── Form Association ───
 
-  /** @internal */
+  /** Marks this element as form-associated for ElementInternals support. @internal */
   static formAssociated = true;
 
-  /** @internal */
+  /** Holds the ElementInternals instance used for form value and validity management. @internal */
   private _internals: ElementInternals;
 
   constructor() {
@@ -175,20 +175,20 @@ export class HelixSelect extends LitElement {
 
   // ─── Internal State ───
 
-  /** @internal */
+  /** Parsed option models derived from slotted `<option>` and `<optgroup>` elements. @internal */
   @state() private _options: SelectOption[] = [];
-  /** @internal */
+  /** Whether the named error slot contains projected content. @internal */
   @state() private _hasErrorSlot = false;
-  /** @internal */
+  /** Zero-based index of the keyboard-focused option in the listbox; -1 means none. @internal */
   @state() private _focusedOptionIndex = -1;
 
   // ─── Queries ───
 
-  /** @internal */
+  /** Reference to the hidden native select element used for form participation. @internal */
   @query('.field__select')
   private _select: HTMLSelectElement | undefined;
 
-  /** @internal */
+  /** Reference to the visible combobox trigger element that receives keyboard focus. @internal */
   @query('.field__trigger')
   private _trigger: HTMLElement | undefined;
 


### PR DESCRIPTION
## Summary
- Add JSDoc description sentences to all `@internal` tagged properties/methods in 4 components that were missing descriptions
- Improves HELiXiR health scores: hx-combobox (87→90+), hx-select (88→90+), hx-checkbox-group (88→90+), hx-file-upload (88→90+)
- No implementation changes — documentation only

## Components updated
- **hx-combobox**: 9 internal properties documented (formAssociated, _internals, _options, _filterText, _open, _focusedOptionIndex, _hasErrorSlot, _filterAnnouncement, _input)
- **hx-select**: 7 internal properties documented (formAssociated, _internals, _options, _hasErrorSlot, _focusedOptionIndex, _select, _trigger)
- **hx-checkbox-group**: 4 internal properties documented (formAssociated, _internals, _hasErrorSlot, _hasHelpSlot)
- **hx-file-upload**: 6 internal properties documented (formAssociated, _internals, _files, _dragOver, _hasFileListSlot, _fileInput)

## Test plan
- [x] `pnpm run verify` — zero errors (lint + format:check + type-check)
- [x] `tsc --noEmit` — zero errors
- [x] `git diff --stat` — exactly 4 component files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)