### PR TITLE
fix(cem): add @internal annotations to private members across all components

### DIFF
--- a/packages/hx-library/src/components/hx-button/hx-button.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.ts
@@ -160,8 +160,10 @@ export class HelixButton extends LitElement {
 
   // ─── Event Handling ───
 
-  /** @private */
-  /** @internal */
+  /**
+   * @internal
+   * @private
+   */
   private _handleClick(e: MouseEvent): void {
     if (this.disabled || this.loading) {
       e.preventDefault();
@@ -194,8 +196,10 @@ export class HelixButton extends LitElement {
 
   // ─── Render Helpers ───
 
-  /** @private */
-  /** @internal */
+  /**
+   * @internal
+   * @private
+   */
   private _renderSpinner(): TemplateResult {
     return html`
       <svg
@@ -225,8 +229,10 @@ export class HelixButton extends LitElement {
     `;
   }
 
-  /** @private */
-  /** @internal */
+  /**
+   * @internal
+   * @private
+   */
   private _renderInner(): TemplateResult {
     return html`
       ${this.loading ? this._renderSpinner() : nothing}


### PR DESCRIPTION
## Summary

Several components expose private members in the Custom Elements Manifest because they lack @internal JSDoc annotations. This was fixed for hx-overflow-menu (PR #1086) but needs to be applied across all components.

**Implementation:**
1. Run `pnpm run cem` and check the output for private members (prefixed with `_`) that appear in the manifest
2. For each, add `/** @internal */` JSDoc annotation above the member
3. Re-run `pnpm run cem` to verify they're excluded

**Acceptance criteria:**
- No ...

---
*Created automatically by Automaker*

<!-- automaker:owner instance=2afff68c-8f8c-4d30-bf66-ed72af3317b0 team= created=2026-03-21T20:12:18.546Z -->