### PR TITLE
fix(lit): fix .bind() memory leak, @state slot tracking, and internal property attribute exposure

### DIFF
--- a/.changeset/lit-audit-property-hygiene.md
+++ b/.changeset/lit-audit-property-hygiene.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+Fix .bind() memory leak in hx-dropdown, @state slot tracking in hx-text-input, and internal property attribute exposure in hx-step

--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
@@ -125,8 +125,6 @@ export class HelixDropdown extends LitElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this._handleOutsideClick = this._handleOutsideClick.bind(this);
-    this._handleKeydown = this._handleKeydown.bind(this);
     this.addEventListener('keydown', this._handleKeydown);
   }
 
@@ -214,7 +212,7 @@ export class HelixDropdown extends LitElement {
     }
   }
 
-  private _handleKeydown(e: KeyboardEvent): void {
+  private _handleKeydown = (e: KeyboardEvent): void => {
     if (e.key === 'Escape' && this.open) {
       e.stopPropagation();
       this._hide(true); // return focus to trigger on Escape
@@ -229,7 +227,7 @@ export class HelixDropdown extends LitElement {
       e.preventDefault();
       this._handleMenuNavigation(e.key);
     }
-  }
+  };
 
   // P2-01: Move focus among menuitem elements using arrow keys.
   private _handleMenuNavigation(key: string): void {
@@ -284,12 +282,12 @@ export class HelixDropdown extends LitElement {
     return null;
   }
 
-  private _handleOutsideClick(e: MouseEvent): void {
+  private _handleOutsideClick = (e: MouseEvent): void => {
     const path = e.composedPath();
     if (!path.includes(this)) {
       this._hide();
     }
-  }
+  };
 
   private _handlePanelClick(e: MouseEvent): void {
     const target = e.target as HTMLElement;

--- a/packages/hx-library/src/components/hx-steps/hx-step.ts
+++ b/packages/hx-library/src/components/hx-steps/hx-step.ts
@@ -69,25 +69,23 @@ export class HelixStep extends LitElement {
   // ─── Internal Properties (set by parent hx-steps) ───
 
   /**
-   * Layout orientation. Set by the parent `<hx-steps>` container.
-   * Reflected as an attribute for CSS styling (`[orientation='vertical']` selector).
+   * Layout orientation. Set by the parent `<hx-steps>` container via JS property.
    * Do not set this attribute directly on `<hx-step>` — use the `orientation`
    * property on the parent `<hx-steps>` container instead. The parent will
    * propagate the value to all child steps via `_syncChildren()`.
    * @internal
    */
-  @property({ type: String, reflect: true })
+  @property({ attribute: false })
   orientation: 'horizontal' | 'vertical' = 'horizontal';
 
   /**
-   * Size variant. Set by the parent `<hx-steps>` container.
-   * Reflected as an attribute for CSS styling. Do not set this attribute
-   * directly on `<hx-step>` — use the `size` property on the parent
-   * `<hx-steps>` container instead. The parent will propagate the value
-   * to all child steps via `_syncChildren()`.
+   * Size variant. Set by the parent `<hx-steps>` container via JS property.
+   * Do not set this attribute directly on `<hx-step>` — use the `size` property
+   * on the parent `<hx-steps>` container instead. The parent will propagate the
+   * value to all child steps via `_syncChildren()`.
    * @internal
    */
-  @property({ type: String, reflect: true })
+  @property({ attribute: false })
   size: 'sm' | 'md' | 'lg' = 'md';
 
   /**
@@ -130,6 +128,12 @@ export class HelixStep extends LitElement {
         this.setAttribute('tabindex', '0');
         this.removeAttribute('aria-disabled');
       }
+    }
+    if (changedProperties.has('orientation')) {
+      this.setAttribute('orientation', this.orientation);
+    }
+    if (changedProperties.has('size')) {
+      this.setAttribute('size', this.size);
     }
   }
 

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, nothing } from 'lit';
-import { customElement, property, query } from 'lit/decorators.js';
+import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
@@ -186,15 +186,15 @@ export class HelixTextInput extends LitElement {
   // ─── Slot Tracking ───
 
   /** @internal */
-  private _hasLabelSlot = false;
+  @state() private _hasLabelSlot = false;
   /** @internal */
-  private _hasErrorSlot = false;
+  @state() private _hasErrorSlot = false;
   /** @internal */
-  private _hasPrefixSlot = false;
+  @state() private _hasPrefixSlot = false;
   /** @internal */
-  private _hasSuffixSlot = false;
+  @state() private _hasSuffixSlot = false;
   /** @internal */
-  private _hasHelpTextSlot = false;
+  @state() private _hasHelpTextSlot = false;
 
   /** @internal */
   private _handleLabelSlotChange(e: Event): void {
@@ -206,35 +206,30 @@ export class HelixTextInput extends LitElement {
         slottedLabel.id = `${this._inputId}-slotted-label`;
       }
     }
-    this.requestUpdate();
   }
 
   /** @internal */
   private _handleErrorSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
     this._hasErrorSlot = slot.assignedElements().length > 0;
-    this.requestUpdate();
   }
 
   /** @internal */
   private _handlePrefixSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
     this._hasPrefixSlot = slot.assignedElements().length > 0;
-    this.requestUpdate();
   }
 
   /** @internal */
   private _handleSuffixSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
     this._hasSuffixSlot = slot.assignedElements().length > 0;
-    this.requestUpdate();
   }
 
   /** @internal */
   private _handleHelpTextSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
     this._hasHelpTextSlot = slot.assignedElements().length > 0;
-    this.requestUpdate();
   }
 
   // ─── Lifecycle ───


### PR DESCRIPTION
## Summary

- **LA-034 (hx-dropdown)**: Replaced `.bind(this)` calls in `connectedCallback` with arrow function class fields for `_handleKeydown` and `_handleOutsideClick`. The bound versions created new function references on each `connectedCallback` call (e.g., when element moves in DOM), causing `removeEventListener` to fail and leaking event listeners.
- **LA-030 (hx-text-input)**: Changed `_hasLabelSlot`, `_hasErrorSlot`, `_hasPrefixSlot`, `_hasSuffixSlot`, `_hasHelpTextSlot` from plain `private` properties with manual `requestUpdate()` calls to `@state()` decorated properties. Lit now handles scheduling re-renders automatically on assignment.
- **LA-040 (hx-step)**: Changed `orientation` and `size` from `@property({ reflect: true })` to `@property({ attribute: false })` since they are `@internal` and set programmatically by the parent `hx-steps` container. Manual attribute reflection added in `updated()` to preserve CSS `:host([orientation='vertical'])` selector behavior.

## Test plan
- [ ] Verify hx-dropdown opens/closes correctly with keyboard and outside-click dismissal
- [ ] Verify hx-text-input renders correctly with slotted label/error/prefix/suffix/help-text
- [ ] Verify hx-steps renders child steps in correct orientation (horizontal/vertical)
- [ ] CI Quality Gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)