### PR TITLE
fix(lit): replace string class concat with classMap directive

### DIFF
--- a/.changeset/lit-audit-classmap-directive.md
+++ b/.changeset/lit-audit-classmap-directive.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+replace string concatenation for css classes with classmap() directive in hx-list-item and hx-tree-item

--- a/packages/hx-library/src/components/hx-list/hx-list-item.ts
+++ b/packages/hx-library/src/components/hx-list/hx-list-item.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { tokenStyles } from '@helixui/tokens/lit';
 import { helixListItemStyles } from './hx-list-item.styles.js';
@@ -157,7 +158,7 @@ export class HelixListItem extends LitElement {
       return html`
         <dt
           part="base"
-          class="list-item ${this.disabled ? 'list-item--disabled' : ''}"
+          class=${classMap({ 'list-item': true, 'list-item--disabled': this.disabled })}
           aria-disabled=${this.disabled ? 'true' : nothing}
         >
           ${this._renderContent()}
@@ -169,7 +170,7 @@ export class HelixListItem extends LitElement {
       return html`
         <dd
           part="base"
-          class="list-item ${this.disabled ? 'list-item--disabled' : ''}"
+          class=${classMap({ 'list-item': true, 'list-item--disabled': this.disabled })}
           aria-disabled=${this.disabled ? 'true' : nothing}
         >
           ${this._renderContent()}
@@ -186,9 +187,11 @@ export class HelixListItem extends LitElement {
         <li
           part="base"
           role="presentation"
-          class="list-item ${this.selected ? 'list-item--selected' : ''} ${this.disabled
-            ? 'list-item--disabled'
-            : ''}"
+          class=${classMap({
+            'list-item': true,
+            'list-item--selected': this.selected,
+            'list-item--disabled': this.disabled,
+          })}
           @click=${this._handleClick}
           @keydown=${this._handleKeydown}
         >
@@ -217,9 +220,11 @@ export class HelixListItem extends LitElement {
     return html`
       <li
         part="base"
-        class="list-item ${this.selected ? 'list-item--selected' : ''} ${this.disabled
-          ? 'list-item--disabled'
-          : ''}"
+        class=${classMap({
+          'list-item': true,
+          'list-item--selected': this.selected,
+          'list-item--disabled': this.disabled,
+        })}
         role="listitem"
         aria-disabled=${this.disabled ? 'true' : nothing}
         @click=${this._handleClick}

--- a/packages/hx-library/src/components/hx-tree-view/hx-tree-item.ts
+++ b/packages/hx-library/src/components/hx-tree-view/hx-tree-item.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { tokenStyles } from '@helixui/tokens/lit';
 import { helixTreeItemStyles } from './hx-tree-item.styles.js';
 
@@ -320,7 +321,7 @@ export class HelixTreeItem extends LitElement {
         </div>
         <div
           part="children"
-          class="children ${this.expanded ? 'children--expanded' : ''}"
+          class=${classMap({ children: true, 'children--expanded': this.expanded })}
           role="group"
           aria-label=${this._labelText ? `${this._labelText} children` : 'children'}
         >


### PR DESCRIPTION
## Summary

Audit findings LA-038, LA-039. Replace string concatenation for CSS classes with Lit's classMap() directive.

**hx-list-item (line 189, 220):**
Replace `class="list-item ${this.selected ? 'list-item--selected' : ''} ${this.disabled ? 'list-item--disabled' : ''}"` with:
```ts
class=${classMap({ 'list-item': true, 'list-item--selected': this.selected, 'list-item--disabled': this.disabled })}
```
Apply to ALL render paths in the component.

**hx-tree-item (line 322):**
Replace `class="children ${th...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-19T18:54:54.857Z -->