### PR TITLE
feat: CEM → SDC generator — auto-generate Drupal Single Directory Components from custom-elements.json

### DIFF
--- a/packages/hx-library/drupal/components/hx-accordion-item/README.md
+++ b/packages/hx-library/drupal/components/hx-accordion-item/README.md
@@ -1,0 +1,59 @@
+# HX Accordion Item
+
+An individual accordion item with collapsible content.
+
+## Usage
+
+```twig
+{% include 'helix:hx-accordion-item' with {
+  expanded: false,
+  disabled: false,
+  level: '3',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| expanded | boolean | false | Whether this item is expanded. |
+| disabled | boolean | false | Whether this item is disabled (cannot be toggled). |
+| level | object | 3 | Heading level (1–6) applied via `role="heading" aria-level` on the summary
+trigger. Defaults to 3. Set to match the document outline around the
+accordion so screen readers surface accordion items in the heading list. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| trigger | The heading/trigger content for this item. |
+| (default) | Default slot for the collapsible body content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-expand | Dispatched when the item is expanded. |
+| hx-collapse | Dispatched when the item is collapsed. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-accordion-border-color | var(--hx-color-neutral-200) | Border color between items. |
+| --hx-accordion-trigger-padding | var(--hx-space-4) | Trigger padding. |
+| --hx-accordion-trigger-color | var(--hx-color-neutral-800) | Trigger text color. |
+| --hx-accordion-trigger-bg | transparent | Trigger background color. |
+| --hx-accordion-trigger-hover-bg | var(--hx-color-neutral-50) | Trigger hover background. |
+| --hx-accordion-icon-color | var(--hx-color-neutral-500) | Icon color. |
+| --hx-accordion-content-padding | 0 var(--hx-space-4) var(--hx-space-4) | Content padding. |
+| --hx-accordion-content-color | var(--hx-color-neutral-600) | Content text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| item | The outer details element container. |
+| trigger | The summary/trigger element. |
+| content | The collapsible content area. |
+| icon | The expand/collapse icon. |

--- a/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.component.yml
@@ -1,0 +1,31 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Accordion Item
+status: experimental
+group: HELiX
+description: 'An individual accordion item with collapsible content.'
+props:
+  type: object
+  properties:
+    expanded:
+      type: boolean
+      title: Expanded
+      description: 'Whether this item is expanded.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether this item is disabled (cannot be toggled).'
+      default: false
+    level:
+      type: object
+      title: Level
+      description: 'Heading level (1–6) applied via `role="heading" aria-level` on the summary trigger. Defaults to 3. Set to match the document outline around the accordion so screen readers surface accordion items in the heading list.'
+      default: '3'
+slots:
+  trigger:
+    title: Trigger
+    description: 'The heading/trigger content for this item.'
+  default:
+    title: Default
+    description: 'Default slot for the collapsible body content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.css
+++ b/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.css
@@ -1,0 +1,22 @@
+/**
+ * HX Accordion Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-accordion-border-color: Border color between items. (default: var(--hx-color-neutral-200))
+ * --hx-accordion-trigger-padding: Trigger padding. (default: var(--hx-space-4))
+ * --hx-accordion-trigger-color: Trigger text color. (default: var(--hx-color-neutral-800))
+ * --hx-accordion-trigger-bg: Trigger background color. (default: transparent)
+ * --hx-accordion-trigger-hover-bg: Trigger hover background. (default: var(--hx-color-neutral-50))
+ * --hx-accordion-icon-color: Icon color. (default: var(--hx-color-neutral-500))
+ * --hx-accordion-content-padding: Content padding. (default: 0 var(--hx-space-4) var(--hx-space-4))
+ * --hx-accordion-content-color: Content text color. (default: var(--hx-color-neutral-600))
+ */
+
+/* Component host styles */
+hx-accordion-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.js
+++ b/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX Accordion Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-accordion-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-accordion-item');
+}

--- a/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.twig
+++ b/packages/hx-library/drupal/components/hx-accordion-item/hx-accordion-item.twig
@@ -1,0 +1,23 @@
+{#
+ /**
+ * @file
+ * HX Accordion Item component template.
+ *
+ * An individual accordion item with collapsible content.
+ *
+ * Available variables:
+ * - expanded: boolean - Whether this item is expanded.
+ * - disabled: boolean - Whether this item is disabled (cannot be toggled).
+ * - level: object - Heading level (1–6) applied via `role="heading" aria-level` on the summary trigger. Defaults to 3. Set to match the document outline around the accordion so screen readers surface accordion items in the heading list.
+ */
+#}
+<hx-accordion-item
+  {% if expanded %}expanded{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if level is defined and level is not empty %}level="{{ level }}"{% endif %}
+>
+  {% if slots.trigger is defined %}
+    <slot name="trigger">{{ slots.trigger }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-accordion-item>

--- a/packages/hx-library/drupal/components/hx-accordion/README.md
+++ b/packages/hx-library/drupal/components/hx-accordion/README.md
@@ -1,0 +1,36 @@
+# HX Accordion
+
+An accordion container that manages collapsible content sections.
+
+## Usage
+
+```twig
+{% include 'helix:hx-accordion' with {
+  mode: 'single',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| mode | object | single | Expansion mode: 'single' collapses all other items when one expands.
+'multi' allows multiple items open simultaneously. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for hx-accordion-item elements. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-accordion-border-radius | var(--hx-border-radius-md) | Outer border radius. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| accordion | The outer container wrapping all accordion items. |

--- a/packages/hx-library/drupal/components/hx-accordion/hx-accordion.component.yml
+++ b/packages/hx-library/drupal/components/hx-accordion/hx-accordion.component.yml
@@ -1,0 +1,18 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Accordion
+status: experimental
+group: HELiX
+description: 'An accordion container that manages collapsible content sections.'
+props:
+  type: object
+  properties:
+    mode:
+      type: object
+      title: Mode
+      description: "Expansion mode: 'single' collapses all other items when one expands. 'multi' allows multiple items open simultaneously."
+      default: 'single'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for hx-accordion-item elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-accordion/hx-accordion.css
+++ b/packages/hx-library/drupal/components/hx-accordion/hx-accordion.css
@@ -1,0 +1,15 @@
+/**
+ * HX Accordion component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-accordion-border-radius: Outer border radius. (default: var(--hx-border-radius-md))
+ */
+
+/* Component host styles */
+hx-accordion {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-accordion/hx-accordion.js
+++ b/packages/hx-library/drupal/components/hx-accordion/hx-accordion.js
@@ -1,0 +1,11 @@
+/**
+ * HX Accordion - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-accordion';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-accordion');
+}

--- a/packages/hx-library/drupal/components/hx-accordion/hx-accordion.twig
+++ b/packages/hx-library/drupal/components/hx-accordion/hx-accordion.twig
@@ -1,0 +1,14 @@
+{#
+ /**
+ * @file
+ * HX Accordion component template.
+ *
+ * An accordion container that manages collapsible content sections.
+ *
+ * Available variables:
+ * - mode: object - Expansion mode: 'single' collapses all other items when one expands. 'multi' allows multiple items open simultaneously.
+ */
+#}
+<hx-accordion {% if mode is defined and mode is not empty %}mode="{{ mode }}"{% endif %}>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-accordion>

--- a/packages/hx-library/drupal/components/hx-action-bar/README.md
+++ b/packages/hx-library/drupal/components/hx-action-bar/README.md
@@ -1,0 +1,60 @@
+# HX Action Bar
+
+A horizontal toolbar container for grouping related action buttons and controls.
+Implements the ARIA toolbar pattern with roving tabindex keyboard navigation.
+
+## Usage
+
+```twig
+{% include 'helix:hx-action-bar' with {
+  size: 'md',
+  variant: 'default',
+  position: 'top',
+  sticky: false,
+  ariaLabel: 'Actions',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| size | object | md | Size of the action bar — propagated as a data attribute to slotted children. |
+| variant | object | default | Visual variant controlling the bar background. |
+| position | object | top | Position and sticky behavior of the action bar.
+- `top` — normal flow (default)
+- `sticky` — sticks to the top of the scroll container; add `scroll-padding-top` to the
+  scroll container equal to the bar height to prevent anchor targets from scrolling behind it
+- `bottom` — sticks to the bottom of the scroll container with iOS safe-area-inset support |
+| sticky | boolean | - |  |
+| ariaLabel | string | Actions | Accessible label for the toolbar.
+Required when multiple toolbars appear on the same page. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| start | Left-aligned actions. |
+| (default) | Center content (default slot). |
+| end | Right-aligned actions. |
+| overflow | Actions revealed when the bar is constrained for space. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-action-bar-bg | transparent | Bar background color (default variant). |
+| --hx-action-bar-border | none | Bar border (default variant). |
+| --hx-action-bar-padding | var(--hx-space-2,0.5rem) var(--hx-space-3,0.75rem) | Inner padding. |
+| --hx-action-bar-gap | var(--hx-space-2,0.5rem) | Gap between slotted items. |
+| --hx-action-bar-z-index | 10 | Z-index when sticky or bottom position. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root toolbar container element. |
+| start | The start (left) slot wrapper. |
+| center | The center (default) slot wrapper. |
+| end | The end (right) slot wrapper. |
+| overflow | The overflow slot wrapper (hidden when no overflow content). |

--- a/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.component.yml
+++ b/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.component.yml
@@ -1,0 +1,45 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Action Bar
+status: experimental
+group: HELiX
+description: 'A horizontal toolbar container for grouping related action buttons and controls. Implements the ARIA toolbar pattern with roving tabindex keyboard navigation.'
+props:
+  type: object
+  properties:
+    size:
+      type: object
+      title: Size
+      description: 'Size of the action bar — propagated as a data attribute to slotted children.'
+      default: 'md'
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant controlling the bar background.'
+      default: 'default'
+    position:
+      type: object
+      title: Position
+      description: 'Position and sticky behavior of the action bar. - `top` — normal flow (default) - `sticky` — sticks to the top of the scroll container; add `scroll-padding-top` to the   scroll container equal to the bar height to prevent anchor targets from scrolling behind it - `bottom` — sticks to the bottom of the scroll container with iOS safe-area-inset support'
+      default: 'top'
+    sticky:
+      type: boolean
+      title: Sticky
+    ariaLabel:
+      type: string
+      title: Aria Label
+      description: 'Accessible label for the toolbar. Required when multiple toolbars appear on the same page.'
+      default: 'Actions'
+slots:
+  start:
+    title: Start
+    description: 'Left-aligned actions.'
+  default:
+    title: Default
+    description: 'Center content (default slot).'
+  end:
+    title: End
+    description: 'Right-aligned actions.'
+  overflow:
+    title: Overflow
+    description: 'Actions revealed when the bar is constrained for space.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.css
+++ b/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.css
@@ -1,0 +1,19 @@
+/**
+ * HX Action Bar component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-action-bar-bg: Bar background color (default variant). (default: transparent)
+ * --hx-action-bar-border: Bar border (default variant). (default: none)
+ * --hx-action-bar-padding: Inner padding. (default: var(--hx-space-2,0.5rem) var(--hx-space-3,0.75rem))
+ * --hx-action-bar-gap: Gap between slotted items. (default: var(--hx-space-2,0.5rem))
+ * --hx-action-bar-z-index: Z-index when sticky or bottom position. (default: 10)
+ */
+
+/* Component host styles */
+hx-action-bar {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.js
+++ b/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.js
@@ -1,0 +1,11 @@
+/**
+ * HX Action Bar - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-action-bar';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-action-bar');
+}

--- a/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.twig
+++ b/packages/hx-library/drupal/components/hx-action-bar/hx-action-bar.twig
@@ -1,0 +1,34 @@
+{#
+ /**
+ * @file
+ * HX Action Bar component template.
+ *
+ * A horizontal toolbar container for grouping related action buttons and controls.
+ * Implements the ARIA toolbar pattern with roving tabindex keyboard navigation.
+ *
+ * Available variables:
+ * - size: object - Size of the action bar — propagated as a data attribute to slotted children.
+ * - variant: object - Visual variant controlling the bar background.
+ * - position: object - Position and sticky behavior of the action bar. - `top` — normal flow (default) - `sticky` — sticks to the top of the scroll container; add `scroll-padding-top` to the   scroll container equal to the bar height to prevent anchor targets from scrolling behind it - `bottom` — sticks to the bottom of the scroll container with iOS safe-area-inset support
+ * - sticky: boolean - 
+ * - ariaLabel: string - Accessible label for the toolbar. Required when multiple toolbars appear on the same page.
+ */
+#}
+<hx-action-bar
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if position is defined and position is not empty %}position="{{ position }}"{% endif %}
+  {% if sticky %}sticky{% endif %}
+  {% if ariaLabel is defined and ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
+>
+  {% if slots.start is defined %}
+    <slot name="start">{{ slots.start }}</slot>
+  {% endif %}
+  {% if slots.end is defined %}
+    <slot name="end">{{ slots.end }}</slot>
+  {% endif %}
+  {% if slots.overflow is defined %}
+    <slot name="overflow">{{ slots.overflow }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-action-bar>

--- a/packages/hx-library/drupal/components/hx-alert/README.md
+++ b/packages/hx-library/drupal/components/hx-alert/README.md
@@ -1,0 +1,80 @@
+# HX Alert
+
+A feedback component for communicating status messages, warnings, and errors.
+Critical for healthcare patient safety alerts.
+
+## Usage
+
+```twig
+{% include 'helix:hx-alert' with {
+  variant: 'info',
+  dismissible: false,
+  heading: '',
+  open: false,
+  showIcon: false,
+  accent: false,
+  returnFocusTo: 'null',
+  closeLabel: 'Close alert',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | info | Visual variant of the alert that determines colors and ARIA semantics. |
+| dismissible | boolean | false | Whether the alert can be dismissed by the user. |
+| heading | string |  | Optional heading text that provides context for the close button's accessible label.
+When provided, the close button is announced as "Close [heading] alert".
+When absent, the close button falls back to "Close alert". |
+| open | boolean | false | Whether the alert is visible. Add the `open` attribute to show the alert. |
+| showIcon | boolean | false | Whether to show the default variant icon. Add `show-icon` attribute to display the icon. |
+| accent | boolean | false | When true, applies a left border accent stripe instead of a full border.
+Common healthcare/enterprise dashboard pattern for visual distinction of alert types. |
+| returnFocusTo | object | null | CSS selector for the element to return focus to after the alert is dismissed.
+When set, the component will find and focus the matching element after dismissal.
+If not set, focus management is the caller's responsibility via the hx-after-close event. |
+| closeLabel | string | Close alert | Accessible label for the dismiss button. Override for localized text. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for alert message content. |
+| title | Optional title/headline for the alert. |
+| icon | Custom icon to override the default variant icon. |
+| actions | Action buttons rendered within the alert. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-close | Dispatched when the user dismisses the alert. |
+| hx-after-close | Dispatched after the alert is dismissed. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-alert-bg | var(--hx-color-info-50) | Alert background color. |
+| --hx-alert-color | var(--hx-color-info-800) | Alert text color. |
+| --hx-alert-border-color | var(--hx-color-info-200) | Alert border color. |
+| --hx-alert-border-radius | var(--hx-border-radius-md) | Alert border radius. |
+| --hx-alert-border-width | var(--hx-border-width-thin) | Alert border width. |
+| --hx-alert-padding | var(--hx-space-4) | Alert padding. |
+| --hx-alert-gap | var(--hx-space-3) | Gap between alert elements. |
+| --hx-alert-icon-color | var(--hx-color-info-500) | Alert icon color. |
+| --hx-alert-font-family | var(--hx-font-family-sans) | Alert font family. |
+| --hx-touch-target-size | 44px | Minimum touch target size for the close button. |
+| --hx-alert-accent-width | 4px | Width of the left border accent stripe. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| alert | The outer alert container. |
+| title | The title/headline container. |
+| icon | The icon container. |
+| message | The message content area. |
+| close-button | The dismiss button (only rendered when dismissible). |
+| actions | The actions container. |

--- a/packages/hx-library/drupal/components/hx-alert/hx-alert.component.yml
+++ b/packages/hx-library/drupal/components/hx-alert/hx-alert.component.yml
@@ -1,0 +1,62 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Alert
+status: experimental
+group: HELiX
+description: 'A feedback component for communicating status messages, warnings, and errors. Critical for healthcare patient safety alerts.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant of the alert that determines colors and ARIA semantics.'
+      default: 'info'
+    dismissible:
+      type: boolean
+      title: Dismissible
+      description: 'Whether the alert can be dismissed by the user.'
+      default: false
+    heading:
+      type: string
+      title: Heading
+      description: 'Optional heading text that provides context for the close button''s accessible label. When provided, the close button is announced as "Close [heading] alert". When absent, the close button falls back to "Close alert".'
+      default: ''
+    open:
+      type: boolean
+      title: Open
+      description: 'Whether the alert is visible. Add the `open` attribute to show the alert.'
+      default: false
+    showIcon:
+      type: boolean
+      title: Show Icon
+      description: 'Whether to show the default variant icon. Add `show-icon` attribute to display the icon.'
+      default: false
+    accent:
+      type: boolean
+      title: Accent
+      description: 'When true, applies a left border accent stripe instead of a full border. Common healthcare/enterprise dashboard pattern for visual distinction of alert types.'
+      default: false
+    returnFocusTo:
+      type: object
+      title: Return Focus To
+      description: "CSS selector for the element to return focus to after the alert is dismissed. When set, the component will find and focus the matching element after dismissal. If not set, focus management is the caller's responsibility via the hx-after-close event."
+      default: 'null'
+    closeLabel:
+      type: string
+      title: Close Label
+      description: 'Accessible label for the dismiss button. Override for localized text.'
+      default: 'Close alert'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for alert message content.'
+  title:
+    title: Title
+    description: 'Optional title/headline for the alert.'
+  icon:
+    title: Icon
+    description: 'Custom icon to override the default variant icon.'
+  actions:
+    title: Actions
+    description: 'Action buttons rendered within the alert.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-alert/hx-alert.css
+++ b/packages/hx-library/drupal/components/hx-alert/hx-alert.css
@@ -1,0 +1,25 @@
+/**
+ * HX Alert component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-alert-bg: Alert background color. (default: var(--hx-color-info-50))
+ * --hx-alert-color: Alert text color. (default: var(--hx-color-info-800))
+ * --hx-alert-border-color: Alert border color. (default: var(--hx-color-info-200))
+ * --hx-alert-border-radius: Alert border radius. (default: var(--hx-border-radius-md))
+ * --hx-alert-border-width: Alert border width. (default: var(--hx-border-width-thin))
+ * --hx-alert-padding: Alert padding. (default: var(--hx-space-4))
+ * --hx-alert-gap: Gap between alert elements. (default: var(--hx-space-3))
+ * --hx-alert-icon-color: Alert icon color. (default: var(--hx-color-info-500))
+ * --hx-alert-font-family: Alert font family. (default: var(--hx-font-family-sans))
+ * --hx-touch-target-size: Minimum touch target size for the close button. (default: 44px)
+ * --hx-alert-accent-width: Width of the left border accent stripe. (default: 4px)
+ */
+
+/* Component host styles */
+hx-alert {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-alert/hx-alert.js
+++ b/packages/hx-library/drupal/components/hx-alert/hx-alert.js
@@ -1,0 +1,11 @@
+/**
+ * HX Alert - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-alert';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-alert');
+}

--- a/packages/hx-library/drupal/components/hx-alert/hx-alert.twig
+++ b/packages/hx-library/drupal/components/hx-alert/hx-alert.twig
@@ -1,0 +1,40 @@
+{#
+ /**
+ * @file
+ * HX Alert component template.
+ *
+ * A feedback component for communicating status messages, warnings, and errors.
+ * Critical for healthcare patient safety alerts.
+ *
+ * Available variables:
+ * - variant: object - Visual variant of the alert that determines colors and ARIA semantics.
+ * - dismissible: boolean - Whether the alert can be dismissed by the user.
+ * - heading: string - Optional heading text that provides context for the close button's accessible label. When provided, the close button is announced as "Close [heading] alert". When absent, the close button falls back to "Close alert".
+ * - open: boolean - Whether the alert is visible. Add the `open` attribute to show the alert.
+ * - showIcon: boolean - Whether to show the default variant icon. Add `show-icon` attribute to display the icon.
+ * - accent: boolean - When true, applies a left border accent stripe instead of a full border. Common healthcare/enterprise dashboard pattern for visual distinction of alert types.
+ * - returnFocusTo: object - CSS selector for the element to return focus to after the alert is dismissed. When set, the component will find and focus the matching element after dismissal. If not set, focus management is the caller's responsibility via the hx-after-close event.
+ * - closeLabel: string - Accessible label for the dismiss button. Override for localized text.
+ */
+#}
+<hx-alert
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if dismissible %}dismissible{% endif %}
+  {% if heading is defined and heading is not empty %}heading="{{ heading }}"{% endif %}
+  {% if open %}open{% endif %}
+  {% if showIcon %}show-icon{% endif %}
+  {% if accent %}accent{% endif %}
+  {% if returnFocusTo is defined and returnFocusTo is not empty %}return-focus-to="{{ returnFocusTo }}"{% endif %}
+  {% if closeLabel is defined and closeLabel is not empty %}close-label="{{ closeLabel }}"{% endif %}
+>
+  {% if slots.title is defined %}
+    <slot name="title">{{ slots.title }}</slot>
+  {% endif %}
+  {% if slots.icon is defined %}
+    <slot name="icon">{{ slots.icon }}</slot>
+  {% endif %}
+  {% if slots.actions is defined %}
+    <slot name="actions">{{ slots.actions }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-alert>

--- a/packages/hx-library/drupal/components/hx-avatar/README.md
+++ b/packages/hx-library/drupal/components/hx-avatar/README.md
@@ -1,0 +1,59 @@
+# HX Avatar
+
+A user avatar component that displays an image, initials, or a fallback icon.
+Supports a badge slot for status indicator overlays.
+
+## Usage
+
+```twig
+{% include 'helix:hx-avatar' with {
+  src: 'undefined',
+  alt: '',
+  label: '',
+  initials: '',
+  size: 'md',
+  shape: 'circle',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| src | object | undefined | Image URL. When provided and successfully loaded, displays the image. |
+| alt | string |  | Accessible label for the image. Required when `src` is provided.
+Used as the container's aria-label in image mode. |
+| label | string |  | Human-readable accessible name for non-image states (initials, fallback icon).
+In healthcare contexts, provide the full person name (e.g., "Dr. Jane Doe") rather than
+relying on raw initials, which screen readers announce as individual letters.
+When set, takes precedence over raw initials and the generic "Avatar" fallback. |
+| initials | string |  | Fallback initials text displayed when no image is available. |
+| size | object | md | Size variant of the avatar. |
+| shape | object | circle | Shape variant of the avatar. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for custom avatar content. Overrides src and initials when slotted content is present. |
+| badge | Status indicator overlay, positioned at the bottom-right of the avatar container. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-avatar-size | - | Computed width and height from the size variant. |
+| --hx-avatar-border-radius | - | Circle = 50%, Square = var(--hx-border-radius-md). |
+| --hx-avatar-bg | var(--hx-color-primary-100) | Background color of the avatar container. |
+| --hx-avatar-color | var(--hx-color-primary-700) | Text and icon color inside the avatar. |
+| --hx-avatar-font-size | - | Font size for the initials text, set per size variant. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| avatar | The outer container element. |
+| image | The img element shown when src is provided. |
+| initials | The initials text span shown as a fallback. |
+| fallback-icon | The SVG person silhouette shown when no src or initials are available. |
+| badge | The badge slot container. |

--- a/packages/hx-library/drupal/components/hx-avatar/hx-avatar.component.yml
+++ b/packages/hx-library/drupal/components/hx-avatar/hx-avatar.component.yml
@@ -1,0 +1,46 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Avatar
+status: experimental
+group: HELiX
+description: 'A user avatar component that displays an image, initials, or a fallback icon. Supports a badge slot for status indicator overlays.'
+props:
+  type: object
+  properties:
+    src:
+      type: object
+      title: Src
+      description: 'Image URL. When provided and successfully loaded, displays the image.'
+      default: 'undefined'
+    alt:
+      type: string
+      title: Alt
+      description: "Accessible label for the image. Required when `src` is provided. Used as the container's aria-label in image mode."
+      default: ''
+    label:
+      type: string
+      title: Label
+      description: 'Human-readable accessible name for non-image states (initials, fallback icon). In healthcare contexts, provide the full person name (e.g., "Dr. Jane Doe") rather than relying on raw initials, which screen readers announce as individual letters. When set, takes precedence over raw initials and the generic "Avatar" fallback.'
+      default: ''
+    initials:
+      type: string
+      title: Initials
+      description: 'Fallback initials text displayed when no image is available.'
+      default: ''
+    size:
+      type: object
+      title: Size
+      description: 'Size variant of the avatar.'
+      default: 'md'
+    shape:
+      type: object
+      title: Shape
+      description: 'Shape variant of the avatar.'
+      default: 'circle'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for custom avatar content. Overrides src and initials when slotted content is present.'
+  badge:
+    title: Badge
+    description: 'Status indicator overlay, positioned at the bottom-right of the avatar container.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-avatar/hx-avatar.css
+++ b/packages/hx-library/drupal/components/hx-avatar/hx-avatar.css
@@ -1,0 +1,19 @@
+/**
+ * HX Avatar component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-avatar-size: Computed width and height from the size variant.
+ * --hx-avatar-border-radius: Circle = 50%, Square = var(--hx-border-radius-md).
+ * --hx-avatar-bg: Background color of the avatar container. (default: var(--hx-color-primary-100))
+ * --hx-avatar-color: Text and icon color inside the avatar. (default: var(--hx-color-primary-700))
+ * --hx-avatar-font-size: Font size for the initials text, set per size variant.
+ */
+
+/* Component host styles */
+hx-avatar {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-avatar/hx-avatar.js
+++ b/packages/hx-library/drupal/components/hx-avatar/hx-avatar.js
@@ -1,0 +1,11 @@
+/**
+ * HX Avatar - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-avatar';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-avatar');
+}

--- a/packages/hx-library/drupal/components/hx-avatar/hx-avatar.twig
+++ b/packages/hx-library/drupal/components/hx-avatar/hx-avatar.twig
@@ -1,0 +1,30 @@
+{#
+ /**
+ * @file
+ * HX Avatar component template.
+ *
+ * A user avatar component that displays an image, initials, or a fallback icon.
+ * Supports a badge slot for status indicator overlays.
+ *
+ * Available variables:
+ * - src: object - Image URL. When provided and successfully loaded, displays the image.
+ * - alt: string - Accessible label for the image. Required when `src` is provided. Used as the container's aria-label in image mode.
+ * - label: string - Human-readable accessible name for non-image states (initials, fallback icon). In healthcare contexts, provide the full person name (e.g., "Dr. Jane Doe") rather than relying on raw initials, which screen readers announce as individual letters. When set, takes precedence over raw initials and the generic "Avatar" fallback.
+ * - initials: string - Fallback initials text displayed when no image is available.
+ * - size: object - Size variant of the avatar.
+ * - shape: object - Shape variant of the avatar.
+ */
+#}
+<hx-avatar
+  {% if src is defined and src is not empty %}src="{{ src }}"{% endif %}
+  {% if alt is defined and alt is not empty %}alt="{{ alt }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if initials is defined and initials is not empty %}initials="{{ initials }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if shape is defined and shape is not empty %}shape="{{ shape }}"{% endif %}
+>
+  {% if slots.badge is defined %}
+    <slot name="badge">{{ slots.badge }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-avatar>

--- a/packages/hx-library/drupal/components/hx-badge/README.md
+++ b/packages/hx-library/drupal/components/hx-badge/README.md
@@ -1,0 +1,76 @@
+# HX Badge
+
+A small status indicator for notifications, counts, and labels.
+
+## Usage
+
+```twig
+{% include 'helix:hx-badge' with {
+  variant: 'primary',
+  size: 'md',
+  pill: false,
+  pulse: false,
+  removable: false,
+  count: 'undefined',
+  max: 99,
+  dotLabel: '',
+  removeLabel: 'Remove',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | primary | Visual style variant of the badge. |
+| size | object | md | Size of the badge. |
+| pill | boolean | false | Whether the badge uses fully rounded (pill) styling. |
+| pulse | boolean | false | Whether the badge displays an animated pulse for attention. |
+| removable | boolean | false | Whether the badge renders a dismiss button. |
+| count | object | undefined | Numeric count to display. When set, renders the count as badge content.
+When count exceeds `max`, displays `${max}+` (e.g. `99+`). |
+| max | number | 99 | Maximum count value before truncation to `${max}+`. Defaults to 99. |
+| dotLabel | string |  | Accessible label for the dot indicator mode (pulse + empty slot).
+Required for WCAG 4.1.2 compliance when using the dot indicator pattern.
+Example: `dot-label="3 new messages"`. |
+| removeLabel | string | Remove | Accessible label for the remove button. Should describe what is being removed.
+Defaults to "Remove". For better accessibility, include context: e.g. "Remove Critical badge". |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for badge content (text, number). When empty with pulse enabled, renders as a dot indicator. |
+| prefix | Icon or content rendered before the badge text. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-remove | Dispatched when the user clicks the remove button. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-badge-bg | var(--hx-color-primary-500) | Badge background color. The primary override point. |
+| --hx-badge-color | var(--hx-color-neutral-0) | Badge text color. The primary override point. |
+| --hx-badge-font-size | - | Badge font size (set per size variant). |
+| --hx-badge-font-weight | var(--hx-font-weight-semibold) | Badge font weight. |
+| --hx-badge-font-family | var(--hx-font-family-sans) | Badge font family. |
+| --hx-badge-border-radius | var(--hx-border-radius-md) | Badge border radius. |
+| --hx-badge-padding-x | - | Badge horizontal padding (set per size variant). |
+| --hx-badge-padding-y | - | Badge vertical padding (set per size variant). |
+| --hx-badge-pulse-color | - | Pulse color matching variant background with reduced opacity. |
+| --hx-badge-dot-size | var(--hx-size-2) | Dot indicator size when rendered without content. |
+| --hx-badge-secondary-bg | var(--hx-color-neutral-100) | Background for the secondary variant. |
+| --hx-badge-secondary-color | var(--hx-color-neutral-700) | Text color for the secondary variant. |
+| --hx-badge-info-bg | var(--hx-color-info-700) | Background for the info variant. |
+| --hx-badge-info-color | var(--hx-color-neutral-0) | Text color for the info variant. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| badge | The badge element. |
+| remove-button | The remove/dismiss button. |

--- a/packages/hx-library/drupal/components/hx-badge/hx-badge.component.yml
+++ b/packages/hx-library/drupal/components/hx-badge/hx-badge.component.yml
@@ -1,0 +1,61 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Badge
+status: experimental
+group: HELiX
+description: 'A small status indicator for notifications, counts, and labels.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the badge.'
+      default: 'primary'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the badge.'
+      default: 'md'
+    pill:
+      type: boolean
+      title: Pill
+      description: 'Whether the badge uses fully rounded (pill) styling.'
+      default: false
+    pulse:
+      type: boolean
+      title: Pulse
+      description: 'Whether the badge displays an animated pulse for attention.'
+      default: false
+    removable:
+      type: boolean
+      title: Removable
+      description: 'Whether the badge renders a dismiss button.'
+      default: false
+    count:
+      type: object
+      title: Count
+      description: 'Numeric count to display. When set, renders the count as badge content. When count exceeds `max`, displays `${max}+` (e.g. `99+`).'
+      default: 'undefined'
+    max:
+      type: number
+      title: Max
+      description: 'Maximum count value before truncation to `${max}+`. Defaults to 99.'
+      default: 99
+    dotLabel:
+      type: string
+      title: Dot Label
+      description: 'Accessible label for the dot indicator mode (pulse + empty slot). Required for WCAG 4.1.2 compliance when using the dot indicator pattern. Example: `dot-label="3 new messages"`.'
+      default: ''
+    removeLabel:
+      type: string
+      title: Remove Label
+      description: 'Accessible label for the remove button. Should describe what is being removed. Defaults to "Remove". For better accessibility, include context: e.g. "Remove Critical badge".'
+      default: 'Remove'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for badge content (text, number). When empty with pulse enabled, renders as a dot indicator.'
+  prefix:
+    title: Prefix
+    description: 'Icon or content rendered before the badge text.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-badge/hx-badge.css
+++ b/packages/hx-library/drupal/components/hx-badge/hx-badge.css
@@ -1,0 +1,28 @@
+/**
+ * HX Badge component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-badge-bg: Badge background color. The primary override point. (default: var(--hx-color-primary-500))
+ * --hx-badge-color: Badge text color. The primary override point. (default: var(--hx-color-neutral-0))
+ * --hx-badge-font-size: Badge font size (set per size variant).
+ * --hx-badge-font-weight: Badge font weight. (default: var(--hx-font-weight-semibold))
+ * --hx-badge-font-family: Badge font family. (default: var(--hx-font-family-sans))
+ * --hx-badge-border-radius: Badge border radius. (default: var(--hx-border-radius-md))
+ * --hx-badge-padding-x: Badge horizontal padding (set per size variant).
+ * --hx-badge-padding-y: Badge vertical padding (set per size variant).
+ * --hx-badge-pulse-color: Pulse color matching variant background with reduced opacity.
+ * --hx-badge-dot-size: Dot indicator size when rendered without content. (default: var(--hx-size-2))
+ * --hx-badge-secondary-bg: Background for the secondary variant. (default: var(--hx-color-neutral-100))
+ * --hx-badge-secondary-color: Text color for the secondary variant. (default: var(--hx-color-neutral-700))
+ * --hx-badge-info-bg: Background for the info variant. (default: var(--hx-color-info-700))
+ * --hx-badge-info-color: Text color for the info variant. (default: var(--hx-color-neutral-0))
+ */
+
+/* Component host styles */
+hx-badge {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-badge/hx-badge.js
+++ b/packages/hx-library/drupal/components/hx-badge/hx-badge.js
@@ -1,0 +1,11 @@
+/**
+ * HX Badge - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-badge';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-badge');
+}

--- a/packages/hx-library/drupal/components/hx-badge/hx-badge.twig
+++ b/packages/hx-library/drupal/components/hx-badge/hx-badge.twig
@@ -1,0 +1,35 @@
+{#
+ /**
+ * @file
+ * HX Badge component template.
+ *
+ * A small status indicator for notifications, counts, and labels.
+ *
+ * Available variables:
+ * - variant: object - Visual style variant of the badge.
+ * - size: object - Size of the badge.
+ * - pill: boolean - Whether the badge uses fully rounded (pill) styling.
+ * - pulse: boolean - Whether the badge displays an animated pulse for attention.
+ * - removable: boolean - Whether the badge renders a dismiss button.
+ * - count: object - Numeric count to display. When set, renders the count as badge content. When count exceeds `max`, displays `${max}+` (e.g. `99+`).
+ * - max: number - Maximum count value before truncation to `${max}+`. Defaults to 99.
+ * - dotLabel: string - Accessible label for the dot indicator mode (pulse + empty slot). Required for WCAG 4.1.2 compliance when using the dot indicator pattern. Example: `dot-label="3 new messages"`.
+ * - removeLabel: string - Accessible label for the remove button. Should describe what is being removed. Defaults to "Remove". For better accessibility, include context: e.g. "Remove Critical badge".
+ */
+#}
+<hx-badge
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if pill %}pill{% endif %}
+  {% if pulse %}pulse{% endif %}
+  {% if removable %}removable{% endif %}
+  {% if count is defined and count is not empty %}count="{{ count }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if dotLabel is defined and dotLabel is not empty %}dot-label="{{ dotLabel }}"{% endif %}
+  {% if removeLabel is defined and removeLabel is not empty %}remove-label="{{ removeLabel }}"{% endif %}
+>
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-badge>

--- a/packages/hx-library/drupal/components/hx-banner/README.md
+++ b/packages/hx-library/drupal/components/hx-banner/README.md
@@ -1,0 +1,73 @@
+# HX Banner
+
+A full-width page-level banner for persistent notifications and announcements.
+Designed for healthcare applications requiring prominent system-level messaging.
+
+## Usage
+
+```twig
+{% include 'helix:hx-banner' with {
+  variant: 'info',
+  position: 'sticky',
+  dismissible: false,
+  heading: '',
+  actionLabel: '',
+  actionHref: '',
+  open: true,
+  closeLabel: 'Dismiss banner',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | info | Visual variant of the banner that determines colors and ARIA semantics. |
+| position | object | sticky | CSS positioning behavior. "sticky" keeps the banner in flow; "fixed" pins it to the viewport. |
+| dismissible | boolean | false | Whether the banner can be dismissed by the user. |
+| heading | string |  | Heading text for the banner, used to provide context in the action link's and
+close button's accessible labels. |
+| actionLabel | string |  | Label text for the optional action link. Requires action-href to render. |
+| actionHref | string |  | URL for the optional action link. Requires action-label to render. |
+| open | boolean | true | Whether the banner is visible. Defaults to true — banners are shown by default. |
+| closeLabel | string | Dismiss banner | Accessible label for the dismiss button. Override for localized text. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for banner message content. |
+| action | Optional slot to override the built-in action link with custom content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-dismiss | Dispatched when the user dismisses the banner. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-banner-bg | var(--hx-color-info-50) | Banner background color. |
+| --hx-banner-color | var(--hx-color-info-800) | Banner text color. |
+| --hx-banner-border-color | var(--hx-color-info-200) | Banner bottom border color. |
+| --hx-banner-border-width | var(--hx-border-width-thin) | Banner bottom border width. |
+| --hx-banner-padding | var(--hx-space-3) var(--hx-space-4) | Banner padding. |
+| --hx-banner-gap | var(--hx-space-3) | Gap between banner elements. |
+| --hx-banner-icon-color | var(--hx-color-info-500) | Banner icon color. |
+| --hx-banner-font-family | var(--hx-font-family-sans) | Banner font family. |
+| --hx-banner-action-color | var(--hx-banner-color) | Action link color. |
+| --hx-banner-position | sticky | CSS position value (sticky or fixed). |
+| --hx-banner-z-index | 100 | Banner z-index for stacking context. |
+| --hx-touch-target-size | 44px | Minimum touch target size for the close button. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| banner | The outer banner container. |
+| icon | The icon container. |
+| message | The message content area. |
+| action | The action link element (only rendered when action-label and action-href are set). |
+| close-button | The dismiss button (only rendered when dismissible). |

--- a/packages/hx-library/drupal/components/hx-banner/hx-banner.component.yml
+++ b/packages/hx-library/drupal/components/hx-banner/hx-banner.component.yml
@@ -1,0 +1,56 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Banner
+status: experimental
+group: HELiX
+description: 'A full-width page-level banner for persistent notifications and announcements. Designed for healthcare applications requiring prominent system-level messaging.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant of the banner that determines colors and ARIA semantics.'
+      default: 'info'
+    position:
+      type: object
+      title: Position
+      description: 'CSS positioning behavior. "sticky" keeps the banner in flow; "fixed" pins it to the viewport.'
+      default: 'sticky'
+    dismissible:
+      type: boolean
+      title: Dismissible
+      description: 'Whether the banner can be dismissed by the user.'
+      default: false
+    heading:
+      type: string
+      title: Heading
+      description: "Heading text for the banner, used to provide context in the action link's and close button's accessible labels."
+      default: ''
+    actionLabel:
+      type: string
+      title: Action Label
+      description: 'Label text for the optional action link. Requires action-href to render.'
+      default: ''
+    actionHref:
+      type: string
+      title: Action Href
+      description: 'URL for the optional action link. Requires action-label to render.'
+      default: ''
+    open:
+      type: boolean
+      title: Open
+      description: 'Whether the banner is visible. Defaults to true — banners are shown by default.'
+      default: true
+    closeLabel:
+      type: string
+      title: Close Label
+      description: 'Accessible label for the dismiss button. Override for localized text.'
+      default: 'Dismiss banner'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for banner message content.'
+  action:
+    title: Action
+    description: 'Optional slot to override the built-in action link with custom content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-banner/hx-banner.css
+++ b/packages/hx-library/drupal/components/hx-banner/hx-banner.css
@@ -1,0 +1,26 @@
+/**
+ * HX Banner component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-banner-bg: Banner background color. (default: var(--hx-color-info-50))
+ * --hx-banner-color: Banner text color. (default: var(--hx-color-info-800))
+ * --hx-banner-border-color: Banner bottom border color. (default: var(--hx-color-info-200))
+ * --hx-banner-border-width: Banner bottom border width. (default: var(--hx-border-width-thin))
+ * --hx-banner-padding: Banner padding. (default: var(--hx-space-3) var(--hx-space-4))
+ * --hx-banner-gap: Gap between banner elements. (default: var(--hx-space-3))
+ * --hx-banner-icon-color: Banner icon color. (default: var(--hx-color-info-500))
+ * --hx-banner-font-family: Banner font family. (default: var(--hx-font-family-sans))
+ * --hx-banner-action-color: Action link color. (default: var(--hx-banner-color))
+ * --hx-banner-position: CSS position value (sticky or fixed). (default: sticky)
+ * --hx-banner-z-index: Banner z-index for stacking context. (default: 100)
+ * --hx-touch-target-size: Minimum touch target size for the close button. (default: 44px)
+ */
+
+/* Component host styles */
+hx-banner {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-banner/hx-banner.js
+++ b/packages/hx-library/drupal/components/hx-banner/hx-banner.js
@@ -1,0 +1,11 @@
+/**
+ * HX Banner - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-banner';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-banner');
+}

--- a/packages/hx-library/drupal/components/hx-banner/hx-banner.twig
+++ b/packages/hx-library/drupal/components/hx-banner/hx-banner.twig
@@ -1,0 +1,34 @@
+{#
+ /**
+ * @file
+ * HX Banner component template.
+ *
+ * A full-width page-level banner for persistent notifications and announcements.
+ * Designed for healthcare applications requiring prominent system-level messaging.
+ *
+ * Available variables:
+ * - variant: object - Visual variant of the banner that determines colors and ARIA semantics.
+ * - position: object - CSS positioning behavior. "sticky" keeps the banner in flow; "fixed" pins it to the viewport.
+ * - dismissible: boolean - Whether the banner can be dismissed by the user.
+ * - heading: string - Heading text for the banner, used to provide context in the action link's and close button's accessible labels.
+ * - actionLabel: string - Label text for the optional action link. Requires action-href to render.
+ * - actionHref: string - URL for the optional action link. Requires action-label to render.
+ * - open: boolean - Whether the banner is visible. Defaults to true — banners are shown by default.
+ * - closeLabel: string - Accessible label for the dismiss button. Override for localized text.
+ */
+#}
+<hx-banner
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if position is defined and position is not empty %}position="{{ position }}"{% endif %}
+  {% if dismissible %}dismissible{% endif %}
+  {% if heading is defined and heading is not empty %}heading="{{ heading }}"{% endif %}
+  {% if actionLabel is defined and actionLabel is not empty %}action-label="{{ actionLabel }}"{% endif %}
+  {% if actionHref is defined and actionHref is not empty %}action-href="{{ actionHref }}"{% endif %}
+  {% if open %}open{% endif %}
+  {% if closeLabel is defined and closeLabel is not empty %}close-label="{{ closeLabel }}"{% endif %}
+>
+  {% if slots.action is defined %}
+    <slot name="action">{{ slots.action }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-banner>

--- a/packages/hx-library/drupal/components/hx-breadcrumb-item/README.md
+++ b/packages/hx-library/drupal/components/hx-breadcrumb-item/README.md
@@ -1,0 +1,56 @@
+# HX Breadcrumb Item
+
+A single breadcrumb navigation item.
+
+## Usage
+
+```twig
+{% include 'helix:hx-breadcrumb-item' with {
+  href: 'undefined',
+  current: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| href | object | undefined | The URL for this breadcrumb link. Omit for the current page item.
+When `current` is true, this attribute is ignored and the item always
+renders as static text per WAI-ARIA APG breadcrumb guidance. |
+| current | boolean | false | Marks this item as the current page. When set, the item always renders as
+static text (never a navigable link) and `aria-current="page"` is placed on
+the inner text element per WAI-ARIA APG breadcrumb guidance, yielding the
+canonical AT announcement ("current page, Patient Records").
+
+Can be set explicitly by consumers (e.g. Drupal Twig templates) to override
+the default positional last-item detection in `hx-breadcrumb`. When any item
+in the breadcrumb has an explicit `current` attribute, the parent will not
+override it. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | The link or page text content. Accepts text, HTML, or icon elements. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-breadcrumb-link-color | var(--hx-color-primary-600) | Link text color. |
+| --hx-breadcrumb-link-hover-color | var(--hx-color-primary-700) | Link hover text color. |
+| --hx-breadcrumb-text-color | var(--hx-color-neutral-700) | Current page text color. |
+| --hx-breadcrumb-separator-content | '/' | Separator character displayed after non-last items. |
+| --hx-breadcrumb-separator-color | var(--hx-color-neutral-400) | Separator color. |
+| --hx-breadcrumb-separator-gap | var(--hx-space-1) | Horizontal margin around separator. |
+| --hx-breadcrumb-item-max-width | - | Optional max-width for text truncation. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| item | Wrapper around the link or text content. |
+| link | The anchor element when href is provided (non-current items only). |
+| text | The span element for the current page or items without href. |
+| separator | The separator element rendered after non-last items. |

--- a/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.component.yml
@@ -1,0 +1,23 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Breadcrumb Item
+status: experimental
+group: HELiX
+description: 'A single breadcrumb navigation item.'
+props:
+  type: object
+  properties:
+    href:
+      type: object
+      title: Href
+      description: 'The URL for this breadcrumb link. Omit for the current page item. When `current` is true, this attribute is ignored and the item always renders as static text per WAI-ARIA APG breadcrumb guidance.'
+      default: 'undefined'
+    current:
+      type: boolean
+      title: Current
+      description: 'Marks this item as the current page. When set, the item always renders as static text (never a navigable link) and `aria-current="page"` is placed on the inner text element per WAI-ARIA APG breadcrumb guidance, yielding the canonical AT announcement ("current page, Patient Records").  Can be set explicitly by consumers (e.g. Drupal Twig templates) to override the default positional last-item detection in `hx-breadcrumb`. When any item in the breadcrumb has an explicit `current` attribute, the parent will not override it.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'The link or page text content. Accepts text, HTML, or icon elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.css
+++ b/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.css
@@ -1,0 +1,21 @@
+/**
+ * HX Breadcrumb Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-breadcrumb-link-color: Link text color. (default: var(--hx-color-primary-600))
+ * --hx-breadcrumb-link-hover-color: Link hover text color. (default: var(--hx-color-primary-700))
+ * --hx-breadcrumb-text-color: Current page text color. (default: var(--hx-color-neutral-700))
+ * --hx-breadcrumb-separator-content: Separator character displayed after non-last items. (default: '/')
+ * --hx-breadcrumb-separator-color: Separator color. (default: var(--hx-color-neutral-400))
+ * --hx-breadcrumb-separator-gap: Horizontal margin around separator. (default: var(--hx-space-1))
+ * --hx-breadcrumb-item-max-width: Optional max-width for text truncation.
+ */
+
+/* Component host styles */
+hx-breadcrumb-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.js
+++ b/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX Breadcrumb Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-breadcrumb-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-breadcrumb-item');
+}

--- a/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.twig
+++ b/packages/hx-library/drupal/components/hx-breadcrumb-item/hx-breadcrumb-item.twig
@@ -1,0 +1,18 @@
+{#
+ /**
+ * @file
+ * HX Breadcrumb Item component template.
+ *
+ * A single breadcrumb navigation item.
+ *
+ * Available variables:
+ * - href: object - The URL for this breadcrumb link. Omit for the current page item. When `current` is true, this attribute is ignored and the item always renders as static text per WAI-ARIA APG breadcrumb guidance.
+ * - current: boolean - Marks this item as the current page. When set, the item always renders as static text (never a navigable link) and `aria-current="page"` is placed on the inner text element per WAI-ARIA APG breadcrumb guidance, yielding the canonical AT announcement ("current page, Patient Records").  Can be set explicitly by consumers (e.g. Drupal Twig templates) to override the default positional last-item detection in `hx-breadcrumb`. When any item in the breadcrumb has an explicit `current` attribute, the parent will not override it.
+ */
+#}
+<hx-breadcrumb-item
+  {% if href is defined and href is not empty %}href="{{ href }}"{% endif %}
+  {% if current %}current{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-breadcrumb-item>

--- a/packages/hx-library/drupal/components/hx-breadcrumb/README.md
+++ b/packages/hx-library/drupal/components/hx-breadcrumb/README.md
@@ -1,0 +1,34 @@
+# HX Breadcrumb
+
+Breadcrumb navigation component with automatic truncation and JSON-LD structured data.
+
+## Usage
+
+```twig
+{% include 'helix:hx-breadcrumb' with {
+  separator: '/',
+  label: 'Breadcrumb',
+  maxItems: 0,
+  jsonLd: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| separator | string | / | The separator character displayed between breadcrumb items. |
+| label | string | Breadcrumb | The accessible label for the nav landmark. |
+| maxItems | number | 0 | Maximum number of items to show before collapsing middle items with an ellipsis.
+Set to 0 (default) to show all items. The ellipsis is a keyboard-accessible
+button; activating it expands the full breadcrumb by setting maxItems to 0. |
+| jsonLd | boolean | false | When true, injects a JSON-LD BreadcrumbList structured data script into the document head.
+
+NOTE: Drupal manages `<head>` content via its own render pipeline. Injecting a
+`<script>` directly via `document.head.appendChild()` in a Drupal context:
+1. Bypasses Drupal's deduplication and `hook_html_head_alter()` hook.
+2. Is not cacheable by Drupal's page cache.
+3. Will be wiped on BigPipe partial page replacements.
+
+For Drupal integrations, leave `json-ld` false and use the structured data
+Twig template instead (see `hx-breadcrumb.twig` in the component directory). |

--- a/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.component.yml
+++ b/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.component.yml
@@ -1,0 +1,29 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Breadcrumb
+status: experimental
+group: HELiX
+description: 'Breadcrumb navigation component with automatic truncation and JSON-LD structured data.'
+props:
+  type: object
+  properties:
+    separator:
+      type: string
+      title: Separator
+      description: 'The separator character displayed between breadcrumb items.'
+      default: '/'
+    label:
+      type: string
+      title: Label
+      description: 'The accessible label for the nav landmark.'
+      default: 'Breadcrumb'
+    maxItems:
+      type: number
+      title: Max Items
+      description: 'Maximum number of items to show before collapsing middle items with an ellipsis. Set to 0 (default) to show all items. The ellipsis is a keyboard-accessible button; activating it expands the full breadcrumb by setting maxItems to 0.'
+      default: 0
+    jsonLd:
+      type: boolean
+      title: Json Ld
+      description: "When true, injects a JSON-LD BreadcrumbList structured data script into the document head.  NOTE: Drupal manages `<head>` content via its own render pipeline. Injecting a `<script>` directly via `document.head.appendChild()` in a Drupal context: 1. Bypasses Drupal's deduplication and `hook_html_head_alter()` hook. 2. Is not cacheable by Drupal's page cache. 3. Will be wiped on BigPipe partial page replacements.  For Drupal integrations, leave `json-ld` false and use the structured data Twig template instead (see `hx-breadcrumb.twig` in the component directory)."
+      default: false
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.css
+++ b/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.css
@@ -1,0 +1,12 @@
+/**
+ * HX Breadcrumb component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-breadcrumb {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.js
+++ b/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.js
@@ -1,0 +1,11 @@
+/**
+ * HX Breadcrumb - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-breadcrumb';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-breadcrumb');
+}

--- a/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.twig
+++ b/packages/hx-library/drupal/components/hx-breadcrumb/hx-breadcrumb.twig
@@ -1,0 +1,21 @@
+{#
+ /**
+ * @file
+ * HX Breadcrumb component template.
+ *
+ * Breadcrumb navigation component with automatic truncation and JSON-LD structured data.
+ *
+ * Available variables:
+ * - separator: string - The separator character displayed between breadcrumb items.
+ * - label: string - The accessible label for the nav landmark.
+ * - maxItems: number - Maximum number of items to show before collapsing middle items with an ellipsis. Set to 0 (default) to show all items. The ellipsis is a keyboard-accessible button; activating it expands the full breadcrumb by setting maxItems to 0.
+ * - jsonLd: boolean - When true, injects a JSON-LD BreadcrumbList structured data script into the document head.  NOTE: Drupal manages `<head>` content via its own render pipeline. Injecting a `<script>` directly via `document.head.appendChild()` in a Drupal context: 1. Bypasses Drupal's deduplication and `hook_html_head_alter()` hook. 2. Is not cacheable by Drupal's page cache. 3. Will be wiped on BigPipe partial page replacements.  For Drupal integrations, leave `json-ld` false and use the structured data Twig template instead (see `hx-breadcrumb.twig` in the component directory).
+ */
+#}
+<hx-breadcrumb
+  {% if separator is defined and separator is not empty %}separator="{{ separator }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if maxItems is defined and maxItems is not empty %}max-items="{{ maxItems }}"{% endif %}
+  {% if jsonLd %}json-ld{% endif %}
+>
+</hx-breadcrumb>

--- a/packages/hx-library/drupal/components/hx-button-group/README.md
+++ b/packages/hx-library/drupal/components/hx-button-group/README.md
@@ -1,0 +1,48 @@
+# HX Button Group
+
+A container component that groups related hx-button elements into a cohesive
+horizontal or vertical action set. Eliminates double borders between adjacent
+buttons and squares off inner border-radius for a unified visual appearance.
+
+**Accessibility:** Always provide an accessible label via `aria-label` or
+`aria-labelledby` so screen readers can announce the group purpose.
+
+## Usage
+
+```twig
+{% include 'helix:hx-button-group' with {
+  orientation: '',
+  size: 'md',
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| orientation | object | - | Layout orientation of the button group. |
+| size | object | md | Size applied to the button group and cascaded to child buttons via
+the --hx-button-group-size CSS custom property. |
+| label | string |  | Accessible label for the button group. Sets aria-label via ElementInternals.
+**Strongly recommended** for WCAG 2.1 AA compliance — without it, screen
+readers announce an unnamed "group". For Drupal/Twig compatibility, prefer
+applying `aria-label` directly as an HTML attribute instead. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot accepting hx-button children. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-button-group-size | md | Size token forwarded to child buttons. Accepts 'sm', 'md', or 'lg'. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| group | The container div element wrapping all slotted buttons. |

--- a/packages/hx-library/drupal/components/hx-button-group/hx-button-group.component.yml
+++ b/packages/hx-library/drupal/components/hx-button-group/hx-button-group.component.yml
@@ -1,0 +1,27 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Button Group
+status: experimental
+group: HELiX
+description: 'A container component that groups related hx-button elements into a cohesive horizontal or vertical action set. Eliminates double borders between adjacent buttons and squares off inner border-radius for a unified visual appearance.  **Accessibility:** Always provide an accessible label via `aria-label` or `aria-labelledby` so screen readers can announce the group purpose.'
+props:
+  type: object
+  properties:
+    orientation:
+      type: object
+      title: Orientation
+      description: 'Layout orientation of the button group.'
+    size:
+      type: object
+      title: Size
+      description: 'Size applied to the button group and cascaded to child buttons via the --hx-button-group-size CSS custom property.'
+      default: 'md'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the button group. Sets aria-label via ElementInternals. **Strongly recommended** for WCAG 2.1 AA compliance — without it, screen readers announce an unnamed "group". For Drupal/Twig compatibility, prefer applying `aria-label` directly as an HTML attribute instead.'
+      default: ''
+slots:
+  default:
+    title: Default
+    description: 'Default slot accepting hx-button children.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-button-group/hx-button-group.css
+++ b/packages/hx-library/drupal/components/hx-button-group/hx-button-group.css
@@ -1,0 +1,15 @@
+/**
+ * HX Button Group component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-button-group-size: Size token forwarded to child buttons. Accepts 'sm', 'md', or 'lg'. (default: md)
+ */
+
+/* Component host styles */
+hx-button-group {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-button-group/hx-button-group.js
+++ b/packages/hx-library/drupal/components/hx-button-group/hx-button-group.js
@@ -1,0 +1,11 @@
+/**
+ * HX Button Group - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-button-group';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-button-group');
+}

--- a/packages/hx-library/drupal/components/hx-button-group/hx-button-group.twig
+++ b/packages/hx-library/drupal/components/hx-button-group/hx-button-group.twig
@@ -1,0 +1,25 @@
+{#
+ /**
+ * @file
+ * HX Button Group component template.
+ *
+ * A container component that groups related hx-button elements into a cohesive
+ * horizontal or vertical action set. Eliminates double borders between adjacent
+ * buttons and squares off inner border-radius for a unified visual appearance.
+ * 
+ * **Accessibility:** Always provide an accessible label via `aria-label` or
+ * `aria-labelledby` so screen readers can announce the group purpose.
+ *
+ * Available variables:
+ * - orientation: object - Layout orientation of the button group.
+ * - size: object - Size applied to the button group and cascaded to child buttons via the --hx-button-group-size CSS custom property.
+ * - label: string - Accessible label for the button group. Sets aria-label via ElementInternals. **Strongly recommended** for WCAG 2.1 AA compliance — without it, screen readers announce an unnamed "group". For Drupal/Twig compatibility, prefer applying `aria-label` directly as an HTML attribute instead.
+ */
+#}
+<hx-button-group
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-button-group>

--- a/packages/hx-library/drupal/components/hx-button/README.md
+++ b/packages/hx-library/drupal/components/hx-button/README.md
@@ -1,0 +1,84 @@
+# HX Button
+
+A production-grade button component for user interaction. Supports multiple
+visual variants, sizes, loading state, prefix/suffix slots, anchor rendering,
+and full ElementInternals form association.
+
+## Usage
+
+```twig
+{% include 'helix:hx-button' with {
+  variant: 'primary',
+  size: 'md',
+  disabled: false,
+  loading: false,
+  type: 'button',
+  href: 'undefined',
+  target: 'undefined',
+  name: 'undefined',
+  value: 'undefined',
+  full: false,
+  inverted: false,
+  ariaLabel: 'null',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | primary | Visual style variant of the button. |
+| size | object | md | Size of the button. |
+| disabled | boolean | false | Whether the button is disabled. Prevents all interaction and form actions. |
+| loading | boolean | false | Whether the button is in a loading state. Shows spinner, prevents interaction,
+and sets aria-busy. Does not set the disabled attribute. |
+| type | object | button | The type attribute for the underlying button element. Ignored when href is set. |
+| href | object | undefined | When set, renders an anchor element instead of a button. |
+| target | object | undefined | Anchor target attribute. Only used when href is set. |
+| name | object | undefined | Form field name submitted via ElementInternals.setFormValue on submit. |
+| value | object | undefined | Form field value submitted via ElementInternals.setFormValue on submit. |
+| full | boolean | false | When true, the button stretches to fill its container width.
+Sets the host to `display: block` and the inner element to `width: 100%`. |
+| inverted | boolean | false | When true, flips button colors for placement on dark or gradient backgrounds.
+Forces text to white and adjusts hover/focus ring colors across all variants. |
+| ariaLabel | object | null | Accessible label forwarded to the inner button/anchor. Required for icon-only usage. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for button label text or content. |
+| prefix | Icon or content rendered before the label. |
+| suffix | Icon or content rendered after the label. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-click | Dispatched when the button is clicked and is neither disabled nor loading. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-button-bg | var(--hx-color-primary-500) | Button background color. |
+| --hx-button-hover-bg | - | Hover background color override. When set, overrides the variant default hover background from outside the shadow DOM. |
+| --hx-button-color | var(--hx-color-neutral-0) | Button text color. |
+| --hx-button-border-color | transparent | Button border color. |
+| --hx-button-border-radius | var(--hx-border-radius-md) | Button border radius. |
+| --hx-button-font-family | var(--hx-font-family-sans) | Button font family. |
+| --hx-button-font-weight | var(--hx-font-weight-semibold) | Button font weight. |
+| --hx-button-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-button-inverted-color | #ffffff | Text color when inverted. |
+| --hx-button-inverted-ghost-hover-bg | rgba(255,255,255,0.15) | Ghost hover bg when inverted. |
+| --hx-button-inverted-focus-ring-color | rgba(255,255,255,0.5) | Focus ring color when inverted. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| button | The native button or anchor element. |
+| label | The label text wrapper span. |
+| prefix | The prefix slot container span. |
+| suffix | The suffix slot container span. |
+| spinner | The loading spinner SVG element. |

--- a/packages/hx-library/drupal/components/hx-button/hx-button.component.yml
+++ b/packages/hx-library/drupal/components/hx-button/hx-button.component.yml
@@ -1,0 +1,79 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Button
+status: experimental
+group: HELiX
+description: 'A production-grade button component for user interaction. Supports multiple visual variants, sizes, loading state, prefix/suffix slots, anchor rendering, and full ElementInternals form association.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the button.'
+      default: 'primary'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the button.'
+      default: 'md'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the button is disabled. Prevents all interaction and form actions.'
+      default: false
+    loading:
+      type: boolean
+      title: Loading
+      description: 'Whether the button is in a loading state. Shows spinner, prevents interaction, and sets aria-busy. Does not set the disabled attribute.'
+      default: false
+    type:
+      type: object
+      title: Type
+      description: 'The type attribute for the underlying button element. Ignored when href is set.'
+      default: 'button'
+    href:
+      type: object
+      title: Href
+      description: 'When set, renders an anchor element instead of a button.'
+      default: 'undefined'
+    target:
+      type: object
+      title: Target
+      description: 'Anchor target attribute. Only used when href is set.'
+      default: 'undefined'
+    name:
+      type: object
+      title: Name
+      description: 'Form field name submitted via ElementInternals.setFormValue on submit.'
+      default: 'undefined'
+    value:
+      type: object
+      title: Value
+      description: 'Form field value submitted via ElementInternals.setFormValue on submit.'
+      default: 'undefined'
+    full:
+      type: boolean
+      title: Full
+      description: 'When true, the button stretches to fill its container width. Sets the host to `display: block` and the inner element to `width: 100%`.'
+      default: false
+    inverted:
+      type: boolean
+      title: Inverted
+      description: 'When true, flips button colors for placement on dark or gradient backgrounds. Forces text to white and adjusts hover/focus ring colors across all variants.'
+      default: false
+    ariaLabel:
+      type: object
+      title: Aria Label
+      description: 'Accessible label forwarded to the inner button/anchor. Required for icon-only usage.'
+      default: 'null'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for button label text or content.'
+  prefix:
+    title: Prefix
+    description: 'Icon or content rendered before the label.'
+  suffix:
+    title: Suffix
+    description: 'Icon or content rendered after the label.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-button/hx-button.css
+++ b/packages/hx-library/drupal/components/hx-button/hx-button.css
@@ -1,0 +1,25 @@
+/**
+ * HX Button component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-button-bg: Button background color. (default: var(--hx-color-primary-500))
+ * --hx-button-hover-bg: Hover background color override. When set, overrides the variant default hover background from outside the shadow DOM.
+ * --hx-button-color: Button text color. (default: var(--hx-color-neutral-0))
+ * --hx-button-border-color: Button border color. (default: transparent)
+ * --hx-button-border-radius: Button border radius. (default: var(--hx-border-radius-md))
+ * --hx-button-font-family: Button font family. (default: var(--hx-font-family-sans))
+ * --hx-button-font-weight: Button font weight. (default: var(--hx-font-weight-semibold))
+ * --hx-button-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-button-inverted-color: Text color when inverted. (default: #ffffff)
+ * --hx-button-inverted-ghost-hover-bg: Ghost hover bg when inverted. (default: rgba(255,255,255,0.15))
+ * --hx-button-inverted-focus-ring-color: Focus ring color when inverted. (default: rgba(255,255,255,0.5))
+ */
+
+/* Component host styles */
+hx-button {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-button/hx-button.js
+++ b/packages/hx-library/drupal/components/hx-button/hx-button.js
@@ -1,0 +1,11 @@
+/**
+ * HX Button - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-button';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-button');
+}

--- a/packages/hx-library/drupal/components/hx-button/hx-button.twig
+++ b/packages/hx-library/drupal/components/hx-button/hx-button.twig
@@ -1,0 +1,46 @@
+{#
+ /**
+ * @file
+ * HX Button component template.
+ *
+ * A production-grade button component for user interaction. Supports multiple
+ * visual variants, sizes, loading state, prefix/suffix slots, anchor rendering,
+ * and full ElementInternals form association.
+ *
+ * Available variables:
+ * - variant: object - Visual style variant of the button.
+ * - size: object - Size of the button.
+ * - disabled: boolean - Whether the button is disabled. Prevents all interaction and form actions.
+ * - loading: boolean - Whether the button is in a loading state. Shows spinner, prevents interaction, and sets aria-busy. Does not set the disabled attribute.
+ * - type: object - The type attribute for the underlying button element. Ignored when href is set.
+ * - href: object - When set, renders an anchor element instead of a button.
+ * - target: object - Anchor target attribute. Only used when href is set.
+ * - name: object - Form field name submitted via ElementInternals.setFormValue on submit.
+ * - value: object - Form field value submitted via ElementInternals.setFormValue on submit.
+ * - full: boolean - When true, the button stretches to fill its container width. Sets the host to `display: block` and the inner element to `width: 100%`.
+ * - inverted: boolean - When true, flips button colors for placement on dark or gradient backgrounds. Forces text to white and adjusts hover/focus ring colors across all variants.
+ * - ariaLabel: object - Accessible label forwarded to the inner button/anchor. Required for icon-only usage.
+ */
+#}
+<hx-button
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if loading %}loading{% endif %}
+  {% if type is defined and type is not empty %}type="{{ type }}"{% endif %}
+  {% if href is defined and href is not empty %}href="{{ href }}"{% endif %}
+  {% if target is defined and target is not empty %}target="{{ target }}"{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if full %}full{% endif %}
+  {% if inverted %}inverted{% endif %}
+  {% if ariaLabel is defined and ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
+>
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-button>

--- a/packages/hx-library/drupal/components/hx-card/README.md
+++ b/packages/hx-library/drupal/components/hx-card/README.md
@@ -1,0 +1,66 @@
+# HX Card
+
+A flexible card component for displaying grouped content.
+
+## Usage
+
+```twig
+{% include 'helix:hx-card' with {
+  variant: 'default',
+  elevation: 'flat',
+  hxHref: 'undefined',
+  hxAriaLabel: 'undefined',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | default | Visual style variant of the card. |
+| elevation | object | flat | Elevation (shadow depth) of the card. |
+| hxHref | object | undefined | Optional URL. When set, the card becomes interactive (clickable)
+and navigates to this URL on click.
+Uses hx-href to avoid conflicting with the native HTML href attribute. |
+| hxAriaLabel | object | undefined | Accessible label for interactive cards. Use this to provide a meaningful
+description of the card's purpose rather than exposing the raw URL.
+Only applies when hx-href is set. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| image | Optional image or media content at the top of the card. |
+| heading | The card heading/title content. Use a semantic heading element (h2, h3, etc.) for proper accessibility. |
+| (default) | Default slot for the card body content. |
+| footer | Optional footer content below the body. |
+| actions | Optional action buttons, rendered with a top border separator. Do NOT use together with hx-href (interactive card + focusable actions is an ARIA anti-pattern). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-click | Dispatched when an interactive card (with hx-href) is clicked. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-card-bg | var(--hx-color-neutral-0) | Card background color. |
+| --hx-card-color | var(--hx-color-neutral-800) | Card text color. |
+| --hx-card-border-color | var(--hx-color-neutral-200) | Card border color. |
+| --hx-card-border-radius | var(--hx-border-radius-lg) | Card border radius. |
+| --hx-card-padding | var(--hx-space-6) | Internal padding for card sections. |
+| --hx-card-gap | var(--hx-space-4) | Gap between card sections. |
+| --hx-card-image-aspect-ratio | 16/9 | Aspect ratio for the image slot. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| card | The outer card container element. |
+| image | The image slot container. |
+| heading | The heading slot container. |
+| body | The body slot container. |
+| footer | The footer slot container. |
+| actions | The actions slot container. |

--- a/packages/hx-library/drupal/components/hx-card/hx-card.component.yml
+++ b/packages/hx-library/drupal/components/hx-card/hx-card.component.yml
@@ -1,0 +1,45 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Card
+status: experimental
+group: HELiX
+description: 'A flexible card component for displaying grouped content.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the card.'
+      default: 'default'
+    elevation:
+      type: object
+      title: Elevation
+      description: 'Elevation (shadow depth) of the card.'
+      default: 'flat'
+    hxHref:
+      type: object
+      title: Hx Href
+      description: 'Optional URL. When set, the card becomes interactive (clickable) and navigates to this URL on click. Uses hx-href to avoid conflicting with the native HTML href attribute.'
+      default: 'undefined'
+    hxAriaLabel:
+      type: object
+      title: Hx Aria Label
+      description: "Accessible label for interactive cards. Use this to provide a meaningful description of the card's purpose rather than exposing the raw URL. Only applies when hx-href is set."
+      default: 'undefined'
+slots:
+  image:
+    title: Image
+    description: 'Optional image or media content at the top of the card.'
+  heading:
+    title: Heading
+    description: 'The card heading/title content. Use a semantic heading element (h2, h3, etc.) for proper accessibility.'
+  default:
+    title: Default
+    description: 'Default slot for the card body content.'
+  footer:
+    title: Footer
+    description: 'Optional footer content below the body.'
+  actions:
+    title: Actions
+    description: 'Optional action buttons, rendered with a top border separator. Do NOT use together with hx-href (interactive card + focusable actions is an ARIA anti-pattern).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-card/hx-card.css
+++ b/packages/hx-library/drupal/components/hx-card/hx-card.css
@@ -1,0 +1,21 @@
+/**
+ * HX Card component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-card-bg: Card background color. (default: var(--hx-color-neutral-0))
+ * --hx-card-color: Card text color. (default: var(--hx-color-neutral-800))
+ * --hx-card-border-color: Card border color. (default: var(--hx-color-neutral-200))
+ * --hx-card-border-radius: Card border radius. (default: var(--hx-border-radius-lg))
+ * --hx-card-padding: Internal padding for card sections. (default: var(--hx-space-6))
+ * --hx-card-gap: Gap between card sections. (default: var(--hx-space-4))
+ * --hx-card-image-aspect-ratio: Aspect ratio for the image slot. (default: 16/9)
+ */
+
+/* Component host styles */
+hx-card {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-card/hx-card.js
+++ b/packages/hx-library/drupal/components/hx-card/hx-card.js
@@ -1,0 +1,11 @@
+/**
+ * HX Card - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-card';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-card');
+}

--- a/packages/hx-library/drupal/components/hx-card/hx-card.twig
+++ b/packages/hx-library/drupal/components/hx-card/hx-card.twig
@@ -1,0 +1,34 @@
+{#
+ /**
+ * @file
+ * HX Card component template.
+ *
+ * A flexible card component for displaying grouped content.
+ *
+ * Available variables:
+ * - variant: object - Visual style variant of the card.
+ * - elevation: object - Elevation (shadow depth) of the card.
+ * - hxHref: object - Optional URL. When set, the card becomes interactive (clickable) and navigates to this URL on click. Uses hx-href to avoid conflicting with the native HTML href attribute.
+ * - hxAriaLabel: object - Accessible label for interactive cards. Use this to provide a meaningful description of the card's purpose rather than exposing the raw URL. Only applies when hx-href is set.
+ */
+#}
+<hx-card
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if elevation is defined and elevation is not empty %}elevation="{{ elevation }}"{% endif %}
+  {% if hxHref is defined and hxHref is not empty %}hx-href="{{ hxHref }}"{% endif %}
+  {% if hxAriaLabel is defined and hxAriaLabel is not empty %}hx-aria-label="{{ hxAriaLabel }}"{% endif %}
+>
+  {% if slots.image is defined %}
+    <slot name="image">{{ slots.image }}</slot>
+  {% endif %}
+  {% if slots.heading is defined %}
+    <slot name="heading">{{ slots.heading }}</slot>
+  {% endif %}
+  {% if slots.footer is defined %}
+    <slot name="footer">{{ slots.footer }}</slot>
+  {% endif %}
+  {% if slots.actions is defined %}
+    <slot name="actions">{{ slots.actions }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-card>

--- a/packages/hx-library/drupal/components/hx-carousel-item/README.md
+++ b/packages/hx-library/drupal/components/hx-carousel-item/README.md
@@ -1,0 +1,31 @@
+# HX Carousel Item
+
+A wrapper for individual carousel slides.
+
+## Usage
+
+```twig
+{% include 'helix:hx-carousel-item' with {
+  slideIndex: 0,
+  totalSlides: 0,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| slideIndex | number | 0 | The 0-based index of this slide within the carousel. Set by hx-carousel. |
+| totalSlides | number | 0 | Total number of slides in the carousel. Set by hx-carousel. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Slide content. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| slide | The slide wrapper element. |

--- a/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.component.yml
@@ -1,0 +1,23 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Carousel Item
+status: experimental
+group: HELiX
+description: 'A wrapper for individual carousel slides.'
+props:
+  type: object
+  properties:
+    slideIndex:
+      type: number
+      title: Slide Index
+      description: 'The 0-based index of this slide within the carousel. Set by hx-carousel.'
+      default: 0
+    totalSlides:
+      type: number
+      title: Total Slides
+      description: 'Total number of slides in the carousel. Set by hx-carousel.'
+      default: 0
+slots:
+  default:
+    title: Default
+    description: 'Slide content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.css
+++ b/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.css
@@ -1,0 +1,12 @@
+/**
+ * HX Carousel Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-carousel-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.js
+++ b/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX Carousel Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-carousel-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-carousel-item');
+}

--- a/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.twig
+++ b/packages/hx-library/drupal/components/hx-carousel-item/hx-carousel-item.twig
@@ -1,0 +1,18 @@
+{#
+ /**
+ * @file
+ * HX Carousel Item component template.
+ *
+ * A wrapper for individual carousel slides.
+ *
+ * Available variables:
+ * - slideIndex: number - The 0-based index of this slide within the carousel. Set by hx-carousel.
+ * - totalSlides: number - Total number of slides in the carousel. Set by hx-carousel.
+ */
+#}
+<hx-carousel-item
+  {% if slideIndex is defined and slideIndex is not empty %}slide-index="{{ slideIndex }}"{% endif %}
+  {% if totalSlides is defined and totalSlides is not empty %}total-slides="{{ totalSlides }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-carousel-item>

--- a/packages/hx-library/drupal/components/hx-carousel/README.md
+++ b/packages/hx-library/drupal/components/hx-carousel/README.md
@@ -1,0 +1,77 @@
+# HX Carousel
+
+A scrollable carousel/slider for images or content slides.
+
+## Usage
+
+```twig
+{% include 'helix:hx-carousel' with {
+  label: 'Carousel',
+  loop: false,
+  autoplay: false,
+  autoplayInterval: 3000,
+  slidesPerPage: 1,
+  slidesPerMove: 1,
+  orientation: 'horizontal',
+  mouseDragging: false,
+  labelPrevSlide: 'Previous slide',
+  labelNextSlide: 'Next slide',
+  labelPauseAutoplay: 'Pause autoplay',
+  labelPlayAutoplay: 'Play autoplay',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string | Carousel | Accessible label identifying this carousel to assistive technology.
+When multiple carousels appear on the same page, each must have a unique label. |
+| loop | boolean | false | Whether the carousel wraps around from last to first slide and vice-versa. |
+| autoplay | boolean | false | Whether the carousel auto-advances slides.
+Automatically pauses on hover, focus, and when prefers-reduced-motion is active. |
+| autoplayInterval | number | 3000 | Milliseconds between auto-advance transitions. |
+| slidesPerPage | number | 1 | Number of slides visible at once. |
+| slidesPerMove | number | 1 | Number of slides to advance per navigation action. |
+| orientation | object | horizontal | Scroll axis of the carousel. |
+| mouseDragging | boolean | false | Whether click-drag scrolling is enabled. |
+| labelPrevSlide | string | Previous slide | Accessible label for the previous slide button. |
+| labelNextSlide | string | Next slide | Accessible label for the next slide button. |
+| labelPauseAutoplay | string | Pause autoplay | Accessible label for the autoplay pause button. |
+| labelPlayAutoplay | string | Play autoplay | Accessible label for the autoplay play button. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | `hx-carousel-item` elements (the slides). |
+| next-button | Custom next navigation button. |
+| previous-button | Custom previous navigation button. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-slide-change | Dispatched when the active slide changes. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-carousel-gap | 0px | Gap between slides. |
+| --hx-carousel-slide-width | 100% | Width override for each slide. |
+| --hx-carousel-nav-btn-size | 2.5rem | Size of previous/next navigation buttons. |
+| --hx-carousel-pagination-dot-size | 0.5rem | Size of pagination dots. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The outer wrapper element. |
+| slide-viewport | The slide viewport/overflow container. |
+| pagination | The pagination dot container. |
+| pagination-item | Individual pagination dot button. |
+| navigation | The previous/next button wrapper. |
+| prev-btn | The previous navigation button. |
+| next-btn | The next navigation button. |
+| play-pause-btn | The autoplay play/pause toggle button. |

--- a/packages/hx-library/drupal/components/hx-carousel/hx-carousel.component.yml
+++ b/packages/hx-library/drupal/components/hx-carousel/hx-carousel.component.yml
@@ -1,0 +1,79 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Carousel
+status: experimental
+group: HELiX
+description: 'A scrollable carousel/slider for images or content slides.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label identifying this carousel to assistive technology. When multiple carousels appear on the same page, each must have a unique label.'
+      default: 'Carousel'
+    loop:
+      type: boolean
+      title: Loop
+      description: 'Whether the carousel wraps around from last to first slide and vice-versa.'
+      default: false
+    autoplay:
+      type: boolean
+      title: Autoplay
+      description: 'Whether the carousel auto-advances slides. Automatically pauses on hover, focus, and when prefers-reduced-motion is active.'
+      default: false
+    autoplayInterval:
+      type: number
+      title: Autoplay Interval
+      description: 'Milliseconds between auto-advance transitions.'
+      default: 3000
+    slidesPerPage:
+      type: number
+      title: Slides Per Page
+      description: 'Number of slides visible at once.'
+      default: 1
+    slidesPerMove:
+      type: number
+      title: Slides Per Move
+      description: 'Number of slides to advance per navigation action.'
+      default: 1
+    orientation:
+      type: object
+      title: Orientation
+      description: 'Scroll axis of the carousel.'
+      default: 'horizontal'
+    mouseDragging:
+      type: boolean
+      title: Mouse Dragging
+      description: 'Whether click-drag scrolling is enabled.'
+      default: false
+    labelPrevSlide:
+      type: string
+      title: Label Prev Slide
+      description: 'Accessible label for the previous slide button.'
+      default: 'Previous slide'
+    labelNextSlide:
+      type: string
+      title: Label Next Slide
+      description: 'Accessible label for the next slide button.'
+      default: 'Next slide'
+    labelPauseAutoplay:
+      type: string
+      title: Label Pause Autoplay
+      description: 'Accessible label for the autoplay pause button.'
+      default: 'Pause autoplay'
+    labelPlayAutoplay:
+      type: string
+      title: Label Play Autoplay
+      description: 'Accessible label for the autoplay play button.'
+      default: 'Play autoplay'
+slots:
+  default:
+    title: Default
+    description: '`hx-carousel-item` elements (the slides).'
+  next-button:
+    title: Next Button
+    description: 'Custom next navigation button.'
+  previous-button:
+    title: Previous Button
+    description: 'Custom previous navigation button.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-carousel/hx-carousel.css
+++ b/packages/hx-library/drupal/components/hx-carousel/hx-carousel.css
@@ -1,0 +1,18 @@
+/**
+ * HX Carousel component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-carousel-gap: Gap between slides. (default: 0px)
+ * --hx-carousel-slide-width: Width override for each slide. (default: 100%)
+ * --hx-carousel-nav-btn-size: Size of previous/next navigation buttons. (default: 2.5rem)
+ * --hx-carousel-pagination-dot-size: Size of pagination dots. (default: 0.5rem)
+ */
+
+/* Component host styles */
+hx-carousel {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-carousel/hx-carousel.js
+++ b/packages/hx-library/drupal/components/hx-carousel/hx-carousel.js
@@ -1,0 +1,11 @@
+/**
+ * HX Carousel - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-carousel';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-carousel');
+}

--- a/packages/hx-library/drupal/components/hx-carousel/hx-carousel.twig
+++ b/packages/hx-library/drupal/components/hx-carousel/hx-carousel.twig
@@ -1,0 +1,44 @@
+{#
+ /**
+ * @file
+ * HX Carousel component template.
+ *
+ * A scrollable carousel/slider for images or content slides.
+ *
+ * Available variables:
+ * - label: string - Accessible label identifying this carousel to assistive technology. When multiple carousels appear on the same page, each must have a unique label.
+ * - loop: boolean - Whether the carousel wraps around from last to first slide and vice-versa.
+ * - autoplay: boolean - Whether the carousel auto-advances slides. Automatically pauses on hover, focus, and when prefers-reduced-motion is active.
+ * - autoplayInterval: number - Milliseconds between auto-advance transitions.
+ * - slidesPerPage: number - Number of slides visible at once.
+ * - slidesPerMove: number - Number of slides to advance per navigation action.
+ * - orientation: object - Scroll axis of the carousel.
+ * - mouseDragging: boolean - Whether click-drag scrolling is enabled.
+ * - labelPrevSlide: string - Accessible label for the previous slide button.
+ * - labelNextSlide: string - Accessible label for the next slide button.
+ * - labelPauseAutoplay: string - Accessible label for the autoplay pause button.
+ * - labelPlayAutoplay: string - Accessible label for the autoplay play button.
+ */
+#}
+<hx-carousel
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if loop %}loop{% endif %}
+  {% if autoplay %}autoplay{% endif %}
+  {% if autoplayInterval is defined and autoplayInterval is not empty %}autoplay-interval="{{ autoplayInterval }}"{% endif %}
+  {% if slidesPerPage is defined and slidesPerPage is not empty %}slides-per-page="{{ slidesPerPage }}"{% endif %}
+  {% if slidesPerMove is defined and slidesPerMove is not empty %}slides-per-move="{{ slidesPerMove }}"{% endif %}
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+  {% if mouseDragging %}mouse-dragging{% endif %}
+  {% if labelPrevSlide is defined and labelPrevSlide is not empty %}label-prev-slide="{{ labelPrevSlide }}"{% endif %}
+  {% if labelNextSlide is defined and labelNextSlide is not empty %}label-next-slide="{{ labelNextSlide }}"{% endif %}
+  {% if labelPauseAutoplay is defined and labelPauseAutoplay is not empty %}label-pause-autoplay="{{ labelPauseAutoplay }}"{% endif %}
+  {% if labelPlayAutoplay is defined and labelPlayAutoplay is not empty %}label-play-autoplay="{{ labelPlayAutoplay }}"{% endif %}
+>
+  {% if slots.next-button is defined %}
+    <slot name="next-button">{{ slots.next-button }}</slot>
+  {% endif %}
+  {% if slots.previous-button is defined %}
+    <slot name="previous-button">{{ slots.previous-button }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-carousel>

--- a/packages/hx-library/drupal/components/hx-checkbox-group/README.md
+++ b/packages/hx-library/drupal/components/hx-checkbox-group/README.md
@@ -1,0 +1,60 @@
+# HX Checkbox Group
+
+A form-associated checkbox group that manages a set of `<hx-checkbox>` children.
+
+## Usage
+
+```twig
+{% include 'helix:hx-checkbox-group' with {
+  name: '',
+  label: '',
+  required: false,
+  disabled: false,
+  error: '',
+  orientation: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | The name used for form submission. Passed to child `hx-checkbox` elements. |
+| label | string |  | The fieldset legend/label text. |
+| required | boolean | false | Whether at least one checkbox must be checked for form submission. |
+| disabled | boolean | false | Whether the entire group is disabled. |
+| error | string |  | Error message to display. When set, the group enters an error state. |
+| orientation | object | - | Layout orientation of the checkbox items. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | `<hx-checkbox>` elements. |
+| label | Rich HTML group label (overrides the label property when used). |
+| error | Custom error content (overrides the error property). |
+| help-text | Group-level help text. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when any child checkbox changes. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-checkbox-group-gap | var(--hx-space-3, 0.75rem) | Gap between checkbox items. |
+| --hx-checkbox-group-label-color | var(--hx-color-neutral-700, #343a40) | Label text color. |
+| --hx-checkbox-group-error-color | var(--hx-color-error-500, #dc3545) | Error message color. |
+| --hx-checkbox-group-help-text-color | var(--hx-color-neutral-500) | Help text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| group | The fieldset wrapper. |
+| label | The legend/label. |
+| help-text | The help text container. |
+| error-message | The error message container. |

--- a/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.component.yml
+++ b/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.component.yml
@@ -1,0 +1,51 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Checkbox Group
+status: experimental
+group: HELiX
+description: 'A form-associated checkbox group that manages a set of `<hx-checkbox>` children.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'The name used for form submission. Passed to child `hx-checkbox` elements.'
+      default: ''
+    label:
+      type: string
+      title: Label
+      description: 'The fieldset legend/label text.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether at least one checkbox must be checked for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the entire group is disabled.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the group enters an error state.'
+      default: ''
+    orientation:
+      type: object
+      title: Orientation
+      description: 'Layout orientation of the checkbox items.'
+slots:
+  default:
+    title: Default
+    description: '`<hx-checkbox>` elements.'
+  label:
+    title: Label
+    description: 'Rich HTML group label (overrides the label property when used).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+  help-text:
+    title: Help Text
+    description: 'Group-level help text.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.css
+++ b/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.css
@@ -1,0 +1,18 @@
+/**
+ * HX Checkbox Group component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-checkbox-group-gap: Gap between checkbox items. (default: var(--hx-space-3, 0.75rem))
+ * --hx-checkbox-group-label-color: Label text color. (default: var(--hx-color-neutral-700, #343a40))
+ * --hx-checkbox-group-error-color: Error message color. (default: var(--hx-color-error-500, #dc3545))
+ * --hx-checkbox-group-help-text-color: Help text color. (default: var(--hx-color-neutral-500))
+ */
+
+/* Component host styles */
+hx-checkbox-group {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.js
+++ b/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.js
@@ -1,0 +1,11 @@
+/**
+ * HX Checkbox Group - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-checkbox-group';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-checkbox-group');
+}

--- a/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.twig
+++ b/packages/hx-library/drupal/components/hx-checkbox-group/hx-checkbox-group.twig
@@ -1,0 +1,35 @@
+{#
+ /**
+ * @file
+ * HX Checkbox Group component template.
+ *
+ * A form-associated checkbox group that manages a set of `<hx-checkbox>` children.
+ *
+ * Available variables:
+ * - name: string - The name used for form submission. Passed to child `hx-checkbox` elements.
+ * - label: string - The fieldset legend/label text.
+ * - required: boolean - Whether at least one checkbox must be checked for form submission.
+ * - disabled: boolean - Whether the entire group is disabled.
+ * - error: string - Error message to display. When set, the group enters an error state.
+ * - orientation: object - Layout orientation of the checkbox items.
+ */
+#}
+<hx-checkbox-group
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-checkbox-group>

--- a/packages/hx-library/drupal/components/hx-checkbox/README.md
+++ b/packages/hx-library/drupal/components/hx-checkbox/README.md
@@ -1,0 +1,79 @@
+# HX Checkbox
+
+A checkbox component with label, validation, and form association.
+
+## Usage
+
+```twig
+{% include 'helix:hx-checkbox' with {
+  checked: false,
+  indeterminate: false,
+  disabled: false,
+  required: false,
+  name: '',
+  value: 'on',
+  label: '',
+  error: '',
+  helpText: '',
+  requiredMessage: 'This field is required.',
+  size: 'md',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| checked | boolean | false | Whether the checkbox is checked. |
+| indeterminate | boolean | false | Whether the checkbox is in an indeterminate state (e.g., for "select all" patterns). |
+| disabled | boolean | false | Whether the checkbox is disabled. |
+| required | boolean | false | Whether the checkbox is required for form submission. |
+| name | string |  | The name of the checkbox, used for form submission. |
+| value | string | on | The value submitted when the checkbox is checked. |
+| label | string |  | The visible label text for the checkbox. |
+| error | string |  | Error message to display. When set, the checkbox enters an error state. |
+| helpText | string |  | Help text displayed below the checkbox for guidance. |
+| requiredMessage | string | This field is required. | Validation message shown when the field is required but empty. |
+| size | object | md | The size of the checkbox. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Custom label content (overrides the label property). Rich HTML allowed — Drupal can include links in consent labels. |
+| error | Custom error content (overrides the error property). |
+| help-text | Custom help text content (overrides the helpText property). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when the checkbox is toggled. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-checkbox-size | var(--hx-size-5, 1.25rem) | Checkbox dimensions. |
+| --hx-checkbox-bg | var(--hx-color-neutral-0, #ffffff) | Unchecked background color. |
+| --hx-checkbox-border-color | var(--hx-color-neutral-300, #ced4da) | Checkbox border color. |
+| --hx-checkbox-border-radius | var(--hx-border-radius-sm, 0.25rem) | Checkbox border radius. |
+| --hx-checkbox-checked-bg | var(--hx-color-primary-500, #2563EB) | Checked background color. |
+| --hx-checkbox-checked-border-color | var(--hx-color-primary-500, #2563EB) | Checked border color. |
+| --hx-checkbox-checkmark-color | var(--hx-color-neutral-0, #ffffff) | Checkmark color. |
+| --hx-checkbox-focus-ring-color | var(--hx-focus-ring-color, #2563EB) | Focus ring color. |
+| --hx-checkbox-label-color | var(--hx-color-neutral-700, #343a40) | Label text color. |
+| --hx-checkbox-help-text-color | var(--hx-color-neutral-500, #6c757d) | Help text color. |
+| --hx-checkbox-hover-border-color | var(--hx-checkbox-border-color) | Border color on hover. |
+| --hx-checkbox-error-color | var(--hx-color-error-500, #dc3545) | Error state color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| checkbox | The visual checkbox element. |
+| checkmark | The SVG checkmark icon inside the checkbox. |
+| label | The label element. |
+| help-text | The help text container. |
+| error | The error message container. |
+| control | The wrapper around checkbox and label. |

--- a/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.component.yml
+++ b/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.component.yml
@@ -1,0 +1,74 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Checkbox
+status: experimental
+group: HELiX
+description: 'A checkbox component with label, validation, and form association.'
+props:
+  type: object
+  properties:
+    checked:
+      type: boolean
+      title: Checked
+      description: 'Whether the checkbox is checked.'
+      default: false
+    indeterminate:
+      type: boolean
+      title: Indeterminate
+      description: 'Whether the checkbox is in an indeterminate state (e.g., for "select all" patterns).'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the checkbox is disabled.'
+      default: false
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the checkbox is required for form submission.'
+      default: false
+    name:
+      type: string
+      title: Name
+      description: 'The name of the checkbox, used for form submission.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The value submitted when the checkbox is checked.'
+      default: 'on'
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the checkbox.'
+      default: ''
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the checkbox enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the checkbox for guidance.'
+      default: ''
+    requiredMessage:
+      type: string
+      title: Required Message
+      description: 'Validation message shown when the field is required but empty.'
+      default: 'This field is required.'
+    size:
+      type: object
+      title: Size
+      description: 'The size of the checkbox.'
+      default: 'md'
+slots:
+  default:
+    title: Default
+    description: 'Custom label content (overrides the label property). Rich HTML allowed — Drupal can include links in consent labels.'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.css
+++ b/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.css
@@ -1,0 +1,26 @@
+/**
+ * HX Checkbox component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-checkbox-size: Checkbox dimensions. (default: var(--hx-size-5, 1.25rem))
+ * --hx-checkbox-bg: Unchecked background color. (default: var(--hx-color-neutral-0, #ffffff))
+ * --hx-checkbox-border-color: Checkbox border color. (default: var(--hx-color-neutral-300, #ced4da))
+ * --hx-checkbox-border-radius: Checkbox border radius. (default: var(--hx-border-radius-sm, 0.25rem))
+ * --hx-checkbox-checked-bg: Checked background color. (default: var(--hx-color-primary-500, #2563EB))
+ * --hx-checkbox-checked-border-color: Checked border color. (default: var(--hx-color-primary-500, #2563EB))
+ * --hx-checkbox-checkmark-color: Checkmark color. (default: var(--hx-color-neutral-0, #ffffff))
+ * --hx-checkbox-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color, #2563EB))
+ * --hx-checkbox-label-color: Label text color. (default: var(--hx-color-neutral-700, #343a40))
+ * --hx-checkbox-help-text-color: Help text color. (default: var(--hx-color-neutral-500, #6c757d))
+ * --hx-checkbox-hover-border-color: Border color on hover. (default: var(--hx-checkbox-border-color))
+ * --hx-checkbox-error-color: Error state color. (default: var(--hx-color-error-500, #dc3545))
+ */
+
+/* Component host styles */
+hx-checkbox {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.js
+++ b/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.js
@@ -1,0 +1,11 @@
+/**
+ * HX Checkbox - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-checkbox';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-checkbox');
+}

--- a/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.twig
+++ b/packages/hx-library/drupal/components/hx-checkbox/hx-checkbox.twig
@@ -1,0 +1,42 @@
+{#
+ /**
+ * @file
+ * HX Checkbox component template.
+ *
+ * A checkbox component with label, validation, and form association.
+ *
+ * Available variables:
+ * - checked: boolean - Whether the checkbox is checked.
+ * - indeterminate: boolean - Whether the checkbox is in an indeterminate state (e.g., for "select all" patterns).
+ * - disabled: boolean - Whether the checkbox is disabled.
+ * - required: boolean - Whether the checkbox is required for form submission.
+ * - name: string - The name of the checkbox, used for form submission.
+ * - value: string - The value submitted when the checkbox is checked.
+ * - label: string - The visible label text for the checkbox.
+ * - error: string - Error message to display. When set, the checkbox enters an error state.
+ * - helpText: string - Help text displayed below the checkbox for guidance.
+ * - requiredMessage: string - Validation message shown when the field is required but empty.
+ * - size: object - The size of the checkbox.
+ */
+#}
+<hx-checkbox
+  {% if checked %}checked{% endif %}
+  {% if indeterminate %}indeterminate{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if required %}required{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if requiredMessage is defined and requiredMessage is not empty %}required-message="{{ requiredMessage }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+>
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-checkbox>

--- a/packages/hx-library/drupal/components/hx-code-snippet/README.md
+++ b/packages/hx-library/drupal/components/hx-code-snippet/README.md
@@ -1,0 +1,75 @@
+# HX Code Snippet
+
+A styled code block with optional copy button and max-lines truncation.
+Supports block (`<pre><code>`) and inline (`<code>`) rendering modes.
+No external syntax highlighting dependency — use the `language` attribute
+as a hint for consumers integrating their own highlighter via slotted content.
+
+## Usage
+
+```twig
+{% include 'helix:hx-code-snippet' with {
+  language: '',
+  inline: false,
+  wrap: false,
+  copyable: false,
+  maxLines: 0,
+  lineNumbers: false,
+  labelCopy: 'Copy code',
+  labelCopied: 'Copied!',
+  labelShowMore: 'Show more',
+  labelShowLess: 'Show less',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| language | string |  | Language hint for consumers to apply syntax highlighting.
+Does not affect rendering directly; it is applied as a `language-*` class
+on the `<code>` element so external highlighters can target it. |
+| inline | boolean | false | When true, renders as an inline `<code>` element instead of a `<pre><code>` block. |
+| wrap | boolean | false | When true, enables word-wrap in block mode. |
+| copyable | boolean | false | When true, shows a copy-to-clipboard button. Add the `copyable` attribute to enable it. |
+| maxLines | number | 0 | Maximum number of lines to display before showing a "Show more" button.
+Set to 0 (default) to disable truncation. |
+| lineNumbers | boolean | false | When true, prepends line numbers to each displayed line in block mode.
+Line numbers are rendered as `aria-hidden` spans so screen readers skip them. |
+| labelCopy | string | Copy code | Label for the copy button in idle state. |
+| labelCopied | string | Copied! | Label for the copy button after successful copy. |
+| labelShowMore | string | Show more | Label for the expand button when content is collapsed. |
+| labelShowLess | string | Show less | Label for the expand button when content is expanded. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Code content as plain text. Note: HTML markup in slot content will be stripped — only text content is extracted. Pre-highlighted HTML is not supported. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-copy | Dispatched when the copy button is clicked. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-code-snippet-bg | var(--hx-color-neutral-900,#0f172a) | Background color. |
+| --hx-code-snippet-color | var(--hx-color-neutral-100,#f1f5f9) | Text color. |
+| --hx-code-snippet-font-family | var(--hx-font-family-mono,monospace) | Font family. |
+| --hx-code-snippet-font-size | var(--hx-font-size-sm,0.875rem) | Font size. |
+| --hx-code-snippet-border-radius | var(--hx-border-radius-md,0.375rem) | Border radius. |
+| --hx-code-snippet-padding | var(--hx-space-4,1rem) | Inner padding (block mode). |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The outermost container (block: `<div>`, inline: `<code>`). |
+| header | The header bar containing the copy button (block mode only). |
+| code | The `<code>` element containing the content. |
+| copy-button | The copy-to-clipboard button. |
+| expand-button | The "Show more / Show less" button. |

--- a/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.component.yml
+++ b/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.component.yml
@@ -1,0 +1,63 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Code Snippet
+status: experimental
+group: HELiX
+description: 'A styled code block with optional copy button and max-lines truncation. Supports block (`<pre><code>`) and inline (`<code>`) rendering modes. No external syntax highlighting dependency — use the `language` attribute as a hint for consumers integrating their own highlighter via slotted content.'
+props:
+  type: object
+  properties:
+    language:
+      type: string
+      title: Language
+      description: 'Language hint for consumers to apply syntax highlighting. Does not affect rendering directly; it is applied as a `language-*` class on the `<code>` element so external highlighters can target it.'
+      default: ''
+    inline:
+      type: boolean
+      title: Inline
+      description: 'When true, renders as an inline `<code>` element instead of a `<pre><code>` block.'
+      default: false
+    wrap:
+      type: boolean
+      title: Wrap
+      description: 'When true, enables word-wrap in block mode.'
+      default: false
+    copyable:
+      type: boolean
+      title: Copyable
+      description: 'When true, shows a copy-to-clipboard button. Add the `copyable` attribute to enable it.'
+      default: false
+    maxLines:
+      type: number
+      title: Max Lines
+      description: 'Maximum number of lines to display before showing a "Show more" button. Set to 0 (default) to disable truncation.'
+      default: 0
+    lineNumbers:
+      type: boolean
+      title: Line Numbers
+      description: 'When true, prepends line numbers to each displayed line in block mode. Line numbers are rendered as `aria-hidden` spans so screen readers skip them.'
+      default: false
+    labelCopy:
+      type: string
+      title: Label Copy
+      description: 'Label for the copy button in idle state.'
+      default: 'Copy code'
+    labelCopied:
+      type: string
+      title: Label Copied
+      description: 'Label for the copy button after successful copy.'
+      default: 'Copied!'
+    labelShowMore:
+      type: string
+      title: Label Show More
+      description: 'Label for the expand button when content is collapsed.'
+      default: 'Show more'
+    labelShowLess:
+      type: string
+      title: Label Show Less
+      description: 'Label for the expand button when content is expanded.'
+      default: 'Show less'
+slots:
+  default:
+    title: Default
+    description: 'Code content as plain text. Note: HTML markup in slot content will be stripped — only text content is extracted. Pre-highlighted HTML is not supported.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.css
+++ b/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.css
@@ -1,0 +1,20 @@
+/**
+ * HX Code Snippet component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-code-snippet-bg: Background color. (default: var(--hx-color-neutral-900,#0f172a))
+ * --hx-code-snippet-color: Text color. (default: var(--hx-color-neutral-100,#f1f5f9))
+ * --hx-code-snippet-font-family: Font family. (default: var(--hx-font-family-mono,monospace))
+ * --hx-code-snippet-font-size: Font size. (default: var(--hx-font-size-sm,0.875rem))
+ * --hx-code-snippet-border-radius: Border radius. (default: var(--hx-border-radius-md,0.375rem))
+ * --hx-code-snippet-padding: Inner padding (block mode). (default: var(--hx-space-4,1rem))
+ */
+
+/* Component host styles */
+hx-code-snippet {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.js
+++ b/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.js
@@ -1,0 +1,11 @@
+/**
+ * HX Code Snippet - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-code-snippet';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-code-snippet');
+}

--- a/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.twig
+++ b/packages/hx-library/drupal/components/hx-code-snippet/hx-code-snippet.twig
@@ -1,0 +1,37 @@
+{#
+ /**
+ * @file
+ * HX Code Snippet component template.
+ *
+ * A styled code block with optional copy button and max-lines truncation.
+ * Supports block (`<pre><code>`) and inline (`<code>`) rendering modes.
+ * No external syntax highlighting dependency — use the `language` attribute
+ * as a hint for consumers integrating their own highlighter via slotted content.
+ *
+ * Available variables:
+ * - language: string - Language hint for consumers to apply syntax highlighting. Does not affect rendering directly; it is applied as a `language-*` class on the `<code>` element so external highlighters can target it.
+ * - inline: boolean - When true, renders as an inline `<code>` element instead of a `<pre><code>` block.
+ * - wrap: boolean - When true, enables word-wrap in block mode.
+ * - copyable: boolean - When true, shows a copy-to-clipboard button. Add the `copyable` attribute to enable it.
+ * - maxLines: number - Maximum number of lines to display before showing a "Show more" button. Set to 0 (default) to disable truncation.
+ * - lineNumbers: boolean - When true, prepends line numbers to each displayed line in block mode. Line numbers are rendered as `aria-hidden` spans so screen readers skip them.
+ * - labelCopy: string - Label for the copy button in idle state.
+ * - labelCopied: string - Label for the copy button after successful copy.
+ * - labelShowMore: string - Label for the expand button when content is collapsed.
+ * - labelShowLess: string - Label for the expand button when content is expanded.
+ */
+#}
+<hx-code-snippet
+  {% if language is defined and language is not empty %}language="{{ language }}"{% endif %}
+  {% if inline %}inline{% endif %}
+  {% if wrap %}wrap{% endif %}
+  {% if copyable %}copyable{% endif %}
+  {% if maxLines is defined and maxLines is not empty %}max-lines="{{ maxLines }}"{% endif %}
+  {% if lineNumbers %}line-numbers{% endif %}
+  {% if labelCopy is defined and labelCopy is not empty %}label-copy="{{ labelCopy }}"{% endif %}
+  {% if labelCopied is defined and labelCopied is not empty %}label-copied="{{ labelCopied }}"{% endif %}
+  {% if labelShowMore is defined and labelShowMore is not empty %}label-show-more="{{ labelShowMore }}"{% endif %}
+  {% if labelShowLess is defined and labelShowLess is not empty %}label-show-less="{{ labelShowLess }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-code-snippet>

--- a/packages/hx-library/drupal/components/hx-color-picker/README.md
+++ b/packages/hx-library/drupal/components/hx-color-picker/README.md
@@ -1,0 +1,85 @@
+# HX Color Picker
+
+A color picker control with gradient picker, hue/opacity sliders, swatches,
+and formatted text input. Supports hex, rgb, hsl, and hsv output formats.
+
+## Usage
+
+```twig
+{% include 'helix:hx-color-picker' with {
+  value: '#000000',
+  format: 'hex',
+  opacity: false,
+  swatchesOnly: false,
+  disabled: false,
+  name: '',
+  inline: false,
+  required: false,
+  labelGradient: 'Color gradient',
+  labelHue: 'Hue',
+  labelOpacity: 'Opacity',
+  labelSwatches: 'Preset colors',
+  labelSwitchFormat: 'Switch color format',
+  labelColorValue: 'Color value',
+  labelPicker: 'Color picker',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | string | #000000 | Current color value as a CSS color string. |
+| format | object | hex | Output format for the color value. |
+| opacity | boolean | false | Whether to show the alpha/opacity channel slider and include alpha in the output. |
+| swatchesOnly | boolean | false | When true, hides the gradient grid and sliders, showing only swatches and the input.
+Useful for compact preset-only color selection UIs. |
+| disabled | boolean | false | Whether the control is disabled. |
+| name | string |  | Form field name for form participation. |
+| inline | boolean | false | When true the picker is shown inline instead of in a popover. |
+| required | boolean | false | When true, the picker requires a non-empty value for form submission. |
+| labelGradient | string | Color gradient | Accessible label for the color gradient canvas. |
+| labelHue | string | Hue | Accessible label for the hue slider. |
+| labelOpacity | string | Opacity | Accessible label for the opacity slider. |
+| labelSwatches | string | Preset colors | Accessible label for the preset color swatches section. |
+| labelSwitchFormat | string | Switch color format | Accessible label for the format-switch button. |
+| labelColorValue | string | Color value | Accessible label for the color value input. |
+| labelPicker | string | Color picker | Accessible label for the color picker dialog/panel. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| trigger | Custom trigger element. Default: a color swatch button. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-input | Dispatched while dragging sliders or grid. |
+| hx-change | Dispatched when a color is committed. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-color-picker-z-index | 1000 | z-index of the popover panel. |
+| --hx-color-picker-width | 260px | Width of the picker panel. |
+| --hx-color-picker-grid-height | 160px | Height of the gradient grid. |
+| --hx-color-picker-thumb-border | #fff | Border color of slider/grid thumbs. |
+| --hx-color-picker-thumb-shadow | rgba(0,0,0,0.3) | Shadow color of slider/grid thumbs. |
+| --hx-color-picker-panel-shadow | rgba(0,0,0,0.15) | Panel drop-shadow color. |
+| --hx-color-picker-swatch-border | rgba(0,0,0,0.1) | Swatch button border color. |
+| --hx-color-picker-swatch-border-hover | rgba(0,0,0,0.3) | Swatch button border on hover. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| trigger | The trigger button element. |
+| swatches | The swatch color buttons container. |
+| grid | The 2D saturation/value gradient picker area. |
+| slider | Shared slider container (also on hue-slider and opacity-slider). |
+| hue-slider | The hue slider track. |
+| opacity-slider | The alpha/opacity slider track. |
+| input | The text input area. |

--- a/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.component.yml
+++ b/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.component.yml
@@ -1,0 +1,88 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Color Picker
+status: experimental
+group: HELiX
+description: 'A color picker control with gradient picker, hue/opacity sliders, swatches, and formatted text input. Supports hex, rgb, hsl, and hsv output formats.'
+props:
+  type: object
+  properties:
+    value:
+      type: string
+      title: Value
+      description: 'Current color value as a CSS color string.'
+      default: '#000000'
+    format:
+      type: object
+      title: Format
+      description: 'Output format for the color value.'
+      default: 'hex'
+    opacity:
+      type: boolean
+      title: Opacity
+      description: 'Whether to show the alpha/opacity channel slider and include alpha in the output.'
+      default: false
+    swatchesOnly:
+      type: boolean
+      title: Swatches Only
+      description: 'When true, hides the gradient grid and sliders, showing only swatches and the input. Useful for compact preset-only color selection UIs.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the control is disabled.'
+      default: false
+    name:
+      type: string
+      title: Name
+      description: 'Form field name for form participation.'
+      default: ''
+    inline:
+      type: boolean
+      title: Inline
+      description: 'When true the picker is shown inline instead of in a popover.'
+      default: false
+    required:
+      type: boolean
+      title: Required
+      description: 'When true, the picker requires a non-empty value for form submission.'
+      default: false
+    labelGradient:
+      type: string
+      title: Label Gradient
+      description: 'Accessible label for the color gradient canvas.'
+      default: 'Color gradient'
+    labelHue:
+      type: string
+      title: Label Hue
+      description: 'Accessible label for the hue slider.'
+      default: 'Hue'
+    labelOpacity:
+      type: string
+      title: Label Opacity
+      description: 'Accessible label for the opacity slider.'
+      default: 'Opacity'
+    labelSwatches:
+      type: string
+      title: Label Swatches
+      description: 'Accessible label for the preset color swatches section.'
+      default: 'Preset colors'
+    labelSwitchFormat:
+      type: string
+      title: Label Switch Format
+      description: 'Accessible label for the format-switch button.'
+      default: 'Switch color format'
+    labelColorValue:
+      type: string
+      title: Label Color Value
+      description: 'Accessible label for the color value input.'
+      default: 'Color value'
+    labelPicker:
+      type: string
+      title: Label Picker
+      description: 'Accessible label for the color picker dialog/panel.'
+      default: 'Color picker'
+slots:
+  trigger:
+    title: Trigger
+    description: 'Custom trigger element. Default: a color swatch button.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.css
+++ b/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.css
@@ -1,0 +1,22 @@
+/**
+ * HX Color Picker component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-color-picker-z-index: z-index of the popover panel. (default: 1000)
+ * --hx-color-picker-width: Width of the picker panel. (default: 260px)
+ * --hx-color-picker-grid-height: Height of the gradient grid. (default: 160px)
+ * --hx-color-picker-thumb-border: Border color of slider/grid thumbs. (default: #fff)
+ * --hx-color-picker-thumb-shadow: Shadow color of slider/grid thumbs. (default: rgba(0,0,0,0.3))
+ * --hx-color-picker-panel-shadow: Panel drop-shadow color. (default: rgba(0,0,0,0.15))
+ * --hx-color-picker-swatch-border: Swatch button border color. (default: rgba(0,0,0,0.1))
+ * --hx-color-picker-swatch-border-hover: Swatch button border on hover. (default: rgba(0,0,0,0.3))
+ */
+
+/* Component host styles */
+hx-color-picker {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.js
+++ b/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.js
@@ -1,0 +1,11 @@
+/**
+ * HX Color Picker - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-color-picker';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-color-picker');
+}

--- a/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.twig
+++ b/packages/hx-library/drupal/components/hx-color-picker/hx-color-picker.twig
@@ -1,0 +1,47 @@
+{#
+ /**
+ * @file
+ * HX Color Picker component template.
+ *
+ * A color picker control with gradient picker, hue/opacity sliders, swatches,
+ * and formatted text input. Supports hex, rgb, hsl, and hsv output formats.
+ *
+ * Available variables:
+ * - value: string - Current color value as a CSS color string.
+ * - format: object - Output format for the color value.
+ * - opacity: boolean - Whether to show the alpha/opacity channel slider and include alpha in the output.
+ * - swatchesOnly: boolean - When true, hides the gradient grid and sliders, showing only swatches and the input. Useful for compact preset-only color selection UIs.
+ * - disabled: boolean - Whether the control is disabled.
+ * - name: string - Form field name for form participation.
+ * - inline: boolean - When true the picker is shown inline instead of in a popover.
+ * - required: boolean - When true, the picker requires a non-empty value for form submission.
+ * - labelGradient: string - Accessible label for the color gradient canvas.
+ * - labelHue: string - Accessible label for the hue slider.
+ * - labelOpacity: string - Accessible label for the opacity slider.
+ * - labelSwatches: string - Accessible label for the preset color swatches section.
+ * - labelSwitchFormat: string - Accessible label for the format-switch button.
+ * - labelColorValue: string - Accessible label for the color value input.
+ * - labelPicker: string - Accessible label for the color picker dialog/panel.
+ */
+#}
+<hx-color-picker
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if format is defined and format is not empty %}format="{{ format }}"{% endif %}
+  {% if opacity %}opacity{% endif %}
+  {% if swatchesOnly %}swatches-only{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if inline %}inline{% endif %}
+  {% if required %}required{% endif %}
+  {% if labelGradient is defined and labelGradient is not empty %}label-gradient="{{ labelGradient }}"{% endif %}
+  {% if labelHue is defined and labelHue is not empty %}label-hue="{{ labelHue }}"{% endif %}
+  {% if labelOpacity is defined and labelOpacity is not empty %}label-opacity="{{ labelOpacity }}"{% endif %}
+  {% if labelSwatches is defined and labelSwatches is not empty %}label-swatches="{{ labelSwatches }}"{% endif %}
+  {% if labelSwitchFormat is defined and labelSwitchFormat is not empty %}label-switch-format="{{ labelSwitchFormat }}"{% endif %}
+  {% if labelColorValue is defined and labelColorValue is not empty %}label-color-value="{{ labelColorValue }}"{% endif %}
+  {% if labelPicker is defined and labelPicker is not empty %}label-picker="{{ labelPicker }}"{% endif %}
+>
+  {% if slots.trigger is defined %}
+    <slot name="trigger">{{ slots.trigger }}</slot>
+  {% endif %}
+</hx-color-picker>

--- a/packages/hx-library/drupal/components/hx-combobox/README.md
+++ b/packages/hx-library/drupal/components/hx-combobox/README.md
@@ -1,0 +1,97 @@
+# HX Combobox
+
+A form-associated combobox component combining a text input with a listbox
+for autocomplete and typeahead. Supports filtering, free-text entry,
+keyboard navigation, and async option loading.
+
+## Usage
+
+```twig
+{% include 'helix:hx-combobox' with {
+  label: '',
+  placeholder: '',
+  value: '',
+  required: false,
+  disabled: false,
+  name: '',
+  error: '',
+  helpText: '',
+  size: 'md',
+  multiple: false,
+  clearable: false,
+  loading: false,
+  filterDebounce: 0,
+  ariaLabel: 'null',
+  labelNoOptions: 'No options found',
+  labelRequired: 'Please select an option.',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | The visible label text for the combobox. |
+| placeholder | string |  | Placeholder text shown in the input when no value is entered. |
+| value | string |  | The current value of the combobox. |
+| required | boolean | false | Whether the combobox is required for form submission. |
+| disabled | boolean | false | Whether the combobox is disabled. |
+| name | string |  | The name used for form submission. |
+| error | string |  | Error message to display. When set, the field enters an error state. |
+| helpText | string |  | Help text displayed below the combobox for guidance. |
+| size | object | md | Size variant of the combobox. |
+| multiple | boolean | false | Whether multiple options can be selected. |
+| clearable | boolean | false | Whether the combobox shows a clear button when a value is set. |
+| loading | boolean | false | Whether the combobox is in a loading state (shows spinner). |
+| filterDebounce | number | 0 | Debounce delay in milliseconds for the filter input event. |
+| ariaLabel | object | null | Accessible name for screen readers, if different from the visible label. |
+| labelNoOptions | string | No options found | Text shown when no options match the current filter. |
+| labelRequired | string | Please select an option. | Validation message shown when the field is required but empty. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| option | Slot for `<option>` elements that populate the listbox. |
+| prefix | Content to display before the text input. |
+| suffix | Content to display after the text input. |
+| empty-label | Content shown when no options match the filter. |
+| label | Custom label content (overrides the label property). |
+| error | Custom error content (overrides the error property). |
+| help-text | Custom help text content (overrides the helpText property). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-show | Dispatched when the listbox opens. |
+| hx-hide | Dispatched when the listbox closes. |
+| hx-input | Dispatched on each keystroke as the user types. |
+| hx-clear | Dispatched when the clear button is activated. |
+| hx-change | Dispatched when an option is selected. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-combobox-bg | var(--hx-color-neutral-0) | Input background color. |
+| --hx-combobox-color | var(--hx-color-neutral-800) | Input text color. |
+| --hx-combobox-border-color | var(--hx-color-neutral-300) | Border color. |
+| --hx-combobox-border-radius | var(--hx-border-radius-md) | Border radius. |
+| --hx-combobox-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-combobox-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-combobox-error-color | var(--hx-color-error-500) | Error state color. |
+| --hx-combobox-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-combobox-listbox-bg | var(--hx-color-neutral-0) | Listbox background color. |
+| --hx-combobox-option-hover-bg | var(--hx-color-primary-50) | Option hover background. |
+| --hx-combobox-option-selected-bg | var(--hx-color-primary-100) | Selected option background. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| input | The native text input element. |
+| listbox | The dropdown panel containing options. |
+| trigger | The input wrapper element acting as the combobox trigger. |
+| clear-button | The button that clears the current value. |
+| loading-indicator | The loading spinner shown during async operations. |

--- a/packages/hx-library/drupal/components/hx-combobox/hx-combobox.component.yml
+++ b/packages/hx-library/drupal/components/hx-combobox/hx-combobox.component.yml
@@ -1,0 +1,111 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Combobox
+status: experimental
+group: HELiX
+description: 'A form-associated combobox component combining a text input with a listbox for autocomplete and typeahead. Supports filtering, free-text entry, keyboard navigation, and async option loading.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the combobox.'
+      default: ''
+    placeholder:
+      type: string
+      title: Placeholder
+      description: 'Placeholder text shown in the input when no value is entered.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The current value of the combobox.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the combobox is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the combobox is disabled.'
+      default: false
+    name:
+      type: string
+      title: Name
+      description: 'The name used for form submission.'
+      default: ''
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the field enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the combobox for guidance.'
+      default: ''
+    size:
+      type: object
+      title: Size
+      description: 'Size variant of the combobox.'
+      default: 'md'
+    multiple:
+      type: boolean
+      title: Multiple
+      description: 'Whether multiple options can be selected.'
+      default: false
+    clearable:
+      type: boolean
+      title: Clearable
+      description: 'Whether the combobox shows a clear button when a value is set.'
+      default: false
+    loading:
+      type: boolean
+      title: Loading
+      description: 'Whether the combobox is in a loading state (shows spinner).'
+      default: false
+    filterDebounce:
+      type: number
+      title: Filter Debounce
+      description: 'Debounce delay in milliseconds for the filter input event.'
+      default: 0
+    ariaLabel:
+      type: object
+      title: Aria Label
+      description: 'Accessible name for screen readers, if different from the visible label.'
+      default: 'null'
+    labelNoOptions:
+      type: string
+      title: Label No Options
+      description: 'Text shown when no options match the current filter.'
+      default: 'No options found'
+    labelRequired:
+      type: string
+      title: Label Required
+      description: 'Validation message shown when the field is required but empty.'
+      default: 'Please select an option.'
+slots:
+  option:
+    title: Option
+    description: 'Slot for `<option>` elements that populate the listbox.'
+  prefix:
+    title: Prefix
+    description: 'Content to display before the text input.'
+  suffix:
+    title: Suffix
+    description: 'Content to display after the text input.'
+  empty-label:
+    title: Empty Label
+    description: 'Content shown when no options match the filter.'
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-combobox/hx-combobox.css
+++ b/packages/hx-library/drupal/components/hx-combobox/hx-combobox.css
@@ -1,0 +1,25 @@
+/**
+ * HX Combobox component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-combobox-bg: Input background color. (default: var(--hx-color-neutral-0))
+ * --hx-combobox-color: Input text color. (default: var(--hx-color-neutral-800))
+ * --hx-combobox-border-color: Border color. (default: var(--hx-color-neutral-300))
+ * --hx-combobox-border-radius: Border radius. (default: var(--hx-border-radius-md))
+ * --hx-combobox-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-combobox-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-combobox-error-color: Error state color. (default: var(--hx-color-error-500))
+ * --hx-combobox-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-combobox-listbox-bg: Listbox background color. (default: var(--hx-color-neutral-0))
+ * --hx-combobox-option-hover-bg: Option hover background. (default: var(--hx-color-primary-50))
+ * --hx-combobox-option-selected-bg: Selected option background. (default: var(--hx-color-primary-100))
+ */
+
+/* Component host styles */
+hx-combobox {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-combobox/hx-combobox.js
+++ b/packages/hx-library/drupal/components/hx-combobox/hx-combobox.js
@@ -1,0 +1,11 @@
+/**
+ * HX Combobox - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-combobox';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-combobox');
+}

--- a/packages/hx-library/drupal/components/hx-combobox/hx-combobox.twig
+++ b/packages/hx-library/drupal/components/hx-combobox/hx-combobox.twig
@@ -1,0 +1,68 @@
+{#
+ /**
+ * @file
+ * HX Combobox component template.
+ *
+ * A form-associated combobox component combining a text input with a listbox
+ * for autocomplete and typeahead. Supports filtering, free-text entry,
+ * keyboard navigation, and async option loading.
+ *
+ * Available variables:
+ * - label: string - The visible label text for the combobox.
+ * - placeholder: string - Placeholder text shown in the input when no value is entered.
+ * - value: string - The current value of the combobox.
+ * - required: boolean - Whether the combobox is required for form submission.
+ * - disabled: boolean - Whether the combobox is disabled.
+ * - name: string - The name used for form submission.
+ * - error: string - Error message to display. When set, the field enters an error state.
+ * - helpText: string - Help text displayed below the combobox for guidance.
+ * - size: object - Size variant of the combobox.
+ * - multiple: boolean - Whether multiple options can be selected.
+ * - clearable: boolean - Whether the combobox shows a clear button when a value is set.
+ * - loading: boolean - Whether the combobox is in a loading state (shows spinner).
+ * - filterDebounce: number - Debounce delay in milliseconds for the filter input event.
+ * - ariaLabel: object - Accessible name for screen readers, if different from the visible label.
+ * - labelNoOptions: string - Text shown when no options match the current filter.
+ * - labelRequired: string - Validation message shown when the field is required but empty.
+ */
+#}
+<hx-combobox
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if placeholder is defined and placeholder is not empty %}placeholder="{{ placeholder }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if multiple %}multiple{% endif %}
+  {% if clearable %}clearable{% endif %}
+  {% if loading %}loading{% endif %}
+  {% if filterDebounce is defined and filterDebounce is not empty %}filter-debounce="{{ filterDebounce }}"{% endif %}
+  {% if ariaLabel is defined and ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
+  {% if labelNoOptions is defined and labelNoOptions is not empty %}label-no-options="{{ labelNoOptions }}"{% endif %}
+  {% if labelRequired is defined and labelRequired is not empty %}label-required="{{ labelRequired }}"{% endif %}
+>
+  {% if slots.option is defined %}
+    <slot name="option">{{ slots.option }}</slot>
+  {% endif %}
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if slots.empty-label is defined %}
+    <slot name="empty-label">{{ slots.empty-label }}</slot>
+  {% endif %}
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+</hx-combobox>

--- a/packages/hx-library/drupal/components/hx-container/README.md
+++ b/packages/hx-library/drupal/components/hx-container/README.md
@@ -1,0 +1,62 @@
+# HX Container
+
+A layout container that constrains content width and provides
+consistent vertical spacing and horizontal gutters.
+
+Uses a two-layer model: the outer host spans full width (background,
+vertical padding), while the inner wrapper constrains max-width,
+centers content, and applies horizontal gutters.
+
+## Accessibility
+
+`hx-container` is a purely visual layout primitive with no semantic meaning.
+It carries no ARIA role and is intentionally transparent to assistive
+technologies. Screen readers announce the container's children directly,
+not the container itself.
+
+The inner wrapper always centers content horizontally (via `margin: auto`).
+This is by design for page-layout use cases. If you need non-centered
+alignment at a specific breakpoint, override `margin-left` and
+`margin-right` on `::part(inner)` from your stylesheet.
+
+## Usage
+
+```twig
+{% include 'helix:hx-container' with {
+  width: 'content',
+  padding: 'none',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| width | object | content | Controls the max-width of the inner content wrapper. |
+| padding | object | none | Vertical padding applied to the outer wrapper. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for container content. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-container-bg | transparent | Background color on the outer wrapper. |
+| --hx-container-gutter | var(--hx-space-6) | Horizontal padding on the inner box. |
+| --hx-container-max-width | - | Override the max-width set by the width property. |
+| --hx-container-content | 72rem | Max-width for the content width preset. |
+| --hx-container-narrow | 48rem | Max-width for the narrow width preset. |
+| --hx-container-sm | 640px | Max-width for the sm width preset. |
+| --hx-container-md | 768px | Max-width for the md width preset. |
+| --hx-container-lg | 1024px | Max-width for the lg width preset. |
+| --hx-container-xl | 1280px | Max-width for the xl width preset. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| inner | The inner wrapper that constrains max-width and applies gutters. |

--- a/packages/hx-library/drupal/components/hx-container/hx-container.component.yml
+++ b/packages/hx-library/drupal/components/hx-container/hx-container.component.yml
@@ -1,0 +1,23 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Container
+status: experimental
+group: HELiX
+description: "A layout container that constrains content width and provides consistent vertical spacing and horizontal gutters.  Uses a two-layer model: the outer host spans full width (background, vertical padding), while the inner wrapper constrains max-width, centers content, and applies horizontal gutters.  ## Accessibility  `hx-container` is a purely visual layout primitive with no semantic meaning. It carries no ARIA role and is intentionally transparent to assistive technologies. Screen readers announce the container's children directly, not the container itself.  The inner wrapper always centers content horizontally (via `margin: auto`). This is by design for page-layout use cases. If you need non-centered alignment at a specific breakpoint, override `margin-left` and `margin-right` on `::part(inner)` from your stylesheet."
+props:
+  type: object
+  properties:
+    width:
+      type: object
+      title: Width
+      description: 'Controls the max-width of the inner content wrapper.'
+      default: 'content'
+    padding:
+      type: object
+      title: Padding
+      description: 'Vertical padding applied to the outer wrapper.'
+      default: 'none'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for container content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-container/hx-container.css
+++ b/packages/hx-library/drupal/components/hx-container/hx-container.css
@@ -1,0 +1,23 @@
+/**
+ * HX Container component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-container-bg: Background color on the outer wrapper. (default: transparent)
+ * --hx-container-gutter: Horizontal padding on the inner box. (default: var(--hx-space-6))
+ * --hx-container-max-width: Override the max-width set by the width property.
+ * --hx-container-content: Max-width for the content width preset. (default: 72rem)
+ * --hx-container-narrow: Max-width for the narrow width preset. (default: 48rem)
+ * --hx-container-sm: Max-width for the sm width preset. (default: 640px)
+ * --hx-container-md: Max-width for the md width preset. (default: 768px)
+ * --hx-container-lg: Max-width for the lg width preset. (default: 1024px)
+ * --hx-container-xl: Max-width for the xl width preset. (default: 1280px)
+ */
+
+/* Component host styles */
+hx-container {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-container/hx-container.js
+++ b/packages/hx-library/drupal/components/hx-container/hx-container.js
@@ -1,0 +1,11 @@
+/**
+ * HX Container - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-container';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-container');
+}

--- a/packages/hx-library/drupal/components/hx-container/hx-container.twig
+++ b/packages/hx-library/drupal/components/hx-container/hx-container.twig
@@ -1,0 +1,35 @@
+{#
+ /**
+ * @file
+ * HX Container component template.
+ *
+ * A layout container that constrains content width and provides
+ * consistent vertical spacing and horizontal gutters.
+ * 
+ * Uses a two-layer model: the outer host spans full width (background,
+ * vertical padding), while the inner wrapper constrains max-width,
+ * centers content, and applies horizontal gutters.
+ * 
+ * ## Accessibility
+ * 
+ * `hx-container` is a purely visual layout primitive with no semantic meaning.
+ * It carries no ARIA role and is intentionally transparent to assistive
+ * technologies. Screen readers announce the container's children directly,
+ * not the container itself.
+ * 
+ * The inner wrapper always centers content horizontally (via `margin: auto`).
+ * This is by design for page-layout use cases. If you need non-centered
+ * alignment at a specific breakpoint, override `margin-left` and
+ * `margin-right` on `::part(inner)` from your stylesheet.
+ *
+ * Available variables:
+ * - width: object - Controls the max-width of the inner content wrapper.
+ * - padding: object - Vertical padding applied to the outer wrapper.
+ */
+#}
+<hx-container
+  {% if width is defined and width is not empty %}width="{{ width }}"{% endif %}
+  {% if padding is defined and padding is not empty %}padding="{{ padding }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-container>

--- a/packages/hx-library/drupal/components/hx-copy-button/README.md
+++ b/packages/hx-library/drupal/components/hx-copy-button/README.md
@@ -1,0 +1,82 @@
+# HX Copy Button
+
+A clipboard copy button component that writes a given value to the system
+clipboard. Provides idle and success states with configurable feedback
+duration, slot-based icon overrides, and an accessible live region that
+announces copy completion to screen reader users.
+
+The `aria-label` reflects the current copy state: idle shows `label`,
+copied state appends " — Copied" so screen reader users who re-focus the
+button after copy receive an accurate accessible name.
+
+Note: `aria-pressed` is intentionally NOT used. This is not a toggle button;
+copied is a transient feedback state, not a persistent on/off toggle.
+
+## Usage
+
+```twig
+{% include 'helix:hx-copy-button' with {
+  value: '',
+  label: 'Copy to clipboard',
+  feedbackDuration: 2000,
+  size: 'md',
+  disabled: false,
+  labelCopied: 'Copied',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | string |  | The text value to write to the clipboard on click. Required for the
+component to perform a copy operation. |
+| label | string | Copy to clipboard | Accessible label applied as `aria-label` and `title` on the button. |
+| feedbackDuration | number | 2000 | Duration in milliseconds to display the success (copied) state before
+reverting to the idle state. Values below 300 ms are clamped to 300 ms
+to ensure the success announcement remains visible long enough for
+assistive technology and human perception. |
+| size | object | md | Visual size of the button. Maps to fixed height and padding tokens.
+Accepts: 'sm' | 'md' | 'lg'. Invalid values are silently coerced to 'md'.
+
+**Accessibility (WCAG 2.5.8):** The `sm` variant uses `--hx-size-8` for
+its minimum width and height. Ensure this token resolves to at least 24×24 px
+(WCAG 2.5.8 AA minimum target size). For touch-primary interfaces such as
+mobile clinical apps, prefer `md` or `lg` to meet the 44×44 px recommended
+target size (WCAG 2.5.5 AAA / Apple HIG / Android guidelines). |
+| disabled | boolean | false | Whether the button is disabled. When true, click events are suppressed
+and clipboard writes do not occur. |
+| labelCopied | string | Copied | Text announced to screen readers and appended to aria-label after a
+successful copy. Also used as the content of the aria-live announcement. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Optional label text rendered inside the button alongside the icon. |
+| copy-icon | Icon shown in the idle (pre-copy) state. |
+| success-icon | Icon shown after a successful clipboard write. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-copy-error | Dispatched when the clipboard write fails (permission denied, iframe restriction, etc.). The `error` detail contains the caught error for diagnostic use. |
+| hx-copy | Dispatched after the value has been successfully written to the clipboard. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-copy-button-bg | transparent | Button background color. |
+| --hx-copy-button-color | var(--hx-color-primary-500) | Icon and text color. |
+| --hx-copy-button-border-color | transparent | Button border color. |
+| --hx-copy-button-border-radius | var(--hx-border-radius-md) | Button border radius. |
+| --hx-copy-button-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| button | The native button element. |
+| icon | The icon container span wrapping the active icon slot. |

--- a/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.component.yml
+++ b/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.component.yml
@@ -1,0 +1,49 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Copy Button
+status: experimental
+group: HELiX
+description: 'A clipboard copy button component that writes a given value to the system clipboard. Provides idle and success states with configurable feedback duration, slot-based icon overrides, and an accessible live region that announces copy completion to screen reader users.  The `aria-label` reflects the current copy state: idle shows `label`, copied state appends " — Copied" so screen reader users who re-focus the button after copy receive an accurate accessible name.  Note: `aria-pressed` is intentionally NOT used. This is not a toggle button; copied is a transient feedback state, not a persistent on/off toggle.'
+props:
+  type: object
+  properties:
+    value:
+      type: string
+      title: Value
+      description: 'The text value to write to the clipboard on click. Required for the component to perform a copy operation.'
+      default: ''
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label applied as `aria-label` and `title` on the button.'
+      default: 'Copy to clipboard'
+    feedbackDuration:
+      type: number
+      title: Feedback Duration
+      description: 'Duration in milliseconds to display the success (copied) state before reverting to the idle state. Values below 300 ms are clamped to 300 ms to ensure the success announcement remains visible long enough for assistive technology and human perception.'
+      default: 2000
+    size:
+      type: object
+      title: Size
+      description: "Visual size of the button. Maps to fixed height and padding tokens. Accepts: 'sm' | 'md' | 'lg'. Invalid values are silently coerced to 'md'.  **Accessibility (WCAG 2.5.8):** The `sm` variant uses `--hx-size-8` for its minimum width and height. Ensure this token resolves to at least 24×24 px (WCAG 2.5.8 AA minimum target size). For touch-primary interfaces such as mobile clinical apps, prefer `md` or `lg` to meet the 44×44 px recommended target size (WCAG 2.5.5 AAA / Apple HIG / Android guidelines)."
+      default: 'md'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the button is disabled. When true, click events are suppressed and clipboard writes do not occur.'
+      default: false
+    labelCopied:
+      type: string
+      title: Label Copied
+      description: 'Text announced to screen readers and appended to aria-label after a successful copy. Also used as the content of the aria-live announcement.'
+      default: 'Copied'
+slots:
+  default:
+    title: Default
+    description: 'Optional label text rendered inside the button alongside the icon.'
+  copy-icon:
+    title: Copy Icon
+    description: 'Icon shown in the idle (pre-copy) state.'
+  success-icon:
+    title: Success Icon
+    description: 'Icon shown after a successful clipboard write.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.css
+++ b/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.css
@@ -1,0 +1,19 @@
+/**
+ * HX Copy Button component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-copy-button-bg: Button background color. (default: transparent)
+ * --hx-copy-button-color: Icon and text color. (default: var(--hx-color-primary-500))
+ * --hx-copy-button-border-color: Button border color. (default: transparent)
+ * --hx-copy-button-border-radius: Button border radius. (default: var(--hx-border-radius-md))
+ * --hx-copy-button-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ */
+
+/* Component host styles */
+hx-copy-button {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.js
+++ b/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.js
@@ -1,0 +1,11 @@
+/**
+ * HX Copy Button - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-copy-button';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-copy-button');
+}

--- a/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.twig
+++ b/packages/hx-library/drupal/components/hx-copy-button/hx-copy-button.twig
@@ -1,0 +1,42 @@
+{#
+ /**
+ * @file
+ * HX Copy Button component template.
+ *
+ * A clipboard copy button component that writes a given value to the system
+ * clipboard. Provides idle and success states with configurable feedback
+ * duration, slot-based icon overrides, and an accessible live region that
+ * announces copy completion to screen reader users.
+ * 
+ * The `aria-label` reflects the current copy state: idle shows `label`,
+ * copied state appends " — Copied" so screen reader users who re-focus the
+ * button after copy receive an accurate accessible name.
+ * 
+ * Note: `aria-pressed` is intentionally NOT used. This is not a toggle button;
+ * copied is a transient feedback state, not a persistent on/off toggle.
+ *
+ * Available variables:
+ * - value: string - The text value to write to the clipboard on click. Required for the component to perform a copy operation.
+ * - label: string - Accessible label applied as `aria-label` and `title` on the button.
+ * - feedbackDuration: number - Duration in milliseconds to display the success (copied) state before reverting to the idle state. Values below 300 ms are clamped to 300 ms to ensure the success announcement remains visible long enough for assistive technology and human perception.
+ * - size: object - Visual size of the button. Maps to fixed height and padding tokens. Accepts: 'sm' | 'md' | 'lg'. Invalid values are silently coerced to 'md'.  **Accessibility (WCAG 2.5.8):** The `sm` variant uses `--hx-size-8` for its minimum width and height. Ensure this token resolves to at least 24×24 px (WCAG 2.5.8 AA minimum target size). For touch-primary interfaces such as mobile clinical apps, prefer `md` or `lg` to meet the 44×44 px recommended target size (WCAG 2.5.5 AAA / Apple HIG / Android guidelines).
+ * - disabled: boolean - Whether the button is disabled. When true, click events are suppressed and clipboard writes do not occur.
+ * - labelCopied: string - Text announced to screen readers and appended to aria-label after a successful copy. Also used as the content of the aria-live announcement.
+ */
+#}
+<hx-copy-button
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if feedbackDuration is defined and feedbackDuration is not empty %}feedback-duration="{{ feedbackDuration }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if labelCopied is defined and labelCopied is not empty %}label-copied="{{ labelCopied }}"{% endif %}
+>
+  {% if slots.copy-icon is defined %}
+    <slot name="copy-icon">{{ slots.copy-icon }}</slot>
+  {% endif %}
+  {% if slots.success-icon is defined %}
+    <slot name="success-icon">{{ slots.success-icon }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-copy-button>

--- a/packages/hx-library/drupal/components/hx-counter/README.md
+++ b/packages/hx-library/drupal/components/hx-counter/README.md
@@ -1,0 +1,48 @@
+# HX Counter
+
+Animated number counter that counts from 0 (or the previous value) to the
+target value using requestAnimationFrame. Respects prefers-reduced-motion.
+
+## Usage
+
+```twig
+{% include 'helix:hx-counter' with {
+  value: 0,
+  duration: 1000,
+  easing: 'ease-out',
+  format: 'integer',
+  prefix: '',
+  suffix: '',
+  size: 'md',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | number | 0 | The target numeric value to count to. |
+| duration | number | 1000 | Animation duration in milliseconds. |
+| easing | object | ease-out | Easing function applied to the animation progress. |
+| format | object | integer | Number format. 'integer' rounds to the nearest whole number;
+'decimal' shows two decimal places. |
+| prefix | string |  | String prepended to the formatted value (e.g., '$'). |
+| suffix | string |  | String appended to the formatted value (e.g., '%'). |
+| size | object | md | Size variant controlling font size. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-counter-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-counter-font-weight | var(--hx-font-weight-bold) | Font weight. |
+| --hx-counter-color | var(--hx-color-neutral-900) | Counter text color. |
+| --hx-counter-font-size-sm | var(--hx-font-size-xl) | Font size at sm. |
+| --hx-counter-font-size-md | var(--hx-font-size-3xl) | Font size at md. |
+| --hx-counter-font-size-lg | var(--hx-font-size-5xl) | Font size at lg. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| counter | The outer counter element. |

--- a/packages/hx-library/drupal/components/hx-counter/hx-counter.component.yml
+++ b/packages/hx-library/drupal/components/hx-counter/hx-counter.component.yml
@@ -1,0 +1,44 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Counter
+status: experimental
+group: HELiX
+description: 'Animated number counter that counts from 0 (or the previous value) to the target value using requestAnimationFrame. Respects prefers-reduced-motion.'
+props:
+  type: object
+  properties:
+    value:
+      type: number
+      title: Value
+      description: 'The target numeric value to count to.'
+      default: 0
+    duration:
+      type: number
+      title: Duration
+      description: 'Animation duration in milliseconds.'
+      default: 1000
+    easing:
+      type: object
+      title: Easing
+      description: 'Easing function applied to the animation progress.'
+      default: 'ease-out'
+    format:
+      type: object
+      title: Format
+      description: "Number format. 'integer' rounds to the nearest whole number; 'decimal' shows two decimal places."
+      default: 'integer'
+    prefix:
+      type: string
+      title: Prefix
+      description: "String prepended to the formatted value (e.g., '$')."
+      default: ''
+    suffix:
+      type: string
+      title: Suffix
+      description: "String appended to the formatted value (e.g., '%')."
+      default: ''
+    size:
+      type: object
+      title: Size
+      description: 'Size variant controlling font size.'
+      default: 'md'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-counter/hx-counter.css
+++ b/packages/hx-library/drupal/components/hx-counter/hx-counter.css
@@ -1,0 +1,20 @@
+/**
+ * HX Counter component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-counter-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-counter-font-weight: Font weight. (default: var(--hx-font-weight-bold))
+ * --hx-counter-color: Counter text color. (default: var(--hx-color-neutral-900))
+ * --hx-counter-font-size-sm: Font size at sm. (default: var(--hx-font-size-xl))
+ * --hx-counter-font-size-md: Font size at md. (default: var(--hx-font-size-3xl))
+ * --hx-counter-font-size-lg: Font size at lg. (default: var(--hx-font-size-5xl))
+ */
+
+/* Component host styles */
+hx-counter {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-counter/hx-counter.js
+++ b/packages/hx-library/drupal/components/hx-counter/hx-counter.js
@@ -1,0 +1,11 @@
+/**
+ * HX Counter - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-counter';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-counter');
+}

--- a/packages/hx-library/drupal/components/hx-counter/hx-counter.twig
+++ b/packages/hx-library/drupal/components/hx-counter/hx-counter.twig
@@ -1,0 +1,28 @@
+{#
+ /**
+ * @file
+ * HX Counter component template.
+ *
+ * Animated number counter that counts from 0 (or the previous value) to the
+ * target value using requestAnimationFrame. Respects prefers-reduced-motion.
+ *
+ * Available variables:
+ * - value: number - The target numeric value to count to.
+ * - duration: number - Animation duration in milliseconds.
+ * - easing: object - Easing function applied to the animation progress.
+ * - format: object - Number format. 'integer' rounds to the nearest whole number; 'decimal' shows two decimal places.
+ * - prefix: string - String prepended to the formatted value (e.g., '$').
+ * - suffix: string - String appended to the formatted value (e.g., '%').
+ * - size: object - Size variant controlling font size.
+ */
+#}
+<hx-counter
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if duration is defined and duration is not empty %}duration="{{ duration }}"{% endif %}
+  {% if easing is defined and easing is not empty %}easing="{{ easing }}"{% endif %}
+  {% if format is defined and format is not empty %}format="{{ format }}"{% endif %}
+  {% if prefix is defined and prefix is not empty %}prefix="{{ prefix }}"{% endif %}
+  {% if suffix is defined and suffix is not empty %}suffix="{{ suffix }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+>
+</hx-counter>

--- a/packages/hx-library/drupal/components/hx-data-table/README.md
+++ b/packages/hx-library/drupal/components/hx-data-table/README.md
@@ -1,0 +1,84 @@
+# HX Data Table
+
+An enterprise data table with sorting, row selection, and keyboard navigation.
+
+## Usage
+
+```twig
+{% include 'helix:hx-data-table' with {
+  columns: '[]',
+  rows: '[]',
+  selectable: false,
+  sortKey: '',
+  sortDirection: 'asc',
+  loading: false,
+  emptyLabel: 'No data',
+  label: '',
+  stickyHeader: false,
+  labelSelectAll: 'Select all rows',
+  page: 1,
+  pageSize: 0,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| columns | object | [] | Column definitions. Each item: `{ key, label, sortable?, width? }`.
+Can be set as a JS array or a JSON string (e.g., from a Drupal Twig attribute). |
+| rows | object | [] | Row data. Each item is a plain object keyed by column `key` values.
+Can be set as a JS array or a JSON string (e.g., from a Drupal Twig attribute). |
+| selectable | boolean | false | When true, renders a checkbox column for row selection. |
+| sortKey | string |  | The column key currently used for sorting. |
+| sortDirection | object | asc | Current sort direction. |
+| loading | boolean | false | When true, renders a loading skeleton and sets `aria-busy="true"` on the host. |
+| emptyLabel | string | No data | Text displayed in the default empty state when `rows` is empty and not loading. |
+| label | string |  | Accessible name for the table. Exposed via `aria-label` on the `<table>` element.
+Required when the table has columns — a missing label is a WCAG 4.1.2 violation. |
+| stickyHeader | boolean | false | When true, the header row is sticky (position: sticky; top: 0). |
+| labelSelectAll | string | Select all rows | Accessible label for the "select all rows" checkbox. |
+| page | number | 1 | Current page (1-based). Set to 0 or leave at default (0) to disable pagination. |
+| pageSize | number | 0 | Number of rows per page. Set to 0 to disable pagination (show all rows). |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| toolbar | Content rendered above the table (e.g., search, actions). |
+| empty | Custom empty-state content rendered when `rows` is empty and not loading. |
+| loading | Custom loading content rendered when `loading` is true. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-sort | Dispatched when a sortable column header is clicked. |
+| hx-row-click | Dispatched when a data row is clicked. |
+| hx-select | Dispatched when row selection changes. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-data-table-header-bg | var(--hx-color-neutral-50) | Header background color. |
+| --hx-data-table-header-color | var(--hx-color-neutral-700) | Header text color. |
+| --hx-data-table-cell-color | var(--hx-color-neutral-900) | Cell text color. |
+| --hx-data-table-border-color | var(--hx-color-neutral-200) | Row border color. |
+| --hx-data-table-row-hover-bg | var(--hx-color-neutral-50) | Row hover background. |
+| --hx-data-table-row-selected-bg | var(--hx-color-primary-50) | Selected row background. |
+| --hx-data-table-empty-color | var(--hx-color-neutral-600) | Empty state text color. |
+| --hx-data-table-min-width | 600px | Minimum table width before horizontal scrolling. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| table | The `<table>` element. |
+| thead | The `<thead>` element. |
+| tbody | The `<tbody>` element. |
+| tr | Each `<tr>` element. |
+| th | Each `<th>` element. |
+| td | Each `<td>` element. |
+| sort-icon | The sort indicator icon `<span>` inside sortable headers. |
+| checkbox | Each `<input type="checkbox">` element. |

--- a/packages/hx-library/drupal/components/hx-data-table/hx-data-table.component.yml
+++ b/packages/hx-library/drupal/components/hx-data-table/hx-data-table.component.yml
@@ -1,0 +1,79 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Data Table
+status: experimental
+group: HELiX
+description: 'An enterprise data table with sorting, row selection, and keyboard navigation.'
+props:
+  type: object
+  properties:
+    columns:
+      type: object
+      title: Columns
+      description: 'Column definitions. Each item: `{ key, label, sortable?, width? }`. Can be set as a JS array or a JSON string (e.g., from a Drupal Twig attribute).'
+      default: '[]'
+    rows:
+      type: object
+      title: Rows
+      description: 'Row data. Each item is a plain object keyed by column `key` values. Can be set as a JS array or a JSON string (e.g., from a Drupal Twig attribute).'
+      default: '[]'
+    selectable:
+      type: boolean
+      title: Selectable
+      description: 'When true, renders a checkbox column for row selection.'
+      default: false
+    sortKey:
+      type: string
+      title: Sort Key
+      description: 'The column key currently used for sorting.'
+      default: ''
+    sortDirection:
+      type: object
+      title: Sort Direction
+      description: 'Current sort direction.'
+      default: 'asc'
+    loading:
+      type: boolean
+      title: Loading
+      description: 'When true, renders a loading skeleton and sets `aria-busy="true"` on the host.'
+      default: false
+    emptyLabel:
+      type: string
+      title: Empty Label
+      description: 'Text displayed in the default empty state when `rows` is empty and not loading.'
+      default: 'No data'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible name for the table. Exposed via `aria-label` on the `<table>` element. Required when the table has columns — a missing label is a WCAG 4.1.2 violation.'
+      default: ''
+    stickyHeader:
+      type: boolean
+      title: Sticky Header
+      description: 'When true, the header row is sticky (position: sticky; top: 0).'
+      default: false
+    labelSelectAll:
+      type: string
+      title: Label Select All
+      description: 'Accessible label for the "select all rows" checkbox.'
+      default: 'Select all rows'
+    page:
+      type: number
+      title: Page
+      description: 'Current page (1-based). Set to 0 or leave at default (0) to disable pagination.'
+      default: 1
+    pageSize:
+      type: number
+      title: Page Size
+      description: 'Number of rows per page. Set to 0 to disable pagination (show all rows).'
+      default: 0
+slots:
+  toolbar:
+    title: Toolbar
+    description: 'Content rendered above the table (e.g., search, actions).'
+  empty:
+    title: Empty
+    description: 'Custom empty-state content rendered when `rows` is empty and not loading.'
+  loading:
+    title: Loading
+    description: 'Custom loading content rendered when `loading` is true.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-data-table/hx-data-table.css
+++ b/packages/hx-library/drupal/components/hx-data-table/hx-data-table.css
@@ -1,0 +1,22 @@
+/**
+ * HX Data Table component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-data-table-header-bg: Header background color. (default: var(--hx-color-neutral-50))
+ * --hx-data-table-header-color: Header text color. (default: var(--hx-color-neutral-700))
+ * --hx-data-table-cell-color: Cell text color. (default: var(--hx-color-neutral-900))
+ * --hx-data-table-border-color: Row border color. (default: var(--hx-color-neutral-200))
+ * --hx-data-table-row-hover-bg: Row hover background. (default: var(--hx-color-neutral-50))
+ * --hx-data-table-row-selected-bg: Selected row background. (default: var(--hx-color-primary-50))
+ * --hx-data-table-empty-color: Empty state text color. (default: var(--hx-color-neutral-600))
+ * --hx-data-table-min-width: Minimum table width before horizontal scrolling. (default: 600px)
+ */
+
+/* Component host styles */
+hx-data-table {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-data-table/hx-data-table.js
+++ b/packages/hx-library/drupal/components/hx-data-table/hx-data-table.js
@@ -1,0 +1,11 @@
+/**
+ * HX Data Table - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-data-table';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-data-table');
+}

--- a/packages/hx-library/drupal/components/hx-data-table/hx-data-table.twig
+++ b/packages/hx-library/drupal/components/hx-data-table/hx-data-table.twig
@@ -1,0 +1,46 @@
+{#
+ /**
+ * @file
+ * HX Data Table component template.
+ *
+ * An enterprise data table with sorting, row selection, and keyboard navigation.
+ *
+ * Available variables:
+ * - columns: object - Column definitions. Each item: `{ key, label, sortable?, width? }`. Can be set as a JS array or a JSON string (e.g., from a Drupal Twig attribute).
+ * - rows: object - Row data. Each item is a plain object keyed by column `key` values. Can be set as a JS array or a JSON string (e.g., from a Drupal Twig attribute).
+ * - selectable: boolean - When true, renders a checkbox column for row selection.
+ * - sortKey: string - The column key currently used for sorting.
+ * - sortDirection: object - Current sort direction.
+ * - loading: boolean - When true, renders a loading skeleton and sets `aria-busy="true"` on the host.
+ * - emptyLabel: string - Text displayed in the default empty state when `rows` is empty and not loading.
+ * - label: string - Accessible name for the table. Exposed via `aria-label` on the `<table>` element. Required when the table has columns — a missing label is a WCAG 4.1.2 violation.
+ * - stickyHeader: boolean - When true, the header row is sticky (position: sticky; top: 0).
+ * - labelSelectAll: string - Accessible label for the "select all rows" checkbox.
+ * - page: number - Current page (1-based). Set to 0 or leave at default (0) to disable pagination.
+ * - pageSize: number - Number of rows per page. Set to 0 to disable pagination (show all rows).
+ */
+#}
+<hx-data-table
+  {% if columns is defined and columns is not empty %}columns="{{ columns }}"{% endif %}
+  {% if rows is defined and rows is not empty %}rows="{{ rows }}"{% endif %}
+  {% if selectable %}selectable{% endif %}
+  {% if sortKey is defined and sortKey is not empty %}sort-key="{{ sortKey }}"{% endif %}
+  {% if sortDirection is defined and sortDirection is not empty %}sort-direction="{{ sortDirection }}"{% endif %}
+  {% if loading %}loading{% endif %}
+  {% if emptyLabel is defined and emptyLabel is not empty %}empty-label="{{ emptyLabel }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if stickyHeader %}sticky-header{% endif %}
+  {% if labelSelectAll is defined and labelSelectAll is not empty %}label-select-all="{{ labelSelectAll }}"{% endif %}
+  {% if page is defined and page is not empty %}page="{{ page }}"{% endif %}
+  {% if pageSize is defined and pageSize is not empty %}page-size="{{ pageSize }}"{% endif %}
+>
+  {% if slots.toolbar is defined %}
+    <slot name="toolbar">{{ slots.toolbar }}</slot>
+  {% endif %}
+  {% if slots.empty is defined %}
+    <slot name="empty">{{ slots.empty }}</slot>
+  {% endif %}
+  {% if slots.loading is defined %}
+    <slot name="loading">{{ slots.loading }}</slot>
+  {% endif %}
+</hx-data-table>

--- a/packages/hx-library/drupal/components/hx-date-picker/README.md
+++ b/packages/hx-library/drupal/components/hx-date-picker/README.md
@@ -1,0 +1,97 @@
+# HX Date Picker
+
+Date picker component for selecting dates with keyboard-accessible calendar popup.
+
+## Usage
+
+```twig
+{% include 'helix:hx-date-picker' with {
+  name: '',
+  value: '',
+  min: '',
+  max: '',
+  label: '',
+  required: false,
+  disabled: false,
+  error: '',
+  helpText: '',
+  format: 'MM/DD/YYYY',
+  locale: 'en-US',
+  labelChooseDate: 'Choose a date',
+  labelPrevMonth: 'Previous month',
+  labelNextMonth: 'Next month',
+  labelOpenCalendar: 'Open calendar',
+  labelCloseCalendar: 'Close calendar',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | The name of the field, used for form submission. |
+| value | string |  | The current value as an ISO 8601 date string (e.g. 2026-03-04). |
+| min | string |  | The minimum selectable date as an ISO 8601 string. |
+| max | string |  | The maximum selectable date as an ISO 8601 string. |
+| label | string |  | The visible label text. |
+| required | boolean | false | Whether the field is required for form submission. |
+| disabled | boolean | false | Whether the field is disabled. |
+| error | string |  | Error message to display. When set, the field enters an error state. |
+| helpText | string |  | Help text displayed below the field for guidance. |
+| format | string | MM/DD/YYYY | Display format hint shown as placeholder (e.g. MM/DD/YYYY). |
+| locale | string | en-US | Locale string used for formatting the display value. |
+| labelChooseDate | string | Choose a date | Accessible label for the calendar grid/dialog. |
+| labelPrevMonth | string | Previous month | Accessible label for the "previous month" button. |
+| labelNextMonth | string | Next month | Accessible label for the "next month" button. |
+| labelOpenCalendar | string | Open calendar | Accessible label for the calendar trigger button when calendar is closed. |
+| labelCloseCalendar | string | Close calendar | Accessible label for the calendar trigger button when calendar is open. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Custom label content (overrides the label property). |
+| help-text | Custom help text content (overrides the helpText property). |
+| error | Custom error content (overrides the error property). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Emitted when the selected date changes. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-date-picker-bg | var(--hx-color-neutral-0) | Input background color. |
+| --hx-date-picker-color | var(--hx-color-neutral-800) | Input text color. |
+| --hx-date-picker-border-color | var(--hx-color-neutral-300) | Border color. |
+| --hx-date-picker-border-radius | var(--hx-border-radius-md) | Border radius. |
+| --hx-date-picker-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-date-picker-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-date-picker-error-color | var(--hx-color-error-500) | Error state color. |
+| --hx-date-picker-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-date-picker-trigger-color | var(--hx-color-neutral-500) | Trigger icon color. |
+| --hx-date-picker-calendar-bg | var(--hx-color-neutral-0) | Calendar background color. |
+| --hx-date-picker-calendar-border-color | var(--hx-color-neutral-200) | Calendar border color. |
+| --hx-date-picker-calendar-min-width | 18rem | Calendar minimum width. |
+| --hx-date-picker-selected-bg | var(--hx-color-primary-500) | Selected day background. |
+| --hx-date-picker-selected-color | var(--hx-color-neutral-0) | Selected day text color. |
+| --hx-date-picker-today-color | var(--hx-color-primary-600) | Today indicator color. |
+| --hx-date-picker-calendar-shadow | 0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -2px rgba(0,0,0,0.1) | Calendar popup box shadow. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| field | The outer field container. |
+| label | The label element. |
+| input-wrapper | The wrapper around input and trigger. |
+| input | The readonly text input displaying the formatted date. |
+| trigger | The calendar icon button. |
+| calendar | The calendar popup dialog. |
+| month-nav | The month navigation header. |
+| day | An individual day button in the calendar grid. |
+| help-text | The help text container. |
+| error | The error message container. |

--- a/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.component.yml
+++ b/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.component.yml
@@ -1,0 +1,99 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Date Picker
+status: experimental
+group: HELiX
+description: 'Date picker component for selecting dates with keyboard-accessible calendar popup.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'The name of the field, used for form submission.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The current value as an ISO 8601 date string (e.g. 2026-03-04).'
+      default: ''
+    min:
+      type: string
+      title: Min
+      description: 'The minimum selectable date as an ISO 8601 string.'
+      default: ''
+    max:
+      type: string
+      title: Max
+      description: 'The maximum selectable date as an ISO 8601 string.'
+      default: ''
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the field is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the field is disabled.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the field enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the field for guidance.'
+      default: ''
+    format:
+      type: string
+      title: Format
+      description: 'Display format hint shown as placeholder (e.g. MM/DD/YYYY).'
+      default: 'MM/DD/YYYY'
+    locale:
+      type: string
+      title: Locale
+      description: 'Locale string used for formatting the display value.'
+      default: 'en-US'
+    labelChooseDate:
+      type: string
+      title: Label Choose Date
+      description: 'Accessible label for the calendar grid/dialog.'
+      default: 'Choose a date'
+    labelPrevMonth:
+      type: string
+      title: Label Prev Month
+      description: 'Accessible label for the "previous month" button.'
+      default: 'Previous month'
+    labelNextMonth:
+      type: string
+      title: Label Next Month
+      description: 'Accessible label for the "next month" button.'
+      default: 'Next month'
+    labelOpenCalendar:
+      type: string
+      title: Label Open Calendar
+      description: 'Accessible label for the calendar trigger button when calendar is closed.'
+      default: 'Open calendar'
+    labelCloseCalendar:
+      type: string
+      title: Label Close Calendar
+      description: 'Accessible label for the calendar trigger button when calendar is open.'
+      default: 'Close calendar'
+slots:
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.css
+++ b/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.css
@@ -1,0 +1,30 @@
+/**
+ * HX Date Picker component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-date-picker-bg: Input background color. (default: var(--hx-color-neutral-0))
+ * --hx-date-picker-color: Input text color. (default: var(--hx-color-neutral-800))
+ * --hx-date-picker-border-color: Border color. (default: var(--hx-color-neutral-300))
+ * --hx-date-picker-border-radius: Border radius. (default: var(--hx-border-radius-md))
+ * --hx-date-picker-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-date-picker-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-date-picker-error-color: Error state color. (default: var(--hx-color-error-500))
+ * --hx-date-picker-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-date-picker-trigger-color: Trigger icon color. (default: var(--hx-color-neutral-500))
+ * --hx-date-picker-calendar-bg: Calendar background color. (default: var(--hx-color-neutral-0))
+ * --hx-date-picker-calendar-border-color: Calendar border color. (default: var(--hx-color-neutral-200))
+ * --hx-date-picker-calendar-min-width: Calendar minimum width. (default: 18rem)
+ * --hx-date-picker-selected-bg: Selected day background. (default: var(--hx-color-primary-500))
+ * --hx-date-picker-selected-color: Selected day text color. (default: var(--hx-color-neutral-0))
+ * --hx-date-picker-today-color: Today indicator color. (default: var(--hx-color-primary-600))
+ * --hx-date-picker-calendar-shadow: Calendar popup box shadow. (default: 0 4px 6px -1px rgba(0,0,0,0.1),0 2px 4px -2px rgba(0,0,0,0.1))
+ */
+
+/* Component host styles */
+hx-date-picker {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.js
+++ b/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.js
@@ -1,0 +1,11 @@
+/**
+ * HX Date Picker - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-date-picker';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-date-picker');
+}

--- a/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.twig
+++ b/packages/hx-library/drupal/components/hx-date-picker/hx-date-picker.twig
@@ -1,0 +1,54 @@
+{#
+ /**
+ * @file
+ * HX Date Picker component template.
+ *
+ * Date picker component for selecting dates with keyboard-accessible calendar popup.
+ *
+ * Available variables:
+ * - name: string - The name of the field, used for form submission.
+ * - value: string - The current value as an ISO 8601 date string (e.g. 2026-03-04).
+ * - min: string - The minimum selectable date as an ISO 8601 string.
+ * - max: string - The maximum selectable date as an ISO 8601 string.
+ * - label: string - The visible label text.
+ * - required: boolean - Whether the field is required for form submission.
+ * - disabled: boolean - Whether the field is disabled.
+ * - error: string - Error message to display. When set, the field enters an error state.
+ * - helpText: string - Help text displayed below the field for guidance.
+ * - format: string - Display format hint shown as placeholder (e.g. MM/DD/YYYY).
+ * - locale: string - Locale string used for formatting the display value.
+ * - labelChooseDate: string - Accessible label for the calendar grid/dialog.
+ * - labelPrevMonth: string - Accessible label for the "previous month" button.
+ * - labelNextMonth: string - Accessible label for the "next month" button.
+ * - labelOpenCalendar: string - Accessible label for the calendar trigger button when calendar is closed.
+ * - labelCloseCalendar: string - Accessible label for the calendar trigger button when calendar is open.
+ */
+#}
+<hx-date-picker
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if min is defined and min is not empty %}min="{{ min }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if format is defined and format is not empty %}format="{{ format }}"{% endif %}
+  {% if locale is defined and locale is not empty %}locale="{{ locale }}"{% endif %}
+  {% if labelChooseDate is defined and labelChooseDate is not empty %}label-choose-date="{{ labelChooseDate }}"{% endif %}
+  {% if labelPrevMonth is defined and labelPrevMonth is not empty %}label-prev-month="{{ labelPrevMonth }}"{% endif %}
+  {% if labelNextMonth is defined and labelNextMonth is not empty %}label-next-month="{{ labelNextMonth }}"{% endif %}
+  {% if labelOpenCalendar is defined and labelOpenCalendar is not empty %}label-open-calendar="{{ labelOpenCalendar }}"{% endif %}
+  {% if labelCloseCalendar is defined and labelCloseCalendar is not empty %}label-close-calendar="{{ labelCloseCalendar }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+</hx-date-picker>

--- a/packages/hx-library/drupal/components/hx-dialog/README.md
+++ b/packages/hx-library/drupal/components/hx-dialog/README.md
@@ -1,0 +1,80 @@
+# HX Dialog
+
+A modal and non-modal dialog component built on the native HTML `<dialog>` element.
+Provides focus trapping, backdrop interaction, keyboard navigation, and full
+ARIA labelling for enterprise healthcare accessibility requirements.
+
+## Usage
+
+```twig
+{% include 'helix:hx-dialog' with {
+  open: false,
+  modal: true,
+  closeOnBackdrop: true,
+  heading: '',
+  variant: 'dialog',
+  description: '',
+  closeLabel: 'Close dialog',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| open | boolean | false | Controls whether the dialog is open. |
+| modal | boolean | true | When true, renders as a modal dialog with a backdrop and focus trap.
+When false, renders as a non-modal dialog. |
+| closeOnBackdrop | boolean | true | When true, clicking the backdrop closes the dialog. |
+| heading | string |  | Text content for the dialog heading. Used as the accessible label via aria-labelledby. |
+| variant | object | dialog | ARIA role variant. Use `'alertdialog'` for urgent dialogs requiring immediate attention
+(e.g., drug interaction warnings, critical lab alerts). Defaults to `'dialog'`. |
+| description | string |  | Optional description text linked to the dialog via `aria-describedby`.
+When provided, screen readers will announce this text when the dialog receives focus.
+Recommended for dialogs that surface critical clinical information. |
+| closeLabel | string | Close dialog | Accessible label for the close button. Override for localized text. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the dialog body content. |
+| header | Slot for custom header content. When provided, replaces the built-in heading. |
+| footer | Slot for action buttons or footer content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-open | Fired when the dialog opens. |
+| hx-close | Fired when the dialog closes for any reason. |
+| hx-cancel | Fired when the dialog is dismissed via Escape key or cancel action. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-dialog-bg | var(--hx-color-neutral-0) | Dialog background color. |
+| --hx-dialog-color | var(--hx-color-neutral-900) | Dialog text color. |
+| --hx-dialog-border-radius | var(--hx-border-radius-lg) | Dialog corner radius. |
+| --hx-dialog-shadow | var(--hx-shadow-xl) | Dialog box shadow. |
+| --hx-dialog-width | 32rem | Dialog width. |
+| --hx-dialog-backdrop-color | var(--hx-color-neutral-900) | Backdrop overlay color. |
+| --hx-dialog-backdrop-opacity | 0.5 | Backdrop overlay opacity (set to 0 to hide; note that opacity:0 makes the backdrop invisible but still present in the layout — use pointer-events carefully if you need a fully non-blocking backdrop). |
+| --hx-dialog-header-padding | - | Padding inside the dialog header. |
+| --hx-dialog-header-border-color | var(--hx-color-neutral-200) | Header bottom border color. |
+| --hx-dialog-heading-color | var(--hx-color-neutral-900) | Heading text color. |
+| --hx-dialog-body-padding | - | Padding inside the dialog body. |
+| --hx-dialog-footer-padding | - | Padding inside the dialog footer. |
+| --hx-dialog-footer-border-color | var(--hx-color-neutral-200) | Footer top border color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| dialog | The inner container div that holds the dialog content. |
+| backdrop | The non-modal backdrop overlay element. |
+| header | The header region containing the heading and header slot. |
+| close-button | The built-in close button in the dialog header. |
+| body | The scrollable body region containing the default slot. |
+| footer | The footer region containing the footer slot. |

--- a/packages/hx-library/drupal/components/hx-dialog/hx-dialog.component.yml
+++ b/packages/hx-library/drupal/components/hx-dialog/hx-dialog.component.yml
@@ -1,0 +1,54 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Dialog
+status: experimental
+group: HELiX
+description: 'A modal and non-modal dialog component built on the native HTML `<dialog>` element. Provides focus trapping, backdrop interaction, keyboard navigation, and full ARIA labelling for enterprise healthcare accessibility requirements.'
+props:
+  type: object
+  properties:
+    open:
+      type: boolean
+      title: Open
+      description: 'Controls whether the dialog is open.'
+      default: false
+    modal:
+      type: boolean
+      title: Modal
+      description: 'When true, renders as a modal dialog with a backdrop and focus trap. When false, renders as a non-modal dialog.'
+      default: true
+    closeOnBackdrop:
+      type: boolean
+      title: Close On Backdrop
+      description: 'When true, clicking the backdrop closes the dialog.'
+      default: true
+    heading:
+      type: string
+      title: Heading
+      description: 'Text content for the dialog heading. Used as the accessible label via aria-labelledby.'
+      default: ''
+    variant:
+      type: object
+      title: Variant
+      description: "ARIA role variant. Use `'alertdialog'` for urgent dialogs requiring immediate attention (e.g., drug interaction warnings, critical lab alerts). Defaults to `'dialog'`."
+      default: 'dialog'
+    description:
+      type: string
+      title: Description
+      description: 'Optional description text linked to the dialog via `aria-describedby`. When provided, screen readers will announce this text when the dialog receives focus. Recommended for dialogs that surface critical clinical information.'
+      default: ''
+    closeLabel:
+      type: string
+      title: Close Label
+      description: 'Accessible label for the close button. Override for localized text.'
+      default: 'Close dialog'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the dialog body content.'
+  header:
+    title: Header
+    description: 'Slot for custom header content. When provided, replaces the built-in heading.'
+  footer:
+    title: Footer
+    description: 'Slot for action buttons or footer content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-dialog/hx-dialog.css
+++ b/packages/hx-library/drupal/components/hx-dialog/hx-dialog.css
@@ -1,0 +1,27 @@
+/**
+ * HX Dialog component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-dialog-bg: Dialog background color. (default: var(--hx-color-neutral-0))
+ * --hx-dialog-color: Dialog text color. (default: var(--hx-color-neutral-900))
+ * --hx-dialog-border-radius: Dialog corner radius. (default: var(--hx-border-radius-lg))
+ * --hx-dialog-shadow: Dialog box shadow. (default: var(--hx-shadow-xl))
+ * --hx-dialog-width: Dialog width. (default: 32rem)
+ * --hx-dialog-backdrop-color: Backdrop overlay color. (default: var(--hx-color-neutral-900))
+ * --hx-dialog-backdrop-opacity: Backdrop overlay opacity (set to 0 to hide; note that opacity:0 makes the backdrop invisible but still present in the layout — use pointer-events carefully if you need a fully non-blocking backdrop). (default: 0.5)
+ * --hx-dialog-header-padding: Padding inside the dialog header.
+ * --hx-dialog-header-border-color: Header bottom border color. (default: var(--hx-color-neutral-200))
+ * --hx-dialog-heading-color: Heading text color. (default: var(--hx-color-neutral-900))
+ * --hx-dialog-body-padding: Padding inside the dialog body.
+ * --hx-dialog-footer-padding: Padding inside the dialog footer.
+ * --hx-dialog-footer-border-color: Footer top border color. (default: var(--hx-color-neutral-200))
+ */
+
+/* Component host styles */
+hx-dialog {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-dialog/hx-dialog.js
+++ b/packages/hx-library/drupal/components/hx-dialog/hx-dialog.js
@@ -1,0 +1,11 @@
+/**
+ * HX Dialog - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-dialog';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-dialog');
+}

--- a/packages/hx-library/drupal/components/hx-dialog/hx-dialog.twig
+++ b/packages/hx-library/drupal/components/hx-dialog/hx-dialog.twig
@@ -1,0 +1,36 @@
+{#
+ /**
+ * @file
+ * HX Dialog component template.
+ *
+ * A modal and non-modal dialog component built on the native HTML `<dialog>` element.
+ * Provides focus trapping, backdrop interaction, keyboard navigation, and full
+ * ARIA labelling for enterprise healthcare accessibility requirements.
+ *
+ * Available variables:
+ * - open: boolean - Controls whether the dialog is open.
+ * - modal: boolean - When true, renders as a modal dialog with a backdrop and focus trap. When false, renders as a non-modal dialog.
+ * - closeOnBackdrop: boolean - When true, clicking the backdrop closes the dialog.
+ * - heading: string - Text content for the dialog heading. Used as the accessible label via aria-labelledby.
+ * - variant: object - ARIA role variant. Use `'alertdialog'` for urgent dialogs requiring immediate attention (e.g., drug interaction warnings, critical lab alerts). Defaults to `'dialog'`.
+ * - description: string - Optional description text linked to the dialog via `aria-describedby`. When provided, screen readers will announce this text when the dialog receives focus. Recommended for dialogs that surface critical clinical information.
+ * - closeLabel: string - Accessible label for the close button. Override for localized text.
+ */
+#}
+<hx-dialog
+  {% if open %}open{% endif %}
+  {% if modal %}modal{% endif %}
+  {% if closeOnBackdrop %}close-on-backdrop{% endif %}
+  {% if heading is defined and heading is not empty %}heading="{{ heading }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if description is defined and description is not empty %}description="{{ description }}"{% endif %}
+  {% if closeLabel is defined and closeLabel is not empty %}close-label="{{ closeLabel }}"{% endif %}
+>
+  {% if slots.header is defined %}
+    <slot name="header">{{ slots.header }}</slot>
+  {% endif %}
+  {% if slots.footer is defined %}
+    <slot name="footer">{{ slots.footer }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-dialog>

--- a/packages/hx-library/drupal/components/hx-divider/README.md
+++ b/packages/hx-library/drupal/components/hx-divider/README.md
@@ -1,0 +1,50 @@
+# HX Divider
+
+A visual separator element for dividing content sections. Supports
+horizontal and vertical orientations, configurable spacing, and an optional
+centered label rendered between two lines.
+
+## Usage
+
+```twig
+{% include 'helix:hx-divider' with {
+  orientation: 'horizontal',
+  spacing: 'md',
+  decorative: false,
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| orientation | object | horizontal | Orientation of the divider. |
+| spacing | object | md | Spacing applied to the block axis (horizontal) or inline axis (vertical). |
+| decorative | boolean | false | When true, renders the divider as decorative only (role="presentation").
+Screen readers will not announce decorative dividers. |
+| label | object | - | Optional text label rendered centered between the divider lines.
+Also sets aria-label on the separator for assistive technologies. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Optional label text rendered centered between two lines. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-divider-color | var(--hx-color-neutral-200) | Line color. |
+| --hx-divider-width | var(--hx-border-width-thin) | Line thickness. |
+| --hx-divider-label-color | var(--hx-color-neutral-500) | Label text color. |
+| --hx-divider-label-font-size | var(--hx-font-size-sm) | Label font size. |
+| --hx-divider-label-gap | var(--hx-space-3) | Gap between lines and label. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root divider element. |
+| label | The optional centered label wrapper. |

--- a/packages/hx-library/drupal/components/hx-divider/hx-divider.component.yml
+++ b/packages/hx-library/drupal/components/hx-divider/hx-divider.component.yml
@@ -1,0 +1,32 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Divider
+status: experimental
+group: HELiX
+description: 'A visual separator element for dividing content sections. Supports horizontal and vertical orientations, configurable spacing, and an optional centered label rendered between two lines.'
+props:
+  type: object
+  properties:
+    orientation:
+      type: object
+      title: Orientation
+      description: 'Orientation of the divider.'
+      default: 'horizontal'
+    spacing:
+      type: object
+      title: Spacing
+      description: 'Spacing applied to the block axis (horizontal) or inline axis (vertical).'
+      default: 'md'
+    decorative:
+      type: boolean
+      title: Decorative
+      description: 'When true, renders the divider as decorative only (role="presentation"). Screen readers will not announce decorative dividers.'
+      default: false
+    label:
+      type: object
+      title: Label
+      description: 'Optional text label rendered centered between the divider lines. Also sets aria-label on the separator for assistive technologies.'
+slots:
+  default:
+    title: Default
+    description: 'Optional label text rendered centered between two lines.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-divider/hx-divider.css
+++ b/packages/hx-library/drupal/components/hx-divider/hx-divider.css
@@ -1,0 +1,19 @@
+/**
+ * HX Divider component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-divider-color: Line color. (default: var(--hx-color-neutral-200))
+ * --hx-divider-width: Line thickness. (default: var(--hx-border-width-thin))
+ * --hx-divider-label-color: Label text color. (default: var(--hx-color-neutral-500))
+ * --hx-divider-label-font-size: Label font size. (default: var(--hx-font-size-sm))
+ * --hx-divider-label-gap: Gap between lines and label. (default: var(--hx-space-3))
+ */
+
+/* Component host styles */
+hx-divider {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-divider/hx-divider.js
+++ b/packages/hx-library/drupal/components/hx-divider/hx-divider.js
@@ -1,0 +1,11 @@
+/**
+ * HX Divider - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-divider';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-divider');
+}

--- a/packages/hx-library/drupal/components/hx-divider/hx-divider.twig
+++ b/packages/hx-library/drupal/components/hx-divider/hx-divider.twig
@@ -1,0 +1,24 @@
+{#
+ /**
+ * @file
+ * HX Divider component template.
+ *
+ * A visual separator element for dividing content sections. Supports
+ * horizontal and vertical orientations, configurable spacing, and an optional
+ * centered label rendered between two lines.
+ *
+ * Available variables:
+ * - orientation: object - Orientation of the divider.
+ * - spacing: object - Spacing applied to the block axis (horizontal) or inline axis (vertical).
+ * - decorative: boolean - When true, renders the divider as decorative only (role="presentation"). Screen readers will not announce decorative dividers.
+ * - label: object - Optional text label rendered centered between the divider lines. Also sets aria-label on the separator for assistive technologies.
+ */
+#}
+<hx-divider
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+  {% if spacing is defined and spacing is not empty %}spacing="{{ spacing }}"{% endif %}
+  {% if decorative %}decorative{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-divider>

--- a/packages/hx-library/drupal/components/hx-drawer/README.md
+++ b/packages/hx-library/drupal/components/hx-drawer/README.md
@@ -1,0 +1,82 @@
+# HX Drawer
+
+A slide-in drawer panel that can appear from any edge of the viewport.
+Supports focus trapping, overlay backdrop, keyboard navigation, and full
+ARIA labelling for enterprise healthcare accessibility requirements.
+
+## Usage
+
+```twig
+{% include 'helix:hx-drawer' with {
+  open: false,
+  placement: 'end',
+  size: 'md',
+  contained: false,
+  noHeader: false,
+  noFooter: false,
+  label: '',
+  closeLabel: 'Close drawer',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| open | boolean | false | Controls whether the drawer is open. |
+| placement | object | end | Which edge of the viewport the drawer slides in from. |
+| size | object | md | The size of the drawer panel. Use 'sm', 'md', 'lg', 'full', or any valid CSS length. |
+| contained | boolean | false | When true, the drawer is constrained to its positioned parent instead of the viewport.
+The host element must have `position: relative` (or the library handles it via :host). |
+| noHeader | boolean | false | When true, the header (title, header-actions, close button) is hidden. |
+| noFooter | boolean | false | When true, the footer slot is hidden. |
+| label | string |  | Accessible label for the dialog when the `label` slot is not populated.
+When the `label` slot is used, `aria-labelledby` takes precedence. |
+| closeLabel | string | Close drawer | Accessible label for the built-in close button. Override for localized text. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | The drawer title text. |
+| header-actions | Action buttons displayed in the header near the close button. |
+| (default) | Default slot for the drawer body content. |
+| footer | Action buttons or footer content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-show | Fired when the drawer begins to open. |
+| hx-after-show | Fired after the drawer open animation completes. |
+| hx-hide | Fired when the drawer begins to close. |
+| hx-after-hide | Fired after the drawer close animation completes. |
+| hx-initial-focus | Fired when initial focus is set inside the drawer. Cancelable to override focus behavior. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-drawer-bg | var(--hx-color-neutral-0) | Drawer panel background color. |
+| --hx-drawer-color | var(--hx-color-neutral-900) | Drawer panel text color. |
+| --hx-drawer-shadow | var(--hx-shadow-xl) | Drawer panel box shadow. |
+| --hx-drawer-backdrop-color | var(--hx-color-neutral-900) | Backdrop color. |
+| --hx-drawer-backdrop-opacity | 0.5 | Backdrop opacity. |
+| --hx-drawer-header-padding | - | Padding inside the header. |
+| --hx-drawer-header-border-color | var(--hx-color-neutral-200) | Header border color. |
+| --hx-drawer-title-color | var(--hx-color-neutral-900) | Title text color. |
+| --hx-drawer-body-padding | - | Padding inside the body. |
+| --hx-drawer-footer-padding | - | Padding inside the footer. |
+| --hx-drawer-footer-border-color | var(--hx-color-neutral-200) | Footer border color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| overlay | The full-screen overlay container (includes backdrop and panel). |
+| panel | The drawer panel itself. |
+| header | The header region containing the title and actions. |
+| title | The drawer title element. |
+| close-btn | The built-in close button. |
+| body | The scrollable body region. |
+| footer | The footer region. |

--- a/packages/hx-library/drupal/components/hx-drawer/hx-drawer.component.yml
+++ b/packages/hx-library/drupal/components/hx-drawer/hx-drawer.component.yml
@@ -1,0 +1,62 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Drawer
+status: experimental
+group: HELiX
+description: 'A slide-in drawer panel that can appear from any edge of the viewport. Supports focus trapping, overlay backdrop, keyboard navigation, and full ARIA labelling for enterprise healthcare accessibility requirements.'
+props:
+  type: object
+  properties:
+    open:
+      type: boolean
+      title: Open
+      description: 'Controls whether the drawer is open.'
+      default: false
+    placement:
+      type: object
+      title: Placement
+      description: 'Which edge of the viewport the drawer slides in from.'
+      default: 'end'
+    size:
+      type: object
+      title: Size
+      description: "The size of the drawer panel. Use 'sm', 'md', 'lg', 'full', or any valid CSS length."
+      default: 'md'
+    contained:
+      type: boolean
+      title: Contained
+      description: 'When true, the drawer is constrained to its positioned parent instead of the viewport. The host element must have `position: relative` (or the library handles it via :host).'
+      default: false
+    noHeader:
+      type: boolean
+      title: No Header
+      description: 'When true, the header (title, header-actions, close button) is hidden.'
+      default: false
+    noFooter:
+      type: boolean
+      title: No Footer
+      description: 'When true, the footer slot is hidden.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the dialog when the `label` slot is not populated. When the `label` slot is used, `aria-labelledby` takes precedence.'
+      default: ''
+    closeLabel:
+      type: string
+      title: Close Label
+      description: 'Accessible label for the built-in close button. Override for localized text.'
+      default: 'Close drawer'
+slots:
+  label:
+    title: Label
+    description: 'The drawer title text.'
+  header-actions:
+    title: Header Actions
+    description: 'Action buttons displayed in the header near the close button.'
+  default:
+    title: Default
+    description: 'Default slot for the drawer body content.'
+  footer:
+    title: Footer
+    description: 'Action buttons or footer content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-drawer/hx-drawer.css
+++ b/packages/hx-library/drupal/components/hx-drawer/hx-drawer.css
@@ -1,0 +1,25 @@
+/**
+ * HX Drawer component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-drawer-bg: Drawer panel background color. (default: var(--hx-color-neutral-0))
+ * --hx-drawer-color: Drawer panel text color. (default: var(--hx-color-neutral-900))
+ * --hx-drawer-shadow: Drawer panel box shadow. (default: var(--hx-shadow-xl))
+ * --hx-drawer-backdrop-color: Backdrop color. (default: var(--hx-color-neutral-900))
+ * --hx-drawer-backdrop-opacity: Backdrop opacity. (default: 0.5)
+ * --hx-drawer-header-padding: Padding inside the header.
+ * --hx-drawer-header-border-color: Header border color. (default: var(--hx-color-neutral-200))
+ * --hx-drawer-title-color: Title text color. (default: var(--hx-color-neutral-900))
+ * --hx-drawer-body-padding: Padding inside the body.
+ * --hx-drawer-footer-padding: Padding inside the footer.
+ * --hx-drawer-footer-border-color: Footer border color. (default: var(--hx-color-neutral-200))
+ */
+
+/* Component host styles */
+hx-drawer {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-drawer/hx-drawer.js
+++ b/packages/hx-library/drupal/components/hx-drawer/hx-drawer.js
@@ -1,0 +1,11 @@
+/**
+ * HX Drawer - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-drawer';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-drawer');
+}

--- a/packages/hx-library/drupal/components/hx-drawer/hx-drawer.twig
+++ b/packages/hx-library/drupal/components/hx-drawer/hx-drawer.twig
@@ -1,0 +1,41 @@
+{#
+ /**
+ * @file
+ * HX Drawer component template.
+ *
+ * A slide-in drawer panel that can appear from any edge of the viewport.
+ * Supports focus trapping, overlay backdrop, keyboard navigation, and full
+ * ARIA labelling for enterprise healthcare accessibility requirements.
+ *
+ * Available variables:
+ * - open: boolean - Controls whether the drawer is open.
+ * - placement: object - Which edge of the viewport the drawer slides in from.
+ * - size: object - The size of the drawer panel. Use 'sm', 'md', 'lg', 'full', or any valid CSS length.
+ * - contained: boolean - When true, the drawer is constrained to its positioned parent instead of the viewport. The host element must have `position: relative` (or the library handles it via :host).
+ * - noHeader: boolean - When true, the header (title, header-actions, close button) is hidden.
+ * - noFooter: boolean - When true, the footer slot is hidden.
+ * - label: string - Accessible label for the dialog when the `label` slot is not populated. When the `label` slot is used, `aria-labelledby` takes precedence.
+ * - closeLabel: string - Accessible label for the built-in close button. Override for localized text.
+ */
+#}
+<hx-drawer
+  {% if open %}open{% endif %}
+  {% if placement is defined and placement is not empty %}placement="{{ placement }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if contained %}contained{% endif %}
+  {% if noHeader %}no-header{% endif %}
+  {% if noFooter %}no-footer{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if closeLabel is defined and closeLabel is not empty %}close-label="{{ closeLabel }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.header-actions is defined %}
+    <slot name="header-actions">{{ slots.header-actions }}</slot>
+  {% endif %}
+  {% if slots.footer is defined %}
+    <slot name="footer">{{ slots.footer }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-drawer>

--- a/packages/hx-library/drupal/components/hx-dropdown/README.md
+++ b/packages/hx-library/drupal/components/hx-dropdown/README.md
@@ -1,0 +1,56 @@
+# HX Dropdown
+
+A dropdown component — a button that opens a floating panel on click.
+
+## Usage
+
+```twig
+{% include 'helix:hx-dropdown' with {
+  open: false,
+  placement: 'bottom-start',
+  disabled: false,
+  distance: 4,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| open | boolean | false | Whether the dropdown panel is open. |
+| placement | object | bottom-start | Preferred placement of the panel relative to the trigger. |
+| disabled | boolean | false | Whether the dropdown is disabled. Prevents opening. |
+| distance | number | 4 | Gap in pixels between the trigger and the panel. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| trigger | The element that opens the dropdown (e.g. hx-button). |
+| (default) | Default slot for dropdown panel content (e.g. menu items). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-show | Dispatched when the dropdown is opened. |
+| hx-hide | Dispatched when the dropdown is closed. |
+| hx-select | Dispatched when a menu item is selected. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-dropdown-panel-bg | var(--hx-color-neutral-0) | Panel background color. |
+| --hx-dropdown-panel-border-color | var(--hx-color-neutral-200) | Panel border color. |
+| --hx-dropdown-panel-border-radius | var(--hx-border-radius-md) | Panel border radius. |
+| --hx-dropdown-panel-shadow | 0 4px 16px rgba(0,0,0,0.12) | Panel box shadow. |
+| --hx-dropdown-panel-z-index | 1000 | Panel z-index. |
+| --hx-dropdown-panel-min-width | 160px | Panel minimum width. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| trigger | The trigger wrapper element. |
+| panel | The floating panel element. |

--- a/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.component.yml
+++ b/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.component.yml
@@ -1,0 +1,36 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Dropdown
+status: experimental
+group: HELiX
+description: 'A dropdown component — a button that opens a floating panel on click.'
+props:
+  type: object
+  properties:
+    open:
+      type: boolean
+      title: Open
+      description: 'Whether the dropdown panel is open.'
+      default: false
+    placement:
+      type: object
+      title: Placement
+      description: 'Preferred placement of the panel relative to the trigger.'
+      default: 'bottom-start'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the dropdown is disabled. Prevents opening.'
+      default: false
+    distance:
+      type: number
+      title: Distance
+      description: 'Gap in pixels between the trigger and the panel.'
+      default: 4
+slots:
+  trigger:
+    title: Trigger
+    description: 'The element that opens the dropdown (e.g. hx-button).'
+  default:
+    title: Default
+    description: 'Default slot for dropdown panel content (e.g. menu items).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.css
+++ b/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.css
@@ -1,0 +1,20 @@
+/**
+ * HX Dropdown component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-dropdown-panel-bg: Panel background color. (default: var(--hx-color-neutral-0))
+ * --hx-dropdown-panel-border-color: Panel border color. (default: var(--hx-color-neutral-200))
+ * --hx-dropdown-panel-border-radius: Panel border radius. (default: var(--hx-border-radius-md))
+ * --hx-dropdown-panel-shadow: Panel box shadow. (default: 0 4px 16px rgba(0,0,0,0.12))
+ * --hx-dropdown-panel-z-index: Panel z-index. (default: 1000)
+ * --hx-dropdown-panel-min-width: Panel minimum width. (default: 160px)
+ */
+
+/* Component host styles */
+hx-dropdown {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.js
+++ b/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.js
@@ -1,0 +1,11 @@
+/**
+ * HX Dropdown - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-dropdown';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-dropdown');
+}

--- a/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.twig
+++ b/packages/hx-library/drupal/components/hx-dropdown/hx-dropdown.twig
@@ -1,0 +1,25 @@
+{#
+ /**
+ * @file
+ * HX Dropdown component template.
+ *
+ * A dropdown component — a button that opens a floating panel on click.
+ *
+ * Available variables:
+ * - open: boolean - Whether the dropdown panel is open.
+ * - placement: object - Preferred placement of the panel relative to the trigger.
+ * - disabled: boolean - Whether the dropdown is disabled. Prevents opening.
+ * - distance: number - Gap in pixels between the trigger and the panel.
+ */
+#}
+<hx-dropdown
+  {% if open %}open{% endif %}
+  {% if placement is defined and placement is not empty %}placement="{{ placement }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if distance is defined and distance is not empty %}distance="{{ distance }}"{% endif %}
+>
+  {% if slots.trigger is defined %}
+    <slot name="trigger">{{ slots.trigger }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-dropdown>

--- a/packages/hx-library/drupal/components/hx-field-label/README.md
+++ b/packages/hx-library/drupal/components/hx-field-label/README.md
@@ -1,0 +1,68 @@
+# HX Field Label
+
+Standardized label for form fields. Used as a consistent sub-component
+for hx-field and other form field components.
+
+## Label Association
+
+**For inputs in light DOM (the typical consumer deployment):** Use
+`aria-labelledby` pointing to the host element's `id`. The `for` attribute
+renders a native `<label for="...">` inside shadow DOM, but the HTML spec
+scopes `for`/`id` lookup to the same tree — a shadow-DOM label cannot
+associate with a light-DOM input. Example:
+
+```html
+<hx-field-label id="label-email">Email</hx-field-label>
+<input id="email" aria-labelledby="label-email" />
+```
+
+**For inputs in the same shadow root:** The `for` attribute works as
+expected for direct label association.
+
+When `for` is unset, renders a `<span>` that can be referenced via
+`aria-labelledby` for labeling controls across the shadow DOM boundary.
+
+## Usage
+
+```twig
+{% include 'helix:hx-field-label' with {
+  for: '',
+  required: false,
+  optional: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| for | string |  | The ID of the associated form control. When set, renders a native
+`<label for="...">` element for direct label association. |
+| required | boolean | false | Whether the associated field is required. Shows a required indicator (*). |
+| optional | boolean | false | Whether the associated field is optional. Shows "(optional)" text. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Label text content. |
+| required-indicator | Custom required marker (defaults to "*"). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-field-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-field-label-required-color | var(--hx-color-danger, var(--hx-color-error-text, #b91c1c)) | Required indicator color. |
+| --hx-font-label-size | var(--hx-font-size-sm) | Label font size. |
+| --hx-font-label-weight | var(--hx-font-weight-medium) | Label font weight. |
+| --hx-font-label-line-height | var(--hx-line-height-normal) | Label line height. |
+| --hx-font-label-family | var(--hx-font-family-sans) | Label font family. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The label or span element. |
+| required-indicator | The required indicator wrapper. |
+| optional-indicator | The optional text indicator. |

--- a/packages/hx-library/drupal/components/hx-field-label/hx-field-label.component.yml
+++ b/packages/hx-library/drupal/components/hx-field-label/hx-field-label.component.yml
@@ -1,0 +1,31 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Field Label
+status: experimental
+group: HELiX
+description: 'Standardized label for form fields. Used as a consistent sub-component for hx-field and other form field components.  ## Label Association  **For inputs in light DOM (the typical consumer deployment):** Use `aria-labelledby` pointing to the host element''s `id`. The `for` attribute renders a native `<label for="...">` inside shadow DOM, but the HTML spec scopes `for`/`id` lookup to the same tree — a shadow-DOM label cannot associate with a light-DOM input. Example:  ```html <hx-field-label id="label-email">Email</hx-field-label> <input id="email" aria-labelledby="label-email" /> ```  **For inputs in the same shadow root:** The `for` attribute works as expected for direct label association.  When `for` is unset, renders a `<span>` that can be referenced via `aria-labelledby` for labeling controls across the shadow DOM boundary.'
+props:
+  type: object
+  properties:
+    for:
+      type: string
+      title: For
+      description: 'The ID of the associated form control. When set, renders a native `<label for="...">` element for direct label association.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the associated field is required. Shows a required indicator (*).'
+      default: false
+    optional:
+      type: boolean
+      title: Optional
+      description: 'Whether the associated field is optional. Shows "(optional)" text.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Label text content.'
+  required-indicator:
+    title: Required Indicator
+    description: 'Custom required marker (defaults to "*").'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-field-label/hx-field-label.css
+++ b/packages/hx-library/drupal/components/hx-field-label/hx-field-label.css
@@ -1,0 +1,20 @@
+/**
+ * HX Field Label component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-field-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-field-label-required-color: Required indicator color. (default: var(--hx-color-danger, var(--hx-color-error-text, #b91c1c)))
+ * --hx-font-label-size: Label font size. (default: var(--hx-font-size-sm))
+ * --hx-font-label-weight: Label font weight. (default: var(--hx-font-weight-medium))
+ * --hx-font-label-line-height: Label line height. (default: var(--hx-line-height-normal))
+ * --hx-font-label-family: Label font family. (default: var(--hx-font-family-sans))
+ */
+
+/* Component host styles */
+hx-field-label {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-field-label/hx-field-label.js
+++ b/packages/hx-library/drupal/components/hx-field-label/hx-field-label.js
@@ -1,0 +1,11 @@
+/**
+ * HX Field Label - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-field-label';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-field-label');
+}

--- a/packages/hx-library/drupal/components/hx-field-label/hx-field-label.twig
+++ b/packages/hx-library/drupal/components/hx-field-label/hx-field-label.twig
@@ -1,0 +1,43 @@
+{#
+ /**
+ * @file
+ * HX Field Label component template.
+ *
+ * Standardized label for form fields. Used as a consistent sub-component
+ * for hx-field and other form field components.
+ * 
+ * ## Label Association
+ * 
+ * **For inputs in light DOM (the typical consumer deployment):** Use
+ * `aria-labelledby` pointing to the host element's `id`. The `for` attribute
+ * renders a native `<label for="...">` inside shadow DOM, but the HTML spec
+ * scopes `for`/`id` lookup to the same tree — a shadow-DOM label cannot
+ * associate with a light-DOM input. Example:
+ * 
+ * ```html
+ * <hx-field-label id="label-email">Email</hx-field-label>
+ * <input id="email" aria-labelledby="label-email" />
+ * ```
+ * 
+ * **For inputs in the same shadow root:** The `for` attribute works as
+ * expected for direct label association.
+ * 
+ * When `for` is unset, renders a `<span>` that can be referenced via
+ * `aria-labelledby` for labeling controls across the shadow DOM boundary.
+ *
+ * Available variables:
+ * - for: string - The ID of the associated form control. When set, renders a native `<label for="...">` element for direct label association.
+ * - required: boolean - Whether the associated field is required. Shows a required indicator (*).
+ * - optional: boolean - Whether the associated field is optional. Shows "(optional)" text.
+ */
+#}
+<hx-field-label
+  {% if for is defined and for is not empty %}for="{{ for }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if optional %}optional{% endif %}
+>
+  {% if slots.required-indicator is defined %}
+    <slot name="required-indicator">{{ slots.required-indicator }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-field-label>

--- a/packages/hx-library/drupal/components/hx-field/README.md
+++ b/packages/hx-library/drupal/components/hx-field/README.md
@@ -1,0 +1,71 @@
+# HX Field
+
+Layout wrapper providing consistent label + input + help text + validation
+message structure for any form control. Use this when wrapping non-HELiX
+form controls or native HTML elements in the HELiX form field pattern.
+
+This component is NOT form-associated — it is a pure visual layout wrapper.
+
+**Light DOM side effect:** This component injects a visually-hidden `<span>`
+into its light DOM children for ARIA describedby linkage across the shadow
+DOM boundary. This span has `id="${fieldId}-desc"` and is removed on
+`disconnectedCallback`. This is an intentional, documented accessibility
+mechanism.
+
+## Usage
+
+```twig
+{% include 'helix:hx-field' with {
+  label: '',
+  required: false,
+  error: '',
+  helpText: '',
+  disabled: false,
+  hxSize: 'md',
+  layout: 'column',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | The visible label text for the field. |
+| required | boolean | false | Whether the field is required. Shows a required indicator on the label. |
+| error | string |  | Error message to display. When set, the field enters an error state. |
+| helpText | string |  | Help text displayed below the control for guidance. |
+| disabled | boolean | false | Visual disabled state applied via opacity. Does not affect slotted control
+interactivity — set disabled on the slotted control directly. |
+| hxSize | object | md | Size variant controlling label and help text font sizes. |
+| layout | object | column | Layout variant. 'column' stacks label above control; 'inline' places them side-by-side. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | The form control element (native or custom). |
+| label | Custom label content (overrides the label property). |
+| help-text | Custom help text content (overrides the helpText property). |
+| error | Custom error content (overrides the error property). |
+| description | Additional descriptive content above the control. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-field-label-color | var(--hx-color-neutral-700) | Label color. |
+| --hx-field-error-color | var(--hx-color-error-500) | Error color. |
+| --hx-field-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-field-gap | var(--hx-space-1, 0.25rem) | Gap between field segments. |
+| --hx-field-help-text-color | var(--hx-color-neutral-500) | Help text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| field | The outer field container. |
+| label | The label element. |
+| control | The wrapper around slotted content. |
+| help-text | The help text container. |
+| error-message | The error message container. |
+| required-indicator | The required asterisk span. |

--- a/packages/hx-library/drupal/components/hx-field/hx-field.component.yml
+++ b/packages/hx-library/drupal/components/hx-field/hx-field.component.yml
@@ -1,0 +1,60 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Field
+status: experimental
+group: HELiX
+description: 'Layout wrapper providing consistent label + input + help text + validation message structure for any form control. Use this when wrapping non-HELiX form controls or native HTML elements in the HELiX form field pattern.  This component is NOT form-associated — it is a pure visual layout wrapper.  **Light DOM side effect:** This component injects a visually-hidden `<span>` into its light DOM children for ARIA describedby linkage across the shadow DOM boundary. This span has `id="${fieldId}-desc"` and is removed on `disconnectedCallback`. This is an intentional, documented accessibility mechanism.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the field.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the field is required. Shows a required indicator on the label.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the field enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the control for guidance.'
+      default: ''
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Visual disabled state applied via opacity. Does not affect slotted control interactivity — set disabled on the slotted control directly.'
+      default: false
+    hxSize:
+      type: object
+      title: Hx Size
+      description: 'Size variant controlling label and help text font sizes.'
+      default: 'md'
+    layout:
+      type: object
+      title: Layout
+      description: "Layout variant. 'column' stacks label above control; 'inline' places them side-by-side."
+      default: 'column'
+slots:
+  default:
+    title: Default
+    description: 'The form control element (native or custom).'
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+  description:
+    title: Description
+    description: 'Additional descriptive content above the control.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-field/hx-field.css
+++ b/packages/hx-library/drupal/components/hx-field/hx-field.css
@@ -1,0 +1,19 @@
+/**
+ * HX Field component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-field-label-color: Label color. (default: var(--hx-color-neutral-700))
+ * --hx-field-error-color: Error color. (default: var(--hx-color-error-500))
+ * --hx-field-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-field-gap: Gap between field segments. (default: var(--hx-space-1, 0.25rem))
+ * --hx-field-help-text-color: Help text color. (default: var(--hx-color-neutral-500))
+ */
+
+/* Component host styles */
+hx-field {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-field/hx-field.js
+++ b/packages/hx-library/drupal/components/hx-field/hx-field.js
@@ -1,0 +1,11 @@
+/**
+ * HX Field - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-field';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-field');
+}

--- a/packages/hx-library/drupal/components/hx-field/hx-field.twig
+++ b/packages/hx-library/drupal/components/hx-field/hx-field.twig
@@ -1,0 +1,50 @@
+{#
+ /**
+ * @file
+ * HX Field component template.
+ *
+ * Layout wrapper providing consistent label + input + help text + validation
+ * message structure for any form control. Use this when wrapping non-HELiX
+ * form controls or native HTML elements in the HELiX form field pattern.
+ * 
+ * This component is NOT form-associated — it is a pure visual layout wrapper.
+ * 
+ * **Light DOM side effect:** This component injects a visually-hidden `<span>`
+ * into its light DOM children for ARIA describedby linkage across the shadow
+ * DOM boundary. This span has `id="${fieldId}-desc"` and is removed on
+ * `disconnectedCallback`. This is an intentional, documented accessibility
+ * mechanism.
+ *
+ * Available variables:
+ * - label: string - The visible label text for the field.
+ * - required: boolean - Whether the field is required. Shows a required indicator on the label.
+ * - error: string - Error message to display. When set, the field enters an error state.
+ * - helpText: string - Help text displayed below the control for guidance.
+ * - disabled: boolean - Visual disabled state applied via opacity. Does not affect slotted control interactivity — set disabled on the slotted control directly.
+ * - hxSize: object - Size variant controlling label and help text font sizes.
+ * - layout: object - Layout variant. 'column' stacks label above control; 'inline' places them side-by-side.
+ */
+#}
+<hx-field
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if hxSize is defined and hxSize is not empty %}hx-size="{{ hxSize }}"{% endif %}
+  {% if layout is defined and layout is not empty %}layout="{{ layout }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.description is defined %}
+    <slot name="description">{{ slots.description }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-field>

--- a/packages/hx-library/drupal/components/hx-file-upload/README.md
+++ b/packages/hx-library/drupal/components/hx-file-upload/README.md
@@ -1,0 +1,75 @@
+# HX File Upload
+
+A drag-and-drop file upload component with client-side validation,
+file list management, per-file progress, and native form association.
+
+## Usage
+
+```twig
+{% include 'helix:hx-file-upload' with {
+  name: '',
+  accept: '',
+  maxSize: 0,
+  maxFiles: 0,
+  multiple: false,
+  label: '',
+  disabled: false,
+  error: '',
+  labelDropzone: 'Drag files here or click to browse',
+  labelFileList: 'Selected files',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | The form field name used during form submission. |
+| accept | string |  | Accepted file types as a comma-separated list of MIME types or extensions.
+Mirrors the native `<input type="file" accept>` attribute. |
+| maxSize | number | 0 | Maximum allowed file size in bytes. 0 means unlimited. |
+| maxFiles | number | 0 | Maximum number of files that can be selected. 0 means unlimited. |
+| multiple | boolean | false | Whether multiple files may be selected at once. |
+| label | string |  | Visible label text for the dropzone. |
+| disabled | boolean | false | Whether the component is disabled. |
+| error | string |  | Error message displayed below the dropzone. Also puts the dropzone in an error visual state. |
+| labelDropzone | string | Drag files here or click to browse | Instructional text shown in the dropzone when no custom slot content is provided.
+Also used as the accessible label for the dropzone. |
+| labelFileList | string | Selected files | Accessible label for the selected files list. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default dropzone content. Replaces the built-in "Drag files here or click to browse" prompt. |
+| file-list | Custom file list display. When provided, the built-in file list is hidden. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-error | Dispatched when file validation fails (type or size constraint). |
+| hx-upload | Dispatched when valid files are selected via drag-and-drop or the file picker. |
+| hx-remove | Dispatched when a file is removed from the list. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-file-upload-dropzone-bg | var(--hx-color-neutral-50) | Dropzone background color. |
+| --hx-file-upload-dropzone-border-color | var(--hx-color-neutral-300) | Dropzone border color. |
+| --hx-file-upload-dropzone-border-radius | var(--hx-border-radius-lg) | Dropzone border radius. |
+| --hx-file-upload-dropzone-active-bg | - | Dropzone background when a file is dragged over. |
+| --hx-file-upload-progress-color | var(--hx-color-primary-500) | Progress bar fill color. |
+| --hx-file-upload-error-color | var(--hx-color-error-500) | Error state and remove-button hover color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| dropzone | The drag-and-drop target area. |
+| file-list | The container wrapping the list of selected files. |
+| file-item | An individual file entry in the list. |
+| progress | The progress bar track for a file item. |
+| label | The visible label element. |
+| error | The error message container below the dropzone. |

--- a/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.component.yml
+++ b/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.component.yml
@@ -1,0 +1,66 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX File Upload
+status: experimental
+group: HELiX
+description: 'A drag-and-drop file upload component with client-side validation, file list management, per-file progress, and native form association.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'The form field name used during form submission.'
+      default: ''
+    accept:
+      type: string
+      title: Accept
+      description: 'Accepted file types as a comma-separated list of MIME types or extensions. Mirrors the native `<input type="file" accept>` attribute.'
+      default: ''
+    maxSize:
+      type: number
+      title: Max Size
+      description: 'Maximum allowed file size in bytes. 0 means unlimited.'
+      default: 0
+    maxFiles:
+      type: number
+      title: Max Files
+      description: 'Maximum number of files that can be selected. 0 means unlimited.'
+      default: 0
+    multiple:
+      type: boolean
+      title: Multiple
+      description: 'Whether multiple files may be selected at once.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'Visible label text for the dropzone.'
+      default: ''
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the component is disabled.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message displayed below the dropzone. Also puts the dropzone in an error visual state.'
+      default: ''
+    labelDropzone:
+      type: string
+      title: Label Dropzone
+      description: 'Instructional text shown in the dropzone when no custom slot content is provided. Also used as the accessible label for the dropzone.'
+      default: 'Drag files here or click to browse'
+    labelFileList:
+      type: string
+      title: Label File List
+      description: 'Accessible label for the selected files list.'
+      default: 'Selected files'
+slots:
+  default:
+    title: Default
+    description: 'Default dropzone content. Replaces the built-in "Drag files here or click to browse" prompt.'
+  file-list:
+    title: File List
+    description: 'Custom file list display. When provided, the built-in file list is hidden.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.css
+++ b/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.css
@@ -1,0 +1,20 @@
+/**
+ * HX File Upload component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-file-upload-dropzone-bg: Dropzone background color. (default: var(--hx-color-neutral-50))
+ * --hx-file-upload-dropzone-border-color: Dropzone border color. (default: var(--hx-color-neutral-300))
+ * --hx-file-upload-dropzone-border-radius: Dropzone border radius. (default: var(--hx-border-radius-lg))
+ * --hx-file-upload-dropzone-active-bg: Dropzone background when a file is dragged over.
+ * --hx-file-upload-progress-color: Progress bar fill color. (default: var(--hx-color-primary-500))
+ * --hx-file-upload-error-color: Error state and remove-button hover color. (default: var(--hx-color-error-500))
+ */
+
+/* Component host styles */
+hx-file-upload {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.js
+++ b/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.js
@@ -1,0 +1,11 @@
+/**
+ * HX File Upload - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-file-upload';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-file-upload');
+}

--- a/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.twig
+++ b/packages/hx-library/drupal/components/hx-file-upload/hx-file-upload.twig
@@ -1,0 +1,38 @@
+{#
+ /**
+ * @file
+ * HX File Upload component template.
+ *
+ * A drag-and-drop file upload component with client-side validation,
+ * file list management, per-file progress, and native form association.
+ *
+ * Available variables:
+ * - name: string - The form field name used during form submission.
+ * - accept: string - Accepted file types as a comma-separated list of MIME types or extensions. Mirrors the native `<input type="file" accept>` attribute.
+ * - maxSize: number - Maximum allowed file size in bytes. 0 means unlimited.
+ * - maxFiles: number - Maximum number of files that can be selected. 0 means unlimited.
+ * - multiple: boolean - Whether multiple files may be selected at once.
+ * - label: string - Visible label text for the dropzone.
+ * - disabled: boolean - Whether the component is disabled.
+ * - error: string - Error message displayed below the dropzone. Also puts the dropzone in an error visual state.
+ * - labelDropzone: string - Instructional text shown in the dropzone when no custom slot content is provided. Also used as the accessible label for the dropzone.
+ * - labelFileList: string - Accessible label for the selected files list.
+ */
+#}
+<hx-file-upload
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if accept is defined and accept is not empty %}accept="{{ accept }}"{% endif %}
+  {% if maxSize is defined and maxSize is not empty %}max-size="{{ maxSize }}"{% endif %}
+  {% if maxFiles is defined and maxFiles is not empty %}max-files="{{ maxFiles }}"{% endif %}
+  {% if multiple %}multiple{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if labelDropzone is defined and labelDropzone is not empty %}label-dropzone="{{ labelDropzone }}"{% endif %}
+  {% if labelFileList is defined and labelFileList is not empty %}label-file-list="{{ labelFileList }}"{% endif %}
+>
+  {% if slots.file-list is defined %}
+    <slot name="file-list">{{ slots.file-list }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-file-upload>

--- a/packages/hx-library/drupal/components/hx-form/README.md
+++ b/packages/hx-library/drupal/components/hx-form/README.md
@@ -1,0 +1,58 @@
+# HX Form
+
+A Light DOM form wrapper that styles native HTML form elements and
+hx-* components with the design system's form styles.
+
+When `action` is set, renders a `<form>` wrapper around slotted content.
+When no `action` is set (the Drupal pattern), renders only a `<slot>`
+so Drupal can provide its own `<form>` tag.
+
+Uses adopted stylesheets to inject scoped CSS into the document without
+Shadow DOM, keeping native form participation and Drupal compatibility.
+
+## Usage
+
+```twig
+{% include 'helix:hx-form' with {
+  action: '',
+  method: 'post',
+  novalidate: false,
+  name: '',
+  enctype: 'application/x-www-form-urlencoded',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| action | string |  | The URL to submit the form to. When empty, the form handles
+submission client-side only and dispatches `hx-submit`. |
+| method | object | post | The HTTP method used when submitting the form. |
+| novalidate | boolean | false | When true, disables the browser's built-in constraint validation
+on form submission. |
+| name | string |  | Identifies the form for scripting and form discovery. |
+| enctype | object | application/x-www-form-urlencoded | The encoding type for form submission. Only used when `action` is set.
+Use `multipart/form-data` for forms with file uploads. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for form fields and controls. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-submit | Dispatched on valid client-side submit when no action is set. |
+| hx-invalid | Dispatched when validation fails on submit. |
+| hx-reset | Dispatched when the form is reset. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-form-gap | var(--hx-space-4) | Gap between form fields. |
+| --hx-form-max-width | none | Maximum width of the form. |
+| --hx-form-padding | 0 | Internal padding of the form. |

--- a/packages/hx-library/drupal/components/hx-form/hx-form.component.yml
+++ b/packages/hx-library/drupal/components/hx-form/hx-form.component.yml
@@ -1,0 +1,38 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Form
+status: experimental
+group: HELiX
+description: "A Light DOM form wrapper that styles native HTML form elements and hx-* components with the design system's form styles.  When `action` is set, renders a `<form>` wrapper around slotted content. When no `action` is set (the Drupal pattern), renders only a `<slot>` so Drupal can provide its own `<form>` tag.  Uses adopted stylesheets to inject scoped CSS into the document without Shadow DOM, keeping native form participation and Drupal compatibility."
+props:
+  type: object
+  properties:
+    action:
+      type: string
+      title: Action
+      description: 'The URL to submit the form to. When empty, the form handles submission client-side only and dispatches `hx-submit`.'
+      default: ''
+    method:
+      type: object
+      title: Method
+      description: 'The HTTP method used when submitting the form.'
+      default: 'post'
+    novalidate:
+      type: boolean
+      title: Novalidate
+      description: "When true, disables the browser's built-in constraint validation on form submission."
+      default: false
+    name:
+      type: string
+      title: Name
+      description: 'Identifies the form for scripting and form discovery.'
+      default: ''
+    enctype:
+      type: object
+      title: Enctype
+      description: 'The encoding type for form submission. Only used when `action` is set. Use `multipart/form-data` for forms with file uploads.'
+      default: 'application/x-www-form-urlencoded'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for form fields and controls.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-form/hx-form.css
+++ b/packages/hx-library/drupal/components/hx-form/hx-form.css
@@ -1,0 +1,17 @@
+/**
+ * HX Form component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-form-gap: Gap between form fields. (default: var(--hx-space-4))
+ * --hx-form-max-width: Maximum width of the form. (default: none)
+ * --hx-form-padding: Internal padding of the form. (default: 0)
+ */
+
+/* Component host styles */
+hx-form {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-form/hx-form.js
+++ b/packages/hx-library/drupal/components/hx-form/hx-form.js
@@ -1,0 +1,11 @@
+/**
+ * HX Form - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-form';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-form');
+}

--- a/packages/hx-library/drupal/components/hx-form/hx-form.twig
+++ b/packages/hx-library/drupal/components/hx-form/hx-form.twig
@@ -1,0 +1,32 @@
+{#
+ /**
+ * @file
+ * HX Form component template.
+ *
+ * A Light DOM form wrapper that styles native HTML form elements and
+ * hx-* components with the design system's form styles.
+ * 
+ * When `action` is set, renders a `<form>` wrapper around slotted content.
+ * When no `action` is set (the Drupal pattern), renders only a `<slot>`
+ * so Drupal can provide its own `<form>` tag.
+ * 
+ * Uses adopted stylesheets to inject scoped CSS into the document without
+ * Shadow DOM, keeping native form participation and Drupal compatibility.
+ *
+ * Available variables:
+ * - action: string - The URL to submit the form to. When empty, the form handles submission client-side only and dispatches `hx-submit`.
+ * - method: object - The HTTP method used when submitting the form.
+ * - novalidate: boolean - When true, disables the browser's built-in constraint validation on form submission.
+ * - name: string - Identifies the form for scripting and form discovery.
+ * - enctype: object - The encoding type for form submission. Only used when `action` is set. Use `multipart/form-data` for forms with file uploads.
+ */
+#}
+<hx-form
+  {% if action is defined and action is not empty %}action="{{ action }}"{% endif %}
+  {% if method is defined and method is not empty %}method="{{ method }}"{% endif %}
+  {% if novalidate %}novalidate{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if enctype is defined and enctype is not empty %}enctype="{{ enctype }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-form>

--- a/packages/hx-library/drupal/components/hx-format-date/README.md
+++ b/packages/hx-library/drupal/components/hx-format-date/README.md
@@ -1,0 +1,65 @@
+# HX Format Date
+
+Formats and displays a date/time value using the browser's `Intl.DateTimeFormat`
+(or `Intl.RelativeTimeFormat` when `relative` is set). Renders as an inline
+`<time>` element — machine-readable via `datetime`, human-readable via formatted text.
+
+No external dependencies. Uses native Intl APIs only.
+
+## Usage
+
+```twig
+{% include 'helix:hx-format-date' with {
+  date: '',
+  lang: '',
+  month: 'undefined',
+  year: 'undefined',
+  day: 'undefined',
+  weekday: 'undefined',
+  hour: 'undefined',
+  minute: 'undefined',
+  second: 'undefined',
+  timeZoneName: 'undefined',
+  timeZone: 'undefined',
+  hourFormat: 'auto',
+  numeric: 'auto',
+  relative: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| date | object |  | The date/time value to format. Accepts an ISO string, a Unix timestamp (ms), or
+a `Date` object. Defaults to the current date/time when empty. |
+| lang | string |  | BCP 47 locale tag used for formatting (e.g. `"en-US"`, `"de"`, `"ja"`).
+Defaults to `document.documentElement.lang`, then `navigator.language`. |
+| month | object | undefined | Month display format. |
+| year | object | undefined | Year display format. |
+| day | object | undefined | Day display format. |
+| weekday | object | undefined | Weekday display format. |
+| hour | object | undefined | Hour display format. |
+| minute | object | undefined | Minute display format. |
+| second | object | undefined | Second display format. |
+| timeZoneName | object | undefined | Time zone name display format. Accepts all values supported by
+`Intl.DateTimeFormatOptions.timeZoneName` including `'short'`, `'long'`,
+`'shortOffset'`, `'longOffset'`, `'shortGeneric'`, and `'longGeneric'`. |
+| timeZone | object | undefined | IANA time zone identifier (e.g. `"America/New_York"`, `"UTC"`). |
+| hourFormat | object | auto | Whether to use 12-hour or 24-hour clock. `"auto"` defers to locale default. |
+| numeric | object | auto | Controls whether `Intl.RelativeTimeFormat` always shows numeric output
+(`"always"`) or uses natural language when possible (`"auto"`, e.g. "yesterday").
+Only used when `relative` is true. |
+| relative | boolean | false | When true, displays a relative time string such as "2 hours ago" or "in 3 days"
+using `Intl.RelativeTimeFormat`.
+
+**Important:** The relative time string is computed once at render time and does
+not auto-update. If the displayed text must stay current (e.g. a live "X minutes
+ago" counter), the consuming component must re-set the `date` property on its own
+interval to trigger a re-render. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner `<time>` element. |

--- a/packages/hx-library/drupal/components/hx-format-date/hx-format-date.component.yml
+++ b/packages/hx-library/drupal/components/hx-format-date/hx-format-date.component.yml
@@ -1,0 +1,79 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Format Date
+status: experimental
+group: HELiX
+description: "Formats and displays a date/time value using the browser's `Intl.DateTimeFormat` (or `Intl.RelativeTimeFormat` when `relative` is set). Renders as an inline `<time>` element — machine-readable via `datetime`, human-readable via formatted text.  No external dependencies. Uses native Intl APIs only."
+props:
+  type: object
+  properties:
+    date:
+      type: object
+      title: Date
+      description: 'The date/time value to format. Accepts an ISO string, a Unix timestamp (ms), or a `Date` object. Defaults to the current date/time when empty.'
+      default: ''
+    lang:
+      type: string
+      title: Lang
+      description: 'BCP 47 locale tag used for formatting (e.g. `"en-US"`, `"de"`, `"ja"`). Defaults to `document.documentElement.lang`, then `navigator.language`.'
+      default: ''
+    month:
+      type: object
+      title: Month
+      description: 'Month display format.'
+      default: 'undefined'
+    year:
+      type: object
+      title: Year
+      description: 'Year display format.'
+      default: 'undefined'
+    day:
+      type: object
+      title: Day
+      description: 'Day display format.'
+      default: 'undefined'
+    weekday:
+      type: object
+      title: Weekday
+      description: 'Weekday display format.'
+      default: 'undefined'
+    hour:
+      type: object
+      title: Hour
+      description: 'Hour display format.'
+      default: 'undefined'
+    minute:
+      type: object
+      title: Minute
+      description: 'Minute display format.'
+      default: 'undefined'
+    second:
+      type: object
+      title: Second
+      description: 'Second display format.'
+      default: 'undefined'
+    timeZoneName:
+      type: object
+      title: Time Zone Name
+      description: "Time zone name display format. Accepts all values supported by `Intl.DateTimeFormatOptions.timeZoneName` including `'short'`, `'long'`, `'shortOffset'`, `'longOffset'`, `'shortGeneric'`, and `'longGeneric'`."
+      default: 'undefined'
+    timeZone:
+      type: object
+      title: Time Zone
+      description: 'IANA time zone identifier (e.g. `"America/New_York"`, `"UTC"`).'
+      default: 'undefined'
+    hourFormat:
+      type: object
+      title: Hour Format
+      description: 'Whether to use 12-hour or 24-hour clock. `"auto"` defers to locale default.'
+      default: 'auto'
+    numeric:
+      type: object
+      title: Numeric
+      description: 'Controls whether `Intl.RelativeTimeFormat` always shows numeric output (`"always"`) or uses natural language when possible (`"auto"`, e.g. "yesterday"). Only used when `relative` is true.'
+      default: 'auto'
+    relative:
+      type: boolean
+      title: Relative
+      description: 'When true, displays a relative time string such as "2 hours ago" or "in 3 days" using `Intl.RelativeTimeFormat`.  **Important:** The relative time string is computed once at render time and does not auto-update. If the displayed text must stay current (e.g. a live "X minutes ago" counter), the consuming component must re-set the `date` property on its own interval to trigger a re-render.'
+      default: false
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-format-date/hx-format-date.css
+++ b/packages/hx-library/drupal/components/hx-format-date/hx-format-date.css
@@ -1,0 +1,12 @@
+/**
+ * HX Format Date component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-format-date {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-format-date/hx-format-date.js
+++ b/packages/hx-library/drupal/components/hx-format-date/hx-format-date.js
@@ -1,0 +1,11 @@
+/**
+ * HX Format Date - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-format-date';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-format-date');
+}

--- a/packages/hx-library/drupal/components/hx-format-date/hx-format-date.twig
+++ b/packages/hx-library/drupal/components/hx-format-date/hx-format-date.twig
@@ -1,0 +1,45 @@
+{#
+ /**
+ * @file
+ * HX Format Date component template.
+ *
+ * Formats and displays a date/time value using the browser's `Intl.DateTimeFormat`
+ * (or `Intl.RelativeTimeFormat` when `relative` is set). Renders as an inline
+ * `<time>` element — machine-readable via `datetime`, human-readable via formatted text.
+ * 
+ * No external dependencies. Uses native Intl APIs only.
+ *
+ * Available variables:
+ * - date: object - The date/time value to format. Accepts an ISO string, a Unix timestamp (ms), or a `Date` object. Defaults to the current date/time when empty.
+ * - lang: string - BCP 47 locale tag used for formatting (e.g. `"en-US"`, `"de"`, `"ja"`). Defaults to `document.documentElement.lang`, then `navigator.language`.
+ * - month: object - Month display format.
+ * - year: object - Year display format.
+ * - day: object - Day display format.
+ * - weekday: object - Weekday display format.
+ * - hour: object - Hour display format.
+ * - minute: object - Minute display format.
+ * - second: object - Second display format.
+ * - timeZoneName: object - Time zone name display format. Accepts all values supported by `Intl.DateTimeFormatOptions.timeZoneName` including `'short'`, `'long'`, `'shortOffset'`, `'longOffset'`, `'shortGeneric'`, and `'longGeneric'`.
+ * - timeZone: object - IANA time zone identifier (e.g. `"America/New_York"`, `"UTC"`).
+ * - hourFormat: object - Whether to use 12-hour or 24-hour clock. `"auto"` defers to locale default.
+ * - numeric: object - Controls whether `Intl.RelativeTimeFormat` always shows numeric output (`"always"`) or uses natural language when possible (`"auto"`, e.g. "yesterday"). Only used when `relative` is true.
+ * - relative: boolean - When true, displays a relative time string such as "2 hours ago" or "in 3 days" using `Intl.RelativeTimeFormat`.  **Important:** The relative time string is computed once at render time and does not auto-update. If the displayed text must stay current (e.g. a live "X minutes ago" counter), the consuming component must re-set the `date` property on its own interval to trigger a re-render.
+ */
+#}
+<hx-format-date
+  {% if date is defined and date is not empty %}date="{{ date }}"{% endif %}
+  {% if lang is defined and lang is not empty %}lang="{{ lang }}"{% endif %}
+  {% if month is defined and month is not empty %}month="{{ month }}"{% endif %}
+  {% if year is defined and year is not empty %}year="{{ year }}"{% endif %}
+  {% if day is defined and day is not empty %}day="{{ day }}"{% endif %}
+  {% if weekday is defined and weekday is not empty %}weekday="{{ weekday }}"{% endif %}
+  {% if hour is defined and hour is not empty %}hour="{{ hour }}"{% endif %}
+  {% if minute is defined and minute is not empty %}minute="{{ minute }}"{% endif %}
+  {% if second is defined and second is not empty %}second="{{ second }}"{% endif %}
+  {% if timeZoneName is defined and timeZoneName is not empty %}time-zone-name="{{ timeZoneName }}"{% endif %}
+  {% if timeZone is defined and timeZone is not empty %}time-zone="{{ timeZone }}"{% endif %}
+  {% if hourFormat is defined and hourFormat is not empty %}hour-format="{{ hourFormat }}"{% endif %}
+  {% if numeric is defined and numeric is not empty %}numeric="{{ numeric }}"{% endif %}
+  {% if relative %}relative{% endif %}
+>
+</hx-format-date>

--- a/packages/hx-library/drupal/components/hx-grid-item/README.md
+++ b/packages/hx-library/drupal/components/hx-grid-item/README.md
@@ -1,0 +1,29 @@
+# HX Grid Item
+
+Optional companion element for precise grid item placement.
+Applies grid-column and grid-row directly to the host element
+so it participates correctly in the parent CSS grid layout.
+
+## Usage
+
+```twig
+{% include 'helix:hx-grid-item' with {
+  column: '',
+  row: '',
+  span: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| column | object | - | CSS grid-column value (e.g., "1 / 3", "span 2"). |
+| row | object | - | CSS grid-row value (e.g., "1 / 2"). |
+| span | object | - | Column span shorthand — equivalent to setting `column: "span N"`. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for item content. |

--- a/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.component.yml
@@ -1,0 +1,25 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Grid Item
+status: experimental
+group: HELiX
+description: 'Optional companion element for precise grid item placement. Applies grid-column and grid-row directly to the host element so it participates correctly in the parent CSS grid layout.'
+props:
+  type: object
+  properties:
+    column:
+      type: object
+      title: Column
+      description: 'CSS grid-column value (e.g., "1 / 3", "span 2").'
+    row:
+      type: object
+      title: Row
+      description: 'CSS grid-row value (e.g., "1 / 2").'
+    span:
+      type: object
+      title: Span
+      description: 'Column span shorthand — equivalent to setting `column: "span N"`.'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for item content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.css
+++ b/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.css
@@ -1,0 +1,12 @@
+/**
+ * HX Grid Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-grid-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.js
+++ b/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX Grid Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-grid-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-grid-item');
+}

--- a/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.twig
+++ b/packages/hx-library/drupal/components/hx-grid-item/hx-grid-item.twig
@@ -1,0 +1,22 @@
+{#
+ /**
+ * @file
+ * HX Grid Item component template.
+ *
+ * Optional companion element for precise grid item placement.
+ * Applies grid-column and grid-row directly to the host element
+ * so it participates correctly in the parent CSS grid layout.
+ *
+ * Available variables:
+ * - column: object - CSS grid-column value (e.g., "1 / 3", "span 2").
+ * - row: object - CSS grid-row value (e.g., "1 / 2").
+ * - span: object - Column span shorthand — equivalent to setting `column: "span N"`.
+ */
+#}
+<hx-grid-item
+  {% if column is defined and column is not empty %}column="{{ column }}"{% endif %}
+  {% if row is defined and row is not empty %}row="{{ row }}"{% endif %}
+  {% if span is defined and span is not empty %}span="{{ span }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-grid-item>

--- a/packages/hx-library/drupal/components/hx-grid/README.md
+++ b/packages/hx-library/drupal/components/hx-grid/README.md
@@ -1,0 +1,48 @@
+# HX Grid
+
+A CSS Grid layout wrapper with design-token-based column and gap system.
+
+## Usage
+
+```twig
+{% include 'helix:hx-grid' with {
+  columns: '1',
+  gap: 'md',
+  rowGap: '',
+  columnGap: '',
+  align: 'stretch',
+  justify: 'stretch',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| columns | object | 1 | Number of equal columns (`repeat(N, 1fr)`) or a CSS grid-template-columns string. |
+| gap | object | md | Gap size applied to both row and column gaps. |
+| rowGap | object | - | Row gap override. When set, takes precedence over `gap` for row spacing. |
+| columnGap | object | - | Column gap override. When set, takes precedence over `gap` for column spacing. |
+| align | object | stretch | Aligns grid items along the block axis (align-items). |
+| justify | object | stretch | Justifies grid items along the inline axis (justify-items). |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for grid content (use `hx-grid-item` for precise placement). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-grid-columns | - | Override the computed grid-template-columns. |
+| --hx-grid-gap | - | Override the computed gap. |
+| --hx-grid-row-gap | - | Override the computed row-gap. |
+| --hx-grid-column-gap | - | Override the computed column-gap. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The grid container element. |

--- a/packages/hx-library/drupal/components/hx-grid/hx-grid.component.yml
+++ b/packages/hx-library/drupal/components/hx-grid/hx-grid.component.yml
@@ -1,0 +1,41 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Grid
+status: experimental
+group: HELiX
+description: 'A CSS Grid layout wrapper with design-token-based column and gap system.'
+props:
+  type: object
+  properties:
+    columns:
+      type: object
+      title: Columns
+      description: 'Number of equal columns (`repeat(N, 1fr)`) or a CSS grid-template-columns string.'
+      default: '1'
+    gap:
+      type: object
+      title: Gap
+      description: 'Gap size applied to both row and column gaps.'
+      default: 'md'
+    rowGap:
+      type: object
+      title: Row Gap
+      description: 'Row gap override. When set, takes precedence over `gap` for row spacing.'
+    columnGap:
+      type: object
+      title: Column Gap
+      description: 'Column gap override. When set, takes precedence over `gap` for column spacing.'
+    align:
+      type: object
+      title: Align
+      description: 'Aligns grid items along the block axis (align-items).'
+      default: 'stretch'
+    justify:
+      type: object
+      title: Justify
+      description: 'Justifies grid items along the inline axis (justify-items).'
+      default: 'stretch'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for grid content (use `hx-grid-item` for precise placement).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-grid/hx-grid.css
+++ b/packages/hx-library/drupal/components/hx-grid/hx-grid.css
@@ -1,0 +1,18 @@
+/**
+ * HX Grid component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-grid-columns: Override the computed grid-template-columns.
+ * --hx-grid-gap: Override the computed gap.
+ * --hx-grid-row-gap: Override the computed row-gap.
+ * --hx-grid-column-gap: Override the computed column-gap.
+ */
+
+/* Component host styles */
+hx-grid {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-grid/hx-grid.js
+++ b/packages/hx-library/drupal/components/hx-grid/hx-grid.js
@@ -1,0 +1,11 @@
+/**
+ * HX Grid - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-grid';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-grid');
+}

--- a/packages/hx-library/drupal/components/hx-grid/hx-grid.twig
+++ b/packages/hx-library/drupal/components/hx-grid/hx-grid.twig
@@ -1,0 +1,26 @@
+{#
+ /**
+ * @file
+ * HX Grid component template.
+ *
+ * A CSS Grid layout wrapper with design-token-based column and gap system.
+ *
+ * Available variables:
+ * - columns: object - Number of equal columns (`repeat(N, 1fr)`) or a CSS grid-template-columns string.
+ * - gap: object - Gap size applied to both row and column gaps.
+ * - rowGap: object - Row gap override. When set, takes precedence over `gap` for row spacing.
+ * - columnGap: object - Column gap override. When set, takes precedence over `gap` for column spacing.
+ * - align: object - Aligns grid items along the block axis (align-items).
+ * - justify: object - Justifies grid items along the inline axis (justify-items).
+ */
+#}
+<hx-grid
+  {% if columns is defined and columns is not empty %}columns="{{ columns }}"{% endif %}
+  {% if gap is defined and gap is not empty %}gap="{{ gap }}"{% endif %}
+  {% if rowGap is defined and rowGap is not empty %}row-gap="{{ rowGap }}"{% endif %}
+  {% if columnGap is defined and columnGap is not empty %}column-gap="{{ columnGap }}"{% endif %}
+  {% if align is defined and align is not empty %}align="{{ align }}"{% endif %}
+  {% if justify is defined and justify is not empty %}justify="{{ justify }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-grid>

--- a/packages/hx-library/drupal/components/hx-help-text/README.md
+++ b/packages/hx-library/drupal/components/hx-help-text/README.md
@@ -1,0 +1,49 @@
+# HX Help Text
+
+Standardized help/hint text displayed below form fields.
+Used by hx-field as a consistent sub-component for guidance and validation messages.
+
+Non-default variants render an inline icon alongside the text to satisfy
+WCAG 1.4.1 (color is not the sole visual indicator). The `error` variant
+uses `role="alert"` for immediate screen-reader announcement; `warning`
+and `success` use `aria-live="polite"` for non-intrusive announcements.
+
+## Usage
+
+```twig
+{% include 'helix:hx-help-text' with {
+  variant: 'default',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | default | Visual variant that determines the text color and icon.
+Use `error` for validation errors, `warning` for cautions, `success` for confirmation. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | The help text content. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-help-text-color | var(--hx-color-neutral-500) | Text color. |
+| --hx-help-text-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-help-text-font-size | var(--hx-font-size-sm) | Font size. |
+| --hx-help-text-font-weight | var(--hx-font-weight-normal) | Font weight. |
+| --hx-help-text-line-height | var(--hx-line-height-normal) | Line height. |
+| --hx-help-text-icon-gap | 0.375rem | Gap between icon and text. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root element of the help text. |
+| icon | The icon wrapper (only rendered for non-default variants). |
+| text | The text wrapper around the default slot. |

--- a/packages/hx-library/drupal/components/hx-help-text/hx-help-text.component.yml
+++ b/packages/hx-library/drupal/components/hx-help-text/hx-help-text.component.yml
@@ -1,0 +1,18 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Help Text
+status: experimental
+group: HELiX
+description: 'Standardized help/hint text displayed below form fields. Used by hx-field as a consistent sub-component for guidance and validation messages.  Non-default variants render an inline icon alongside the text to satisfy WCAG 1.4.1 (color is not the sole visual indicator). The `error` variant uses `role="alert"` for immediate screen-reader announcement; `warning` and `success` use `aria-live="polite"` for non-intrusive announcements.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant that determines the text color and icon. Use `error` for validation errors, `warning` for cautions, `success` for confirmation.'
+      default: 'default'
+slots:
+  default:
+    title: Default
+    description: 'The help text content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-help-text/hx-help-text.css
+++ b/packages/hx-library/drupal/components/hx-help-text/hx-help-text.css
@@ -1,0 +1,20 @@
+/**
+ * HX Help Text component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-help-text-color: Text color. (default: var(--hx-color-neutral-500))
+ * --hx-help-text-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-help-text-font-size: Font size. (default: var(--hx-font-size-sm))
+ * --hx-help-text-font-weight: Font weight. (default: var(--hx-font-weight-normal))
+ * --hx-help-text-line-height: Line height. (default: var(--hx-line-height-normal))
+ * --hx-help-text-icon-gap: Gap between icon and text. (default: 0.375rem)
+ */
+
+/* Component host styles */
+hx-help-text {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-help-text/hx-help-text.js
+++ b/packages/hx-library/drupal/components/hx-help-text/hx-help-text.js
@@ -1,0 +1,11 @@
+/**
+ * HX Help Text - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-help-text';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-help-text');
+}

--- a/packages/hx-library/drupal/components/hx-help-text/hx-help-text.twig
+++ b/packages/hx-library/drupal/components/hx-help-text/hx-help-text.twig
@@ -1,0 +1,20 @@
+{#
+ /**
+ * @file
+ * HX Help Text component template.
+ *
+ * Standardized help/hint text displayed below form fields.
+ * Used by hx-field as a consistent sub-component for guidance and validation messages.
+ * 
+ * Non-default variants render an inline icon alongside the text to satisfy
+ * WCAG 1.4.1 (color is not the sole visual indicator). The `error` variant
+ * uses `role="alert"` for immediate screen-reader announcement; `warning`
+ * and `success` use `aria-live="polite"` for non-intrusive announcements.
+ *
+ * Available variables:
+ * - variant: object - Visual variant that determines the text color and icon. Use `error` for validation errors, `warning` for cautions, `success` for confirmation.
+ */
+#}
+<hx-help-text {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-help-text>

--- a/packages/hx-library/drupal/components/hx-icon-button/README.md
+++ b/packages/hx-library/drupal/components/hx-icon-button/README.md
@@ -1,0 +1,67 @@
+# HX Icon Button
+
+An icon-only button component for compact, accessible actions.
+Renders a square button or anchor element containing a single icon.
+The `label` property is required and provides the accessible name
+via `aria-label` and a native tooltip via the `title` attribute.
+
+## Usage
+
+```twig
+{% include 'helix:hx-icon-button' with {
+  label: '',
+  variant: 'ghost',
+  size: 'md',
+  type: 'button',
+  disabled: false,
+  href: 'undefined',
+  name: 'undefined',
+  value: 'undefined',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | Accessible name for the button. Required. Rendered as `aria-label` and
+`title` on the underlying element. The component renders nothing when absent,
+and a console warning is emitted to alert developers during authoring. |
+| variant | object | ghost | Visual style variant of the button. |
+| size | object | md | Size of the button. |
+| type | object | button | The type attribute for the underlying button element.
+Has no effect when `href` is set. |
+| disabled | boolean | false | Whether the button is disabled. |
+| href | object | undefined | When set, renders an `<a>` element instead of a `<button>`. |
+| name | object | undefined | Name submitted with form data. Only applicable when rendering as a button. |
+| value | object | undefined | Value submitted with form data. Only applicable when rendering as a button. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Icon element to display (hx-icon, svg, or img). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-click | Dispatched when the button is clicked (not disabled). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-icon-button-bg | transparent | Button background color. |
+| --hx-icon-button-color | var(--hx-color-primary-500) | Icon color. |
+| --hx-icon-button-border-color | transparent | Button border color. |
+| --hx-icon-button-border-radius | var(--hx-border-radius-md) | Button border radius. |
+| --hx-icon-button-size | - | Explicit width and height override for the button. |
+| --hx-icon-button-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| button | The native button or anchor element. |
+| icon | The icon container span wrapping the default slot. |

--- a/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.component.yml
+++ b/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.component.yml
@@ -1,0 +1,53 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Icon Button
+status: experimental
+group: HELiX
+description: 'An icon-only button component for compact, accessible actions. Renders a square button or anchor element containing a single icon. The `label` property is required and provides the accessible name via `aria-label` and a native tooltip via the `title` attribute.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'Accessible name for the button. Required. Rendered as `aria-label` and `title` on the underlying element. The component renders nothing when absent, and a console warning is emitted to alert developers during authoring.'
+      default: ''
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the button.'
+      default: 'ghost'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the button.'
+      default: 'md'
+    type:
+      type: object
+      title: Type
+      description: 'The type attribute for the underlying button element. Has no effect when `href` is set.'
+      default: 'button'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the button is disabled.'
+      default: false
+    href:
+      type: object
+      title: Href
+      description: 'When set, renders an `<a>` element instead of a `<button>`.'
+      default: 'undefined'
+    name:
+      type: object
+      title: Name
+      description: 'Name submitted with form data. Only applicable when rendering as a button.'
+      default: 'undefined'
+    value:
+      type: object
+      title: Value
+      description: 'Value submitted with form data. Only applicable when rendering as a button.'
+      default: 'undefined'
+slots:
+  default:
+    title: Default
+    description: 'Icon element to display (hx-icon, svg, or img).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.css
+++ b/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.css
@@ -1,0 +1,20 @@
+/**
+ * HX Icon Button component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-icon-button-bg: Button background color. (default: transparent)
+ * --hx-icon-button-color: Icon color. (default: var(--hx-color-primary-500))
+ * --hx-icon-button-border-color: Button border color. (default: transparent)
+ * --hx-icon-button-border-radius: Button border radius. (default: var(--hx-border-radius-md))
+ * --hx-icon-button-size: Explicit width and height override for the button.
+ * --hx-icon-button-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ */
+
+/* Component host styles */
+hx-icon-button {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.js
+++ b/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.js
@@ -1,0 +1,11 @@
+/**
+ * HX Icon Button - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-icon-button';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-icon-button');
+}

--- a/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.twig
+++ b/packages/hx-library/drupal/components/hx-icon-button/hx-icon-button.twig
@@ -1,0 +1,33 @@
+{#
+ /**
+ * @file
+ * HX Icon Button component template.
+ *
+ * An icon-only button component for compact, accessible actions.
+ * Renders a square button or anchor element containing a single icon.
+ * The `label` property is required and provides the accessible name
+ * via `aria-label` and a native tooltip via the `title` attribute.
+ *
+ * Available variables:
+ * - label: string - Accessible name for the button. Required. Rendered as `aria-label` and `title` on the underlying element. The component renders nothing when absent, and a console warning is emitted to alert developers during authoring.
+ * - variant: object - Visual style variant of the button.
+ * - size: object - Size of the button.
+ * - type: object - The type attribute for the underlying button element. Has no effect when `href` is set.
+ * - disabled: boolean - Whether the button is disabled.
+ * - href: object - When set, renders an `<a>` element instead of a `<button>`.
+ * - name: object - Name submitted with form data. Only applicable when rendering as a button.
+ * - value: object - Value submitted with form data. Only applicable when rendering as a button.
+ */
+#}
+<hx-icon-button
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if type is defined and type is not empty %}type="{{ type }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if href is defined and href is not empty %}href="{{ href }}"{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-icon-button>

--- a/packages/hx-library/drupal/components/hx-icon/README.md
+++ b/packages/hx-library/drupal/components/hx-icon/README.md
@@ -1,0 +1,66 @@
+# HX Icon
+
+An icon component that supports inline SVG fetching and SVG sprite sheet references.
+Decorative icons are automatically hidden from assistive technology.
+When a label is provided the icon is announced as an image with that label.
+
+**Render modes:**
+- **Sprite mode** (recommended for Drupal/SSR): Set `name` and optionally `sprite-url`.
+  Renders an `<svg><use href="...#name">` — works server-side without JavaScript.
+- **Inline mode**: Set `src` to a URL of a standalone SVG file. The component fetches,
+  sanitizes, and embeds the SVG markup. Requires JavaScript; not server-side renderable.
+  For Drupal/Twig templates use sprite mode to avoid content shift before hydration.
+
+## Usage
+
+```twig
+{% include 'helix:hx-icon' with {
+  name: '',
+  src: 'undefined',
+  spriteUrl: 'undefined',
+  size: 'md',
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | Icon name used as the fragment identifier when referencing a sprite sheet.
+For sprite mode provide the bare symbol id (e.g. `check`). The component
+will build the full href as `${spriteUrl}#${name}`. If `name` already
+starts with `#` it is used as-is (inline sprite reference without a base
+URL). |
+| src | object | undefined | URL of a standalone SVG file to fetch and render inline. Takes precedence
+over sprite mode when both `src` and `spriteUrl`/`name` are set.
+
+**Note:** Inline mode requires browser JavaScript (`fetch` + `DOMParser`).
+It is not server-side renderable. For Drupal/Twig use sprite mode instead. |
+| spriteUrl | object | undefined | Base URL of the SVG sprite sheet. Used together with `name` to construct
+the `<use>` href: `${spriteUrl}#${name}`. |
+| size | object | md | Size variant of the icon.
+
+Set via the `hx-size` HTML attribute (e.g. `hx-size="lg"`) or via the
+`size` JavaScript property (e.g. `el.size = 'lg'`). Both are equivalent —
+the `attribute: 'hx-size'` mapping is used to avoid colliding with the
+native `<input>` `size` attribute in Drupal attribute-passthrough scenarios.
+The CEM exposes both the JS property name (`size`) and the HTML attribute
+name (`hx-size`). |
+| label | string |  | Accessible label for the icon. When non-empty, `role="img"` and
+`aria-label` are applied so assistive technology announces the icon.
+When empty the icon is treated as decorative and `aria-hidden="true"` is
+applied. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-icon-size | var(--hx-size-6,1.5rem) | Width and height of the icon. |
+| --hx-icon-color | currentColor | Icon color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| svg | The SVG element rendered in sprite mode, or the inline SVG container in inline mode. In sprite mode this is an `<svg>` element; in inline mode it is a `<span>` element wrapping the fetched SVG. Both expose the same `part` name for consistent external styling via `::part(svg)`. |

--- a/packages/hx-library/drupal/components/hx-icon/hx-icon.component.yml
+++ b/packages/hx-library/drupal/components/hx-icon/hx-icon.component.yml
@@ -1,0 +1,34 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Icon
+status: experimental
+group: HELiX
+description: 'An icon component that supports inline SVG fetching and SVG sprite sheet references. Decorative icons are automatically hidden from assistive technology. When a label is provided the icon is announced as an image with that label.  **Render modes:** - **Sprite mode** (recommended for Drupal/SSR): Set `name` and optionally `sprite-url`.   Renders an `<svg><use href="...#name">` — works server-side without JavaScript. - **Inline mode**: Set `src` to a URL of a standalone SVG file. The component fetches,   sanitizes, and embeds the SVG markup. Requires JavaScript; not server-side renderable.   For Drupal/Twig templates use sprite mode to avoid content shift before hydration.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'Icon name used as the fragment identifier when referencing a sprite sheet. For sprite mode provide the bare symbol id (e.g. `check`). The component will build the full href as `${spriteUrl}#${name}`. If `name` already starts with `#` it is used as-is (inline sprite reference without a base URL).'
+      default: ''
+    src:
+      type: object
+      title: Src
+      description: 'URL of a standalone SVG file to fetch and render inline. Takes precedence over sprite mode when both `src` and `spriteUrl`/`name` are set.  **Note:** Inline mode requires browser JavaScript (`fetch` + `DOMParser`). It is not server-side renderable. For Drupal/Twig use sprite mode instead.'
+      default: 'undefined'
+    spriteUrl:
+      type: object
+      title: Sprite Url
+      description: 'Base URL of the SVG sprite sheet. Used together with `name` to construct the `<use>` href: `${spriteUrl}#${name}`.'
+      default: 'undefined'
+    size:
+      type: object
+      title: Size
+      description: 'Size variant of the icon.  Set via the `hx-size` HTML attribute (e.g. `hx-size="lg"`) or via the `size` JavaScript property (e.g. `el.size = ''lg''`). Both are equivalent — the `attribute: ''hx-size''` mapping is used to avoid colliding with the native `<input>` `size` attribute in Drupal attribute-passthrough scenarios. The CEM exposes both the JS property name (`size`) and the HTML attribute name (`hx-size`).'
+      default: 'md'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the icon. When non-empty, `role="img"` and `aria-label` are applied so assistive technology announces the icon. When empty the icon is treated as decorative and `aria-hidden="true"` is applied.'
+      default: ''
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-icon/hx-icon.css
+++ b/packages/hx-library/drupal/components/hx-icon/hx-icon.css
@@ -1,0 +1,16 @@
+/**
+ * HX Icon component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-icon-size: Width and height of the icon. (default: var(--hx-size-6,1.5rem))
+ * --hx-icon-color: Icon color. (default: currentColor)
+ */
+
+/* Component host styles */
+hx-icon {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-icon/hx-icon.js
+++ b/packages/hx-library/drupal/components/hx-icon/hx-icon.js
@@ -1,0 +1,11 @@
+/**
+ * HX Icon - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-icon';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-icon');
+}

--- a/packages/hx-library/drupal/components/hx-icon/hx-icon.twig
+++ b/packages/hx-library/drupal/components/hx-icon/hx-icon.twig
@@ -1,0 +1,32 @@
+{#
+ /**
+ * @file
+ * HX Icon component template.
+ *
+ * An icon component that supports inline SVG fetching and SVG sprite sheet references.
+ * Decorative icons are automatically hidden from assistive technology.
+ * When a label is provided the icon is announced as an image with that label.
+ * 
+ * **Render modes:**
+ * - **Sprite mode** (recommended for Drupal/SSR): Set `name` and optionally `sprite-url`.
+ *   Renders an `<svg><use href="...#name">` — works server-side without JavaScript.
+ * - **Inline mode**: Set `src` to a URL of a standalone SVG file. The component fetches,
+ *   sanitizes, and embeds the SVG markup. Requires JavaScript; not server-side renderable.
+ *   For Drupal/Twig templates use sprite mode to avoid content shift before hydration.
+ *
+ * Available variables:
+ * - name: string - Icon name used as the fragment identifier when referencing a sprite sheet. For sprite mode provide the bare symbol id (e.g. `check`). The component will build the full href as `${spriteUrl}#${name}`. If `name` already starts with `#` it is used as-is (inline sprite reference without a base URL).
+ * - src: object - URL of a standalone SVG file to fetch and render inline. Takes precedence over sprite mode when both `src` and `spriteUrl`/`name` are set.  **Note:** Inline mode requires browser JavaScript (`fetch` + `DOMParser`). It is not server-side renderable. For Drupal/Twig use sprite mode instead.
+ * - spriteUrl: object - Base URL of the SVG sprite sheet. Used together with `name` to construct the `<use>` href: `${spriteUrl}#${name}`.
+ * - size: object - Size variant of the icon.  Set via the `hx-size` HTML attribute (e.g. `hx-size="lg"`) or via the `size` JavaScript property (e.g. `el.size = 'lg'`). Both are equivalent — the `attribute: 'hx-size'` mapping is used to avoid colliding with the native `<input>` `size` attribute in Drupal attribute-passthrough scenarios. The CEM exposes both the JS property name (`size`) and the HTML attribute name (`hx-size`).
+ * - label: string - Accessible label for the icon. When non-empty, `role="img"` and `aria-label` are applied so assistive technology announces the icon. When empty the icon is treated as decorative and `aria-hidden="true"` is applied.
+ */
+#}
+<hx-icon
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if src is defined and src is not empty %}src="{{ src }}"{% endif %}
+  {% if spriteUrl is defined and spriteUrl is not empty %}sprite-url="{{ spriteUrl }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+</hx-icon>

--- a/packages/hx-library/drupal/components/hx-image/README.md
+++ b/packages/hx-library/drupal/components/hx-image/README.md
@@ -1,0 +1,88 @@
+# HX Image
+
+An accessible image wrapper with lazy loading, fallback support, aspect ratio control,
+responsive image (srcset/sizes) support, and optional caption.
+
+## Usage
+
+```twig
+{% include 'helix:hx-image' with {
+  src: '',
+  alt: 'undefined',
+  decorative: false,
+  width: 'undefined',
+  height: 'undefined',
+  loading: 'lazy',
+  fit: 'undefined',
+  ratio: 'undefined',
+  rounded: 'undefined',
+  fallbackSrc: 'undefined',
+  srcset: 'undefined',
+  sizes: 'undefined',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| src | string |  | The URL of the image to display. |
+| alt | object | undefined | Accessible text description of the image.
+Required for informative images. Use the `decorative` prop for decorative images
+instead of setting this to an empty string — explicit decorative intent is preferred. |
+| decorative | boolean | false | Marks the image as decorative (hidden from screen readers).
+Use this instead of `alt=""` to make decorative intent explicit in markup.
+When set, the inner img receives `alt=""` and `role="presentation"`. |
+| width | object | undefined | Width of the image element. |
+| height | object | undefined | Height of the image element. |
+| loading | object | lazy | Loading strategy for the image. |
+| fit | object | undefined | How the image should be resized to fit its container.
+Maps to CSS object-fit. |
+| ratio | object | undefined | CSS aspect-ratio value (e.g. "16/9", "1", "4/3").
+When set, the container maintains this ratio. |
+| rounded | object | undefined | Border radius for the image.
+Boolean attribute (or `true`) applies the theme's medium radius token.
+A string value is used directly as a CSS border-radius value (e.g. "1rem", "50%").
+
+Note: When set as an HTML attribute (`<hx-image rounded>`), Lit receives the value as
+an empty string (`''`). When set programmatically (`el.rounded = true`), it receives
+a boolean. Both forms apply the theme radius token. |
+| fallbackSrc | object | undefined | Fallback image URL shown when the primary src fails to load. |
+| srcset | object | undefined | A comma-separated list of image candidates for responsive images.
+Passed directly to the inner img's srcset attribute.
+Enables Drupal responsive image styles and browser-native image selection. |
+| sizes | object | undefined | Media conditions indicating which image size to use alongside srcset.
+Works in conjunction with the `srcset` attribute. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| fallback | Custom content shown when the image fails to load and no fallback-src is set. |
+| caption | Optional caption content rendered in a figcaption element below the image. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-load | Dispatched when the image has successfully loaded. |
+| hx-error | Dispatched when the image fails to load (including after fallback-src also fails). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-image-object-fit | - | Controls how the image fills its container. Maps to object-fit. |
+| --hx-image-border-radius | - | Border radius of the image. Overridden by the `rounded` prop. |
+| --hx-image-aspect-ratio | - | Aspect ratio of the image container. Overridden by the `ratio` prop. |
+| --hx-image-caption-color | - | Text color for the caption. |
+| --hx-image-caption-font-size | - | Font size for the caption. |
+| --hx-image-caption-padding | - | Padding for the caption. |
+| --hx-image-fallback-min-height | - | Minimum height of the error/fallback container. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner img element. |
+| caption | The figcaption element (visible only when caption content is present). |

--- a/packages/hx-library/drupal/components/hx-image/hx-image.component.yml
+++ b/packages/hx-library/drupal/components/hx-image/hx-image.component.yml
@@ -1,0 +1,76 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Image
+status: experimental
+group: HELiX
+description: 'An accessible image wrapper with lazy loading, fallback support, aspect ratio control, responsive image (srcset/sizes) support, and optional caption.'
+props:
+  type: object
+  properties:
+    src:
+      type: string
+      title: Src
+      description: 'The URL of the image to display.'
+      default: ''
+    alt:
+      type: object
+      title: Alt
+      description: 'Accessible text description of the image. Required for informative images. Use the `decorative` prop for decorative images instead of setting this to an empty string — explicit decorative intent is preferred.'
+      default: 'undefined'
+    decorative:
+      type: boolean
+      title: Decorative
+      description: 'Marks the image as decorative (hidden from screen readers). Use this instead of `alt=""` to make decorative intent explicit in markup. When set, the inner img receives `alt=""` and `role="presentation"`.'
+      default: false
+    width:
+      type: object
+      title: Width
+      description: 'Width of the image element.'
+      default: 'undefined'
+    height:
+      type: object
+      title: Height
+      description: 'Height of the image element.'
+      default: 'undefined'
+    loading:
+      type: object
+      title: Loading
+      description: 'Loading strategy for the image.'
+      default: 'lazy'
+    fit:
+      type: object
+      title: Fit
+      description: 'How the image should be resized to fit its container. Maps to CSS object-fit.'
+      default: 'undefined'
+    ratio:
+      type: object
+      title: Ratio
+      description: 'CSS aspect-ratio value (e.g. "16/9", "1", "4/3"). When set, the container maintains this ratio.'
+      default: 'undefined'
+    rounded:
+      type: object
+      title: Rounded
+      description: 'Border radius for the image. Boolean attribute (or `true`) applies the theme''s medium radius token. A string value is used directly as a CSS border-radius value (e.g. "1rem", "50%").  Note: When set as an HTML attribute (`<hx-image rounded>`), Lit receives the value as an empty string (`''''`). When set programmatically (`el.rounded = true`), it receives a boolean. Both forms apply the theme radius token.'
+      default: 'undefined'
+    fallbackSrc:
+      type: object
+      title: Fallback Src
+      description: 'Fallback image URL shown when the primary src fails to load.'
+      default: 'undefined'
+    srcset:
+      type: object
+      title: Srcset
+      description: "A comma-separated list of image candidates for responsive images. Passed directly to the inner img's srcset attribute. Enables Drupal responsive image styles and browser-native image selection."
+      default: 'undefined'
+    sizes:
+      type: object
+      title: Sizes
+      description: 'Media conditions indicating which image size to use alongside srcset. Works in conjunction with the `srcset` attribute.'
+      default: 'undefined'
+slots:
+  fallback:
+    title: Fallback
+    description: 'Custom content shown when the image fails to load and no fallback-src is set.'
+  caption:
+    title: Caption
+    description: 'Optional caption content rendered in a figcaption element below the image.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-image/hx-image.css
+++ b/packages/hx-library/drupal/components/hx-image/hx-image.css
@@ -1,0 +1,21 @@
+/**
+ * HX Image component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-image-object-fit: Controls how the image fills its container. Maps to object-fit.
+ * --hx-image-border-radius: Border radius of the image. Overridden by the `rounded` prop.
+ * --hx-image-aspect-ratio: Aspect ratio of the image container. Overridden by the `ratio` prop.
+ * --hx-image-caption-color: Text color for the caption.
+ * --hx-image-caption-font-size: Font size for the caption.
+ * --hx-image-caption-padding: Padding for the caption.
+ * --hx-image-fallback-min-height: Minimum height of the error/fallback container.
+ */
+
+/* Component host styles */
+hx-image {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-image/hx-image.js
+++ b/packages/hx-library/drupal/components/hx-image/hx-image.js
@@ -1,0 +1,11 @@
+/**
+ * HX Image - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-image';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-image');
+}

--- a/packages/hx-library/drupal/components/hx-image/hx-image.twig
+++ b/packages/hx-library/drupal/components/hx-image/hx-image.twig
@@ -1,0 +1,44 @@
+{#
+ /**
+ * @file
+ * HX Image component template.
+ *
+ * An accessible image wrapper with lazy loading, fallback support, aspect ratio control,
+ * responsive image (srcset/sizes) support, and optional caption.
+ *
+ * Available variables:
+ * - src: string - The URL of the image to display.
+ * - alt: object - Accessible text description of the image. Required for informative images. Use the `decorative` prop for decorative images instead of setting this to an empty string — explicit decorative intent is preferred.
+ * - decorative: boolean - Marks the image as decorative (hidden from screen readers). Use this instead of `alt=""` to make decorative intent explicit in markup. When set, the inner img receives `alt=""` and `role="presentation"`.
+ * - width: object - Width of the image element.
+ * - height: object - Height of the image element.
+ * - loading: object - Loading strategy for the image.
+ * - fit: object - How the image should be resized to fit its container. Maps to CSS object-fit.
+ * - ratio: object - CSS aspect-ratio value (e.g. "16/9", "1", "4/3"). When set, the container maintains this ratio.
+ * - rounded: object - Border radius for the image. Boolean attribute (or `true`) applies the theme's medium radius token. A string value is used directly as a CSS border-radius value (e.g. "1rem", "50%").  Note: When set as an HTML attribute (`<hx-image rounded>`), Lit receives the value as an empty string (`''`). When set programmatically (`el.rounded = true`), it receives a boolean. Both forms apply the theme radius token.
+ * - fallbackSrc: object - Fallback image URL shown when the primary src fails to load.
+ * - srcset: object - A comma-separated list of image candidates for responsive images. Passed directly to the inner img's srcset attribute. Enables Drupal responsive image styles and browser-native image selection.
+ * - sizes: object - Media conditions indicating which image size to use alongside srcset. Works in conjunction with the `srcset` attribute.
+ */
+#}
+<hx-image
+  {% if src is defined and src is not empty %}src="{{ src }}"{% endif %}
+  {% if alt is defined and alt is not empty %}alt="{{ alt }}"{% endif %}
+  {% if decorative %}decorative{% endif %}
+  {% if width is defined and width is not empty %}width="{{ width }}"{% endif %}
+  {% if height is defined and height is not empty %}height="{{ height }}"{% endif %}
+  {% if loading is defined and loading is not empty %}loading="{{ loading }}"{% endif %}
+  {% if fit is defined and fit is not empty %}fit="{{ fit }}"{% endif %}
+  {% if ratio is defined and ratio is not empty %}ratio="{{ ratio }}"{% endif %}
+  {% if rounded is defined and rounded is not empty %}rounded="{{ rounded }}"{% endif %}
+  {% if fallbackSrc is defined and fallbackSrc is not empty %}fallback-src="{{ fallbackSrc }}"{% endif %}
+  {% if srcset is defined and srcset is not empty %}srcset="{{ srcset }}"{% endif %}
+  {% if sizes is defined and sizes is not empty %}sizes="{{ sizes }}"{% endif %}
+>
+  {% if slots.fallback is defined %}
+    <slot name="fallback">{{ slots.fallback }}</slot>
+  {% endif %}
+  {% if slots.caption is defined %}
+    <slot name="caption">{{ slots.caption }}</slot>
+  {% endif %}
+</hx-image>

--- a/packages/hx-library/drupal/components/hx-link/README.md
+++ b/packages/hx-library/drupal/components/hx-link/README.md
@@ -1,0 +1,71 @@
+# HX Link
+
+A semantic hyperlink component with accessibility-first design.
+Renders a native `<a>` element for enabled state and a `<span>` for
+disabled state with full keyboard and screen reader support.
+
+## Usage
+
+```twig
+{% include 'helix:hx-link' with {
+  href: 'undefined',
+  target: 'undefined',
+  variant: 'default',
+  disabled: false,
+  download: 'undefined',
+  rel: 'undefined',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| href | object | undefined | The URL the link points to. |
+| target | object | undefined | Where to display the linked URL (_self, _blank, etc.).
+When set to "_blank", automatically adds rel="noopener noreferrer"
+and shows an external-link indicator. |
+| variant | object | default | Visual style variant of the link. |
+| disabled | boolean | false | Whether the link is disabled. Renders a span instead of an anchor.
+The disabled span is keyboard-focusable (tabindex="0") and announces
+as a disabled link to screen readers. |
+| download | object | undefined | Prompts the user to download the linked URL. When set to a string,
+the value is used as the suggested filename. |
+| rel | object | undefined | Relationship between the current document and the linked URL.
+Automatically set to "noopener noreferrer" when target="_blank". |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for link label text or content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-click | Dispatched when the link is clicked and is not disabled. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-link-color | var(--hx-color-primary-500) | Default link color. |
+| --hx-link-color-hover | var(--hx-color-primary-700) | Hover color. |
+| --hx-link-color-active | var(--hx-color-primary-800) | Active color. |
+| --hx-link-color-disabled | var(--hx-color-neutral-400) | Disabled color. |
+| --hx-link-color-subtle | var(--hx-color-neutral-600) | Subtle variant color. |
+| --hx-link-color-danger | var(--hx-color-error-text) | Danger variant color. |
+| --hx-link-color-danger-hover | var(--hx-color-error-700) | Danger variant hover color. |
+| --hx-link-font-family | var(--hx-font-family-sans) | Link font family. |
+| --hx-link-text-decoration | underline | Link text decoration. |
+| --hx-link-text-decoration-hover | underline | Hover text decoration. |
+| --hx-link-underline-offset | 2px | Text underline offset. |
+| --hx-link-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| link | The inner anchor or span element. |
+| external-icon | The external link icon SVG (when target="_blank"). |

--- a/packages/hx-library/drupal/components/hx-link/hx-link.component.yml
+++ b/packages/hx-library/drupal/components/hx-link/hx-link.component.yml
@@ -1,0 +1,43 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Link
+status: experimental
+group: HELiX
+description: 'A semantic hyperlink component with accessibility-first design. Renders a native `<a>` element for enabled state and a `<span>` for disabled state with full keyboard and screen reader support.'
+props:
+  type: object
+  properties:
+    href:
+      type: object
+      title: Href
+      description: 'The URL the link points to.'
+      default: 'undefined'
+    target:
+      type: object
+      title: Target
+      description: 'Where to display the linked URL (_self, _blank, etc.). When set to "_blank", automatically adds rel="noopener noreferrer" and shows an external-link indicator.'
+      default: 'undefined'
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the link.'
+      default: 'default'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the link is disabled. Renders a span instead of an anchor. The disabled span is keyboard-focusable (tabindex="0") and announces as a disabled link to screen readers.'
+      default: false
+    download:
+      type: object
+      title: Download
+      description: 'Prompts the user to download the linked URL. When set to a string, the value is used as the suggested filename.'
+      default: 'undefined'
+    rel:
+      type: object
+      title: Rel
+      description: 'Relationship between the current document and the linked URL. Automatically set to "noopener noreferrer" when target="_blank".'
+      default: 'undefined'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for link label text or content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-link/hx-link.css
+++ b/packages/hx-library/drupal/components/hx-link/hx-link.css
@@ -1,0 +1,26 @@
+/**
+ * HX Link component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-link-color: Default link color. (default: var(--hx-color-primary-500))
+ * --hx-link-color-hover: Hover color. (default: var(--hx-color-primary-700))
+ * --hx-link-color-active: Active color. (default: var(--hx-color-primary-800))
+ * --hx-link-color-disabled: Disabled color. (default: var(--hx-color-neutral-400))
+ * --hx-link-color-subtle: Subtle variant color. (default: var(--hx-color-neutral-600))
+ * --hx-link-color-danger: Danger variant color. (default: var(--hx-color-error-text))
+ * --hx-link-color-danger-hover: Danger variant hover color. (default: var(--hx-color-error-700))
+ * --hx-link-font-family: Link font family. (default: var(--hx-font-family-sans))
+ * --hx-link-text-decoration: Link text decoration. (default: underline)
+ * --hx-link-text-decoration-hover: Hover text decoration. (default: underline)
+ * --hx-link-underline-offset: Text underline offset. (default: 2px)
+ * --hx-link-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ */
+
+/* Component host styles */
+hx-link {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-link/hx-link.js
+++ b/packages/hx-library/drupal/components/hx-link/hx-link.js
@@ -1,0 +1,11 @@
+/**
+ * HX Link - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-link';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-link');
+}

--- a/packages/hx-library/drupal/components/hx-link/hx-link.twig
+++ b/packages/hx-library/drupal/components/hx-link/hx-link.twig
@@ -1,0 +1,28 @@
+{#
+ /**
+ * @file
+ * HX Link component template.
+ *
+ * A semantic hyperlink component with accessibility-first design.
+ * Renders a native `<a>` element for enabled state and a `<span>` for
+ * disabled state with full keyboard and screen reader support.
+ *
+ * Available variables:
+ * - href: object - The URL the link points to.
+ * - target: object - Where to display the linked URL (_self, _blank, etc.). When set to "_blank", automatically adds rel="noopener noreferrer" and shows an external-link indicator.
+ * - variant: object - Visual style variant of the link.
+ * - disabled: boolean - Whether the link is disabled. Renders a span instead of an anchor. The disabled span is keyboard-focusable (tabindex="0") and announces as a disabled link to screen readers.
+ * - download: object - Prompts the user to download the linked URL. When set to a string, the value is used as the suggested filename.
+ * - rel: object - Relationship between the current document and the linked URL. Automatically set to "noopener noreferrer" when target="_blank".
+ */
+#}
+<hx-link
+  {% if href is defined and href is not empty %}href="{{ href }}"{% endif %}
+  {% if target is defined and target is not empty %}target="{{ target }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if download is defined and download is not empty %}download="{{ download }}"{% endif %}
+  {% if rel is defined and rel is not empty %}rel="{{ rel }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-link>

--- a/packages/hx-library/drupal/components/hx-list-item/README.md
+++ b/packages/hx-library/drupal/components/hx-list-item/README.md
@@ -1,0 +1,64 @@
+# HX List Item
+
+A rich list item for use inside `hx-list`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-list-item' with {
+  disabled: false,
+  selected: false,
+  href: 'undefined',
+  value: 'undefined',
+  interactive: false,
+  type: 'default',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| disabled | boolean | false | Whether the item is disabled. Prevents interaction. |
+| selected | boolean | false | Whether the item is selected (used in interactive mode). |
+| href | object | undefined | When set, renders the item as a link (only in non-interactive variants). |
+| value | object | undefined | The value associated with this item (used with hx-select). |
+| interactive | boolean | false | Set by the parent hx-list to indicate this item is part of an interactive listbox.
+Controls CSS styling and ARIA role via host attributes. |
+| type | object | default | Item type for description list variant. Use 'term' for <dt> and 'definition' for <dd>. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the item label text. |
+| prefix | Icon, avatar, or content rendered before the label. |
+| suffix | Icon, badge, or text rendered after the label. |
+| description | Secondary descriptive text rendered below the label. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-list-item-click | Dispatched when the item is clicked and not disabled. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-list-item-padding | var(--hx-space-3) | Item padding. |
+| --hx-list-item-color | var(--hx-color-neutral-900) | Item text color. |
+| --hx-list-item-bg-hover | var(--hx-color-neutral-50) | Item hover background. |
+| --hx-list-item-bg-selected | var(--hx-color-primary-50) | Selected item background. |
+| --hx-list-item-color-selected | var(--hx-color-primary-700) | Selected item text color. |
+| --hx-list-item-description-color | var(--hx-color-neutral-500) | Description text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root item element (li, dt, dd, or wrapper). |
+| prefix | The prefix slot container. |
+| label | The label slot container. |
+| description | The description slot container. |
+| suffix | The suffix slot container. |

--- a/packages/hx-library/drupal/components/hx-list-item/hx-list-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-list-item/hx-list-item.component.yml
@@ -1,0 +1,52 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX List Item
+status: experimental
+group: HELiX
+description: 'A rich list item for use inside `hx-list`.'
+props:
+  type: object
+  properties:
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the item is disabled. Prevents interaction.'
+      default: false
+    selected:
+      type: boolean
+      title: Selected
+      description: 'Whether the item is selected (used in interactive mode).'
+      default: false
+    href:
+      type: object
+      title: Href
+      description: 'When set, renders the item as a link (only in non-interactive variants).'
+      default: 'undefined'
+    value:
+      type: object
+      title: Value
+      description: 'The value associated with this item (used with hx-select).'
+      default: 'undefined'
+    interactive:
+      type: boolean
+      title: Interactive
+      description: 'Set by the parent hx-list to indicate this item is part of an interactive listbox. Controls CSS styling and ARIA role via host attributes.'
+      default: false
+    type:
+      type: object
+      title: Type
+      description: "Item type for description list variant. Use 'term' for <dt> and 'definition' for <dd>."
+      default: 'default'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the item label text.'
+  prefix:
+    title: Prefix
+    description: 'Icon, avatar, or content rendered before the label.'
+  suffix:
+    title: Suffix
+    description: 'Icon, badge, or text rendered after the label.'
+  description:
+    title: Description
+    description: 'Secondary descriptive text rendered below the label.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-list-item/hx-list-item.css
+++ b/packages/hx-library/drupal/components/hx-list-item/hx-list-item.css
@@ -1,0 +1,20 @@
+/**
+ * HX List Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-list-item-padding: Item padding. (default: var(--hx-space-3))
+ * --hx-list-item-color: Item text color. (default: var(--hx-color-neutral-900))
+ * --hx-list-item-bg-hover: Item hover background. (default: var(--hx-color-neutral-50))
+ * --hx-list-item-bg-selected: Selected item background. (default: var(--hx-color-primary-50))
+ * --hx-list-item-color-selected: Selected item text color. (default: var(--hx-color-primary-700))
+ * --hx-list-item-description-color: Description text color. (default: var(--hx-color-neutral-500))
+ */
+
+/* Component host styles */
+hx-list-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-list-item/hx-list-item.js
+++ b/packages/hx-library/drupal/components/hx-list-item/hx-list-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX List Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-list-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-list-item');
+}

--- a/packages/hx-library/drupal/components/hx-list-item/hx-list-item.twig
+++ b/packages/hx-library/drupal/components/hx-list-item/hx-list-item.twig
@@ -1,0 +1,35 @@
+{#
+ /**
+ * @file
+ * HX List Item component template.
+ *
+ * A rich list item for use inside `hx-list`.
+ *
+ * Available variables:
+ * - disabled: boolean - Whether the item is disabled. Prevents interaction.
+ * - selected: boolean - Whether the item is selected (used in interactive mode).
+ * - href: object - When set, renders the item as a link (only in non-interactive variants).
+ * - value: object - The value associated with this item (used with hx-select).
+ * - interactive: boolean - Set by the parent hx-list to indicate this item is part of an interactive listbox. Controls CSS styling and ARIA role via host attributes.
+ * - type: object - Item type for description list variant. Use 'term' for <dt> and 'definition' for <dd>.
+ */
+#}
+<hx-list-item
+  {% if disabled %}disabled{% endif %}
+  {% if selected %}selected{% endif %}
+  {% if href is defined and href is not empty %}href="{{ href }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if interactive %}interactive{% endif %}
+  {% if type is defined and type is not empty %}type="{{ type }}"{% endif %}
+>
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if slots.description is defined %}
+    <slot name="description">{{ slots.description }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-list-item>

--- a/packages/hx-library/drupal/components/hx-list/README.md
+++ b/packages/hx-library/drupal/components/hx-list/README.md
@@ -1,0 +1,46 @@
+# HX List
+
+A styled list container supporting plain, bulleted, numbered, description, and interactive variants.
+
+## Usage
+
+```twig
+{% include 'helix:hx-list' with {
+  variant: 'plain',
+  divided: false,
+  label: 'undefined',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | plain | Visual variant of the list. |
+| divided | boolean | false | Whether to show dividers between list items. |
+| label | object | undefined | Accessible label for the list. Required when variant is "interactive" (listbox role). |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `hx-list-item` elements. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-select | Dispatched when an item is clicked in interactive mode. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-list-gap | 0 | Gap between list items. |
+| --hx-list-divider-color | var(--hx-color-neutral-200) | Divider line color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root list element. |

--- a/packages/hx-library/drupal/components/hx-list/hx-list.component.yml
+++ b/packages/hx-library/drupal/components/hx-list/hx-list.component.yml
@@ -1,0 +1,28 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX List
+status: experimental
+group: HELiX
+description: 'A styled list container supporting plain, bulleted, numbered, description, and interactive variants.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant of the list.'
+      default: 'plain'
+    divided:
+      type: boolean
+      title: Divided
+      description: 'Whether to show dividers between list items.'
+      default: false
+    label:
+      type: object
+      title: Label
+      description: 'Accessible label for the list. Required when variant is "interactive" (listbox role).'
+      default: 'undefined'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `hx-list-item` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-list/hx-list.css
+++ b/packages/hx-library/drupal/components/hx-list/hx-list.css
@@ -1,0 +1,16 @@
+/**
+ * HX List component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-list-gap: Gap between list items. (default: 0)
+ * --hx-list-divider-color: Divider line color. (default: var(--hx-color-neutral-200))
+ */
+
+/* Component host styles */
+hx-list {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-list/hx-list.js
+++ b/packages/hx-library/drupal/components/hx-list/hx-list.js
@@ -1,0 +1,11 @@
+/**
+ * HX List - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-list';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-list');
+}

--- a/packages/hx-library/drupal/components/hx-list/hx-list.twig
+++ b/packages/hx-library/drupal/components/hx-list/hx-list.twig
@@ -1,0 +1,20 @@
+{#
+ /**
+ * @file
+ * HX List component template.
+ *
+ * A styled list container supporting plain, bulleted, numbered, description, and interactive variants.
+ *
+ * Available variables:
+ * - variant: object - Visual variant of the list.
+ * - divided: boolean - Whether to show dividers between list items.
+ * - label: object - Accessible label for the list. Required when variant is "interactive" (listbox role).
+ */
+#}
+<hx-list
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if divided %}divided{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-list>

--- a/packages/hx-library/drupal/components/hx-menu-divider/README.md
+++ b/packages/hx-library/drupal/components/hx-menu-divider/README.md
@@ -1,0 +1,22 @@
+# HX Menu Divider
+
+A visual separator for grouping items within an `hx-menu`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-menu-divider' with {
+} %}
+```
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-menu-divider-color | var(--hx-color-neutral-200) | Divider line color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root separator element. |

--- a/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.component.yml
+++ b/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.component.yml
@@ -1,0 +1,6 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Menu Divider
+status: experimental
+group: HELiX
+description: 'A visual separator for grouping items within an `hx-menu`.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.css
+++ b/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.css
@@ -1,0 +1,15 @@
+/**
+ * HX Menu Divider component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-menu-divider-color: Divider line color. (default: var(--hx-color-neutral-200))
+ */
+
+/* Component host styles */
+hx-menu-divider {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.js
+++ b/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.js
@@ -1,0 +1,11 @@
+/**
+ * HX Menu Divider - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-menu-divider';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-menu-divider');
+}

--- a/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.twig
+++ b/packages/hx-library/drupal/components/hx-menu-divider/hx-menu-divider.twig
@@ -1,0 +1,10 @@
+{#
+ /**
+ * @file
+ * HX Menu Divider component template.
+ *
+ * A visual separator for grouping items within an `hx-menu`.
+ */
+#}
+<hx-menu-divider>
+</hx-menu-divider>

--- a/packages/hx-library/drupal/components/hx-menu-item/README.md
+++ b/packages/hx-library/drupal/components/hx-menu-item/README.md
@@ -1,0 +1,62 @@
+# HX Menu Item
+
+A single interactive item for use inside `hx-menu`. Supports normal, checkbox,
+and radio types, loading state, prefix/suffix slots, and submenu nesting.
+Use `aria-label` on the parent `hx-menu` to provide an accessible name.
+
+## Usage
+
+```twig
+{% include 'helix:hx-menu-item' with {
+  value: '',
+  disabled: false,
+  checked: false,
+  type: 'normal',
+  loading: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | string |  | The value associated with this item, emitted in the hx-select event. |
+| disabled | boolean | false | Whether the item is disabled. Prevents interaction and event dispatch. |
+| checked | boolean | false | Whether the item is checked. Only meaningful when type="checkbox". |
+| type | object | normal | The type of menu item. "checkbox" renders a checkmark and toggles checked state.
+"radio" renders a checkmark and emits selection for radio-group behavior. |
+| loading | boolean | false | Whether the item is in a loading state. Shows a spinner and prevents interaction. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the item label. |
+| prefix | Icon or content rendered before the label. |
+| suffix | Shortcut text or icon rendered after the label. |
+| submenu | A nested hx-menu for submenu content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-item-select | Dispatched when the item is activated via click, Enter, or Space. |
+| hx-item-submenu-open | Dispatched when ArrowRight is pressed on an item with a submenu. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-menu-item-color | var(--hx-color-neutral-900) | Item text color. |
+| --hx-menu-item-hover-bg | var(--hx-color-neutral-100) | Item hover/focus background. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root item element. |
+| prefix | Prefix slot wrapper. |
+| label | Label slot wrapper. |
+| suffix | Suffix slot wrapper. |
+| submenu-icon | The chevron icon indicating a submenu. |
+| checked-icon | The checkmark icon for checkbox-type items. |

--- a/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.component.yml
@@ -1,0 +1,47 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Menu Item
+status: experimental
+group: HELiX
+description: 'A single interactive item for use inside `hx-menu`. Supports normal, checkbox, and radio types, loading state, prefix/suffix slots, and submenu nesting. Use `aria-label` on the parent `hx-menu` to provide an accessible name.'
+props:
+  type: object
+  properties:
+    value:
+      type: string
+      title: Value
+      description: 'The value associated with this item, emitted in the hx-select event.'
+      default: ''
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the item is disabled. Prevents interaction and event dispatch.'
+      default: false
+    checked:
+      type: boolean
+      title: Checked
+      description: 'Whether the item is checked. Only meaningful when type="checkbox".'
+      default: false
+    type:
+      type: object
+      title: Type
+      description: 'The type of menu item. "checkbox" renders a checkmark and toggles checked state. "radio" renders a checkmark and emits selection for radio-group behavior.'
+      default: 'normal'
+    loading:
+      type: boolean
+      title: Loading
+      description: 'Whether the item is in a loading state. Shows a spinner and prevents interaction.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the item label.'
+  prefix:
+    title: Prefix
+    description: 'Icon or content rendered before the label.'
+  suffix:
+    title: Suffix
+    description: 'Shortcut text or icon rendered after the label.'
+  submenu:
+    title: Submenu
+    description: 'A nested hx-menu for submenu content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.css
+++ b/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.css
@@ -1,0 +1,16 @@
+/**
+ * HX Menu Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-menu-item-color: Item text color. (default: var(--hx-color-neutral-900))
+ * --hx-menu-item-hover-bg: Item hover/focus background. (default: var(--hx-color-neutral-100))
+ */
+
+/* Component host styles */
+hx-menu-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.js
+++ b/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX Menu Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-menu-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-menu-item');
+}

--- a/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.twig
+++ b/packages/hx-library/drupal/components/hx-menu-item/hx-menu-item.twig
@@ -1,0 +1,35 @@
+{#
+ /**
+ * @file
+ * HX Menu Item component template.
+ *
+ * A single interactive item for use inside `hx-menu`. Supports normal, checkbox,
+ * and radio types, loading state, prefix/suffix slots, and submenu nesting.
+ * Use `aria-label` on the parent `hx-menu` to provide an accessible name.
+ *
+ * Available variables:
+ * - value: string - The value associated with this item, emitted in the hx-select event.
+ * - disabled: boolean - Whether the item is disabled. Prevents interaction and event dispatch.
+ * - checked: boolean - Whether the item is checked. Only meaningful when type="checkbox".
+ * - type: object - The type of menu item. "checkbox" renders a checkmark and toggles checked state. "radio" renders a checkmark and emits selection for radio-group behavior.
+ * - loading: boolean - Whether the item is in a loading state. Shows a spinner and prevents interaction.
+ */
+#}
+<hx-menu-item
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if checked %}checked{% endif %}
+  {% if type is defined and type is not empty %}type="{{ type }}"{% endif %}
+  {% if loading %}loading{% endif %}
+>
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if slots.submenu is defined %}
+    <slot name="submenu">{{ slots.submenu }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-menu-item>

--- a/packages/hx-library/drupal/components/hx-menu/README.md
+++ b/packages/hx-library/drupal/components/hx-menu/README.md
@@ -1,0 +1,48 @@
+# HX Menu
+
+A menu container that manages keyboard navigation over a list of menu items.
+Use with `hx-menu-item` and `hx-menu-divider`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-menu' with {
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | Accessible label for the menu. Rendered as `aria-label` on the inner
+`role="menu"` element when set. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for hx-menu-item and hx-menu-divider elements. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-close | Dispatched when Escape is pressed. |
+| hx-select | Dispatched when an item is selected. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-menu-bg | var(--hx-color-neutral-0) | Menu background color. |
+| --hx-menu-border-color | var(--hx-color-neutral-200) | Menu border color. |
+| --hx-menu-border-radius | var(--hx-border-radius-md) | Menu border radius. |
+| --hx-menu-shadow | - | Menu box shadow. |
+| --hx-menu-min-width | 10rem | Minimum menu width. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root menu element. |

--- a/packages/hx-library/drupal/components/hx-menu/hx-menu.component.yml
+++ b/packages/hx-library/drupal/components/hx-menu/hx-menu.component.yml
@@ -1,0 +1,18 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Menu
+status: experimental
+group: HELiX
+description: 'A menu container that manages keyboard navigation over a list of menu items. Use with `hx-menu-item` and `hx-menu-divider`.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the menu. Rendered as `aria-label` on the inner `role="menu"` element when set.'
+      default: ''
+slots:
+  default:
+    title: Default
+    description: 'Default slot for hx-menu-item and hx-menu-divider elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-menu/hx-menu.css
+++ b/packages/hx-library/drupal/components/hx-menu/hx-menu.css
@@ -1,0 +1,19 @@
+/**
+ * HX Menu component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-menu-bg: Menu background color. (default: var(--hx-color-neutral-0))
+ * --hx-menu-border-color: Menu border color. (default: var(--hx-color-neutral-200))
+ * --hx-menu-border-radius: Menu border radius. (default: var(--hx-border-radius-md))
+ * --hx-menu-shadow: Menu box shadow.
+ * --hx-menu-min-width: Minimum menu width. (default: 10rem)
+ */
+
+/* Component host styles */
+hx-menu {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-menu/hx-menu.js
+++ b/packages/hx-library/drupal/components/hx-menu/hx-menu.js
@@ -1,0 +1,11 @@
+/**
+ * HX Menu - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-menu';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-menu');
+}

--- a/packages/hx-library/drupal/components/hx-menu/hx-menu.twig
+++ b/packages/hx-library/drupal/components/hx-menu/hx-menu.twig
@@ -1,0 +1,15 @@
+{#
+ /**
+ * @file
+ * HX Menu component template.
+ *
+ * A menu container that manages keyboard navigation over a list of menu items.
+ * Use with `hx-menu-item` and `hx-menu-divider`.
+ *
+ * Available variables:
+ * - label: string - Accessible label for the menu. Rendered as `aria-label` on the inner `role="menu"` element when set.
+ */
+#}
+<hx-menu {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-menu>

--- a/packages/hx-library/drupal/components/hx-meter/README.md
+++ b/packages/hx-library/drupal/components/hx-meter/README.md
@@ -1,0 +1,61 @@
+# HX Meter
+
+A scalar measurement within a known range — e.g., disk usage, health score,
+or any numeric value with defined min/max bounds. Supports low/high/optimum
+threshold markers for semantic color feedback.
+
+## Usage
+
+```twig
+{% include 'helix:hx-meter' with {
+  value: 0,
+  min: 0,
+  max: 100,
+  low: '',
+  high: '',
+  optimum: '',
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | number | 0 | Current value of the meter. |
+| min | number | 0 | Minimum value of the range. |
+| max | number | 100 | Maximum value of the range. |
+| low | object | - | Threshold below which the value is considered suboptimal (lower range warning). |
+| high | object | - | Threshold above which the value is considered suboptimal (upper range warning). |
+| optimum | object | - | The optimal value within the range. Used to determine which zone is "good". |
+| label | object | - | Accessible label for the meter. Used as the visible label text and as
+the source for `aria-labelledby`. When only slot content is provided
+(no `label` attribute), the slot content is used for the accessible name. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Visible label rendered above the meter track. When using this slot without the `label` attribute, the accessible name is derived from the slot content via `aria-labelledby`. The `label` attribute is NOT required when slot content is provided — the component detects slot content and switches to `aria-labelledby` automatically. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-meter-track-height | - | Height of the track bar. |
+| --hx-meter-track-color | - | Background color of the unfilled track. |
+| --hx-meter-track-radius | - | Border radius of the track. |
+| --hx-meter-indicator-color | - | Default filled bar color (no thresholds). |
+| --hx-meter-color-optimum | - | Color when value is in the optimum zone. |
+| --hx-meter-color-warning | - | Color when value is in a warning zone. |
+| --hx-meter-color-danger | - | Color when value is in the danger zone. |
+| --hx-meter-label-color | - | Label text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The outer wrapper element. |
+| track | The unfilled track bar element. |
+| indicator | The filled bar indicating the current value. |
+| label | The label wrapper element. |

--- a/packages/hx-library/drupal/components/hx-meter/hx-meter.component.yml
+++ b/packages/hx-library/drupal/components/hx-meter/hx-meter.component.yml
@@ -1,0 +1,44 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Meter
+status: experimental
+group: HELiX
+description: 'A scalar measurement within a known range — e.g., disk usage, health score, or any numeric value with defined min/max bounds. Supports low/high/optimum threshold markers for semantic color feedback.'
+props:
+  type: object
+  properties:
+    value:
+      type: number
+      title: Value
+      description: 'Current value of the meter.'
+      default: 0
+    min:
+      type: number
+      title: Min
+      description: 'Minimum value of the range.'
+      default: 0
+    max:
+      type: number
+      title: Max
+      description: 'Maximum value of the range.'
+      default: 100
+    low:
+      type: object
+      title: Low
+      description: 'Threshold below which the value is considered suboptimal (lower range warning).'
+    high:
+      type: object
+      title: High
+      description: 'Threshold above which the value is considered suboptimal (upper range warning).'
+    optimum:
+      type: object
+      title: Optimum
+      description: 'The optimal value within the range. Used to determine which zone is "good".'
+    label:
+      type: object
+      title: Label
+      description: 'Accessible label for the meter. Used as the visible label text and as the source for `aria-labelledby`. When only slot content is provided (no `label` attribute), the slot content is used for the accessible name.'
+slots:
+  label:
+    title: Label
+    description: 'Visible label rendered above the meter track. When using this slot without the `label` attribute, the accessible name is derived from the slot content via `aria-labelledby`. The `label` attribute is NOT required when slot content is provided — the component detects slot content and switches to `aria-labelledby` automatically.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-meter/hx-meter.css
+++ b/packages/hx-library/drupal/components/hx-meter/hx-meter.css
@@ -1,0 +1,22 @@
+/**
+ * HX Meter component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-meter-track-height: Height of the track bar.
+ * --hx-meter-track-color: Background color of the unfilled track.
+ * --hx-meter-track-radius: Border radius of the track.
+ * --hx-meter-indicator-color: Default filled bar color (no thresholds).
+ * --hx-meter-color-optimum: Color when value is in the optimum zone.
+ * --hx-meter-color-warning: Color when value is in a warning zone.
+ * --hx-meter-color-danger: Color when value is in the danger zone.
+ * --hx-meter-label-color: Label text color.
+ */
+
+/* Component host styles */
+hx-meter {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-meter/hx-meter.js
+++ b/packages/hx-library/drupal/components/hx-meter/hx-meter.js
@@ -1,0 +1,11 @@
+/**
+ * HX Meter - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-meter';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-meter');
+}

--- a/packages/hx-library/drupal/components/hx-meter/hx-meter.twig
+++ b/packages/hx-library/drupal/components/hx-meter/hx-meter.twig
@@ -1,0 +1,32 @@
+{#
+ /**
+ * @file
+ * HX Meter component template.
+ *
+ * A scalar measurement within a known range — e.g., disk usage, health score,
+ * or any numeric value with defined min/max bounds. Supports low/high/optimum
+ * threshold markers for semantic color feedback.
+ *
+ * Available variables:
+ * - value: number - Current value of the meter.
+ * - min: number - Minimum value of the range.
+ * - max: number - Maximum value of the range.
+ * - low: object - Threshold below which the value is considered suboptimal (lower range warning).
+ * - high: object - Threshold above which the value is considered suboptimal (upper range warning).
+ * - optimum: object - The optimal value within the range. Used to determine which zone is "good".
+ * - label: object - Accessible label for the meter. Used as the visible label text and as the source for `aria-labelledby`. When only slot content is provided (no `label` attribute), the slot content is used for the accessible name.
+ */
+#}
+<hx-meter
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if min is defined and min is not empty %}min="{{ min }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if low is defined and low is not empty %}low="{{ low }}"{% endif %}
+  {% if high is defined and high is not empty %}high="{{ high }}"{% endif %}
+  {% if optimum is defined and optimum is not empty %}optimum="{{ optimum }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+</hx-meter>

--- a/packages/hx-library/drupal/components/hx-nav-item/README.md
+++ b/packages/hx-library/drupal/components/hx-nav-item/README.md
@@ -1,0 +1,55 @@
+# HX Nav Item
+
+A navigation item for use inside hx-side-nav.
+Supports icons, badges, sub-navigation, and active/disabled states.
+
+## Usage
+
+```twig
+{% include 'helix:hx-nav-item' with {
+  href: '',
+  active: false,
+  expanded: false,
+  disabled: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| href | string |  | The URL this nav item links to. |
+| active | boolean | false | Whether this item is the current/active page. |
+| expanded | boolean | false | Whether the sub-navigation is expanded. |
+| disabled | boolean | false | Whether this nav item is disabled. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for item label text. |
+| icon | Icon to display before the label. |
+| badge | Badge content (e.g., notification count). |
+| children | Nested hx-nav-item children for sub-navigation. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-nav-item-color | var(--hx-color-neutral-300) | Item text color. |
+| --hx-nav-item-hover-bg | - | Item hover background. |
+| --hx-nav-item-hover-color | var(--hx-color-neutral-100) | Item hover text color. |
+| --hx-nav-item-active-bg | var(--hx-color-primary-600) | Active item background. |
+| --hx-nav-item-active-color | var(--hx-color-neutral-50) | Active item text color. |
+| --hx-nav-item-padding | - | Item padding. |
+| --hx-nav-item-host-bg | var(--hx-color-neutral-900) | Component host background color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| link | The anchor or button element. |
+| icon | The icon container. |
+| label | The label container. |
+| badge | The badge container. |
+| children | The children container. |

--- a/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.component.yml
@@ -1,0 +1,42 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Nav Item
+status: experimental
+group: HELiX
+description: 'A navigation item for use inside hx-side-nav. Supports icons, badges, sub-navigation, and active/disabled states.'
+props:
+  type: object
+  properties:
+    href:
+      type: string
+      title: Href
+      description: 'The URL this nav item links to.'
+      default: ''
+    active:
+      type: boolean
+      title: Active
+      description: 'Whether this item is the current/active page.'
+      default: false
+    expanded:
+      type: boolean
+      title: Expanded
+      description: 'Whether the sub-navigation is expanded.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether this nav item is disabled.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for item label text.'
+  icon:
+    title: Icon
+    description: 'Icon to display before the label.'
+  badge:
+    title: Badge
+    description: 'Badge content (e.g., notification count).'
+  children:
+    title: Children
+    description: 'Nested hx-nav-item children for sub-navigation.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.css
+++ b/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.css
@@ -1,0 +1,21 @@
+/**
+ * HX Nav Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-nav-item-color: Item text color. (default: var(--hx-color-neutral-300))
+ * --hx-nav-item-hover-bg: Item hover background.
+ * --hx-nav-item-hover-color: Item hover text color. (default: var(--hx-color-neutral-100))
+ * --hx-nav-item-active-bg: Active item background. (default: var(--hx-color-primary-600))
+ * --hx-nav-item-active-color: Active item text color. (default: var(--hx-color-neutral-50))
+ * --hx-nav-item-padding: Item padding.
+ * --hx-nav-item-host-bg: Component host background color. (default: var(--hx-color-neutral-900))
+ */
+
+/* Component host styles */
+hx-nav-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.js
+++ b/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX Nav Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-nav-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-nav-item');
+}

--- a/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.twig
+++ b/packages/hx-library/drupal/components/hx-nav-item/hx-nav-item.twig
@@ -1,0 +1,32 @@
+{#
+ /**
+ * @file
+ * HX Nav Item component template.
+ *
+ * A navigation item for use inside hx-side-nav.
+ * Supports icons, badges, sub-navigation, and active/disabled states.
+ *
+ * Available variables:
+ * - href: string - The URL this nav item links to.
+ * - active: boolean - Whether this item is the current/active page.
+ * - expanded: boolean - Whether the sub-navigation is expanded.
+ * - disabled: boolean - Whether this nav item is disabled.
+ */
+#}
+<hx-nav-item
+  {% if href is defined and href is not empty %}href="{{ href }}"{% endif %}
+  {% if active %}active{% endif %}
+  {% if expanded %}expanded{% endif %}
+  {% if disabled %}disabled{% endif %}
+>
+  {% if slots.icon is defined %}
+    <slot name="icon">{{ slots.icon }}</slot>
+  {% endif %}
+  {% if slots.badge is defined %}
+    <slot name="badge">{{ slots.badge }}</slot>
+  {% endif %}
+  {% if slots.children is defined %}
+    <slot name="children">{{ slots.children }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-nav-item>

--- a/packages/hx-library/drupal/components/hx-nav/README.md
+++ b/packages/hx-library/drupal/components/hx-nav/README.md
@@ -1,0 +1,62 @@
+# HX Nav
+
+Primary and secondary navigation component.
+Supports horizontal menu bar and vertical sidebar patterns.
+Mobile responsive with hamburger toggle.
+
+## Usage
+
+```twig
+{% include 'helix:hx-nav' with {
+  items: '[]',
+  orientation: 'horizontal',
+  label: 'Main navigation',
+  labelOpenMenu: 'Open navigation menu',
+  labelCloseMenu: 'Close navigation menu',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| items | object | [] | Navigation items array. |
+| orientation | object | horizontal | Layout orientation: 'horizontal' (menu bar) or 'vertical' (sidebar). |
+| label | string | Main navigation | Accessible label for the nav landmark. |
+| labelOpenMenu | string | Open navigation menu | Accessible label for the navigation toggle button when menu is closed. |
+| labelCloseMenu | string | Close navigation menu | Accessible label for the navigation toggle button when menu is open. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-nav-select | Dispatched when a nav item is activated. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-nav-bg | var(--hx-color-neutral-900) | Navigation background color. |
+| --hx-nav-color | var(--hx-color-neutral-100) | Navigation text color. |
+| --hx-nav-font-family | var(--hx-font-family-sans) | Navigation font family. |
+| --hx-nav-link-color | var(--hx-color-neutral-100) | Link text color. |
+| --hx-nav-link-hover-bg | var(--hx-color-neutral-700) | Link hover background. |
+| --hx-nav-link-hover-color | var(--hx-color-white) | Link hover text color. |
+| --hx-nav-link-active-bg | var(--hx-color-primary-600) | Active link background. |
+| --hx-nav-link-active-color | var(--hx-color-white) | Active link text color. |
+| --hx-nav-submenu-bg | var(--hx-color-neutral-800) | Submenu background color. |
+| --hx-nav-submenu-min-width | 12rem | Submenu minimum width. |
+| --hx-nav-font-size | var(--hx-font-size-sm) | Navigation font size. |
+| --hx-nav-padding | var(--hx-space-2) var(--hx-space-4) | Navigation padding. |
+| --hx-nav-item-padding | var(--hx-space-2) var(--hx-space-3) | Item padding. |
+| --hx-nav-border-radius | var(--hx-border-radius-sm) | Item border radius. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| nav | The nav landmark element. |
+| list | The top-level list element. |
+| item | Each list item wrapper. |
+| link | The anchor or button element inside each item. |
+| toggle | The mobile hamburger toggle button. |

--- a/packages/hx-library/drupal/components/hx-nav/hx-nav.component.yml
+++ b/packages/hx-library/drupal/components/hx-nav/hx-nav.component.yml
@@ -1,0 +1,34 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Nav
+status: experimental
+group: HELiX
+description: 'Primary and secondary navigation component. Supports horizontal menu bar and vertical sidebar patterns. Mobile responsive with hamburger toggle.'
+props:
+  type: object
+  properties:
+    items:
+      type: object
+      title: Items
+      description: 'Navigation items array.'
+      default: '[]'
+    orientation:
+      type: object
+      title: Orientation
+      description: "Layout orientation: 'horizontal' (menu bar) or 'vertical' (sidebar)."
+      default: 'horizontal'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the nav landmark.'
+      default: 'Main navigation'
+    labelOpenMenu:
+      type: string
+      title: Label Open Menu
+      description: 'Accessible label for the navigation toggle button when menu is closed.'
+      default: 'Open navigation menu'
+    labelCloseMenu:
+      type: string
+      title: Label Close Menu
+      description: 'Accessible label for the navigation toggle button when menu is open.'
+      default: 'Close navigation menu'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-nav/hx-nav.css
+++ b/packages/hx-library/drupal/components/hx-nav/hx-nav.css
@@ -1,0 +1,28 @@
+/**
+ * HX Nav component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-nav-bg: Navigation background color. (default: var(--hx-color-neutral-900))
+ * --hx-nav-color: Navigation text color. (default: var(--hx-color-neutral-100))
+ * --hx-nav-font-family: Navigation font family. (default: var(--hx-font-family-sans))
+ * --hx-nav-link-color: Link text color. (default: var(--hx-color-neutral-100))
+ * --hx-nav-link-hover-bg: Link hover background. (default: var(--hx-color-neutral-700))
+ * --hx-nav-link-hover-color: Link hover text color. (default: var(--hx-color-white))
+ * --hx-nav-link-active-bg: Active link background. (default: var(--hx-color-primary-600))
+ * --hx-nav-link-active-color: Active link text color. (default: var(--hx-color-white))
+ * --hx-nav-submenu-bg: Submenu background color. (default: var(--hx-color-neutral-800))
+ * --hx-nav-submenu-min-width: Submenu minimum width. (default: 12rem)
+ * --hx-nav-font-size: Navigation font size. (default: var(--hx-font-size-sm))
+ * --hx-nav-padding: Navigation padding. (default: var(--hx-space-2) var(--hx-space-4))
+ * --hx-nav-item-padding: Item padding. (default: var(--hx-space-2) var(--hx-space-3))
+ * --hx-nav-border-radius: Item border radius. (default: var(--hx-border-radius-sm))
+ */
+
+/* Component host styles */
+hx-nav {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-nav/hx-nav.js
+++ b/packages/hx-library/drupal/components/hx-nav/hx-nav.js
@@ -1,0 +1,11 @@
+/**
+ * HX Nav - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-nav';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-nav');
+}

--- a/packages/hx-library/drupal/components/hx-nav/hx-nav.twig
+++ b/packages/hx-library/drupal/components/hx-nav/hx-nav.twig
@@ -1,0 +1,25 @@
+{#
+ /**
+ * @file
+ * HX Nav component template.
+ *
+ * Primary and secondary navigation component.
+ * Supports horizontal menu bar and vertical sidebar patterns.
+ * Mobile responsive with hamburger toggle.
+ *
+ * Available variables:
+ * - items: object - Navigation items array.
+ * - orientation: object - Layout orientation: 'horizontal' (menu bar) or 'vertical' (sidebar).
+ * - label: string - Accessible label for the nav landmark.
+ * - labelOpenMenu: string - Accessible label for the navigation toggle button when menu is closed.
+ * - labelCloseMenu: string - Accessible label for the navigation toggle button when menu is open.
+ */
+#}
+<hx-nav
+  {% if items is defined and items is not empty %}items="{{ items }}"{% endif %}
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if labelOpenMenu is defined and labelOpenMenu is not empty %}label-open-menu="{{ labelOpenMenu }}"{% endif %}
+  {% if labelCloseMenu is defined and labelCloseMenu is not empty %}label-close-menu="{{ labelCloseMenu }}"{% endif %}
+>
+</hx-nav>

--- a/packages/hx-library/drupal/components/hx-number-input/README.md
+++ b/packages/hx-library/drupal/components/hx-number-input/README.md
@@ -1,0 +1,91 @@
+# HX Number Input
+
+A numeric input component with stepper controls, label, validation, and
+full form association. Designed for healthcare data-entry contexts where
+precise numeric values (dosage, age, measurements) must be captured safely.
+
+## Usage
+
+```twig
+{% include 'helix:hx-number-input' with {
+  name: '',
+  value: 'null',
+  required: false,
+  disabled: false,
+  readonly: false,
+  min: 'undefined',
+  max: 'undefined',
+  step: 1,
+  label: '',
+  error: '',
+  helpText: '',
+  size: 'md',
+  noStepper: false,
+  labelIncrement: 'Increment',
+  labelDecrement: 'Decrement',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | The name of the input, used for form submission. |
+| value | object | null | The current numeric value of the input. Null when the field is empty. |
+| required | boolean | false | Whether the input is required for form submission. |
+| disabled | boolean | false | Whether the input is disabled. |
+| readonly | boolean | false | Whether the input is read-only. |
+| min | object | undefined | Minimum allowed value. When reached, the decrement button is disabled. |
+| max | object | undefined | Maximum allowed value. When reached, the increment button is disabled. |
+| step | number | 1 | The amount to increment or decrement on each step action. |
+| label | string |  | The visible label text for the input. |
+| error | string |  | Error message to display. When set, the input enters an error state. |
+| helpText | string |  | Help text displayed below the input for guidance. |
+| size | object | md | Size variant controlling input padding and font size. |
+| noStepper | boolean | false | When set, hides the +/- stepper buttons. |
+| labelIncrement | string | Increment | Accessible label for the increment button. |
+| labelDecrement | string | Decrement | Accessible label for the decrement button. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Custom label content (overrides the label property). Use for Drupal Form API rendered labels. |
+| help-text | Custom help text content (overrides the helpText property). |
+| error | Custom error content (overrides the error property). Use for Drupal Form API rendered errors. |
+| prefix | Content rendered before the input (e.g., a unit icon). |
+| suffix | Content rendered after the input and before the stepper buttons (e.g., a unit label). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when the input loses focus after its value changed. |
+| hx-input | Dispatched on every keystroke as the user types. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-number-input-bg | var(--hx-color-neutral-0) | Input background color. |
+| --hx-number-input-color | var(--hx-color-neutral-800) | Input text color. |
+| --hx-number-input-border-color | var(--hx-color-neutral-300) | Input border color. |
+| --hx-number-input-border-radius | var(--hx-border-radius-md) | Input border radius. |
+| --hx-number-input-error-color | var(--hx-color-error-500) | Error state color. |
+| --hx-number-input-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-number-input-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-number-input-font-family | var(--hx-font-family-sans) | Font family. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| field | The outer field container. |
+| label | The label element. |
+| input-wrapper | The wrapper around prefix, input, suffix, and stepper. |
+| input | The native input element. |
+| help-text | The help text container. |
+| error-message | The error message container. |
+| stepper | The stepper button group container. |
+| increment | The increment (+) button. |
+| decrement | The decrement (-) button. |

--- a/packages/hx-library/drupal/components/hx-number-input/hx-number-input.component.yml
+++ b/packages/hx-library/drupal/components/hx-number-input/hx-number-input.component.yml
@@ -1,0 +1,100 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Number Input
+status: experimental
+group: HELiX
+description: 'A numeric input component with stepper controls, label, validation, and full form association. Designed for healthcare data-entry contexts where precise numeric values (dosage, age, measurements) must be captured safely.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'The name of the input, used for form submission.'
+      default: ''
+    value:
+      type: object
+      title: Value
+      description: 'The current numeric value of the input. Null when the field is empty.'
+      default: 'null'
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the input is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the input is disabled.'
+      default: false
+    readonly:
+      type: boolean
+      title: Readonly
+      description: 'Whether the input is read-only.'
+      default: false
+    min:
+      type: object
+      title: Min
+      description: 'Minimum allowed value. When reached, the decrement button is disabled.'
+      default: 'undefined'
+    max:
+      type: object
+      title: Max
+      description: 'Maximum allowed value. When reached, the increment button is disabled.'
+      default: 'undefined'
+    step:
+      type: number
+      title: Step
+      description: 'The amount to increment or decrement on each step action.'
+      default: 1
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the input.'
+      default: ''
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the input enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the input for guidance.'
+      default: ''
+    size:
+      type: object
+      title: Size
+      description: 'Size variant controlling input padding and font size.'
+      default: 'md'
+    noStepper:
+      type: boolean
+      title: No Stepper
+      description: 'When set, hides the +/- stepper buttons.'
+      default: false
+    labelIncrement:
+      type: string
+      title: Label Increment
+      description: 'Accessible label for the increment button.'
+      default: 'Increment'
+    labelDecrement:
+      type: string
+      title: Label Decrement
+      description: 'Accessible label for the decrement button.'
+      default: 'Decrement'
+slots:
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property). Use for Drupal Form API rendered labels.'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property). Use for Drupal Form API rendered errors.'
+  prefix:
+    title: Prefix
+    description: 'Content rendered before the input (e.g., a unit icon).'
+  suffix:
+    title: Suffix
+    description: 'Content rendered after the input and before the stepper buttons (e.g., a unit label).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-number-input/hx-number-input.css
+++ b/packages/hx-library/drupal/components/hx-number-input/hx-number-input.css
@@ -1,0 +1,22 @@
+/**
+ * HX Number Input component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-number-input-bg: Input background color. (default: var(--hx-color-neutral-0))
+ * --hx-number-input-color: Input text color. (default: var(--hx-color-neutral-800))
+ * --hx-number-input-border-color: Input border color. (default: var(--hx-color-neutral-300))
+ * --hx-number-input-border-radius: Input border radius. (default: var(--hx-border-radius-md))
+ * --hx-number-input-error-color: Error state color. (default: var(--hx-color-error-500))
+ * --hx-number-input-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-number-input-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-number-input-font-family: Font family. (default: var(--hx-font-family-sans))
+ */
+
+/* Component host styles */
+hx-number-input {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-number-input/hx-number-input.js
+++ b/packages/hx-library/drupal/components/hx-number-input/hx-number-input.js
@@ -1,0 +1,11 @@
+/**
+ * HX Number Input - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-number-input';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-number-input');
+}

--- a/packages/hx-library/drupal/components/hx-number-input/hx-number-input.twig
+++ b/packages/hx-library/drupal/components/hx-number-input/hx-number-input.twig
@@ -1,0 +1,60 @@
+{#
+ /**
+ * @file
+ * HX Number Input component template.
+ *
+ * A numeric input component with stepper controls, label, validation, and
+ * full form association. Designed for healthcare data-entry contexts where
+ * precise numeric values (dosage, age, measurements) must be captured safely.
+ *
+ * Available variables:
+ * - name: string - The name of the input, used for form submission.
+ * - value: object - The current numeric value of the input. Null when the field is empty.
+ * - required: boolean - Whether the input is required for form submission.
+ * - disabled: boolean - Whether the input is disabled.
+ * - readonly: boolean - Whether the input is read-only.
+ * - min: object - Minimum allowed value. When reached, the decrement button is disabled.
+ * - max: object - Maximum allowed value. When reached, the increment button is disabled.
+ * - step: number - The amount to increment or decrement on each step action.
+ * - label: string - The visible label text for the input.
+ * - error: string - Error message to display. When set, the input enters an error state.
+ * - helpText: string - Help text displayed below the input for guidance.
+ * - size: object - Size variant controlling input padding and font size.
+ * - noStepper: boolean - When set, hides the +/- stepper buttons.
+ * - labelIncrement: string - Accessible label for the increment button.
+ * - labelDecrement: string - Accessible label for the decrement button.
+ */
+#}
+<hx-number-input
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if readonly %}readonly{% endif %}
+  {% if min is defined and min is not empty %}min="{{ min }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if step is defined and step is not empty %}step="{{ step }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if noStepper %}no-stepper{% endif %}
+  {% if labelIncrement is defined and labelIncrement is not empty %}label-increment="{{ labelIncrement }}"{% endif %}
+  {% if labelDecrement is defined and labelDecrement is not empty %}label-decrement="{{ labelDecrement }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+</hx-number-input>

--- a/packages/hx-library/drupal/components/hx-overflow-menu/README.md
+++ b/packages/hx-library/drupal/components/hx-overflow-menu/README.md
@@ -1,0 +1,63 @@
+# HX Overflow Menu
+
+An overflow menu (kebab/meatball menu) that reveals hidden actions via a
+floating panel. Composed from a trigger button and a slotted menu panel.
+
+## Usage
+
+```twig
+{% include 'helix:hx-overflow-menu' with {
+  placement: 'bottom-end',
+  size: 'md',
+  disabled: false,
+  icon: 'vertical',
+  label: 'More actions',
+  menuLabel: 'Actions',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| placement | object | bottom-end | Preferred placement of the floating panel relative to the trigger. |
+| size | object | md | Size of the trigger button. |
+| disabled | boolean | false | Whether the trigger button is disabled. |
+| icon | object | vertical | Icon orientation: vertical (kebab ⋮) or horizontal (meatball ···). |
+| label | string | More actions | Accessible label for the trigger button. |
+| menuLabel | string | Actions | Accessible label for the menu panel. Reflected as `menu-label`. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Menu items (e.g. `<button role="menuitem">` or `<hx-menu-item>` elements). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-show | Dispatched when the panel opens. |
+| hx-hide | Dispatched when the panel closes. |
+| hx-select | Dispatched when a menu item is selected. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-overflow-menu-panel-bg | var(--hx-color-neutral-0,#fff) | Panel background color. |
+| --hx-overflow-menu-panel-border | 1px solid var(--hx-color-neutral-200,#e5e7eb) | Panel border. |
+| --hx-overflow-menu-panel-border-radius | var(--hx-border-radius-md) | Panel border radius. |
+| --hx-overflow-menu-panel-shadow | 0 4px 16px rgba(0,0,0,0.12) | Panel box shadow. |
+| --hx-overflow-menu-panel-min-width | 160px | Minimum panel width. |
+| --hx-overflow-menu-panel-z-index | 1000 | Panel z-index. |
+| --hx-overflow-menu-button-color | var(--hx-color-neutral-600) | Trigger icon color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| button | The trigger icon button element. |
+| trigger | Alias for button — the trigger icon button element. |
+| panel | The floating menu panel container. |
+| menu | Alias for panel — the floating menu panel container. |

--- a/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.component.yml
+++ b/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.component.yml
@@ -1,0 +1,43 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Overflow Menu
+status: experimental
+group: HELiX
+description: 'An overflow menu (kebab/meatball menu) that reveals hidden actions via a floating panel. Composed from a trigger button and a slotted menu panel.'
+props:
+  type: object
+  properties:
+    placement:
+      type: object
+      title: Placement
+      description: 'Preferred placement of the floating panel relative to the trigger.'
+      default: 'bottom-end'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the trigger button.'
+      default: 'md'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the trigger button is disabled.'
+      default: false
+    icon:
+      type: object
+      title: Icon
+      description: 'Icon orientation: vertical (kebab ⋮) or horizontal (meatball ···).'
+      default: 'vertical'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the trigger button.'
+      default: 'More actions'
+    menuLabel:
+      type: string
+      title: Menu Label
+      description: 'Accessible label for the menu panel. Reflected as `menu-label`.'
+      default: 'Actions'
+slots:
+  default:
+    title: Default
+    description: 'Menu items (e.g. `<button role="menuitem">` or `<hx-menu-item>` elements).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.css
+++ b/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.css
@@ -1,0 +1,21 @@
+/**
+ * HX Overflow Menu component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-overflow-menu-panel-bg: Panel background color. (default: var(--hx-color-neutral-0,#fff))
+ * --hx-overflow-menu-panel-border: Panel border. (default: 1px solid var(--hx-color-neutral-200,#e5e7eb))
+ * --hx-overflow-menu-panel-border-radius: Panel border radius. (default: var(--hx-border-radius-md))
+ * --hx-overflow-menu-panel-shadow: Panel box shadow. (default: 0 4px 16px rgba(0,0,0,0.12))
+ * --hx-overflow-menu-panel-min-width: Minimum panel width. (default: 160px)
+ * --hx-overflow-menu-panel-z-index: Panel z-index. (default: 1000)
+ * --hx-overflow-menu-button-color: Trigger icon color. (default: var(--hx-color-neutral-600))
+ */
+
+/* Component host styles */
+hx-overflow-menu {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.js
+++ b/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.js
@@ -1,0 +1,11 @@
+/**
+ * HX Overflow Menu - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-overflow-menu';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-overflow-menu');
+}

--- a/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.twig
+++ b/packages/hx-library/drupal/components/hx-overflow-menu/hx-overflow-menu.twig
@@ -1,0 +1,27 @@
+{#
+ /**
+ * @file
+ * HX Overflow Menu component template.
+ *
+ * An overflow menu (kebab/meatball menu) that reveals hidden actions via a
+ * floating panel. Composed from a trigger button and a slotted menu panel.
+ *
+ * Available variables:
+ * - placement: object - Preferred placement of the floating panel relative to the trigger.
+ * - size: object - Size of the trigger button.
+ * - disabled: boolean - Whether the trigger button is disabled.
+ * - icon: object - Icon orientation: vertical (kebab ⋮) or horizontal (meatball ···).
+ * - label: string - Accessible label for the trigger button.
+ * - menuLabel: string - Accessible label for the menu panel. Reflected as `menu-label`.
+ */
+#}
+<hx-overflow-menu
+  {% if placement is defined and placement is not empty %}placement="{{ placement }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if icon is defined and icon is not empty %}icon="{{ icon }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if menuLabel is defined and menuLabel is not empty %}menu-label="{{ menuLabel }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-overflow-menu>

--- a/packages/hx-library/drupal/components/hx-pagination/README.md
+++ b/packages/hx-library/drupal/components/hx-pagination/README.md
@@ -1,0 +1,80 @@
+# HX Pagination
+
+A pagination component for navigating content listings.
+
+## Usage
+
+```twig
+{% include 'helix:hx-pagination' with {
+  totalPages: 1,
+  currentPage: 1,
+  siblingCount: 1,
+  boundaryCount: 1,
+  showFirstLast: false,
+  label: 'Pagination',
+  pageSize: 25,
+  showPageSize: false,
+  labelRowsPerPage: 'Rows per page:',
+  labelFirstPage: 'First page',
+  labelPrevPage: 'Previous page',
+  labelNextPage: 'Next page',
+  labelLastPage: 'Last page',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| totalPages | number | 1 | Total number of pages. |
+| currentPage | number | 1 | The currently active page (1-based). |
+| siblingCount | number | 1 | Number of page buttons shown on each side of the current page. |
+| boundaryCount | number | 1 | Number of pages always shown at the start and end of the list. |
+| showFirstLast | boolean | false | Whether to show First and Last page buttons. |
+| label | string | Pagination | Accessible label for the `<nav>` element. |
+| pageSize | number | 25 | The number of items displayed per page. When set, a page-size selector
+`<select>` is rendered. Set `show-page-size` to display the selector. |
+| showPageSize | boolean | false | Whether to show the page-size selector UI. |
+| labelRowsPerPage | string | Rows per page: | Label text for the rows-per-page selector. |
+| labelFirstPage | string | First page | Accessible label for the first-page button. |
+| labelPrevPage | string | Previous page | Accessible label for the previous-page button. |
+| labelNextPage | string | Next page | Accessible label for the next-page button. |
+| labelLastPage | string | Last page | Accessible label for the last-page button. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-page-change | Fired when the user navigates to a new page. |
+| hx-page-size-change | Fired when the user selects a new page size. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-pagination-gap | 0.25rem | Gap between pagination buttons. Inherits from --hx-spacing-1. |
+| --hx-pagination-button-size | 2.25rem | Minimum width and height of each button. |
+| --hx-pagination-border-color | - | Border color of buttons. Inherits from --hx-color-border (final fallback: #d1d5db). |
+| --hx-pagination-border-radius | - | Border radius of buttons. Inherits from --hx-border-radius-md (final fallback: 0.375rem). |
+| --hx-pagination-bg | - | Background color of buttons. Inherits from --hx-color-surface (final fallback: #ffffff). |
+| --hx-pagination-color | - | Text color of buttons. Inherits from --hx-color-text-primary (final fallback: #111827). |
+| --hx-pagination-hover-bg | - | Background color of buttons on hover. Inherits from --hx-color-surface-hover (final fallback: #f3f4f6). |
+| --hx-pagination-hover-border-color | - | Border color of buttons on hover. Inherits from --hx-color-primary (final fallback: #2563eb). |
+| --hx-pagination-active-bg | - | Background color of the active/current page button. Inherits from --hx-color-primary (final fallback: #2563eb). |
+| --hx-pagination-active-color | - | Text color of the active/current page button. Inherits from --hx-color-surface (final fallback: #ffffff). |
+| --hx-pagination-active-border-color | - | Border color of the active/current page button. Defaults to --hx-pagination-active-bg. |
+| --hx-pagination-ellipsis-color | - | Color of ellipsis characters. Inherits from --hx-color-text-secondary (final fallback: #6b7280). |
+| --hx-transition-fast | 150ms | Duration used for hover/focus transitions. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| nav | The wrapping `<nav>` element. |
+| list | The `<ul>` containing pagination items. |
+| item | Each `<li>` item. |
+| button | Each page button or prev/next control. |
+| ellipsis | The ellipsis (`…`) span between page groups. |
+| page-size-wrapper | The wrapper `<div>` around the page-size selector. |
+| page-size-label | The `<label>` element for the page-size selector. |
+| page-size-select | The `<select>` element for page-size. |

--- a/packages/hx-library/drupal/components/hx-pagination/hx-pagination.component.yml
+++ b/packages/hx-library/drupal/components/hx-pagination/hx-pagination.component.yml
@@ -1,0 +1,74 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Pagination
+status: experimental
+group: HELiX
+description: 'A pagination component for navigating content listings.'
+props:
+  type: object
+  properties:
+    totalPages:
+      type: number
+      title: Total Pages
+      description: 'Total number of pages.'
+      default: 1
+    currentPage:
+      type: number
+      title: Current Page
+      description: 'The currently active page (1-based).'
+      default: 1
+    siblingCount:
+      type: number
+      title: Sibling Count
+      description: 'Number of page buttons shown on each side of the current page.'
+      default: 1
+    boundaryCount:
+      type: number
+      title: Boundary Count
+      description: 'Number of pages always shown at the start and end of the list.'
+      default: 1
+    showFirstLast:
+      type: boolean
+      title: Show First Last
+      description: 'Whether to show First and Last page buttons.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the `<nav>` element.'
+      default: 'Pagination'
+    pageSize:
+      type: number
+      title: Page Size
+      description: 'The number of items displayed per page. When set, a page-size selector `<select>` is rendered. Set `show-page-size` to display the selector.'
+      default: 25
+    showPageSize:
+      type: boolean
+      title: Show Page Size
+      description: 'Whether to show the page-size selector UI.'
+      default: false
+    labelRowsPerPage:
+      type: string
+      title: Label Rows Per Page
+      description: 'Label text for the rows-per-page selector.'
+      default: 'Rows per page:'
+    labelFirstPage:
+      type: string
+      title: Label First Page
+      description: 'Accessible label for the first-page button.'
+      default: 'First page'
+    labelPrevPage:
+      type: string
+      title: Label Prev Page
+      description: 'Accessible label for the previous-page button.'
+      default: 'Previous page'
+    labelNextPage:
+      type: string
+      title: Label Next Page
+      description: 'Accessible label for the next-page button.'
+      default: 'Next page'
+    labelLastPage:
+      type: string
+      title: Label Last Page
+      description: 'Accessible label for the last-page button.'
+      default: 'Last page'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-pagination/hx-pagination.css
+++ b/packages/hx-library/drupal/components/hx-pagination/hx-pagination.css
@@ -1,0 +1,27 @@
+/**
+ * HX Pagination component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-pagination-gap: Gap between pagination buttons. Inherits from --hx-spacing-1. (default: 0.25rem)
+ * --hx-pagination-button-size: Minimum width and height of each button. (default: 2.25rem)
+ * --hx-pagination-border-color: Border color of buttons. Inherits from --hx-color-border (final fallback: #d1d5db).
+ * --hx-pagination-border-radius: Border radius of buttons. Inherits from --hx-border-radius-md (final fallback: 0.375rem).
+ * --hx-pagination-bg: Background color of buttons. Inherits from --hx-color-surface (final fallback: #ffffff).
+ * --hx-pagination-color: Text color of buttons. Inherits from --hx-color-text-primary (final fallback: #111827).
+ * --hx-pagination-hover-bg: Background color of buttons on hover. Inherits from --hx-color-surface-hover (final fallback: #f3f4f6).
+ * --hx-pagination-hover-border-color: Border color of buttons on hover. Inherits from --hx-color-primary (final fallback: #2563eb).
+ * --hx-pagination-active-bg: Background color of the active/current page button. Inherits from --hx-color-primary (final fallback: #2563eb).
+ * --hx-pagination-active-color: Text color of the active/current page button. Inherits from --hx-color-surface (final fallback: #ffffff).
+ * --hx-pagination-active-border-color: Border color of the active/current page button. Defaults to --hx-pagination-active-bg.
+ * --hx-pagination-ellipsis-color: Color of ellipsis characters. Inherits from --hx-color-text-secondary (final fallback: #6b7280).
+ * --hx-transition-fast: Duration used for hover/focus transitions. (default: 150ms)
+ */
+
+/* Component host styles */
+hx-pagination {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-pagination/hx-pagination.js
+++ b/packages/hx-library/drupal/components/hx-pagination/hx-pagination.js
@@ -1,0 +1,11 @@
+/**
+ * HX Pagination - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-pagination';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-pagination');
+}

--- a/packages/hx-library/drupal/components/hx-pagination/hx-pagination.twig
+++ b/packages/hx-library/drupal/components/hx-pagination/hx-pagination.twig
@@ -1,0 +1,39 @@
+{#
+ /**
+ * @file
+ * HX Pagination component template.
+ *
+ * A pagination component for navigating content listings.
+ *
+ * Available variables:
+ * - totalPages: number - Total number of pages.
+ * - currentPage: number - The currently active page (1-based).
+ * - siblingCount: number - Number of page buttons shown on each side of the current page.
+ * - boundaryCount: number - Number of pages always shown at the start and end of the list.
+ * - showFirstLast: boolean - Whether to show First and Last page buttons.
+ * - label: string - Accessible label for the `<nav>` element.
+ * - pageSize: number - The number of items displayed per page. When set, a page-size selector `<select>` is rendered. Set `show-page-size` to display the selector.
+ * - showPageSize: boolean - Whether to show the page-size selector UI.
+ * - labelRowsPerPage: string - Label text for the rows-per-page selector.
+ * - labelFirstPage: string - Accessible label for the first-page button.
+ * - labelPrevPage: string - Accessible label for the previous-page button.
+ * - labelNextPage: string - Accessible label for the next-page button.
+ * - labelLastPage: string - Accessible label for the last-page button.
+ */
+#}
+<hx-pagination
+  {% if totalPages is defined and totalPages is not empty %}total-pages="{{ totalPages }}"{% endif %}
+  {% if currentPage is defined and currentPage is not empty %}current-page="{{ currentPage }}"{% endif %}
+  {% if siblingCount is defined and siblingCount is not empty %}sibling-count="{{ siblingCount }}"{% endif %}
+  {% if boundaryCount is defined and boundaryCount is not empty %}boundary-count="{{ boundaryCount }}"{% endif %}
+  {% if showFirstLast %}show-first-last{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if pageSize is defined and pageSize is not empty %}page-size="{{ pageSize }}"{% endif %}
+  {% if showPageSize %}show-page-size{% endif %}
+  {% if labelRowsPerPage is defined and labelRowsPerPage is not empty %}label-rows-per-page="{{ labelRowsPerPage }}"{% endif %}
+  {% if labelFirstPage is defined and labelFirstPage is not empty %}label-first-page="{{ labelFirstPage }}"{% endif %}
+  {% if labelPrevPage is defined and labelPrevPage is not empty %}label-prev-page="{{ labelPrevPage }}"{% endif %}
+  {% if labelNextPage is defined and labelNextPage is not empty %}label-next-page="{{ labelNextPage }}"{% endif %}
+  {% if labelLastPage is defined and labelLastPage is not empty %}label-last-page="{{ labelLastPage }}"{% endif %}
+>
+</hx-pagination>

--- a/packages/hx-library/drupal/components/hx-popover/README.md
+++ b/packages/hx-library/drupal/components/hx-popover/README.md
@@ -1,0 +1,68 @@
+# HX Popover
+
+A popover that displays rich floating content attached to a trigger element.
+
+## Usage
+
+```twig
+{% include 'helix:hx-popover' with {
+  open: false,
+  placement: 'bottom',
+  trigger: 'click',
+  distance: 8,
+  skidding: 0,
+  arrow: false,
+  label: 'Popover',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| open | boolean | false | Whether the popover is open. |
+| placement | object | bottom | Preferred placement of the popover relative to the anchor. |
+| trigger | object | click | How the popover is triggered. |
+| distance | number | 8 | Distance in pixels between the popover and the anchor. |
+| skidding | number | 0 | Alignment offset in pixels along the anchor. |
+| arrow | boolean | false | Whether to show an arrow pointing to the anchor. |
+| label | string | Popover | Accessible label for the popover body (sets aria-label on the dialog). |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| anchor | The trigger element that opens the popover. |
+| (default) | Default slot for popover body content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-show | Emitted when the popover begins to show. |
+| hx-after-show | Emitted after the popover is fully visible. |
+| hx-hide | Emitted when the popover begins to hide. |
+| hx-after-hide | Emitted after the popover is fully hidden. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-popover-bg | var(--hx-color-neutral-0) | Popover background color. |
+| --hx-popover-color | var(--hx-color-neutral-900) | Popover text color. |
+| --hx-popover-font-size | var(--hx-font-size-sm) | Popover font size. |
+| --hx-popover-max-width | 320px | Maximum popover width. |
+| --hx-popover-padding | - | Popover padding. |
+| --hx-popover-border-color | var(--hx-color-neutral-200) | Popover border color. |
+| --hx-popover-border-radius | var(--hx-border-radius-md) | Popover border radius. |
+| --hx-popover-shadow | - | Popover box shadow. |
+| --hx-popover-z-index | 9999 | Popover z-index. |
+| --hx-popover-transition-duration | 0.2s | Show/hide transition duration. |
+| --hx-popover-arrow-size | 10px | Size of the arrow indicator. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| body | The popover body container element. |
+| arrow | The arrow indicator element. |

--- a/packages/hx-library/drupal/components/hx-popover/hx-popover.component.yml
+++ b/packages/hx-library/drupal/components/hx-popover/hx-popover.component.yml
@@ -1,0 +1,51 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Popover
+status: experimental
+group: HELiX
+description: 'A popover that displays rich floating content attached to a trigger element.'
+props:
+  type: object
+  properties:
+    open:
+      type: boolean
+      title: Open
+      description: 'Whether the popover is open.'
+      default: false
+    placement:
+      type: object
+      title: Placement
+      description: 'Preferred placement of the popover relative to the anchor.'
+      default: 'bottom'
+    trigger:
+      type: object
+      title: Trigger
+      description: 'How the popover is triggered.'
+      default: 'click'
+    distance:
+      type: number
+      title: Distance
+      description: 'Distance in pixels between the popover and the anchor.'
+      default: 8
+    skidding:
+      type: number
+      title: Skidding
+      description: 'Alignment offset in pixels along the anchor.'
+      default: 0
+    arrow:
+      type: boolean
+      title: Arrow
+      description: 'Whether to show an arrow pointing to the anchor.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the popover body (sets aria-label on the dialog).'
+      default: 'Popover'
+slots:
+  anchor:
+    title: Anchor
+    description: 'The trigger element that opens the popover.'
+  default:
+    title: Default
+    description: 'Default slot for popover body content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-popover/hx-popover.css
+++ b/packages/hx-library/drupal/components/hx-popover/hx-popover.css
@@ -1,0 +1,25 @@
+/**
+ * HX Popover component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-popover-bg: Popover background color. (default: var(--hx-color-neutral-0))
+ * --hx-popover-color: Popover text color. (default: var(--hx-color-neutral-900))
+ * --hx-popover-font-size: Popover font size. (default: var(--hx-font-size-sm))
+ * --hx-popover-max-width: Maximum popover width. (default: 320px)
+ * --hx-popover-padding: Popover padding.
+ * --hx-popover-border-color: Popover border color. (default: var(--hx-color-neutral-200))
+ * --hx-popover-border-radius: Popover border radius. (default: var(--hx-border-radius-md))
+ * --hx-popover-shadow: Popover box shadow.
+ * --hx-popover-z-index: Popover z-index. (default: 9999)
+ * --hx-popover-transition-duration: Show/hide transition duration. (default: 0.2s)
+ * --hx-popover-arrow-size: Size of the arrow indicator. (default: 10px)
+ */
+
+/* Component host styles */
+hx-popover {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-popover/hx-popover.js
+++ b/packages/hx-library/drupal/components/hx-popover/hx-popover.js
@@ -1,0 +1,11 @@
+/**
+ * HX Popover - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-popover';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-popover');
+}

--- a/packages/hx-library/drupal/components/hx-popover/hx-popover.twig
+++ b/packages/hx-library/drupal/components/hx-popover/hx-popover.twig
@@ -1,0 +1,31 @@
+{#
+ /**
+ * @file
+ * HX Popover component template.
+ *
+ * A popover that displays rich floating content attached to a trigger element.
+ *
+ * Available variables:
+ * - open: boolean - Whether the popover is open.
+ * - placement: object - Preferred placement of the popover relative to the anchor.
+ * - trigger: object - How the popover is triggered.
+ * - distance: number - Distance in pixels between the popover and the anchor.
+ * - skidding: number - Alignment offset in pixels along the anchor.
+ * - arrow: boolean - Whether to show an arrow pointing to the anchor.
+ * - label: string - Accessible label for the popover body (sets aria-label on the dialog).
+ */
+#}
+<hx-popover
+  {% if open %}open{% endif %}
+  {% if placement is defined and placement is not empty %}placement="{{ placement }}"{% endif %}
+  {% if trigger is defined and trigger is not empty %}trigger="{{ trigger }}"{% endif %}
+  {% if distance is defined and distance is not empty %}distance="{{ distance }}"{% endif %}
+  {% if skidding is defined and skidding is not empty %}skidding="{{ skidding }}"{% endif %}
+  {% if arrow %}arrow{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if slots.anchor is defined %}
+    <slot name="anchor">{{ slots.anchor }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-popover>

--- a/packages/hx-library/drupal/components/hx-popup/README.md
+++ b/packages/hx-library/drupal/components/hx-popup/README.md
@@ -1,0 +1,87 @@
+# HX Popup
+
+A low-level positioning primitive that anchors a floating panel to a reference element.
+This is the base that hx-tooltip, hx-dropdown, and hx-popover build upon.
+
+## Usage
+
+```twig
+{% include 'helix:hx-popup' with {
+  anchor: 'null',
+  placement: 'bottom',
+  active: false,
+  distance: 0,
+  skidding: 0,
+  arrow: false,
+  arrowPlacement: 'null',
+  arrowPadding: 10,
+  flip: false,
+  flipFallbackPlacements: '[]',
+  shift: false,
+  autoSize: false,
+  strategy: 'fixed',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| anchor | object | null | The reference element to anchor the popup to.
+
+- **Attribute form** (`anchor="#selector"`): Accepts a CSS selector string resolved via
+  `querySelector` from the component's root node. Use this in HTML/Twig markup.
+- **Property form** (`el.anchor = element`): Accepts an `Element` reference directly.
+  Setting an Element via JS property does NOT reflect to the attribute.
+
+If not set, the element in the `anchor` slot is used. |
+| placement | object | bottom | Preferred placement of the popup relative to the anchor. |
+| active | boolean | false | Whether the popup is visible. |
+| distance | number | 0 | Gap in pixels between the popup and the anchor element. |
+| skidding | number | 0 | Offset in pixels along the anchor element's axis. |
+| arrow | boolean | false | Whether to show an arrow pointing to the anchor element. |
+| arrowPlacement | object | null | Manual placement of the arrow along the popup edge.
+When not set, floating-ui calculates the optimal position. |
+| arrowPadding | number | 10 | Minimum padding in pixels from the popup edge to the arrow. |
+| flip | boolean | false | When true, flips the popup to the opposite side to avoid overflow. |
+| flipFallbackPlacements | object | [] | Fallback placements to try when flipping. Accepts a JSON array string. |
+| shift | boolean | false | When true, shifts the popup along the axis to remain in the viewport. |
+| autoSize | boolean | false | When true, resizes the popup to fit within the viewport.
+Sets --hx-auto-size-available-width and --hx-auto-size-available-height CSS custom
+properties on `:host` so they cascade into shadow DOM and are readable from light DOM. |
+| strategy | object | fixed | Positioning strategy passed to floating-ui's `computePosition`.
+
+- `'fixed'` (default): works for most cases; positions relative to the viewport.
+- `'absolute'`: use inside `overflow: hidden` / scroll containers where the popup is
+  positioned relative to the nearest positioned ancestor instead of the viewport. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| anchor | The reference element the popup is anchored to. |
+| (default) | Default slot for popup content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-reposition | Emitted after the popup is repositioned. ## Accessibility Contract `hx-popup` is a **positioning utility**, not an interactive widget. It does not provide ARIA semantics. Consumers are responsible for all accessibility: - **Popup role**: Add `role="tooltip"`, `role="dialog"`, `role="listbox"`, etc. to the slotted popup content depending on its purpose. - **Trigger state**: The element that triggers the popup MUST set `aria-expanded="true/false"`. - **Association**: Use `aria-controls` on the trigger to reference the popup content element, and `aria-labelledby` / `aria-describedby` as appropriate. - **Focus management**: `hx-popup` does NOT trap focus. Consumers building dialogs or menus MUST implement focus trapping and keyboard dismiss (Escape key) themselves. - **Visibility**: The popup is hidden via `display: none` (CSS) and the `inert` attribute when inactive. Both are reliable accessibility-tree hiding mechanisms. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-popup-z-index | 9000 | Z-index of the popup container. |
+| --hx-popup-transition | none | Transition applied to the popup element. Consumers who need enter/exit animations can set this property AND override the default `display: none` hide mechanism via `::part(popup)`. Example: ```css hx-popup { --hx-popup-transition: opacity 0.2s ease; } hx-popup:not([active])::part(popup) { display: block; opacity: 0; pointer-events: none; } hx-popup[active]::part(popup) { opacity: 1; } ``` |
+| --hx-arrow-size | 8px | Size of the arrow element. |
+| --hx-arrow-color | var(--hx-color-surface-overlay, #ffffff) | Color of the arrow element. |
+| --hx-auto-size-available-width | - | Available width set by auto-size middleware (on :host). |
+| --hx-auto-size-available-height | - | Available height set by auto-size middleware (on :host). |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| popup | The popup container element. |
+| arrow | The arrow indicator element (only present when `arrow` is true). |

--- a/packages/hx-library/drupal/components/hx-popup/hx-popup.component.yml
+++ b/packages/hx-library/drupal/components/hx-popup/hx-popup.component.yml
@@ -1,0 +1,81 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Popup
+status: experimental
+group: HELiX
+description: 'A low-level positioning primitive that anchors a floating panel to a reference element. This is the base that hx-tooltip, hx-dropdown, and hx-popover build upon.'
+props:
+  type: object
+  properties:
+    anchor:
+      type: object
+      title: Anchor
+      description: 'The reference element to anchor the popup to.  - **Attribute form** (`anchor="#selector"`): Accepts a CSS selector string resolved via   `querySelector` from the component''s root node. Use this in HTML/Twig markup. - **Property form** (`el.anchor = element`): Accepts an `Element` reference directly.   Setting an Element via JS property does NOT reflect to the attribute.  If not set, the element in the `anchor` slot is used.'
+      default: 'null'
+    placement:
+      type: object
+      title: Placement
+      description: 'Preferred placement of the popup relative to the anchor.'
+      default: 'bottom'
+    active:
+      type: boolean
+      title: Active
+      description: 'Whether the popup is visible.'
+      default: false
+    distance:
+      type: number
+      title: Distance
+      description: 'Gap in pixels between the popup and the anchor element.'
+      default: 0
+    skidding:
+      type: number
+      title: Skidding
+      description: "Offset in pixels along the anchor element's axis."
+      default: 0
+    arrow:
+      type: boolean
+      title: Arrow
+      description: 'Whether to show an arrow pointing to the anchor element.'
+      default: false
+    arrowPlacement:
+      type: object
+      title: Arrow Placement
+      description: 'Manual placement of the arrow along the popup edge. When not set, floating-ui calculates the optimal position.'
+      default: 'null'
+    arrowPadding:
+      type: number
+      title: Arrow Padding
+      description: 'Minimum padding in pixels from the popup edge to the arrow.'
+      default: 10
+    flip:
+      type: boolean
+      title: Flip
+      description: 'When true, flips the popup to the opposite side to avoid overflow.'
+      default: false
+    flipFallbackPlacements:
+      type: object
+      title: Flip Fallback Placements
+      description: 'Fallback placements to try when flipping. Accepts a JSON array string.'
+      default: '[]'
+    shift:
+      type: boolean
+      title: Shift
+      description: 'When true, shifts the popup along the axis to remain in the viewport.'
+      default: false
+    autoSize:
+      type: boolean
+      title: Auto Size
+      description: 'When true, resizes the popup to fit within the viewport. Sets --hx-auto-size-available-width and --hx-auto-size-available-height CSS custom properties on `:host` so they cascade into shadow DOM and are readable from light DOM.'
+      default: false
+    strategy:
+      type: object
+      title: Strategy
+      description: "Positioning strategy passed to floating-ui's `computePosition`.  - `'fixed'` (default): works for most cases; positions relative to the viewport. - `'absolute'`: use inside `overflow: hidden` / scroll containers where the popup is   positioned relative to the nearest positioned ancestor instead of the viewport."
+      default: 'fixed'
+slots:
+  anchor:
+    title: Anchor
+    description: 'The reference element the popup is anchored to.'
+  default:
+    title: Default
+    description: 'Default slot for popup content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-popup/hx-popup.css
+++ b/packages/hx-library/drupal/components/hx-popup/hx-popup.css
@@ -1,0 +1,20 @@
+/**
+ * HX Popup component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-popup-z-index: Z-index of the popup container. (default: 9000)
+ * --hx-popup-transition: Transition applied to the popup element. Consumers who need enter/exit animations can set this property AND override the default `display: none` hide mechanism via `::part(popup)`. Example: ```css hx-popup { --hx-popup-transition: opacity 0.2s ease; } hx-popup:not([active])::part(popup) { display: block; opacity: 0; pointer-events: none; } hx-popup[active]::part(popup) { opacity: 1; } ``` (default: none)
+ * --hx-arrow-size: Size of the arrow element. (default: 8px)
+ * --hx-arrow-color: Color of the arrow element. (default: var(--hx-color-surface-overlay, #ffffff))
+ * --hx-auto-size-available-width: Available width set by auto-size middleware (on :host).
+ * --hx-auto-size-available-height: Available height set by auto-size middleware (on :host).
+ */
+
+/* Component host styles */
+hx-popup {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-popup/hx-popup.js
+++ b/packages/hx-library/drupal/components/hx-popup/hx-popup.js
@@ -1,0 +1,11 @@
+/**
+ * HX Popup - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-popup';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-popup');
+}

--- a/packages/hx-library/drupal/components/hx-popup/hx-popup.twig
+++ b/packages/hx-library/drupal/components/hx-popup/hx-popup.twig
@@ -1,0 +1,44 @@
+{#
+ /**
+ * @file
+ * HX Popup component template.
+ *
+ * A low-level positioning primitive that anchors a floating panel to a reference element.
+ * This is the base that hx-tooltip, hx-dropdown, and hx-popover build upon.
+ *
+ * Available variables:
+ * - anchor: object - The reference element to anchor the popup to.  - **Attribute form** (`anchor="#selector"`): Accepts a CSS selector string resolved via   `querySelector` from the component's root node. Use this in HTML/Twig markup. - **Property form** (`el.anchor = element`): Accepts an `Element` reference directly.   Setting an Element via JS property does NOT reflect to the attribute.  If not set, the element in the `anchor` slot is used.
+ * - placement: object - Preferred placement of the popup relative to the anchor.
+ * - active: boolean - Whether the popup is visible.
+ * - distance: number - Gap in pixels between the popup and the anchor element.
+ * - skidding: number - Offset in pixels along the anchor element's axis.
+ * - arrow: boolean - Whether to show an arrow pointing to the anchor element.
+ * - arrowPlacement: object - Manual placement of the arrow along the popup edge. When not set, floating-ui calculates the optimal position.
+ * - arrowPadding: number - Minimum padding in pixels from the popup edge to the arrow.
+ * - flip: boolean - When true, flips the popup to the opposite side to avoid overflow.
+ * - flipFallbackPlacements: object - Fallback placements to try when flipping. Accepts a JSON array string.
+ * - shift: boolean - When true, shifts the popup along the axis to remain in the viewport.
+ * - autoSize: boolean - When true, resizes the popup to fit within the viewport. Sets --hx-auto-size-available-width and --hx-auto-size-available-height CSS custom properties on `:host` so they cascade into shadow DOM and are readable from light DOM.
+ * - strategy: object - Positioning strategy passed to floating-ui's `computePosition`.  - `'fixed'` (default): works for most cases; positions relative to the viewport. - `'absolute'`: use inside `overflow: hidden` / scroll containers where the popup is   positioned relative to the nearest positioned ancestor instead of the viewport.
+ */
+#}
+<hx-popup
+  {% if anchor is defined and anchor is not empty %}anchor="{{ anchor }}"{% endif %}
+  {% if placement is defined and placement is not empty %}placement="{{ placement }}"{% endif %}
+  {% if active %}active{% endif %}
+  {% if distance is defined and distance is not empty %}distance="{{ distance }}"{% endif %}
+  {% if skidding is defined and skidding is not empty %}skidding="{{ skidding }}"{% endif %}
+  {% if arrow %}arrow{% endif %}
+  {% if arrowPlacement is defined and arrowPlacement is not empty %}arrow-placement="{{ arrowPlacement }}"{% endif %}
+  {% if arrowPadding is defined and arrowPadding is not empty %}arrow-padding="{{ arrowPadding }}"{% endif %}
+  {% if flip %}flip{% endif %}
+  {% if flipFallbackPlacements is defined and flipFallbackPlacements is not empty %}flip-fallback-placements="{{ flipFallbackPlacements }}"{% endif %}
+  {% if shift %}shift{% endif %}
+  {% if autoSize %}auto-size{% endif %}
+  {% if strategy is defined and strategy is not empty %}strategy="{{ strategy }}"{% endif %}
+>
+  {% if slots.anchor is defined %}
+    <slot name="anchor">{{ slots.anchor }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-popup>

--- a/packages/hx-library/drupal/components/hx-progress-bar/README.md
+++ b/packages/hx-library/drupal/components/hx-progress-bar/README.md
@@ -1,0 +1,66 @@
+# HX Progress Bar
+
+A linear progress indicator for determinate and indeterminate states.
+
+## Usage
+
+```twig
+{% include 'helix:hx-progress-bar' with {
+  value: 'null',
+  min: 0,
+  max: 100,
+  indeterminate: false,
+  label: '',
+  description: '',
+  size: 'md',
+  variant: 'default',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | object | null | Current progress value (min–max). Set to null for indeterminate state. |
+| min | number | 0 | Minimum value for the progress bar. |
+| max | number | 100 | Maximum value for the progress bar. |
+| indeterminate | boolean | false | When true, displays an animated indeterminate loading state regardless of value. |
+| label | string |  | Accessible label for the progress bar (maps to aria-label when no label slot content is used). |
+| description | string |  | Additional description for the progress operation, linked via aria-describedby. |
+| size | object | md | Size of the progress bar track. |
+| variant | object | default | Visual variant controlling the indicator color. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Visible label text rendered above the progress bar track. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-complete | Emitted when progress reaches 100%. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-progress-bar-track-bg | var(--hx-color-neutral-100) | Track background color. |
+| --hx-progress-bar-indicator-bg | var(--hx-color-primary-500) | Indicator fill color. |
+| --hx-progress-bar-border-radius | var(--hx-border-radius-full) | Track border radius. |
+| --hx-progress-bar-height-sm | var(--hx-size-1) | Track height for size="sm". |
+| --hx-progress-bar-height-md | var(--hx-size-2) | Track height for size="md". |
+| --hx-progress-bar-height-lg | var(--hx-size-3) | Track height for size="lg". |
+| --hx-progress-bar-label-font-family | var(--hx-font-family-sans) | Label font family. |
+| --hx-progress-bar-label-font-size | var(--hx-font-size-sm) | Label font size. |
+| --hx-progress-bar-label-font-weight | var(--hx-font-weight-medium) | Label font weight. |
+| --hx-progress-bar-label-color | var(--hx-color-neutral-700) | Label text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| track | The outer track container element. |
+| fill | The filled portion indicating progress. |
+| label | The label slot wrapper element. |

--- a/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.component.yml
+++ b/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.component.yml
@@ -1,0 +1,53 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Progress Bar
+status: experimental
+group: HELiX
+description: 'A linear progress indicator for determinate and indeterminate states.'
+props:
+  type: object
+  properties:
+    value:
+      type: object
+      title: Value
+      description: 'Current progress value (min–max). Set to null for indeterminate state.'
+      default: 'null'
+    min:
+      type: number
+      title: Min
+      description: 'Minimum value for the progress bar.'
+      default: 0
+    max:
+      type: number
+      title: Max
+      description: 'Maximum value for the progress bar.'
+      default: 100
+    indeterminate:
+      type: boolean
+      title: Indeterminate
+      description: 'When true, displays an animated indeterminate loading state regardless of value.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the progress bar (maps to aria-label when no label slot content is used).'
+      default: ''
+    description:
+      type: string
+      title: Description
+      description: 'Additional description for the progress operation, linked via aria-describedby.'
+      default: ''
+    size:
+      type: object
+      title: Size
+      description: 'Size of the progress bar track.'
+      default: 'md'
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant controlling the indicator color.'
+      default: 'default'
+slots:
+  label:
+    title: Label
+    description: 'Visible label text rendered above the progress bar track.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.css
+++ b/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.css
@@ -1,0 +1,24 @@
+/**
+ * HX Progress Bar component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-progress-bar-track-bg: Track background color. (default: var(--hx-color-neutral-100))
+ * --hx-progress-bar-indicator-bg: Indicator fill color. (default: var(--hx-color-primary-500))
+ * --hx-progress-bar-border-radius: Track border radius. (default: var(--hx-border-radius-full))
+ * --hx-progress-bar-height-sm: Track height for size="sm". (default: var(--hx-size-1))
+ * --hx-progress-bar-height-md: Track height for size="md". (default: var(--hx-size-2))
+ * --hx-progress-bar-height-lg: Track height for size="lg". (default: var(--hx-size-3))
+ * --hx-progress-bar-label-font-family: Label font family. (default: var(--hx-font-family-sans))
+ * --hx-progress-bar-label-font-size: Label font size. (default: var(--hx-font-size-sm))
+ * --hx-progress-bar-label-font-weight: Label font weight. (default: var(--hx-font-weight-medium))
+ * --hx-progress-bar-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ */
+
+/* Component host styles */
+hx-progress-bar {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.js
+++ b/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.js
@@ -1,0 +1,11 @@
+/**
+ * HX Progress Bar - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-progress-bar';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-progress-bar');
+}

--- a/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.twig
+++ b/packages/hx-library/drupal/components/hx-progress-bar/hx-progress-bar.twig
@@ -1,0 +1,32 @@
+{#
+ /**
+ * @file
+ * HX Progress Bar component template.
+ *
+ * A linear progress indicator for determinate and indeterminate states.
+ *
+ * Available variables:
+ * - value: object - Current progress value (min–max). Set to null for indeterminate state.
+ * - min: number - Minimum value for the progress bar.
+ * - max: number - Maximum value for the progress bar.
+ * - indeterminate: boolean - When true, displays an animated indeterminate loading state regardless of value.
+ * - label: string - Accessible label for the progress bar (maps to aria-label when no label slot content is used).
+ * - description: string - Additional description for the progress operation, linked via aria-describedby.
+ * - size: object - Size of the progress bar track.
+ * - variant: object - Visual variant controlling the indicator color.
+ */
+#}
+<hx-progress-bar
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if min is defined and min is not empty %}min="{{ min }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if indeterminate %}indeterminate{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if description is defined and description is not empty %}description="{{ description }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+</hx-progress-bar>

--- a/packages/hx-library/drupal/components/hx-progress-ring/README.md
+++ b/packages/hx-library/drupal/components/hx-progress-ring/README.md
@@ -1,0 +1,53 @@
+# HX Progress Ring
+
+SVG-based circular progress indicator. Supports determinate and indeterminate modes,
+multiple size variants, semantic color variants, and a center content slot.
+
+## Usage
+
+```twig
+{% include 'helix:hx-progress-ring' with {
+  value: 'null',
+  max: 100,
+  size: 'md',
+  strokeWidth: 4,
+  variant: 'default',
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | object | null | Current progress value (0–max). When null, renders in indeterminate mode. |
+| max | number | 100 | Maximum value for the progress range. Defaults to 100. Used for aria-valuemax. |
+| size | object | md | Size of the ring. Controls SVG diameter. |
+| strokeWidth | number | 4 | Stroke width of the ring circles in SVG user units. |
+| variant | object | default | Semantic color variant. |
+| label | string |  | Accessible label for the progressbar. Exposed as aria-label.
+Set this attribute to satisfy WCAG 4.1.2. When absent, aria-busy reflects
+indeterminate state and a console warning is emitted. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for center content (percentage text, icon, etc.). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-progress-ring-track-color | var(--hx-color-neutral-200) | Track stroke color. |
+| --hx-progress-ring-indicator-color | var(--hx-color-primary-500) | Indicator stroke color. |
+| --hx-progress-ring-label-color | var(--hx-color-neutral-900) | Center label text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The SVG element. |
+| track | The background circle track. |
+| indicator | The progress arc indicator. |
+| label | The center slot wrapper div. |

--- a/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.component.yml
+++ b/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.component.yml
@@ -1,0 +1,43 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Progress Ring
+status: experimental
+group: HELiX
+description: 'SVG-based circular progress indicator. Supports determinate and indeterminate modes, multiple size variants, semantic color variants, and a center content slot.'
+props:
+  type: object
+  properties:
+    value:
+      type: object
+      title: Value
+      description: 'Current progress value (0–max). When null, renders in indeterminate mode.'
+      default: 'null'
+    max:
+      type: number
+      title: Max
+      description: 'Maximum value for the progress range. Defaults to 100. Used for aria-valuemax.'
+      default: 100
+    size:
+      type: object
+      title: Size
+      description: 'Size of the ring. Controls SVG diameter.'
+      default: 'md'
+    strokeWidth:
+      type: number
+      title: Stroke Width
+      description: 'Stroke width of the ring circles in SVG user units.'
+      default: 4
+    variant:
+      type: object
+      title: Variant
+      description: 'Semantic color variant.'
+      default: 'default'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the progressbar. Exposed as aria-label. Set this attribute to satisfy WCAG 4.1.2. When absent, aria-busy reflects indeterminate state and a console warning is emitted.'
+      default: ''
+slots:
+  default:
+    title: Default
+    description: 'Default slot for center content (percentage text, icon, etc.).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.css
+++ b/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.css
@@ -1,0 +1,17 @@
+/**
+ * HX Progress Ring component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-progress-ring-track-color: Track stroke color. (default: var(--hx-color-neutral-200))
+ * --hx-progress-ring-indicator-color: Indicator stroke color. (default: var(--hx-color-primary-500))
+ * --hx-progress-ring-label-color: Center label text color. (default: var(--hx-color-neutral-900))
+ */
+
+/* Component host styles */
+hx-progress-ring {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.js
+++ b/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.js
@@ -1,0 +1,11 @@
+/**
+ * HX Progress Ring - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-progress-ring';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-progress-ring');
+}

--- a/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.twig
+++ b/packages/hx-library/drupal/components/hx-progress-ring/hx-progress-ring.twig
@@ -1,0 +1,27 @@
+{#
+ /**
+ * @file
+ * HX Progress Ring component template.
+ *
+ * SVG-based circular progress indicator. Supports determinate and indeterminate modes,
+ * multiple size variants, semantic color variants, and a center content slot.
+ *
+ * Available variables:
+ * - value: object - Current progress value (0–max). When null, renders in indeterminate mode.
+ * - max: number - Maximum value for the progress range. Defaults to 100. Used for aria-valuemax.
+ * - size: object - Size of the ring. Controls SVG diameter.
+ * - strokeWidth: number - Stroke width of the ring circles in SVG user units.
+ * - variant: object - Semantic color variant.
+ * - label: string - Accessible label for the progressbar. Exposed as aria-label. Set this attribute to satisfy WCAG 4.1.2. When absent, aria-busy reflects indeterminate state and a console warning is emitted.
+ */
+#}
+<hx-progress-ring
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if strokeWidth is defined and strokeWidth is not empty %}stroke-width="{{ strokeWidth }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-progress-ring>

--- a/packages/hx-library/drupal/components/hx-prose/README.md
+++ b/packages/hx-library/drupal/components/hx-prose/README.md
@@ -1,0 +1,43 @@
+# HX Prose
+
+A Light DOM prose container that applies typographic styles to rich text
+content such as CKEditor output, Markdown-rendered HTML, or any structured
+body copy.
+
+Renders in the Light DOM (no Shadow DOM) so that global and scoped styles
+can target child elements directly. Uses the AdoptedStylesheetsController
+to inject scoped prose CSS into the document without duplication.
+
+## Usage
+
+```twig
+{% include 'helix:hx-prose' with {
+  size: 'base',
+  maxWidth: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| size | object | base | Typography scale for the prose content. |
+| maxWidth | string |  | Maximum content width. When set, overrides the --hx-prose-max-width token.
+Accepts any valid CSS width value (e.g., '640px', '80ch', '100%'). |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for rich text content (headings, paragraphs, lists, tables, etc.). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-prose-max-width | 720px | Maximum content width. |
+| --hx-prose-font-size | var(--hx-font-size-base) | Base font size. |
+| --hx-prose-line-height | var(--hx-line-height-relaxed) | Base line height. |
+| --hx-prose-color | var(--hx-color-text) | Body text color. |
+| --hx-prose-heading-color | var(--hx-color-text-strong) | Heading color. |
+| --hx-prose-link-color | var(--hx-color-primary) | Link color. |

--- a/packages/hx-library/drupal/components/hx-prose/hx-prose.component.yml
+++ b/packages/hx-library/drupal/components/hx-prose/hx-prose.component.yml
@@ -1,0 +1,23 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Prose
+status: experimental
+group: HELiX
+description: 'A Light DOM prose container that applies typographic styles to rich text content such as CKEditor output, Markdown-rendered HTML, or any structured body copy.  Renders in the Light DOM (no Shadow DOM) so that global and scoped styles can target child elements directly. Uses the AdoptedStylesheetsController to inject scoped prose CSS into the document without duplication.'
+props:
+  type: object
+  properties:
+    size:
+      type: object
+      title: Size
+      description: 'Typography scale for the prose content.'
+      default: 'base'
+    maxWidth:
+      type: string
+      title: Max Width
+      description: "Maximum content width. When set, overrides the --hx-prose-max-width token. Accepts any valid CSS width value (e.g., '640px', '80ch', '100%')."
+      default: ''
+slots:
+  default:
+    title: Default
+    description: 'Default slot for rich text content (headings, paragraphs, lists, tables, etc.).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-prose/hx-prose.css
+++ b/packages/hx-library/drupal/components/hx-prose/hx-prose.css
@@ -1,0 +1,20 @@
+/**
+ * HX Prose component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-prose-max-width: Maximum content width. (default: 720px)
+ * --hx-prose-font-size: Base font size. (default: var(--hx-font-size-base))
+ * --hx-prose-line-height: Base line height. (default: var(--hx-line-height-relaxed))
+ * --hx-prose-color: Body text color. (default: var(--hx-color-text))
+ * --hx-prose-heading-color: Heading color. (default: var(--hx-color-text-strong))
+ * --hx-prose-link-color: Link color. (default: var(--hx-color-primary))
+ */
+
+/* Component host styles */
+hx-prose {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-prose/hx-prose.js
+++ b/packages/hx-library/drupal/components/hx-prose/hx-prose.js
@@ -1,0 +1,11 @@
+/**
+ * HX Prose - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-prose';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-prose');
+}

--- a/packages/hx-library/drupal/components/hx-prose/hx-prose.twig
+++ b/packages/hx-library/drupal/components/hx-prose/hx-prose.twig
@@ -1,0 +1,24 @@
+{#
+ /**
+ * @file
+ * HX Prose component template.
+ *
+ * A Light DOM prose container that applies typographic styles to rich text
+ * content such as CKEditor output, Markdown-rendered HTML, or any structured
+ * body copy.
+ * 
+ * Renders in the Light DOM (no Shadow DOM) so that global and scoped styles
+ * can target child elements directly. Uses the AdoptedStylesheetsController
+ * to inject scoped prose CSS into the document without duplication.
+ *
+ * Available variables:
+ * - size: object - Typography scale for the prose content.
+ * - maxWidth: string - Maximum content width. When set, overrides the --hx-prose-max-width token. Accepts any valid CSS width value (e.g., '640px', '80ch', '100%').
+ */
+#}
+<hx-prose
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if maxWidth is defined and maxWidth is not empty %}max-width="{{ maxWidth }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-prose>

--- a/packages/hx-library/drupal/components/hx-radio-group/README.md
+++ b/packages/hx-library/drupal/components/hx-radio-group/README.md
@@ -1,0 +1,65 @@
+# HX Radio Group
+
+A form-associated radio group that manages a set of `<hx-radio>` children.
+
+## Usage
+
+```twig
+{% include 'helix:hx-radio-group' with {
+  value: '',
+  name: '',
+  label: '',
+  required: false,
+  disabled: false,
+  error: '',
+  helpText: '',
+  orientation: 'vertical',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | string |  | The selected radio's value. |
+| name | string |  | The name used for form submission. |
+| label | string |  | The fieldset legend/label text. |
+| required | boolean | false | Whether a selection is required for form submission. |
+| disabled | boolean | false | Whether the entire group is disabled. |
+| error | string |  | Error message to display. When set, the group enters an error state. |
+| helpText | string |  | Help text displayed below the group for guidance. |
+| orientation | object | vertical | Layout orientation of the radio items. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | `<hx-radio>` elements. |
+| error | Custom error content (overrides the error property). |
+| help-text | Custom help text content (overrides the helpText property). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when the selected radio changes. |
+| hx-radio-select | Internal event dispatched by `hx-radio` when selected; consumed by the group. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-radio-group-gap | var(--hx-space-3, 0.75rem) | Gap between radio items. |
+| --hx-radio-group-label-color | var(--hx-color-neutral-700, #343a40) | Label text color. |
+| --hx-radio-group-error-color | var(--hx-color-error-500, #dc3545) | Error message color. |
+| --hx-radio-group-help-text-color | var(--hx-color-neutral-500, #6c757d) | Help text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| fieldset | The fieldset wrapper. |
+| legend | The legend/label. |
+| group | The container for radio items. |
+| error | The error message. |
+| help-text | The help text. |

--- a/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.component.yml
+++ b/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.component.yml
@@ -1,0 +1,59 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Radio Group
+status: experimental
+group: HELiX
+description: 'A form-associated radio group that manages a set of `<hx-radio>` children.'
+props:
+  type: object
+  properties:
+    value:
+      type: string
+      title: Value
+      description: "The selected radio's value."
+      default: ''
+    name:
+      type: string
+      title: Name
+      description: 'The name used for form submission.'
+      default: ''
+    label:
+      type: string
+      title: Label
+      description: 'The fieldset legend/label text.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether a selection is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the entire group is disabled.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the group enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the group for guidance.'
+      default: ''
+    orientation:
+      type: object
+      title: Orientation
+      description: 'Layout orientation of the radio items.'
+      default: 'vertical'
+slots:
+  default:
+    title: Default
+    description: '`<hx-radio>` elements.'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.css
+++ b/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.css
@@ -1,0 +1,18 @@
+/**
+ * HX Radio Group component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-radio-group-gap: Gap between radio items. (default: var(--hx-space-3, 0.75rem))
+ * --hx-radio-group-label-color: Label text color. (default: var(--hx-color-neutral-700, #343a40))
+ * --hx-radio-group-error-color: Error message color. (default: var(--hx-color-error-500, #dc3545))
+ * --hx-radio-group-help-text-color: Help text color. (default: var(--hx-color-neutral-500, #6c757d))
+ */
+
+/* Component host styles */
+hx-radio-group {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.js
+++ b/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.js
@@ -1,0 +1,11 @@
+/**
+ * HX Radio Group - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-radio-group';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-radio-group');
+}

--- a/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.twig
+++ b/packages/hx-library/drupal/components/hx-radio-group/hx-radio-group.twig
@@ -1,0 +1,36 @@
+{#
+ /**
+ * @file
+ * HX Radio Group component template.
+ *
+ * A form-associated radio group that manages a set of `<hx-radio>` children.
+ *
+ * Available variables:
+ * - value: string - The selected radio's value.
+ * - name: string - The name used for form submission.
+ * - label: string - The fieldset legend/label text.
+ * - required: boolean - Whether a selection is required for form submission.
+ * - disabled: boolean - Whether the entire group is disabled.
+ * - error: string - Error message to display. When set, the group enters an error state.
+ * - helpText: string - Help text displayed below the group for guidance.
+ * - orientation: object - Layout orientation of the radio items.
+ */
+#}
+<hx-radio-group
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+>
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-radio-group>

--- a/packages/hx-library/drupal/components/hx-radio/README.md
+++ b/packages/hx-library/drupal/components/hx-radio/README.md
@@ -1,0 +1,48 @@
+# HX Radio
+
+An individual radio button, designed to be used inside a `<hx-radio-group>`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-radio' with {
+  value: '',
+  label: '',
+  disabled: false,
+  checked: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | string |  | The value this radio represents. |
+| label | string |  | Visible label text for the radio. |
+| disabled | boolean | false | Whether this radio is disabled. |
+| checked | boolean | false | Whether this radio is checked. Managed by the parent group. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Custom label content (overrides the label property). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-radio-size | var(--hx-size-5, 1.25rem) | Radio circle size. |
+| --hx-radio-border-color | var(--hx-color-neutral-300, #ced4da) | Radio border color. |
+| --hx-radio-checked-bg | var(--hx-color-primary-500, #2563EB) | Checked background color. |
+| --hx-radio-checked-border-color | var(--hx-color-primary-500, #2563EB) | Checked border color. |
+| --hx-radio-dot-color | var(--hx-color-neutral-0, #ffffff) | Inner dot color when checked. |
+| --hx-radio-focus-ring-color | var(--hx-focus-ring-color, #2563EB) | Focus ring color. |
+| --hx-radio-label-color | var(--hx-color-neutral-700, #343a40) | Label text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| radio | The visual radio circle. |
+| label | The label text. |

--- a/packages/hx-library/drupal/components/hx-radio/hx-radio.component.yml
+++ b/packages/hx-library/drupal/components/hx-radio/hx-radio.component.yml
@@ -1,0 +1,33 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Radio
+status: experimental
+group: HELiX
+description: 'An individual radio button, designed to be used inside a `<hx-radio-group>`.'
+props:
+  type: object
+  properties:
+    value:
+      type: string
+      title: Value
+      description: 'The value this radio represents.'
+      default: ''
+    label:
+      type: string
+      title: Label
+      description: 'Visible label text for the radio.'
+      default: ''
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether this radio is disabled.'
+      default: false
+    checked:
+      type: boolean
+      title: Checked
+      description: 'Whether this radio is checked. Managed by the parent group.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Custom label content (overrides the label property).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-radio/hx-radio.css
+++ b/packages/hx-library/drupal/components/hx-radio/hx-radio.css
@@ -1,0 +1,21 @@
+/**
+ * HX Radio component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-radio-size: Radio circle size. (default: var(--hx-size-5, 1.25rem))
+ * --hx-radio-border-color: Radio border color. (default: var(--hx-color-neutral-300, #ced4da))
+ * --hx-radio-checked-bg: Checked background color. (default: var(--hx-color-primary-500, #2563EB))
+ * --hx-radio-checked-border-color: Checked border color. (default: var(--hx-color-primary-500, #2563EB))
+ * --hx-radio-dot-color: Inner dot color when checked. (default: var(--hx-color-neutral-0, #ffffff))
+ * --hx-radio-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color, #2563EB))
+ * --hx-radio-label-color: Label text color. (default: var(--hx-color-neutral-700, #343a40))
+ */
+
+/* Component host styles */
+hx-radio {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-radio/hx-radio.js
+++ b/packages/hx-library/drupal/components/hx-radio/hx-radio.js
@@ -1,0 +1,11 @@
+/**
+ * HX Radio - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-radio';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-radio');
+}

--- a/packages/hx-library/drupal/components/hx-radio/hx-radio.twig
+++ b/packages/hx-library/drupal/components/hx-radio/hx-radio.twig
@@ -1,0 +1,22 @@
+{#
+ /**
+ * @file
+ * HX Radio component template.
+ *
+ * An individual radio button, designed to be used inside a `<hx-radio-group>`.
+ *
+ * Available variables:
+ * - value: string - The value this radio represents.
+ * - label: string - Visible label text for the radio.
+ * - disabled: boolean - Whether this radio is disabled.
+ * - checked: boolean - Whether this radio is checked. Managed by the parent group.
+ */
+#}
+<hx-radio
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if checked %}checked{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-radio>

--- a/packages/hx-library/drupal/components/hx-rating/README.md
+++ b/packages/hx-library/drupal/components/hx-rating/README.md
@@ -1,0 +1,76 @@
+# HX Rating
+
+A star rating input component for user feedback and display.
+Supports whole and half-star ratings, keyboard navigation, hover preview,
+and native form participation via ElementInternals.
+
+### Accessibility
+
+- **Interactive mode (precision=1)**: Uses `role="radiogroup"` with individual `role="radio"` stars.
+  Each star has `aria-label` ("1 star", "2 stars", etc.) and `aria-checked`.
+- **Interactive mode (precision=0.5)**: Uses `role="slider"` with `aria-valuemin`, `aria-valuemax`,
+  `aria-valuenow`, and `aria-valuetext` (e.g. "2.5 out of 5 stars"). Star elements are
+  `aria-hidden="true"` decorative visuals. This avoids a WCAG 2.5.3 label-content-name mismatch
+  that would occur if a `role="radio"` labeled "3 stars" were checked for a value of 2.5.
+- **Readonly mode**: Uses `role="img"` with a descriptive `aria-label` ("Rating: 3 out of 5").
+- **Keyboard**: Arrow keys (Left/Right/Up/Down) adjust value by `precision` step.
+  Home sets to 0, End sets to `max`. Focus follows the active tab stop.
+- **Disabled**: Sets `aria-disabled="true"` on the group and prevents interaction.
+
+## Usage
+
+```twig
+{% include 'helix:hx-rating' with {
+  value: 0,
+  max: 5,
+  precision: '1',
+  readonly: false,
+  disabled: false,
+  name: '',
+  label: '',
+  required: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| value | number | 0 | The current rating value (0 to max). |
+| max | number | 5 | The maximum number of stars. |
+| precision | object | 1 | The minimum selectable increment. Use 0.5 for half-star ratings. |
+| readonly | boolean | false | When true, the rating is display-only and cannot be changed. |
+| disabled | boolean | false | When true, the rating is disabled and cannot be interacted with. |
+| name | string |  | The name submitted with the form. |
+| label | string |  | Accessible label for the rating group. |
+| required | boolean | false | When true, a non-zero rating is required for form submission. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| icon | Custom rating icon. Receives `data-state` attribute ("full" | "half" | "empty"). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when the rating value changes. |
+| hx-hover | Dispatched while hovering over a star for preview. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-rating-color | var(--hx-color-warning-400,#fbbf24) | Filled star color. |
+| --hx-rating-empty-color | var(--hx-color-neutral-300,#d1d5db) | Empty star color. |
+| --hx-rating-hover-color | var(--hx-color-warning-300,#fcd34d) | Star color on hover. |
+| --hx-rating-size | var(--hx-font-size-xl,1.25rem) | Star icon size. |
+| --hx-rating-gap | var(--hx-space-1,0.25rem) | Gap between stars. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The outer container element. |
+| symbol | Each individual star/icon element. |

--- a/packages/hx-library/drupal/components/hx-rating/hx-rating.component.yml
+++ b/packages/hx-library/drupal/components/hx-rating/hx-rating.component.yml
@@ -1,0 +1,53 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Rating
+status: experimental
+group: HELiX
+description: 'A star rating input component for user feedback and display. Supports whole and half-star ratings, keyboard navigation, hover preview, and native form participation via ElementInternals.  ### Accessibility  - **Interactive mode (precision=1)**: Uses `role="radiogroup"` with individual `role="radio"` stars.   Each star has `aria-label` ("1 star", "2 stars", etc.) and `aria-checked`. - **Interactive mode (precision=0.5)**: Uses `role="slider"` with `aria-valuemin`, `aria-valuemax`,   `aria-valuenow`, and `aria-valuetext` (e.g. "2.5 out of 5 stars"). Star elements are   `aria-hidden="true"` decorative visuals. This avoids a WCAG 2.5.3 label-content-name mismatch   that would occur if a `role="radio"` labeled "3 stars" were checked for a value of 2.5. - **Readonly mode**: Uses `role="img"` with a descriptive `aria-label` ("Rating: 3 out of 5"). - **Keyboard**: Arrow keys (Left/Right/Up/Down) adjust value by `precision` step.   Home sets to 0, End sets to `max`. Focus follows the active tab stop. - **Disabled**: Sets `aria-disabled="true"` on the group and prevents interaction.'
+props:
+  type: object
+  properties:
+    value:
+      type: number
+      title: Value
+      description: 'The current rating value (0 to max).'
+      default: 0
+    max:
+      type: number
+      title: Max
+      description: 'The maximum number of stars.'
+      default: 5
+    precision:
+      type: object
+      title: Precision
+      description: 'The minimum selectable increment. Use 0.5 for half-star ratings.'
+      default: '1'
+    readonly:
+      type: boolean
+      title: Readonly
+      description: 'When true, the rating is display-only and cannot be changed.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'When true, the rating is disabled and cannot be interacted with.'
+      default: false
+    name:
+      type: string
+      title: Name
+      description: 'The name submitted with the form.'
+      default: ''
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the rating group.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'When true, a non-zero rating is required for form submission.'
+      default: false
+slots:
+  icon:
+    title: Icon
+    description: 'Custom rating icon. Receives `data-state` attribute ("full" | "half" | "empty").'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-rating/hx-rating.css
+++ b/packages/hx-library/drupal/components/hx-rating/hx-rating.css
@@ -1,0 +1,19 @@
+/**
+ * HX Rating component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-rating-color: Filled star color. (default: var(--hx-color-warning-400,#fbbf24))
+ * --hx-rating-empty-color: Empty star color. (default: var(--hx-color-neutral-300,#d1d5db))
+ * --hx-rating-hover-color: Star color on hover. (default: var(--hx-color-warning-300,#fcd34d))
+ * --hx-rating-size: Star icon size. (default: var(--hx-font-size-xl,1.25rem))
+ * --hx-rating-gap: Gap between stars. (default: var(--hx-space-1,0.25rem))
+ */
+
+/* Component host styles */
+hx-rating {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-rating/hx-rating.js
+++ b/packages/hx-library/drupal/components/hx-rating/hx-rating.js
@@ -1,0 +1,11 @@
+/**
+ * HX Rating - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-rating';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-rating');
+}

--- a/packages/hx-library/drupal/components/hx-rating/hx-rating.twig
+++ b/packages/hx-library/drupal/components/hx-rating/hx-rating.twig
@@ -1,0 +1,47 @@
+{#
+ /**
+ * @file
+ * HX Rating component template.
+ *
+ * A star rating input component for user feedback and display.
+ * Supports whole and half-star ratings, keyboard navigation, hover preview,
+ * and native form participation via ElementInternals.
+ * 
+ * ### Accessibility
+ * 
+ * - **Interactive mode (precision=1)**: Uses `role="radiogroup"` with individual `role="radio"` stars.
+ *   Each star has `aria-label` ("1 star", "2 stars", etc.) and `aria-checked`.
+ * - **Interactive mode (precision=0.5)**: Uses `role="slider"` with `aria-valuemin`, `aria-valuemax`,
+ *   `aria-valuenow`, and `aria-valuetext` (e.g. "2.5 out of 5 stars"). Star elements are
+ *   `aria-hidden="true"` decorative visuals. This avoids a WCAG 2.5.3 label-content-name mismatch
+ *   that would occur if a `role="radio"` labeled "3 stars" were checked for a value of 2.5.
+ * - **Readonly mode**: Uses `role="img"` with a descriptive `aria-label` ("Rating: 3 out of 5").
+ * - **Keyboard**: Arrow keys (Left/Right/Up/Down) adjust value by `precision` step.
+ *   Home sets to 0, End sets to `max`. Focus follows the active tab stop.
+ * - **Disabled**: Sets `aria-disabled="true"` on the group and prevents interaction.
+ *
+ * Available variables:
+ * - value: number - The current rating value (0 to max).
+ * - max: number - The maximum number of stars.
+ * - precision: object - The minimum selectable increment. Use 0.5 for half-star ratings.
+ * - readonly: boolean - When true, the rating is display-only and cannot be changed.
+ * - disabled: boolean - When true, the rating is disabled and cannot be interacted with.
+ * - name: string - The name submitted with the form.
+ * - label: string - Accessible label for the rating group.
+ * - required: boolean - When true, a non-zero rating is required for form submission.
+ */
+#}
+<hx-rating
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if precision is defined and precision is not empty %}precision="{{ precision }}"{% endif %}
+  {% if readonly %}readonly{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if required %}required{% endif %}
+>
+  {% if slots.icon is defined %}
+    <slot name="icon">{{ slots.icon }}</slot>
+  {% endif %}
+</hx-rating>

--- a/packages/hx-library/drupal/components/hx-select/README.md
+++ b/packages/hx-library/drupal/components/hx-select/README.md
@@ -1,0 +1,88 @@
+# HX Select
+
+A form-associated select component with custom styling, label, error, and
+help text. Options are provided via slotted `<option>` (and `<optgroup>`)
+elements in the light DOM. The component wraps a hidden native `<select>`
+for form participation and provides a combobox trigger for consistent
+cross-browser styling.
+
+## Usage
+
+```twig
+{% include 'helix:hx-select' with {
+  label: '',
+  placeholder: '',
+  value: '',
+  required: false,
+  disabled: false,
+  name: '',
+  error: '',
+  helpText: '',
+  size: 'md',
+  ariaLabel: 'null',
+  open: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | The visible label text for the select. |
+| placeholder | string |  | Placeholder text shown in the trigger when no option is selected. |
+| value | string |  | The current value of the select. |
+| required | boolean | false | Whether the select is required for form submission. |
+| disabled | boolean | false | Whether the select is disabled. |
+| name | string |  | The name used for form submission. |
+| error | string |  | Error message to display. When set, the field enters an error state. |
+| helpText | string |  | Help text displayed below the select for guidance. |
+| size | object | md | Size variant of the select trigger. |
+| ariaLabel | object | null | Accessible name for screen readers, if different from the visible label. |
+| open | boolean | false | Controls whether the dropdown listbox is open. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `<option>` and `<optgroup>` elements. |
+| label | Custom label content (overrides the label property). |
+| error | Custom error content (overrides the error property). |
+| help-text | Custom help text content (overrides the helpText property). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when the selected option changes. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-select-bg | var(--hx-color-neutral-0) | Select background color. |
+| --hx-select-color | var(--hx-color-neutral-800) | Select text color. |
+| --hx-select-border-color | var(--hx-color-neutral-300) | Select border color. |
+| --hx-select-border-radius | var(--hx-border-radius-md) | Select border radius. |
+| --hx-select-font-family | var(--hx-font-family-sans) | Select font family. |
+| --hx-select-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-select-error-color | var(--hx-color-error-500) | Error state color. |
+| --hx-select-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-select-chevron-color | var(--hx-color-neutral-500) | Chevron indicator color. |
+| --hx-select-listbox-bg | var(--hx-color-neutral-0) | Listbox panel background color. |
+| --hx-select-option-hover-bg | var(--hx-color-primary-50) | Option hover background color. |
+| --hx-select-option-selected-bg | var(--hx-color-primary-100) | Selected option background color. |
+| --hx-select-placeholder-color | var(--hx-color-neutral-400) | Placeholder text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| field | The outer field container. |
+| label | The label element. |
+| select-wrapper | The wrapper containing the trigger and listbox. |
+| select | The hidden native select element (kept for form participation). |
+| trigger | The button that opens/closes the dropdown. |
+| listbox | The dropdown panel containing options. |
+| option | Individual option items in the listbox. |
+| help-text | The help text container. |
+| error | The error message container. |

--- a/packages/hx-library/drupal/components/hx-select/hx-select.component.yml
+++ b/packages/hx-library/drupal/components/hx-select/hx-select.component.yml
@@ -1,0 +1,77 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Select
+status: experimental
+group: HELiX
+description: 'A form-associated select component with custom styling, label, error, and help text. Options are provided via slotted `<option>` (and `<optgroup>`) elements in the light DOM. The component wraps a hidden native `<select>` for form participation and provides a combobox trigger for consistent cross-browser styling.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the select.'
+      default: ''
+    placeholder:
+      type: string
+      title: Placeholder
+      description: 'Placeholder text shown in the trigger when no option is selected.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The current value of the select.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the select is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the select is disabled.'
+      default: false
+    name:
+      type: string
+      title: Name
+      description: 'The name used for form submission.'
+      default: ''
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the field enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the select for guidance.'
+      default: ''
+    size:
+      type: object
+      title: Size
+      description: 'Size variant of the select trigger.'
+      default: 'md'
+    ariaLabel:
+      type: object
+      title: Aria Label
+      description: 'Accessible name for screen readers, if different from the visible label.'
+      default: 'null'
+    open:
+      type: boolean
+      title: Open
+      description: 'Controls whether the dropdown listbox is open.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `<option>` and `<optgroup>` elements.'
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-select/hx-select.css
+++ b/packages/hx-library/drupal/components/hx-select/hx-select.css
@@ -1,0 +1,27 @@
+/**
+ * HX Select component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-select-bg: Select background color. (default: var(--hx-color-neutral-0))
+ * --hx-select-color: Select text color. (default: var(--hx-color-neutral-800))
+ * --hx-select-border-color: Select border color. (default: var(--hx-color-neutral-300))
+ * --hx-select-border-radius: Select border radius. (default: var(--hx-border-radius-md))
+ * --hx-select-font-family: Select font family. (default: var(--hx-font-family-sans))
+ * --hx-select-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-select-error-color: Error state color. (default: var(--hx-color-error-500))
+ * --hx-select-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-select-chevron-color: Chevron indicator color. (default: var(--hx-color-neutral-500))
+ * --hx-select-listbox-bg: Listbox panel background color. (default: var(--hx-color-neutral-0))
+ * --hx-select-option-hover-bg: Option hover background color. (default: var(--hx-color-primary-50))
+ * --hx-select-option-selected-bg: Selected option background color. (default: var(--hx-color-primary-100))
+ * --hx-select-placeholder-color: Placeholder text color. (default: var(--hx-color-neutral-400))
+ */
+
+/* Component host styles */
+hx-select {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-select/hx-select.js
+++ b/packages/hx-library/drupal/components/hx-select/hx-select.js
@@ -1,0 +1,11 @@
+/**
+ * HX Select - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-select';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-select');
+}

--- a/packages/hx-library/drupal/components/hx-select/hx-select.twig
+++ b/packages/hx-library/drupal/components/hx-select/hx-select.twig
@@ -1,0 +1,49 @@
+{#
+ /**
+ * @file
+ * HX Select component template.
+ *
+ * A form-associated select component with custom styling, label, error, and
+ * help text. Options are provided via slotted `<option>` (and `<optgroup>`)
+ * elements in the light DOM. The component wraps a hidden native `<select>`
+ * for form participation and provides a combobox trigger for consistent
+ * cross-browser styling.
+ *
+ * Available variables:
+ * - label: string - The visible label text for the select.
+ * - placeholder: string - Placeholder text shown in the trigger when no option is selected.
+ * - value: string - The current value of the select.
+ * - required: boolean - Whether the select is required for form submission.
+ * - disabled: boolean - Whether the select is disabled.
+ * - name: string - The name used for form submission.
+ * - error: string - Error message to display. When set, the field enters an error state.
+ * - helpText: string - Help text displayed below the select for guidance.
+ * - size: object - Size variant of the select trigger.
+ * - ariaLabel: object - Accessible name for screen readers, if different from the visible label.
+ * - open: boolean - Controls whether the dropdown listbox is open.
+ */
+#}
+<hx-select
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if placeholder is defined and placeholder is not empty %}placeholder="{{ placeholder }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if ariaLabel is defined and ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
+  {% if open %}open{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-select>

--- a/packages/hx-library/drupal/components/hx-side-nav/README.md
+++ b/packages/hx-library/drupal/components/hx-side-nav/README.md
@@ -1,0 +1,58 @@
+# HX Side Nav
+
+A collapsible left-side navigation panel with nested menu item support.
+Designed for clinical portals, admin dashboards, and department navigation.
+
+## Usage
+
+```twig
+{% include 'helix:hx-side-nav' with {
+  collapsed: false,
+  label: 'Main Navigation',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| collapsed | boolean | false | When true, the nav collapses to show icons only. |
+| label | string | Main Navigation | The accessible label for the nav landmark. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for hx-nav-item children. |
+| header | Logo or branding content. |
+| footer | User profile or settings content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-collapse | Dispatched when the nav collapses to icon-only mode. |
+| hx-expand | Dispatched when the nav expands to full width. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-side-nav-width | 16rem | Full expanded width. |
+| --hx-side-nav-collapsed-width | 3.5rem | Collapsed icon-only width. |
+| --hx-side-nav-bg | var(--hx-color-neutral-900) | Background color. |
+| --hx-side-nav-color | var(--hx-color-neutral-100) | Text color. |
+| --hx-side-nav-border-color | var(--hx-color-neutral-700) | Border color. |
+| --hx-side-nav-header-padding | var(--hx-space-4) | Header padding. |
+| --hx-side-nav-footer-padding | var(--hx-space-4) | Footer padding. |
+| --hx-side-nav-toggle-color | var(--hx-color-neutral-400) | Toggle button icon color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| nav | The outer nav element. |
+| header | The header section. |
+| body | The scrollable body section. |
+| footer | The footer section. |
+| toggle | The collapse/expand toggle button. |

--- a/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.component.yml
+++ b/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.component.yml
@@ -1,0 +1,29 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Side Nav
+status: experimental
+group: HELiX
+description: 'A collapsible left-side navigation panel with nested menu item support. Designed for clinical portals, admin dashboards, and department navigation.'
+props:
+  type: object
+  properties:
+    collapsed:
+      type: boolean
+      title: Collapsed
+      description: 'When true, the nav collapses to show icons only.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'The accessible label for the nav landmark.'
+      default: 'Main Navigation'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for hx-nav-item children.'
+  header:
+    title: Header
+    description: 'Logo or branding content.'
+  footer:
+    title: Footer
+    description: 'User profile or settings content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.css
+++ b/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.css
@@ -1,0 +1,22 @@
+/**
+ * HX Side Nav component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-side-nav-width: Full expanded width. (default: 16rem)
+ * --hx-side-nav-collapsed-width: Collapsed icon-only width. (default: 3.5rem)
+ * --hx-side-nav-bg: Background color. (default: var(--hx-color-neutral-900))
+ * --hx-side-nav-color: Text color. (default: var(--hx-color-neutral-100))
+ * --hx-side-nav-border-color: Border color. (default: var(--hx-color-neutral-700))
+ * --hx-side-nav-header-padding: Header padding. (default: var(--hx-space-4))
+ * --hx-side-nav-footer-padding: Footer padding. (default: var(--hx-space-4))
+ * --hx-side-nav-toggle-color: Toggle button icon color. (default: var(--hx-color-neutral-400))
+ */
+
+/* Component host styles */
+hx-side-nav {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.js
+++ b/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.js
@@ -1,0 +1,11 @@
+/**
+ * HX Side Nav - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-side-nav';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-side-nav');
+}

--- a/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.twig
+++ b/packages/hx-library/drupal/components/hx-side-nav/hx-side-nav.twig
@@ -1,0 +1,25 @@
+{#
+ /**
+ * @file
+ * HX Side Nav component template.
+ *
+ * A collapsible left-side navigation panel with nested menu item support.
+ * Designed for clinical portals, admin dashboards, and department navigation.
+ *
+ * Available variables:
+ * - collapsed: boolean - When true, the nav collapses to show icons only.
+ * - label: string - The accessible label for the nav landmark.
+ */
+#}
+<hx-side-nav
+  {% if collapsed %}collapsed{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if slots.header is defined %}
+    <slot name="header">{{ slots.header }}</slot>
+  {% endif %}
+  {% if slots.footer is defined %}
+    <slot name="footer">{{ slots.footer }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-side-nav>

--- a/packages/hx-library/drupal/components/hx-skeleton/README.md
+++ b/packages/hx-library/drupal/components/hx-skeleton/README.md
@@ -1,0 +1,56 @@
+# HX Skeleton
+
+An animated placeholder used to indicate loading content.
+Purely decorative — hidden from assistive technology.
+Supports a `loaded` state that announces content availability to screen readers.
+
+## Usage
+
+```twig
+{% include 'helix:hx-skeleton' with {
+  variant: 'rect',
+  width: '100%',
+  height: 'undefined',
+  animated: true,
+  loaded: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | rect | Shape variant of the skeleton placeholder. |
+| width | string | 100% | CSS width of the skeleton. Accepts any valid CSS width value. |
+| height | object | undefined | CSS height of the skeleton. Accepts any valid CSS height value.
+Defaults vary by variant when not set. |
+| animated | boolean | true | Whether the shimmer wave animation is active.
+Set to false to display a static skeleton. |
+| loaded | boolean | false | When true, hides the skeleton and dispatches an `hx-loaded` event.
+Consumers should pair this with an external `aria-live` region to
+announce loading completion to assistive technology users. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-loaded | Dispatched when `loaded` transitions to `true`. Consumers should use this event to update an external `aria-live` region announcing content availability. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-skeleton-bg | var(--hx-color-neutral-200) | Skeleton background color. |
+| --hx-skeleton-shimmer-color | rgba(255,255,255,0.4) | Shimmer highlight color. |
+| --hx-skeleton-shimmer-width | 200% | Shimmer sweep width (background-size X axis). |
+| --hx-skeleton-duration | 1.5s | Shimmer animation duration. |
+| --hx-skeleton-text-radius | var(--hx-border-radius-full) | Border radius for text variant. |
+| --hx-skeleton-rect-radius | var(--hx-border-radius-sm) | Border radius for rect variant. |
+| --hx-skeleton-button-radius | var(--hx-border-radius-md) | Border radius for button variant. |
+| --hx-skeleton-circle-radius | 50% | Border radius for circle variant. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner skeleton element. |

--- a/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.component.yml
+++ b/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.component.yml
@@ -1,0 +1,34 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Skeleton
+status: experimental
+group: HELiX
+description: 'An animated placeholder used to indicate loading content. Purely decorative — hidden from assistive technology. Supports a `loaded` state that announces content availability to screen readers.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Shape variant of the skeleton placeholder.'
+      default: 'rect'
+    width:
+      type: string
+      title: Width
+      description: 'CSS width of the skeleton. Accepts any valid CSS width value.'
+      default: '100%'
+    height:
+      type: object
+      title: Height
+      description: 'CSS height of the skeleton. Accepts any valid CSS height value. Defaults vary by variant when not set.'
+      default: 'undefined'
+    animated:
+      type: boolean
+      title: Animated
+      description: 'Whether the shimmer wave animation is active. Set to false to display a static skeleton.'
+      default: true
+    loaded:
+      type: boolean
+      title: Loaded
+      description: 'When true, hides the skeleton and dispatches an `hx-loaded` event. Consumers should pair this with an external `aria-live` region to announce loading completion to assistive technology users.'
+      default: false
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.css
+++ b/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.css
@@ -1,0 +1,22 @@
+/**
+ * HX Skeleton component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-skeleton-bg: Skeleton background color. (default: var(--hx-color-neutral-200))
+ * --hx-skeleton-shimmer-color: Shimmer highlight color. (default: rgba(255,255,255,0.4))
+ * --hx-skeleton-shimmer-width: Shimmer sweep width (background-size X axis). (default: 200%)
+ * --hx-skeleton-duration: Shimmer animation duration. (default: 1.5s)
+ * --hx-skeleton-text-radius: Border radius for text variant. (default: var(--hx-border-radius-full))
+ * --hx-skeleton-rect-radius: Border radius for rect variant. (default: var(--hx-border-radius-sm))
+ * --hx-skeleton-button-radius: Border radius for button variant. (default: var(--hx-border-radius-md))
+ * --hx-skeleton-circle-radius: Border radius for circle variant. (default: 50%)
+ */
+
+/* Component host styles */
+hx-skeleton {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.js
+++ b/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.js
@@ -1,0 +1,11 @@
+/**
+ * HX Skeleton - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-skeleton';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-skeleton');
+}

--- a/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.twig
+++ b/packages/hx-library/drupal/components/hx-skeleton/hx-skeleton.twig
@@ -1,0 +1,25 @@
+{#
+ /**
+ * @file
+ * HX Skeleton component template.
+ *
+ * An animated placeholder used to indicate loading content.
+ * Purely decorative — hidden from assistive technology.
+ * Supports a `loaded` state that announces content availability to screen readers.
+ *
+ * Available variables:
+ * - variant: object - Shape variant of the skeleton placeholder.
+ * - width: string - CSS width of the skeleton. Accepts any valid CSS width value.
+ * - height: object - CSS height of the skeleton. Accepts any valid CSS height value. Defaults vary by variant when not set.
+ * - animated: boolean - Whether the shimmer wave animation is active. Set to false to display a static skeleton.
+ * - loaded: boolean - When true, hides the skeleton and dispatches an `hx-loaded` event. Consumers should pair this with an external `aria-live` region to announce loading completion to assistive technology users.
+ */
+#}
+<hx-skeleton
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if width is defined and width is not empty %}width="{{ width }}"{% endif %}
+  {% if height is defined and height is not empty %}height="{{ height }}"{% endif %}
+  {% if animated %}animated{% endif %}
+  {% if loaded %}loaded{% endif %}
+>
+</hx-skeleton>

--- a/packages/hx-library/drupal/components/hx-slider/README.md
+++ b/packages/hx-library/drupal/components/hx-slider/README.md
@@ -1,0 +1,93 @@
+# HX Slider
+
+A range slider component for selecting a numeric value within a min/max boundary.
+Supports tick marks, value display, range labels, and native form participation
+via ElementInternals.
+
+The native `<input type="range">` receives `role="slider"` with `aria-valuenow`,
+`aria-valuemin`, and `aria-valuemax`. Label association uses `aria-labelledby`
+when a label is present, or `aria-label` as a fallback. Help text is linked via
+`aria-describedby`. Keyboard navigation follows the native range behavior:
+Arrow keys increment/decrement by step, Home jumps to min, End jumps to max.
+
+## Usage
+
+```twig
+{% include 'helix:hx-slider' with {
+  name: '',
+  value: 0,
+  min: 0,
+  max: 100,
+  step: 1,
+  disabled: false,
+  label: '',
+  helpText: '',
+  showValue: false,
+  showTicks: false,
+  size: 'md',
+  valueText: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | The name submitted with the form. |
+| value | number | 0 | The current numeric value of the slider. |
+| min | number | 0 | The minimum allowed value. |
+| max | number | 100 | The maximum allowed value. |
+| step | number | 1 | The stepping interval between values. |
+| disabled | boolean | false | Whether the slider is disabled. |
+| label | string |  | The visible label text for the slider. |
+| helpText | string |  | Help text displayed below the slider for guidance. |
+| showValue | boolean | false | When true, the current value is shown next to the label. |
+| showTicks | boolean | false | When true, tick marks are rendered at each step interval. |
+| size | object | md | The size variant of the slider. |
+| valueText | string |  | Human-readable text alternative for the current value, announced by screen readers
+instead of the numeric value. For example, on a pain scale: "7 — Moderate-Severe". |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Custom label content (overrides the label property). |
+| help-text | Custom help text content (overrides the helpText property). |
+| min-label | Label rendered at the minimum end of the slider. |
+| max-label | Label rendered at the maximum end of the slider. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-input | Dispatched continuously while the user drags. |
+| hx-change | Dispatched when the user releases the thumb. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-slider-track-bg | var(--hx-color-neutral-200) | Track background color. |
+| --hx-slider-fill-bg | var(--hx-color-primary-500) | Fill/progress color. |
+| --hx-slider-thumb-bg | var(--hx-color-neutral-0) | Thumb background color. |
+| --hx-slider-thumb-border-color | var(--hx-color-primary-500) | Thumb border color. |
+| --hx-slider-thumb-border-width | 2px | Thumb border width. |
+| --hx-slider-thumb-shadow | var(--hx-shadow-sm) | Thumb box shadow. |
+| --hx-slider-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-slider-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-slider-value-color | var(--hx-color-neutral-600) | Value display text color. |
+| --hx-slider-tick-color | var(--hx-color-neutral-400) | Tick mark color. |
+| --hx-slider-range-label-color | var(--hx-color-neutral-500) | Range label text color. |
+| --hx-slider-help-text-color | var(--hx-color-neutral-500) | Help text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| slider | The outer container element. |
+| track | The track background element. |
+| fill | The filled portion of the track showing progress. |
+| thumb | The draggable thumb overlay element. |
+| label | The label element. |
+| value-display | The element displaying the current numeric value. |
+| tick | Each individual tick mark element. |

--- a/packages/hx-library/drupal/components/hx-slider/hx-slider.component.yml
+++ b/packages/hx-library/drupal/components/hx-slider/hx-slider.component.yml
@@ -1,0 +1,82 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Slider
+status: experimental
+group: HELiX
+description: 'A range slider component for selecting a numeric value within a min/max boundary. Supports tick marks, value display, range labels, and native form participation via ElementInternals.  The native `<input type="range">` receives `role="slider"` with `aria-valuenow`, `aria-valuemin`, and `aria-valuemax`. Label association uses `aria-labelledby` when a label is present, or `aria-label` as a fallback. Help text is linked via `aria-describedby`. Keyboard navigation follows the native range behavior: Arrow keys increment/decrement by step, Home jumps to min, End jumps to max.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'The name submitted with the form.'
+      default: ''
+    value:
+      type: number
+      title: Value
+      description: 'The current numeric value of the slider.'
+      default: 0
+    min:
+      type: number
+      title: Min
+      description: 'The minimum allowed value.'
+      default: 0
+    max:
+      type: number
+      title: Max
+      description: 'The maximum allowed value.'
+      default: 100
+    step:
+      type: number
+      title: Step
+      description: 'The stepping interval between values.'
+      default: 1
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the slider is disabled.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the slider.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the slider for guidance.'
+      default: ''
+    showValue:
+      type: boolean
+      title: Show Value
+      description: 'When true, the current value is shown next to the label.'
+      default: false
+    showTicks:
+      type: boolean
+      title: Show Ticks
+      description: 'When true, tick marks are rendered at each step interval.'
+      default: false
+    size:
+      type: object
+      title: Size
+      description: 'The size variant of the slider.'
+      default: 'md'
+    valueText:
+      type: string
+      title: Value Text
+      description: 'Human-readable text alternative for the current value, announced by screen readers instead of the numeric value. For example, on a pain scale: "7 — Moderate-Severe".'
+      default: ''
+slots:
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+  min-label:
+    title: Min Label
+    description: 'Label rendered at the minimum end of the slider.'
+  max-label:
+    title: Max Label
+    description: 'Label rendered at the maximum end of the slider.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-slider/hx-slider.css
+++ b/packages/hx-library/drupal/components/hx-slider/hx-slider.css
@@ -1,0 +1,26 @@
+/**
+ * HX Slider component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-slider-track-bg: Track background color. (default: var(--hx-color-neutral-200))
+ * --hx-slider-fill-bg: Fill/progress color. (default: var(--hx-color-primary-500))
+ * --hx-slider-thumb-bg: Thumb background color. (default: var(--hx-color-neutral-0))
+ * --hx-slider-thumb-border-color: Thumb border color. (default: var(--hx-color-primary-500))
+ * --hx-slider-thumb-border-width: Thumb border width. (default: 2px)
+ * --hx-slider-thumb-shadow: Thumb box shadow. (default: var(--hx-shadow-sm))
+ * --hx-slider-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-slider-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-slider-value-color: Value display text color. (default: var(--hx-color-neutral-600))
+ * --hx-slider-tick-color: Tick mark color. (default: var(--hx-color-neutral-400))
+ * --hx-slider-range-label-color: Range label text color. (default: var(--hx-color-neutral-500))
+ * --hx-slider-help-text-color: Help text color. (default: var(--hx-color-neutral-500))
+ */
+
+/* Component host styles */
+hx-slider {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-slider/hx-slider.js
+++ b/packages/hx-library/drupal/components/hx-slider/hx-slider.js
@@ -1,0 +1,11 @@
+/**
+ * HX Slider - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-slider';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-slider');
+}

--- a/packages/hx-library/drupal/components/hx-slider/hx-slider.twig
+++ b/packages/hx-library/drupal/components/hx-slider/hx-slider.twig
@@ -1,0 +1,57 @@
+{#
+ /**
+ * @file
+ * HX Slider component template.
+ *
+ * A range slider component for selecting a numeric value within a min/max boundary.
+ * Supports tick marks, value display, range labels, and native form participation
+ * via ElementInternals.
+ * 
+ * The native `<input type="range">` receives `role="slider"` with `aria-valuenow`,
+ * `aria-valuemin`, and `aria-valuemax`. Label association uses `aria-labelledby`
+ * when a label is present, or `aria-label` as a fallback. Help text is linked via
+ * `aria-describedby`. Keyboard navigation follows the native range behavior:
+ * Arrow keys increment/decrement by step, Home jumps to min, End jumps to max.
+ *
+ * Available variables:
+ * - name: string - The name submitted with the form.
+ * - value: number - The current numeric value of the slider.
+ * - min: number - The minimum allowed value.
+ * - max: number - The maximum allowed value.
+ * - step: number - The stepping interval between values.
+ * - disabled: boolean - Whether the slider is disabled.
+ * - label: string - The visible label text for the slider.
+ * - helpText: string - Help text displayed below the slider for guidance.
+ * - showValue: boolean - When true, the current value is shown next to the label.
+ * - showTicks: boolean - When true, tick marks are rendered at each step interval.
+ * - size: object - The size variant of the slider.
+ * - valueText: string - Human-readable text alternative for the current value, announced by screen readers instead of the numeric value. For example, on a pain scale: "7 — Moderate-Severe".
+ */
+#}
+<hx-slider
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if min is defined and min is not empty %}min="{{ min }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if step is defined and step is not empty %}step="{{ step }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if showValue %}show-value{% endif %}
+  {% if showTicks %}show-ticks{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if valueText is defined and valueText is not empty %}value-text="{{ valueText }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if slots.min-label is defined %}
+    <slot name="min-label">{{ slots.min-label }}</slot>
+  {% endif %}
+  {% if slots.max-label is defined %}
+    <slot name="max-label">{{ slots.max-label }}</slot>
+  {% endif %}
+</hx-slider>

--- a/packages/hx-library/drupal/components/hx-spinner/README.md
+++ b/packages/hx-library/drupal/components/hx-spinner/README.md
@@ -1,0 +1,50 @@
+# HX Spinner
+
+A circular loading indicator for inline and overlay loading states.
+Purely visual — no slots. Announces loading state to screen readers via
+`role="status"` and an `aria-label` (customizable via the `label` prop).
+
+When used alongside visible loading text, set `decorative` to suppress
+duplicate AT announcements.
+
+## Usage
+
+```twig
+{% include 'helix:hx-spinner' with {
+  size: 'md',
+  variant: 'default',
+  label: 'Loading',
+  decorative: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| size | object | md | Size of the spinner. Accepts `SpinnerSize` token values ('sm' | 'md' | 'lg'),
+or any valid CSS size string (e.g. "3rem", "48px") for custom dimensions.
+
+The type is `SpinnerSize | string` which widens to `string` at the TypeScript
+level — this is intentional to support CSS size overrides. Use `SpinnerSize`
+values for standard sizing; custom strings bypass token-based scaling. |
+| variant | object | default | Visual variant of the spinner. |
+| label | string | Loading | Accessible label announced to screen readers. Defaults to "Loading".
+Reflected as an attribute for Drupal/Twig compatibility. |
+| decorative | boolean | false | When true, the spinner is decorative and suppresses all ARIA announcements.
+Use this when the spinner appears alongside visible loading text to prevent
+duplicate announcements. Sets `role="presentation"` and removes `aria-label`. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-spinner-color | - | Spinner arc color. Defaults per variant. |
+| --hx-spinner-track-color | - | Spinner track color. Defaults per variant. |
+| --hx-duration-spinner | - | Duration of the rotation animation. Defaults to 750ms. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The SVG spinner element. |

--- a/packages/hx-library/drupal/components/hx-spinner/hx-spinner.component.yml
+++ b/packages/hx-library/drupal/components/hx-spinner/hx-spinner.component.yml
@@ -1,0 +1,29 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Spinner
+status: experimental
+group: HELiX
+description: 'A circular loading indicator for inline and overlay loading states. Purely visual — no slots. Announces loading state to screen readers via `role="status"` and an `aria-label` (customizable via the `label` prop).  When used alongside visible loading text, set `decorative` to suppress duplicate AT announcements.'
+props:
+  type: object
+  properties:
+    size:
+      type: object
+      title: Size
+      description: 'Size of the spinner. Accepts `SpinnerSize` token values (''sm'' | ''md'' | ''lg''), or any valid CSS size string (e.g. "3rem", "48px") for custom dimensions.  The type is `SpinnerSize | string` which widens to `string` at the TypeScript level — this is intentional to support CSS size overrides. Use `SpinnerSize` values for standard sizing; custom strings bypass token-based scaling.'
+      default: 'md'
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant of the spinner.'
+      default: 'default'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label announced to screen readers. Defaults to "Loading". Reflected as an attribute for Drupal/Twig compatibility.'
+      default: 'Loading'
+    decorative:
+      type: boolean
+      title: Decorative
+      description: 'When true, the spinner is decorative and suppresses all ARIA announcements. Use this when the spinner appears alongside visible loading text to prevent duplicate announcements. Sets `role="presentation"` and removes `aria-label`.'
+      default: false
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-spinner/hx-spinner.css
+++ b/packages/hx-library/drupal/components/hx-spinner/hx-spinner.css
@@ -1,0 +1,17 @@
+/**
+ * HX Spinner component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-spinner-color: Spinner arc color. Defaults per variant.
+ * --hx-spinner-track-color: Spinner track color. Defaults per variant.
+ * --hx-duration-spinner: Duration of the rotation animation. Defaults to 750ms.
+ */
+
+/* Component host styles */
+hx-spinner {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-spinner/hx-spinner.js
+++ b/packages/hx-library/drupal/components/hx-spinner/hx-spinner.js
@@ -1,0 +1,11 @@
+/**
+ * HX Spinner - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-spinner';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-spinner');
+}

--- a/packages/hx-library/drupal/components/hx-spinner/hx-spinner.twig
+++ b/packages/hx-library/drupal/components/hx-spinner/hx-spinner.twig
@@ -1,0 +1,26 @@
+{#
+ /**
+ * @file
+ * HX Spinner component template.
+ *
+ * A circular loading indicator for inline and overlay loading states.
+ * Purely visual — no slots. Announces loading state to screen readers via
+ * `role="status"` and an `aria-label` (customizable via the `label` prop).
+ * 
+ * When used alongside visible loading text, set `decorative` to suppress
+ * duplicate AT announcements.
+ *
+ * Available variables:
+ * - size: object - Size of the spinner. Accepts `SpinnerSize` token values ('sm' | 'md' | 'lg'), or any valid CSS size string (e.g. "3rem", "48px") for custom dimensions.  The type is `SpinnerSize | string` which widens to `string` at the TypeScript level — this is intentional to support CSS size overrides. Use `SpinnerSize` values for standard sizing; custom strings bypass token-based scaling.
+ * - variant: object - Visual variant of the spinner.
+ * - label: string - Accessible label announced to screen readers. Defaults to "Loading". Reflected as an attribute for Drupal/Twig compatibility.
+ * - decorative: boolean - When true, the spinner is decorative and suppresses all ARIA announcements. Use this when the spinner appears alongside visible loading text to prevent duplicate announcements. Sets `role="presentation"` and removes `aria-label`.
+ */
+#}
+<hx-spinner
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if decorative %}decorative{% endif %}
+>
+</hx-spinner>

--- a/packages/hx-library/drupal/components/hx-split-button/README.md
+++ b/packages/hx-library/drupal/components/hx-split-button/README.md
@@ -1,0 +1,70 @@
+# HX Split Button
+
+A split button combining a primary action button with an attached dropdown
+menu for secondary actions. Implements the ARIA menu button pattern for
+full keyboard and screen reader support.
+
+## Usage
+
+```twig
+{% include 'helix:hx-split-button' with {
+  variant: 'primary',
+  size: 'md',
+  disabled: false,
+  label: 'undefined',
+  triggerLabel: 'More actions',
+  menuLabel: 'Secondary actions',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | primary | Visual style variant of the split button. |
+| size | object | md | Size of the split button. |
+| disabled | boolean | false | Whether the split button is disabled. Both the primary button and the
+trigger are disabled when this is true. |
+| label | object | undefined | Primary button label text. When set, overrides the default slot content. |
+| triggerLabel | string | More actions | Accessible label for the dropdown trigger button. Override for localization. |
+| menuLabel | string | Secondary actions | Accessible label for the dropdown menu panel. Override for localization. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Primary button label text. |
+| menu | `hx-menu-item` children rendered in the dropdown panel. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-click | Dispatched when the primary button is clicked and is not disabled. |
+| hx-select | Dispatched when a menu item is selected from the dropdown. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-split-button-menu-max-height | 18rem | Maximum height of the dropdown menu panel before scrolling. |
+| --hx-split-button-bg | var(--hx-color-primary-500) | Background color for both buttons. |
+| --hx-split-button-color | var(--hx-color-neutral-0) | Text/icon color for both buttons. |
+| --hx-split-button-border-color | transparent | Border color. |
+| --hx-split-button-border-radius | var(--hx-border-radius-md) | Border radius. |
+| --hx-split-button-divider-color | var(--hx-color-primary-400) | Color of the divider between primary and trigger. |
+| --hx-split-button-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-split-button-font-weight | var(--hx-font-weight-semibold) | Font weight. |
+| --hx-split-button-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-split-button-menu-bg | var(--hx-color-neutral-0) | Dropdown menu background. |
+| --hx-split-button-menu-border-color | var(--hx-color-neutral-200) | Dropdown menu border color. |
+| --hx-split-button-menu-border-radius | var(--hx-border-radius-md) | Dropdown menu border radius. |
+| --hx-split-button-menu-shadow | - | Dropdown menu box shadow. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| button | The primary action button element. |
+| trigger | The dropdown trigger button element. |
+| menu | The dropdown menu panel. |

--- a/packages/hx-library/drupal/components/hx-split-button/hx-split-button.component.yml
+++ b/packages/hx-library/drupal/components/hx-split-button/hx-split-button.component.yml
@@ -1,0 +1,46 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Split Button
+status: experimental
+group: HELiX
+description: 'A split button combining a primary action button with an attached dropdown menu for secondary actions. Implements the ARIA menu button pattern for full keyboard and screen reader support.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the split button.'
+      default: 'primary'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the split button.'
+      default: 'md'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the split button is disabled. Both the primary button and the trigger are disabled when this is true.'
+      default: false
+    label:
+      type: object
+      title: Label
+      description: 'Primary button label text. When set, overrides the default slot content.'
+      default: 'undefined'
+    triggerLabel:
+      type: string
+      title: Trigger Label
+      description: 'Accessible label for the dropdown trigger button. Override for localization.'
+      default: 'More actions'
+    menuLabel:
+      type: string
+      title: Menu Label
+      description: 'Accessible label for the dropdown menu panel. Override for localization.'
+      default: 'Secondary actions'
+slots:
+  default:
+    title: Default
+    description: 'Primary button label text.'
+  menu:
+    title: Menu
+    description: '`hx-menu-item` children rendered in the dropdown panel.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-split-button/hx-split-button.css
+++ b/packages/hx-library/drupal/components/hx-split-button/hx-split-button.css
@@ -1,0 +1,27 @@
+/**
+ * HX Split Button component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-split-button-menu-max-height: Maximum height of the dropdown menu panel before scrolling. (default: 18rem)
+ * --hx-split-button-bg: Background color for both buttons. (default: var(--hx-color-primary-500))
+ * --hx-split-button-color: Text/icon color for both buttons. (default: var(--hx-color-neutral-0))
+ * --hx-split-button-border-color: Border color. (default: transparent)
+ * --hx-split-button-border-radius: Border radius. (default: var(--hx-border-radius-md))
+ * --hx-split-button-divider-color: Color of the divider between primary and trigger. (default: var(--hx-color-primary-400))
+ * --hx-split-button-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-split-button-font-weight: Font weight. (default: var(--hx-font-weight-semibold))
+ * --hx-split-button-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-split-button-menu-bg: Dropdown menu background. (default: var(--hx-color-neutral-0))
+ * --hx-split-button-menu-border-color: Dropdown menu border color. (default: var(--hx-color-neutral-200))
+ * --hx-split-button-menu-border-radius: Dropdown menu border radius. (default: var(--hx-border-radius-md))
+ * --hx-split-button-menu-shadow: Dropdown menu box shadow.
+ */
+
+/* Component host styles */
+hx-split-button {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-split-button/hx-split-button.js
+++ b/packages/hx-library/drupal/components/hx-split-button/hx-split-button.js
@@ -1,0 +1,11 @@
+/**
+ * HX Split Button - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-split-button';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-split-button');
+}

--- a/packages/hx-library/drupal/components/hx-split-button/hx-split-button.twig
+++ b/packages/hx-library/drupal/components/hx-split-button/hx-split-button.twig
@@ -1,0 +1,31 @@
+{#
+ /**
+ * @file
+ * HX Split Button component template.
+ *
+ * A split button combining a primary action button with an attached dropdown
+ * menu for secondary actions. Implements the ARIA menu button pattern for
+ * full keyboard and screen reader support.
+ *
+ * Available variables:
+ * - variant: object - Visual style variant of the split button.
+ * - size: object - Size of the split button.
+ * - disabled: boolean - Whether the split button is disabled. Both the primary button and the trigger are disabled when this is true.
+ * - label: object - Primary button label text. When set, overrides the default slot content.
+ * - triggerLabel: string - Accessible label for the dropdown trigger button. Override for localization.
+ * - menuLabel: string - Accessible label for the dropdown menu panel. Override for localization.
+ */
+#}
+<hx-split-button
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if triggerLabel is defined and triggerLabel is not empty %}trigger-label="{{ triggerLabel }}"{% endif %}
+  {% if menuLabel is defined and menuLabel is not empty %}menu-label="{{ menuLabel }}"{% endif %}
+>
+  {% if slots.menu is defined %}
+    <slot name="menu">{{ slots.menu }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-split-button>

--- a/packages/hx-library/drupal/components/hx-split-panel/README.md
+++ b/packages/hx-library/drupal/components/hx-split-panel/README.md
@@ -1,0 +1,71 @@
+# HX Split Panel
+
+A resizable two-pane layout with a draggable divider.
+
+## Usage
+
+```twig
+{% include 'helix:hx-split-panel' with {
+  position: 50,
+  positionInPixels: '',
+  orientation: 'horizontal',
+  min: 0,
+  max: 100,
+  snap: '[]',
+  disabled: false,
+  collapsible: false,
+  collapsed: 'null',
+  labelResize: 'Resize panels',
+  labelCollapseStart: 'Collapse start panel',
+  labelCollapseEnd: 'Collapse end panel',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| position | number | 50 | Position of the divider as a percentage (0–100) of the start panel. |
+| positionInPixels | object | - | Position of the divider in pixels (alternative to `position`).
+When set, takes precedence over `position` until the host is measured. |
+| orientation | object | horizontal | Orientation of the split. |
+| min | number | 0 | Minimum position as a percentage (0–100). Prevents full collapse of start panel. |
+| max | number | 100 | Maximum position as a percentage (0–100). Prevents full expansion of start panel. |
+| snap | object | [] | Snap points as an array of percentages. The divider snaps to the
+nearest point within a 5% threshold.
+Accepts JSON array string in HTML: snap="[25, 50, 75]" |
+| disabled | boolean | false | When true, the divider cannot be dragged. |
+| collapsible | boolean | false | When true, collapse/expand buttons appear on the divider. |
+| collapsed | object | null | Which panel is collapsed: 'start', 'end', or null (not collapsed). |
+| labelResize | string | Resize panels | Accessible label for the resize divider handle. |
+| labelCollapseStart | string | Collapse start panel | Accessible label for the collapse-start panel button. |
+| labelCollapseEnd | string | Collapse end panel | Accessible label for the collapse-end panel button. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| start | The first (start) panel content. |
+| end | The second (end) panel content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-reposition | Fired when the divider is moved. Detail: `{ position: number }`. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-split-panel-divider-size | 4px | Width (horizontal) or height (vertical) of the divider. |
+| --hx-split-panel-divider-color | var(--hx-color-neutral-200) | Default divider color. |
+| --hx-split-panel-divider-hover-color | var(--hx-color-primary-500) | Divider color on hover/focus. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| start | The start panel container. |
+| divider | The draggable divider element. |
+| end | The end panel container. |

--- a/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.component.yml
+++ b/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.component.yml
@@ -1,0 +1,75 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Split Panel
+status: experimental
+group: HELiX
+description: 'A resizable two-pane layout with a draggable divider.'
+props:
+  type: object
+  properties:
+    position:
+      type: number
+      title: Position
+      description: 'Position of the divider as a percentage (0–100) of the start panel.'
+      default: 50
+    positionInPixels:
+      type: object
+      title: Position In Pixels
+      description: 'Position of the divider in pixels (alternative to `position`). When set, takes precedence over `position` until the host is measured.'
+    orientation:
+      type: object
+      title: Orientation
+      description: 'Orientation of the split.'
+      default: 'horizontal'
+    min:
+      type: number
+      title: Min
+      description: 'Minimum position as a percentage (0–100). Prevents full collapse of start panel.'
+      default: 0
+    max:
+      type: number
+      title: Max
+      description: 'Maximum position as a percentage (0–100). Prevents full expansion of start panel.'
+      default: 100
+    snap:
+      type: object
+      title: Snap
+      description: 'Snap points as an array of percentages. The divider snaps to the nearest point within a 5% threshold. Accepts JSON array string in HTML: snap="[25, 50, 75]"'
+      default: '[]'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'When true, the divider cannot be dragged.'
+      default: false
+    collapsible:
+      type: boolean
+      title: Collapsible
+      description: 'When true, collapse/expand buttons appear on the divider.'
+      default: false
+    collapsed:
+      type: object
+      title: Collapsed
+      description: "Which panel is collapsed: 'start', 'end', or null (not collapsed)."
+      default: 'null'
+    labelResize:
+      type: string
+      title: Label Resize
+      description: 'Accessible label for the resize divider handle.'
+      default: 'Resize panels'
+    labelCollapseStart:
+      type: string
+      title: Label Collapse Start
+      description: 'Accessible label for the collapse-start panel button.'
+      default: 'Collapse start panel'
+    labelCollapseEnd:
+      type: string
+      title: Label Collapse End
+      description: 'Accessible label for the collapse-end panel button.'
+      default: 'Collapse end panel'
+slots:
+  start:
+    title: Start
+    description: 'The first (start) panel content.'
+  end:
+    title: End
+    description: 'The second (end) panel content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.css
+++ b/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.css
@@ -1,0 +1,17 @@
+/**
+ * HX Split Panel component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-split-panel-divider-size: Width (horizontal) or height (vertical) of the divider. (default: 4px)
+ * --hx-split-panel-divider-color: Default divider color. (default: var(--hx-color-neutral-200))
+ * --hx-split-panel-divider-hover-color: Divider color on hover/focus. (default: var(--hx-color-primary-500))
+ */
+
+/* Component host styles */
+hx-split-panel {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.js
+++ b/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.js
@@ -1,0 +1,11 @@
+/**
+ * HX Split Panel - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-split-panel';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-split-panel');
+}

--- a/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.twig
+++ b/packages/hx-library/drupal/components/hx-split-panel/hx-split-panel.twig
@@ -1,0 +1,43 @@
+{#
+ /**
+ * @file
+ * HX Split Panel component template.
+ *
+ * A resizable two-pane layout with a draggable divider.
+ *
+ * Available variables:
+ * - position: number - Position of the divider as a percentage (0–100) of the start panel.
+ * - positionInPixels: object - Position of the divider in pixels (alternative to `position`). When set, takes precedence over `position` until the host is measured.
+ * - orientation: object - Orientation of the split.
+ * - min: number - Minimum position as a percentage (0–100). Prevents full collapse of start panel.
+ * - max: number - Maximum position as a percentage (0–100). Prevents full expansion of start panel.
+ * - snap: object - Snap points as an array of percentages. The divider snaps to the nearest point within a 5% threshold. Accepts JSON array string in HTML: snap="[25, 50, 75]"
+ * - disabled: boolean - When true, the divider cannot be dragged.
+ * - collapsible: boolean - When true, collapse/expand buttons appear on the divider.
+ * - collapsed: object - Which panel is collapsed: 'start', 'end', or null (not collapsed).
+ * - labelResize: string - Accessible label for the resize divider handle.
+ * - labelCollapseStart: string - Accessible label for the collapse-start panel button.
+ * - labelCollapseEnd: string - Accessible label for the collapse-end panel button.
+ */
+#}
+<hx-split-panel
+  {% if position is defined and position is not empty %}position="{{ position }}"{% endif %}
+  {% if positionInPixels is defined and positionInPixels is not empty %}position-in-pixels="{{ positionInPixels }}"{% endif %}
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+  {% if min is defined and min is not empty %}min="{{ min }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if snap is defined and snap is not empty %}snap="{{ snap }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if collapsible %}collapsible{% endif %}
+  {% if collapsed is defined and collapsed is not empty %}collapsed="{{ collapsed }}"{% endif %}
+  {% if labelResize is defined and labelResize is not empty %}label-resize="{{ labelResize }}"{% endif %}
+  {% if labelCollapseStart is defined and labelCollapseStart is not empty %}label-collapse-start="{{ labelCollapseStart }}"{% endif %}
+  {% if labelCollapseEnd is defined and labelCollapseEnd is not empty %}label-collapse-end="{{ labelCollapseEnd }}"{% endif %}
+>
+  {% if slots.start is defined %}
+    <slot name="start">{{ slots.start }}</slot>
+  {% endif %}
+  {% if slots.end is defined %}
+    <slot name="end">{{ slots.end }}</slot>
+  {% endif %}
+</hx-split-panel>

--- a/packages/hx-library/drupal/components/hx-stack/README.md
+++ b/packages/hx-library/drupal/components/hx-stack/README.md
@@ -1,0 +1,39 @@
+# HX Stack
+
+A flexbox layout wrapper for consistent vertical/horizontal spacing between children.
+
+## Usage
+
+```twig
+{% include 'helix:hx-stack' with {
+  direction: 'vertical',
+  gap: 'md',
+  align: 'stretch',
+  justify: 'start',
+  wrap: false,
+  inline: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| direction | object | vertical | Direction of the stack layout. |
+| gap | object | md | Gap between children using design tokens. |
+| align | object | stretch | Align-items value for cross-axis alignment. |
+| justify | object | start | Justify-content value for main-axis distribution. |
+| wrap | boolean | false | When true, children wrap onto multiple lines. |
+| inline | boolean | false | When true, the component renders as `display: inline-flex`. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for any child content. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner flex container. |

--- a/packages/hx-library/drupal/components/hx-stack/hx-stack.component.yml
+++ b/packages/hx-library/drupal/components/hx-stack/hx-stack.component.yml
@@ -1,0 +1,43 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Stack
+status: experimental
+group: HELiX
+description: 'A flexbox layout wrapper for consistent vertical/horizontal spacing between children.'
+props:
+  type: object
+  properties:
+    direction:
+      type: object
+      title: Direction
+      description: 'Direction of the stack layout.'
+      default: 'vertical'
+    gap:
+      type: object
+      title: Gap
+      description: 'Gap between children using design tokens.'
+      default: 'md'
+    align:
+      type: object
+      title: Align
+      description: 'Align-items value for cross-axis alignment.'
+      default: 'stretch'
+    justify:
+      type: object
+      title: Justify
+      description: 'Justify-content value for main-axis distribution.'
+      default: 'start'
+    wrap:
+      type: boolean
+      title: Wrap
+      description: 'When true, children wrap onto multiple lines.'
+      default: false
+    inline:
+      type: boolean
+      title: Inline
+      description: 'When true, the component renders as `display: inline-flex`.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for any child content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-stack/hx-stack.css
+++ b/packages/hx-library/drupal/components/hx-stack/hx-stack.css
@@ -1,0 +1,12 @@
+/**
+ * HX Stack component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-stack {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-stack/hx-stack.js
+++ b/packages/hx-library/drupal/components/hx-stack/hx-stack.js
@@ -1,0 +1,11 @@
+/**
+ * HX Stack - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-stack';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-stack');
+}

--- a/packages/hx-library/drupal/components/hx-stack/hx-stack.twig
+++ b/packages/hx-library/drupal/components/hx-stack/hx-stack.twig
@@ -1,0 +1,26 @@
+{#
+ /**
+ * @file
+ * HX Stack component template.
+ *
+ * A flexbox layout wrapper for consistent vertical/horizontal spacing between children.
+ *
+ * Available variables:
+ * - direction: object - Direction of the stack layout.
+ * - gap: object - Gap between children using design tokens.
+ * - align: object - Align-items value for cross-axis alignment.
+ * - justify: object - Justify-content value for main-axis distribution.
+ * - wrap: boolean - When true, children wrap onto multiple lines.
+ * - inline: boolean - When true, the component renders as `display: inline-flex`.
+ */
+#}
+<hx-stack
+  {% if direction is defined and direction is not empty %}direction="{{ direction }}"{% endif %}
+  {% if gap is defined and gap is not empty %}gap="{{ gap }}"{% endif %}
+  {% if align is defined and align is not empty %}align="{{ align }}"{% endif %}
+  {% if justify is defined and justify is not empty %}justify="{{ justify }}"{% endif %}
+  {% if wrap %}wrap{% endif %}
+  {% if inline %}inline{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-stack>

--- a/packages/hx-library/drupal/components/hx-stat/README.md
+++ b/packages/hx-library/drupal/components/hx-stat/README.md
@@ -1,0 +1,63 @@
+# HX Stat
+
+A static stat display component for presenting key metrics in a healthcare dashboard.
+
+## Usage
+
+```twig
+{% include 'helix:hx-stat' with {
+  label: '',
+  value: '',
+  trend: 'neutral',
+  size: 'md',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | The metric label displayed below the value. |
+| value | string |  | The metric value displayed prominently. |
+| trend | object | neutral | Trend direction indicator. 'neutral' hides the indicator. |
+| size | object | md | Size variant controlling font size. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| icon | Optional icon displayed alongside the stat value. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-stat-gap | var(--hx-space-1) | Gap between value and label. |
+| --hx-stat-header-gap | var(--hx-space-2) | Gap between icon and value in the header row. |
+| --hx-stat-color | var(--hx-color-neutral-800) | Default text color. |
+| --hx-stat-value-color | var(--hx-color-neutral-900) | Value text color. |
+| --hx-stat-label-color | var(--hx-color-neutral-500) | Label text color. |
+| --hx-stat-icon-color | var(--hx-color-primary-500) | Icon color. |
+| --hx-stat-value-font-weight | var(--hx-font-weight-bold) | Value font weight. |
+| --hx-stat-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-stat-value-font-size-sm | var(--hx-font-size-xl) | Value font size at sm. |
+| --hx-stat-value-font-size-md | var(--hx-font-size-3xl) | Value font size at md. |
+| --hx-stat-value-font-size-lg | var(--hx-font-size-5xl) | Value font size at lg. |
+| --hx-stat-label-font-size-sm | var(--hx-font-size-xs) | Label font size at sm. |
+| --hx-stat-label-font-size-md | var(--hx-font-size-sm) | Label font size at md. |
+| --hx-stat-label-font-size-lg | var(--hx-font-size-md) | Label font size at lg. |
+| --hx-stat-trend-up-color | var(--hx-color-success-700) | Trend up text color. |
+| --hx-stat-trend-up-bg | var(--hx-color-success-50) | Trend up background color. |
+| --hx-stat-trend-down-color | var(--hx-color-error-700) | Trend down text color. |
+| --hx-stat-trend-down-bg | var(--hx-color-error-50) | Trend down background color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| container | The outer stat container element. |
+| header | The row containing the value and optional icon. |
+| value | The stat value element. |
+| label | The stat label element. |
+| trend | The trend indicator element (only rendered when trend is not 'neutral'). |
+| icon | The icon slot container. |

--- a/packages/hx-library/drupal/components/hx-stat/hx-stat.component.yml
+++ b/packages/hx-library/drupal/components/hx-stat/hx-stat.component.yml
@@ -1,0 +1,33 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Stat
+status: experimental
+group: HELiX
+description: 'A static stat display component for presenting key metrics in a healthcare dashboard.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'The metric label displayed below the value.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The metric value displayed prominently.'
+      default: ''
+    trend:
+      type: object
+      title: Trend
+      description: "Trend direction indicator. 'neutral' hides the indicator."
+      default: 'neutral'
+    size:
+      type: object
+      title: Size
+      description: 'Size variant controlling font size.'
+      default: 'md'
+slots:
+  icon:
+    title: Icon
+    description: 'Optional icon displayed alongside the stat value.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-stat/hx-stat.css
+++ b/packages/hx-library/drupal/components/hx-stat/hx-stat.css
@@ -1,0 +1,32 @@
+/**
+ * HX Stat component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-stat-gap: Gap between value and label. (default: var(--hx-space-1))
+ * --hx-stat-header-gap: Gap between icon and value in the header row. (default: var(--hx-space-2))
+ * --hx-stat-color: Default text color. (default: var(--hx-color-neutral-800))
+ * --hx-stat-value-color: Value text color. (default: var(--hx-color-neutral-900))
+ * --hx-stat-label-color: Label text color. (default: var(--hx-color-neutral-500))
+ * --hx-stat-icon-color: Icon color. (default: var(--hx-color-primary-500))
+ * --hx-stat-value-font-weight: Value font weight. (default: var(--hx-font-weight-bold))
+ * --hx-stat-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-stat-value-font-size-sm: Value font size at sm. (default: var(--hx-font-size-xl))
+ * --hx-stat-value-font-size-md: Value font size at md. (default: var(--hx-font-size-3xl))
+ * --hx-stat-value-font-size-lg: Value font size at lg. (default: var(--hx-font-size-5xl))
+ * --hx-stat-label-font-size-sm: Label font size at sm. (default: var(--hx-font-size-xs))
+ * --hx-stat-label-font-size-md: Label font size at md. (default: var(--hx-font-size-sm))
+ * --hx-stat-label-font-size-lg: Label font size at lg. (default: var(--hx-font-size-md))
+ * --hx-stat-trend-up-color: Trend up text color. (default: var(--hx-color-success-700))
+ * --hx-stat-trend-up-bg: Trend up background color. (default: var(--hx-color-success-50))
+ * --hx-stat-trend-down-color: Trend down text color. (default: var(--hx-color-error-700))
+ * --hx-stat-trend-down-bg: Trend down background color. (default: var(--hx-color-error-50))
+ */
+
+/* Component host styles */
+hx-stat {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-stat/hx-stat.js
+++ b/packages/hx-library/drupal/components/hx-stat/hx-stat.js
@@ -1,0 +1,11 @@
+/**
+ * HX Stat - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-stat';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-stat');
+}

--- a/packages/hx-library/drupal/components/hx-stat/hx-stat.twig
+++ b/packages/hx-library/drupal/components/hx-stat/hx-stat.twig
@@ -1,0 +1,24 @@
+{#
+ /**
+ * @file
+ * HX Stat component template.
+ *
+ * A static stat display component for presenting key metrics in a healthcare dashboard.
+ *
+ * Available variables:
+ * - label: string - The metric label displayed below the value.
+ * - value: string - The metric value displayed prominently.
+ * - trend: object - Trend direction indicator. 'neutral' hides the indicator.
+ * - size: object - Size variant controlling font size.
+ */
+#}
+<hx-stat
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if trend is defined and trend is not empty %}trend="{{ trend }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+>
+  {% if slots.icon is defined %}
+    <slot name="icon">{{ slots.icon }}</slot>
+  {% endif %}
+</hx-stat>

--- a/packages/hx-library/drupal/components/hx-status-indicator/README.md
+++ b/packages/hx-library/drupal/components/hx-status-indicator/README.md
@@ -1,0 +1,55 @@
+# HX Status Indicator
+
+A colored dot/badge indicating system or entity health status.
+Purely visual — no slots. Supports an animated pulse ring.
+
+Uses `role="img"` with an auto-generated `aria-label` (e.g. "Status: Online").
+When used decoratively alongside visible text that conveys the same status information
+(e.g. "Provider is available"), set `aria-hidden="true"` on the host element to prevent
+duplicate announcements to screen reader users. This is the recommended composition
+pattern in healthcare dashboards.
+
+## Usage
+
+```twig
+{% include 'helix:hx-status-indicator' with {
+  status: 'unknown',
+  size: 'md',
+  pulse: false,
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| status | object | unknown | The status to display. |
+| size | object | md | Size of the indicator dot. |
+| pulse | boolean | false | Whether to show an animated pulse ring around the dot.
+Animation is suppressed when prefers-reduced-motion is active. |
+| label | string |  | Accessible label for the indicator. Defaults to "Status: {Status}".
+Set aria-hidden="true" on the host when status is conveyed by adjacent text. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-status-indicator-color-online | - | Override color for the "online" status dot. |
+| --hx-status-indicator-color-offline | - | Override color for the "offline" status dot. |
+| --hx-status-indicator-color-away | - | Override color for the "away" status dot. |
+| --hx-status-indicator-color-busy | - | Override color for the "busy" status dot. |
+| --hx-status-indicator-color-unknown | - | Override color for the "unknown" status dot. |
+| --hx-status-indicator-size-sm | - | Override size for the "sm" variant. |
+| --hx-status-indicator-size-md | - | Override size for the "md" variant. |
+| --hx-status-indicator-size-lg | - | Override size for the "lg" variant. |
+| --hx-status-indicator-pulse-duration | - | Override pulse animation duration. |
+| --hx-status-indicator-pulse-scale | - | Override pulse animation max scale. |
+| --hx-status-indicator-pulse-color | - | Override pulse ring color independently from dot color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The dot element. |
+| pulse-ring | The animated pulse ring element. |

--- a/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.component.yml
+++ b/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.component.yml
@@ -1,0 +1,29 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Status Indicator
+status: experimental
+group: HELiX
+description: 'A colored dot/badge indicating system or entity health status. Purely visual — no slots. Supports an animated pulse ring.  Uses `role="img"` with an auto-generated `aria-label` (e.g. "Status: Online"). When used decoratively alongside visible text that conveys the same status information (e.g. "Provider is available"), set `aria-hidden="true"` on the host element to prevent duplicate announcements to screen reader users. This is the recommended composition pattern in healthcare dashboards.'
+props:
+  type: object
+  properties:
+    status:
+      type: object
+      title: Status
+      description: 'The status to display.'
+      default: 'unknown'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the indicator dot.'
+      default: 'md'
+    pulse:
+      type: boolean
+      title: Pulse
+      description: 'Whether to show an animated pulse ring around the dot. Animation is suppressed when prefers-reduced-motion is active.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the indicator. Defaults to "Status: {Status}". Set aria-hidden="true" on the host when status is conveyed by adjacent text.'
+      default: ''
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.css
+++ b/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.css
@@ -1,0 +1,25 @@
+/**
+ * HX Status Indicator component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-status-indicator-color-online: Override color for the "online" status dot.
+ * --hx-status-indicator-color-offline: Override color for the "offline" status dot.
+ * --hx-status-indicator-color-away: Override color for the "away" status dot.
+ * --hx-status-indicator-color-busy: Override color for the "busy" status dot.
+ * --hx-status-indicator-color-unknown: Override color for the "unknown" status dot.
+ * --hx-status-indicator-size-sm: Override size for the "sm" variant.
+ * --hx-status-indicator-size-md: Override size for the "md" variant.
+ * --hx-status-indicator-size-lg: Override size for the "lg" variant.
+ * --hx-status-indicator-pulse-duration: Override pulse animation duration.
+ * --hx-status-indicator-pulse-scale: Override pulse animation max scale.
+ * --hx-status-indicator-pulse-color: Override pulse ring color independently from dot color.
+ */
+
+/* Component host styles */
+hx-status-indicator {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.js
+++ b/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.js
@@ -1,0 +1,11 @@
+/**
+ * HX Status Indicator - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-status-indicator';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-status-indicator');
+}

--- a/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.twig
+++ b/packages/hx-library/drupal/components/hx-status-indicator/hx-status-indicator.twig
@@ -1,0 +1,28 @@
+{#
+ /**
+ * @file
+ * HX Status Indicator component template.
+ *
+ * A colored dot/badge indicating system or entity health status.
+ * Purely visual — no slots. Supports an animated pulse ring.
+ * 
+ * Uses `role="img"` with an auto-generated `aria-label` (e.g. "Status: Online").
+ * When used decoratively alongside visible text that conveys the same status information
+ * (e.g. "Provider is available"), set `aria-hidden="true"` on the host element to prevent
+ * duplicate announcements to screen reader users. This is the recommended composition
+ * pattern in healthcare dashboards.
+ *
+ * Available variables:
+ * - status: object - The status to display.
+ * - size: object - Size of the indicator dot.
+ * - pulse: boolean - Whether to show an animated pulse ring around the dot. Animation is suppressed when prefers-reduced-motion is active.
+ * - label: string - Accessible label for the indicator. Defaults to "Status: {Status}". Set aria-hidden="true" on the host when status is conveyed by adjacent text.
+ */
+#}
+<hx-status-indicator
+  {% if status is defined and status is not empty %}status="{{ status }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if pulse %}pulse{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+</hx-status-indicator>

--- a/packages/hx-library/drupal/components/hx-step/README.md
+++ b/packages/hx-library/drupal/components/hx-step/README.md
@@ -1,0 +1,57 @@
+# HX Step
+
+An individual step, designed to be used inside an `<hx-steps>` container.
+Represents a single step in a multi-step wizard or progress indicator.
+
+## Usage
+
+```twig
+{% include 'helix:hx-step' with {
+  label: '',
+  status: 'pending',
+  description: '',
+  disabled: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | The step label text. |
+| status | object | pending | Current status of the step. |
+| description | string |  | Optional description text shown below the label. |
+| disabled | boolean | false | Whether the step is disabled and non-interactive. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| icon | Custom icon for the step indicator. Shown when status is `pending` or `active`. |
+| label | Step label text. Falls back to the `label` property. |
+| description | Step description text. Falls back to the `description` property. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-steps-indicator-size | 2rem | Indicator circle diameter. |
+| --hx-steps-indicator-font-size | var(--hx-font-size-sm) | Indicator text size. |
+| --hx-steps-indicator-icon-size | 1rem | Indicator icon size. |
+| --hx-steps-label-font-size | var(--hx-font-size-sm) | Label font size. |
+| --hx-steps-description-font-size | var(--hx-font-size-xs) | Description font size. |
+| --hx-steps-connector-color | var(--hx-color-neutral-200) | Connector line color. |
+| --hx-steps-connector-complete-color | var(--hx-color-primary-500) | Connector color when step is complete. |
+| --hx-steps-connector-thickness | var(--hx-border-width,2px) | Connector line thickness. |
+| --hx-steps-label-color | var(--hx-color-neutral-600) | Label text color. |
+| --hx-steps-description-color | var(--hx-color-neutral-500) | Description text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The outermost wrapper element. |
+| indicator | The circular step indicator. |
+| connector | The line connecting this step to the next. |
+| label | The step label element. |
+| description | The step description element. |

--- a/packages/hx-library/drupal/components/hx-step/hx-step.component.yml
+++ b/packages/hx-library/drupal/components/hx-step/hx-step.component.yml
@@ -1,0 +1,39 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Step
+status: experimental
+group: HELiX
+description: 'An individual step, designed to be used inside an `<hx-steps>` container. Represents a single step in a multi-step wizard or progress indicator.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'The step label text.'
+      default: ''
+    status:
+      type: object
+      title: Status
+      description: 'Current status of the step.'
+      default: 'pending'
+    description:
+      type: string
+      title: Description
+      description: 'Optional description text shown below the label.'
+      default: ''
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the step is disabled and non-interactive.'
+      default: false
+slots:
+  icon:
+    title: Icon
+    description: 'Custom icon for the step indicator. Shown when status is `pending` or `active`.'
+  label:
+    title: Label
+    description: 'Step label text. Falls back to the `label` property.'
+  description:
+    title: Description
+    description: 'Step description text. Falls back to the `description` property.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-step/hx-step.css
+++ b/packages/hx-library/drupal/components/hx-step/hx-step.css
@@ -1,0 +1,24 @@
+/**
+ * HX Step component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-steps-indicator-size: Indicator circle diameter. (default: 2rem)
+ * --hx-steps-indicator-font-size: Indicator text size. (default: var(--hx-font-size-sm))
+ * --hx-steps-indicator-icon-size: Indicator icon size. (default: 1rem)
+ * --hx-steps-label-font-size: Label font size. (default: var(--hx-font-size-sm))
+ * --hx-steps-description-font-size: Description font size. (default: var(--hx-font-size-xs))
+ * --hx-steps-connector-color: Connector line color. (default: var(--hx-color-neutral-200))
+ * --hx-steps-connector-complete-color: Connector color when step is complete. (default: var(--hx-color-primary-500))
+ * --hx-steps-connector-thickness: Connector line thickness. (default: var(--hx-border-width,2px))
+ * --hx-steps-label-color: Label text color. (default: var(--hx-color-neutral-600))
+ * --hx-steps-description-color: Description text color. (default: var(--hx-color-neutral-500))
+ */
+
+/* Component host styles */
+hx-step {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-step/hx-step.js
+++ b/packages/hx-library/drupal/components/hx-step/hx-step.js
@@ -1,0 +1,11 @@
+/**
+ * HX Step - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-step';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-step');
+}

--- a/packages/hx-library/drupal/components/hx-step/hx-step.twig
+++ b/packages/hx-library/drupal/components/hx-step/hx-step.twig
@@ -1,0 +1,31 @@
+{#
+ /**
+ * @file
+ * HX Step component template.
+ *
+ * An individual step, designed to be used inside an `<hx-steps>` container.
+ * Represents a single step in a multi-step wizard or progress indicator.
+ *
+ * Available variables:
+ * - label: string - The step label text.
+ * - status: object - Current status of the step.
+ * - description: string - Optional description text shown below the label.
+ * - disabled: boolean - Whether the step is disabled and non-interactive.
+ */
+#}
+<hx-step
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if status is defined and status is not empty %}status="{{ status }}"{% endif %}
+  {% if description is defined and description is not empty %}description="{{ description }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+>
+  {% if slots.icon is defined %}
+    <slot name="icon">{{ slots.icon }}</slot>
+  {% endif %}
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.description is defined %}
+    <slot name="description">{{ slots.description }}</slot>
+  {% endif %}
+</hx-step>

--- a/packages/hx-library/drupal/components/hx-steps/README.md
+++ b/packages/hx-library/drupal/components/hx-steps/README.md
@@ -1,0 +1,52 @@
+# HX Steps
+
+A multi-step wizard / stepper progress indicator. Renders a sequence of
+`<hx-step>` children as a horizontal or vertical step tracker with connector
+lines and status-based styling.
+
+Provide an `aria-label` on `<hx-steps>` to describe the step process for assistive technology.
+
+## Usage
+
+```twig
+{% include 'helix:hx-steps' with {
+  orientation: 'horizontal',
+  size: 'md',
+  ariaLabel: 'null',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| orientation | object | horizontal | Layout orientation of the steps. |
+| size | object | md | Size variant of the steps. |
+| ariaLabel | object | null | Accessible label for the list. Forwarded to the inner list element. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `<hx-step>` elements. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-step-click | Dispatched when a step is clicked. Detail contains the clicked `step` element and its zero-based `index`. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-steps-indicator-size | 2rem | Step indicator circle diameter. |
+| --hx-steps-connector-color | var(--hx-color-neutral-200) | Connector line color. |
+| --hx-steps-label-color | var(--hx-color-neutral-600) | Step label text color. |
+| --hx-steps-description-color | var(--hx-color-neutral-500) | Step description color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner wrapper element. |

--- a/packages/hx-library/drupal/components/hx-steps/hx-steps.component.yml
+++ b/packages/hx-library/drupal/components/hx-steps/hx-steps.component.yml
@@ -1,0 +1,28 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Steps
+status: experimental
+group: HELiX
+description: 'A multi-step wizard / stepper progress indicator. Renders a sequence of `<hx-step>` children as a horizontal or vertical step tracker with connector lines and status-based styling.  Provide an `aria-label` on `<hx-steps>` to describe the step process for assistive technology.'
+props:
+  type: object
+  properties:
+    orientation:
+      type: object
+      title: Orientation
+      description: 'Layout orientation of the steps.'
+      default: 'horizontal'
+    size:
+      type: object
+      title: Size
+      description: 'Size variant of the steps.'
+      default: 'md'
+    ariaLabel:
+      type: object
+      title: Aria Label
+      description: 'Accessible label for the list. Forwarded to the inner list element.'
+      default: 'null'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `<hx-step>` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-steps/hx-steps.css
+++ b/packages/hx-library/drupal/components/hx-steps/hx-steps.css
@@ -1,0 +1,18 @@
+/**
+ * HX Steps component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-steps-indicator-size: Step indicator circle diameter. (default: 2rem)
+ * --hx-steps-connector-color: Connector line color. (default: var(--hx-color-neutral-200))
+ * --hx-steps-label-color: Step label text color. (default: var(--hx-color-neutral-600))
+ * --hx-steps-description-color: Step description color. (default: var(--hx-color-neutral-500))
+ */
+
+/* Component host styles */
+hx-steps {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-steps/hx-steps.js
+++ b/packages/hx-library/drupal/components/hx-steps/hx-steps.js
@@ -1,0 +1,11 @@
+/**
+ * HX Steps - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-steps';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-steps');
+}

--- a/packages/hx-library/drupal/components/hx-steps/hx-steps.twig
+++ b/packages/hx-library/drupal/components/hx-steps/hx-steps.twig
@@ -1,0 +1,24 @@
+{#
+ /**
+ * @file
+ * HX Steps component template.
+ *
+ * A multi-step wizard / stepper progress indicator. Renders a sequence of
+ * `<hx-step>` children as a horizontal or vertical step tracker with connector
+ * lines and status-based styling.
+ * 
+ * Provide an `aria-label` on `<hx-steps>` to describe the step process for assistive technology.
+ *
+ * Available variables:
+ * - orientation: object - Layout orientation of the steps.
+ * - size: object - Size variant of the steps.
+ * - ariaLabel: object - Accessible label for the list. Forwarded to the inner list element.
+ */
+#}
+<hx-steps
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if ariaLabel is defined and ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-steps>

--- a/packages/hx-library/drupal/components/hx-structured-list-row/README.md
+++ b/packages/hx-library/drupal/components/hx-structured-list-row/README.md
@@ -1,0 +1,35 @@
+# HX Structured List Row
+
+A single row within an `hx-structured-list`. Renders a label/value pair
+with an optional actions area.
+
+## Usage
+
+```twig
+{% include 'helix:hx-structured-list-row' with {
+} %}
+```
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | The term or key label (`<dt>` semantics). |
+| (default) | The value or definition (`<dd>` semantics). |
+| actions | Optional action controls (edit button, etc.). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-structured-list-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-structured-list-value-color | var(--hx-color-neutral-900) | Value text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root row element. |
+| label | The label (`dt`) cell. |
+| value | The value (`dd`) cell. |
+| actions | The actions cell. |

--- a/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.component.yml
+++ b/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.component.yml
@@ -1,0 +1,16 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Structured List Row
+status: experimental
+group: HELiX
+description: 'A single row within an `hx-structured-list`. Renders a label/value pair with an optional actions area.'
+slots:
+  label:
+    title: Label
+    description: 'The term or key label (`<dt>` semantics).'
+  default:
+    title: Default
+    description: 'The value or definition (`<dd>` semantics).'
+  actions:
+    title: Actions
+    description: 'Optional action controls (edit button, etc.).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.css
+++ b/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.css
@@ -1,0 +1,16 @@
+/**
+ * HX Structured List Row component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-structured-list-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-structured-list-value-color: Value text color. (default: var(--hx-color-neutral-900))
+ */
+
+/* Component host styles */
+hx-structured-list-row {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.js
+++ b/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.js
@@ -1,0 +1,11 @@
+/**
+ * HX Structured List Row - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-structured-list-row';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-structured-list-row');
+}

--- a/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.twig
+++ b/packages/hx-library/drupal/components/hx-structured-list-row/hx-structured-list-row.twig
@@ -1,0 +1,18 @@
+{#
+ /**
+ * @file
+ * HX Structured List Row component template.
+ *
+ * A single row within an `hx-structured-list`. Renders a label/value pair
+ * with an optional actions area.
+ */
+#}
+<hx-structured-list-row>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.actions is defined %}
+    <slot name="actions">{{ slots.actions }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-structured-list-row>

--- a/packages/hx-library/drupal/components/hx-structured-list/README.md
+++ b/packages/hx-library/drupal/components/hx-structured-list/README.md
@@ -1,0 +1,47 @@
+# HX Structured List
+
+Container for structured key-value data display. Renders as a description
+list for accessible term/definition semantics. Use `hx-structured-list-row`
+as direct children.
+
+## Usage
+
+```twig
+{% include 'helix:hx-structured-list' with {
+  bordered: false,
+  condensed: false,
+  striped: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| bordered | boolean | false | Renders a border around the entire list. |
+| condensed | boolean | false | Reduces row padding for denser layouts. |
+| striped | boolean | false | Alternates row background colors for easier scanning. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | One or more `hx-structured-list-row` elements. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-structured-list-border-color | var(--hx-color-neutral-200) | Border color when bordered. |
+| --hx-structured-list-border-width | var(--hx-border-width-thin) | Border width when bordered. |
+| --hx-structured-list-stripe-bg | var(--hx-color-neutral-50) | Stripe background color. |
+| --hx-structured-list-padding-block | var(--hx-space-4) | Row block padding. |
+| --hx-structured-list-padding-inline | var(--hx-space-4) | Row inline padding. |
+| --hx-structured-list-condensed-padding-block | var(--hx-space-2) | Row block padding (condensed). |
+| --hx-structured-list-condensed-padding-inline | var(--hx-space-3) | Row inline padding (condensed). |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root list element. |

--- a/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.component.yml
+++ b/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.component.yml
@@ -1,0 +1,28 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Structured List
+status: experimental
+group: HELiX
+description: 'Container for structured key-value data display. Renders as a description list for accessible term/definition semantics. Use `hx-structured-list-row` as direct children.'
+props:
+  type: object
+  properties:
+    bordered:
+      type: boolean
+      title: Bordered
+      description: 'Renders a border around the entire list.'
+      default: false
+    condensed:
+      type: boolean
+      title: Condensed
+      description: 'Reduces row padding for denser layouts.'
+      default: false
+    striped:
+      type: boolean
+      title: Striped
+      description: 'Alternates row background colors for easier scanning.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'One or more `hx-structured-list-row` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.css
+++ b/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.css
@@ -1,0 +1,21 @@
+/**
+ * HX Structured List component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-structured-list-border-color: Border color when bordered. (default: var(--hx-color-neutral-200))
+ * --hx-structured-list-border-width: Border width when bordered. (default: var(--hx-border-width-thin))
+ * --hx-structured-list-stripe-bg: Stripe background color. (default: var(--hx-color-neutral-50))
+ * --hx-structured-list-padding-block: Row block padding. (default: var(--hx-space-4))
+ * --hx-structured-list-padding-inline: Row inline padding. (default: var(--hx-space-4))
+ * --hx-structured-list-condensed-padding-block: Row block padding (condensed). (default: var(--hx-space-2))
+ * --hx-structured-list-condensed-padding-inline: Row inline padding (condensed). (default: var(--hx-space-3))
+ */
+
+/* Component host styles */
+hx-structured-list {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.js
+++ b/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.js
@@ -1,0 +1,11 @@
+/**
+ * HX Structured List - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-structured-list';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-structured-list');
+}

--- a/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.twig
+++ b/packages/hx-library/drupal/components/hx-structured-list/hx-structured-list.twig
@@ -1,0 +1,22 @@
+{#
+ /**
+ * @file
+ * HX Structured List component template.
+ *
+ * Container for structured key-value data display. Renders as a description
+ * list for accessible term/definition semantics. Use `hx-structured-list-row`
+ * as direct children.
+ *
+ * Available variables:
+ * - bordered: boolean - Renders a border around the entire list.
+ * - condensed: boolean - Reduces row padding for denser layouts.
+ * - striped: boolean - Alternates row background colors for easier scanning.
+ */
+#}
+<hx-structured-list
+  {% if bordered %}bordered{% endif %}
+  {% if condensed %}condensed{% endif %}
+  {% if striped %}striped{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-structured-list>

--- a/packages/hx-library/drupal/components/hx-switch/README.md
+++ b/packages/hx-library/drupal/components/hx-switch/README.md
@@ -1,0 +1,78 @@
+# HX Switch
+
+A toggle switch component for on/off states.
+
+Uses `role="switch"` with `aria-checked` to convey toggle state.
+Supports keyboard activation via Space key (per ARIA APG switch pattern).
+Label association is handled through `aria-labelledby`, and
+error/help text are linked via `aria-describedby`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-switch' with {
+  checked: false,
+  disabled: false,
+  required: false,
+  name: '',
+  value: 'on',
+  label: '',
+  size: 'md',
+  error: '',
+  helpText: '',
+  requiredMessage: 'This field is required.',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| checked | boolean | false | Whether the switch is toggled on. |
+| disabled | boolean | false | Whether the switch is disabled. |
+| required | boolean | false | Whether the switch is required for form submission. |
+| name | string |  | The name of the switch, used for form submission. |
+| value | string | on | The value submitted when the switch is checked. |
+| label | string |  | The visible label text for the switch. |
+| size | object | md | Size variant of the switch. |
+| error | string |  | Error message to display. When set, the switch enters an error state. |
+| helpText | string |  | Help text displayed below the switch for guidance. |
+| requiredMessage | string | This field is required. | Validation message shown when the field is required but empty. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Custom label content (overrides the label property). |
+| error | Custom error content (overrides the error property). |
+| help-text | Custom help text content (overrides the helpText property). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when the switch is toggled. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-switch-track-bg | var(--hx-color-neutral-300) | Track background color. |
+| --hx-switch-track-checked-bg | var(--hx-color-primary-500) | Track background when checked. |
+| --hx-switch-thumb-bg | var(--hx-color-neutral-0) | Thumb background color. |
+| --hx-switch-thumb-shadow | var(--hx-shadow-sm) | Thumb box shadow. |
+| --hx-switch-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-switch-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-switch-error-color | var(--hx-color-error-500) | Error message color. |
+| --hx-switch-help-text-color | var(--hx-color-neutral-500) | Help text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| switch | The switch container (track + thumb wrapper). |
+| track | The track background element. |
+| thumb | The sliding thumb element. |
+| label | The label text element. |
+| help-text | The help text container. |
+| error | The error message container. |

--- a/packages/hx-library/drupal/components/hx-switch/hx-switch.component.yml
+++ b/packages/hx-library/drupal/components/hx-switch/hx-switch.component.yml
@@ -1,0 +1,69 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Switch
+status: experimental
+group: HELiX
+description: 'A toggle switch component for on/off states.  Uses `role="switch"` with `aria-checked` to convey toggle state. Supports keyboard activation via Space key (per ARIA APG switch pattern). Label association is handled through `aria-labelledby`, and error/help text are linked via `aria-describedby`.'
+props:
+  type: object
+  properties:
+    checked:
+      type: boolean
+      title: Checked
+      description: 'Whether the switch is toggled on.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the switch is disabled.'
+      default: false
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the switch is required for form submission.'
+      default: false
+    name:
+      type: string
+      title: Name
+      description: 'The name of the switch, used for form submission.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The value submitted when the switch is checked.'
+      default: 'on'
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the switch.'
+      default: ''
+    size:
+      type: object
+      title: Size
+      description: 'Size variant of the switch.'
+      default: 'md'
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the switch enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the switch for guidance.'
+      default: ''
+    requiredMessage:
+      type: string
+      title: Required Message
+      description: 'Validation message shown when the field is required but empty.'
+      default: 'This field is required.'
+slots:
+  default:
+    title: Default
+    description: 'Custom label content (overrides the label property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-switch/hx-switch.css
+++ b/packages/hx-library/drupal/components/hx-switch/hx-switch.css
@@ -1,0 +1,22 @@
+/**
+ * HX Switch component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-switch-track-bg: Track background color. (default: var(--hx-color-neutral-300))
+ * --hx-switch-track-checked-bg: Track background when checked. (default: var(--hx-color-primary-500))
+ * --hx-switch-thumb-bg: Thumb background color. (default: var(--hx-color-neutral-0))
+ * --hx-switch-thumb-shadow: Thumb box shadow. (default: var(--hx-shadow-sm))
+ * --hx-switch-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-switch-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-switch-error-color: Error message color. (default: var(--hx-color-error-500))
+ * --hx-switch-help-text-color: Help text color. (default: var(--hx-color-neutral-500))
+ */
+
+/* Component host styles */
+hx-switch {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-switch/hx-switch.js
+++ b/packages/hx-library/drupal/components/hx-switch/hx-switch.js
@@ -1,0 +1,11 @@
+/**
+ * HX Switch - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-switch';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-switch');
+}

--- a/packages/hx-library/drupal/components/hx-switch/hx-switch.twig
+++ b/packages/hx-library/drupal/components/hx-switch/hx-switch.twig
@@ -1,0 +1,45 @@
+{#
+ /**
+ * @file
+ * HX Switch component template.
+ *
+ * A toggle switch component for on/off states.
+ * 
+ * Uses `role="switch"` with `aria-checked` to convey toggle state.
+ * Supports keyboard activation via Space key (per ARIA APG switch pattern).
+ * Label association is handled through `aria-labelledby`, and
+ * error/help text are linked via `aria-describedby`.
+ *
+ * Available variables:
+ * - checked: boolean - Whether the switch is toggled on.
+ * - disabled: boolean - Whether the switch is disabled.
+ * - required: boolean - Whether the switch is required for form submission.
+ * - name: string - The name of the switch, used for form submission.
+ * - value: string - The value submitted when the switch is checked.
+ * - label: string - The visible label text for the switch.
+ * - size: object - Size variant of the switch.
+ * - error: string - Error message to display. When set, the switch enters an error state.
+ * - helpText: string - Help text displayed below the switch for guidance.
+ * - requiredMessage: string - Validation message shown when the field is required but empty.
+ */
+#}
+<hx-switch
+  {% if checked %}checked{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if required %}required{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if requiredMessage is defined and requiredMessage is not empty %}required-message="{{ requiredMessage }}"{% endif %}
+>
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-switch>

--- a/packages/hx-library/drupal/components/hx-tab-panel/README.md
+++ b/packages/hx-library/drupal/components/hx-tab-panel/README.md
@@ -1,0 +1,37 @@
+# HX Tab Panel
+
+A content panel associated with an `<hx-tab>`, managed by a parent `<hx-tabs>`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tab-panel' with {
+  name: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | The name that corresponds to the `panel` attribute on the associated `<hx-tab>`. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for panel content. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-tabs-panel-padding | var(--hx-space-4, 1rem) | Panel inner padding. |
+| --hx-tabs-panel-color | var(--hx-color-neutral-700, #343a40) | Panel text color. |
+| --hx-tabs-focus-ring-color | var(--hx-focus-ring-color, #2563eb) | Focus ring color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| panel | The panel content wrapper. |

--- a/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.component.yml
+++ b/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.component.yml
@@ -1,0 +1,18 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tab Panel
+status: experimental
+group: HELiX
+description: 'A content panel associated with an `<hx-tab>`, managed by a parent `<hx-tabs>`.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'The name that corresponds to the `panel` attribute on the associated `<hx-tab>`.'
+      default: ''
+slots:
+  default:
+    title: Default
+    description: 'Default slot for panel content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.css
+++ b/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.css
@@ -1,0 +1,17 @@
+/**
+ * HX Tab Panel component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-tabs-panel-padding: Panel inner padding. (default: var(--hx-space-4, 1rem))
+ * --hx-tabs-panel-color: Panel text color. (default: var(--hx-color-neutral-700, #343a40))
+ * --hx-tabs-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color, #2563eb))
+ */
+
+/* Component host styles */
+hx-tab-panel {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.js
+++ b/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tab Panel - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tab-panel';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tab-panel');
+}

--- a/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.twig
+++ b/packages/hx-library/drupal/components/hx-tab-panel/hx-tab-panel.twig
@@ -1,0 +1,14 @@
+{#
+ /**
+ * @file
+ * HX Tab Panel component template.
+ *
+ * A content panel associated with an `<hx-tab>`, managed by a parent `<hx-tabs>`.
+ *
+ * Available variables:
+ * - name: string - The name that corresponds to the `panel` attribute on the associated `<hx-tab>`.
+ */
+#}
+<hx-tab-panel {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tab-panel>

--- a/packages/hx-library/drupal/components/hx-tab/README.md
+++ b/packages/hx-library/drupal/components/hx-tab/README.md
@@ -1,0 +1,56 @@
+# HX Tab
+
+An individual tab button, designed to be used inside an `<hx-tabs>` container.
+Must be placed in the `tab` named slot of `<hx-tabs>`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tab' with {
+  panel: '',
+  selected: false,
+  disabled: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| panel | string |  | The name of the `<hx-tab-panel>` this tab controls. Must match the `name`
+attribute on the corresponding `<hx-tab-panel>`. |
+| selected | boolean | false | Whether this tab is currently selected. Managed by the parent `<hx-tabs>`. |
+| disabled | boolean | false | Whether this tab is disabled. Prevents selection and keyboard navigation. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the tab label text or content. |
+| prefix | Icon or content rendered before the label. |
+| suffix | Icon or content rendered after the label. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-tabs-tab-color | var(--hx-color-neutral-600, #495057) | Inactive tab text color. |
+| --hx-tabs-tab-active-color | var(--hx-color-primary-600, #1d4ed8) | Active tab text color. |
+| --hx-tabs-tab-hover-color | var(--hx-color-neutral-800, #212529) | Tab hover text color. |
+| --hx-tabs-tab-hover-bg | var(--hx-color-neutral-50, #f8f9fa) | Tab hover background. |
+| --hx-tabs-tab-font-size | var(--hx-font-size-md, 1rem) | Tab font size. |
+| --hx-tabs-tab-font-weight | var(--hx-font-weight-medium, 500) | Tab font weight. |
+| --hx-tabs-tab-active-font-weight | var(--hx-font-weight-semibold, 600) | Active tab font weight. |
+| --hx-tabs-tab-padding-x | var(--hx-space-4, 1rem) | Horizontal tab padding. |
+| --hx-tabs-tab-padding-y | var(--hx-space-2, 0.5rem) | Vertical tab padding. |
+| --hx-tabs-indicator-color | var(--hx-color-primary-500, #2563eb) | Active indicator color. |
+| --hx-tabs-indicator-size | 2px | Active indicator thickness. |
+| --hx-tabs-focus-ring-color | var(--hx-focus-ring-color, #2563eb) | Focus ring color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| tab | The underlying button element. |
+| prefix | The container for prefix slot content (e.g. icons). |
+| suffix | The container for suffix slot content (e.g. badges). |

--- a/packages/hx-library/drupal/components/hx-tab/hx-tab.component.yml
+++ b/packages/hx-library/drupal/components/hx-tab/hx-tab.component.yml
@@ -1,0 +1,34 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tab
+status: experimental
+group: HELiX
+description: 'An individual tab button, designed to be used inside an `<hx-tabs>` container. Must be placed in the `tab` named slot of `<hx-tabs>`.'
+props:
+  type: object
+  properties:
+    panel:
+      type: string
+      title: Panel
+      description: 'The name of the `<hx-tab-panel>` this tab controls. Must match the `name` attribute on the corresponding `<hx-tab-panel>`.'
+      default: ''
+    selected:
+      type: boolean
+      title: Selected
+      description: 'Whether this tab is currently selected. Managed by the parent `<hx-tabs>`.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether this tab is disabled. Prevents selection and keyboard navigation.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the tab label text or content.'
+  prefix:
+    title: Prefix
+    description: 'Icon or content rendered before the label.'
+  suffix:
+    title: Suffix
+    description: 'Icon or content rendered after the label.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tab/hx-tab.css
+++ b/packages/hx-library/drupal/components/hx-tab/hx-tab.css
@@ -1,0 +1,26 @@
+/**
+ * HX Tab component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-tabs-tab-color: Inactive tab text color. (default: var(--hx-color-neutral-600, #495057))
+ * --hx-tabs-tab-active-color: Active tab text color. (default: var(--hx-color-primary-600, #1d4ed8))
+ * --hx-tabs-tab-hover-color: Tab hover text color. (default: var(--hx-color-neutral-800, #212529))
+ * --hx-tabs-tab-hover-bg: Tab hover background. (default: var(--hx-color-neutral-50, #f8f9fa))
+ * --hx-tabs-tab-font-size: Tab font size. (default: var(--hx-font-size-md, 1rem))
+ * --hx-tabs-tab-font-weight: Tab font weight. (default: var(--hx-font-weight-medium, 500))
+ * --hx-tabs-tab-active-font-weight: Active tab font weight. (default: var(--hx-font-weight-semibold, 600))
+ * --hx-tabs-tab-padding-x: Horizontal tab padding. (default: var(--hx-space-4, 1rem))
+ * --hx-tabs-tab-padding-y: Vertical tab padding. (default: var(--hx-space-2, 0.5rem))
+ * --hx-tabs-indicator-color: Active indicator color. (default: var(--hx-color-primary-500, #2563eb))
+ * --hx-tabs-indicator-size: Active indicator thickness. (default: 2px)
+ * --hx-tabs-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color, #2563eb))
+ */
+
+/* Component host styles */
+hx-tab {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tab/hx-tab.js
+++ b/packages/hx-library/drupal/components/hx-tab/hx-tab.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tab - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tab';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tab');
+}

--- a/packages/hx-library/drupal/components/hx-tab/hx-tab.twig
+++ b/packages/hx-library/drupal/components/hx-tab/hx-tab.twig
@@ -1,0 +1,27 @@
+{#
+ /**
+ * @file
+ * HX Tab component template.
+ *
+ * An individual tab button, designed to be used inside an `<hx-tabs>` container.
+ * Must be placed in the `tab` named slot of `<hx-tabs>`.
+ *
+ * Available variables:
+ * - panel: string - The name of the `<hx-tab-panel>` this tab controls. Must match the `name` attribute on the corresponding `<hx-tab-panel>`.
+ * - selected: boolean - Whether this tab is currently selected. Managed by the parent `<hx-tabs>`.
+ * - disabled: boolean - Whether this tab is disabled. Prevents selection and keyboard navigation.
+ */
+#}
+<hx-tab
+  {% if panel is defined and panel is not empty %}panel="{{ panel }}"{% endif %}
+  {% if selected %}selected{% endif %}
+  {% if disabled %}disabled{% endif %}
+>
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tab>

--- a/packages/hx-library/drupal/components/hx-table/README.md
+++ b/packages/hx-library/drupal/components/hx-table/README.md
@@ -1,0 +1,53 @@
+# HX Table
+
+A semantic table container with variant styling and accessibility support.
+Compose with `hx-thead`, `hx-tbody`, `hx-tfoot`, `hx-tr`, `hx-th`, and `hx-td`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-table' with {
+  label: '',
+  caption: '',
+  variant: 'default',
+  stickyHeader: false,
+  fullWidth: true,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | Accessible name for the table (WCAG 4.1.2 requirement).
+Exposed via `aria-label` on the `<table>` element. |
+| caption | string |  | Visible caption text. When set, renders a `<caption>` element.
+Use the `caption` slot for richer caption content. |
+| variant | object | default | Visual variant that controls row styling. |
+| stickyHeader | boolean | false | When true, the header row stays fixed while the table body scrolls. |
+| fullWidth | boolean | true | When true, the table expands to fill 100% of its container width. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `hx-thead`, `hx-tbody`, and `hx-tfoot` sub-components. |
+| caption | Custom caption content rendered inside the `<caption>` element. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-table-border-color | var(--hx-color-neutral-200, #e2e8f0) | Cell border color. |
+| --hx-table-header-bg | var(--hx-color-neutral-50, #f8fafc) | Header row background. |
+| --hx-table-header-color | var(--hx-color-neutral-700, #334155) | Header text color. |
+| --hx-table-cell-color | var(--hx-color-neutral-900, #0f172a) | Cell text color. |
+| --hx-table-row-hover-bg | var(--hx-color-neutral-50, #f8fafc) | Row hover background. |
+| --hx-table-stripe-bg | var(--hx-color-neutral-50, #f8fafc) | Striped row background. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| table | The `<table>` element. |
+| caption | The `<caption>` element. |

--- a/packages/hx-library/drupal/components/hx-table/hx-table.component.yml
+++ b/packages/hx-library/drupal/components/hx-table/hx-table.component.yml
@@ -1,0 +1,41 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Table
+status: experimental
+group: HELiX
+description: 'A semantic table container with variant styling and accessibility support. Compose with `hx-thead`, `hx-tbody`, `hx-tfoot`, `hx-tr`, `hx-th`, and `hx-td`.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'Accessible name for the table (WCAG 4.1.2 requirement). Exposed via `aria-label` on the `<table>` element.'
+      default: ''
+    caption:
+      type: string
+      title: Caption
+      description: 'Visible caption text. When set, renders a `<caption>` element. Use the `caption` slot for richer caption content.'
+      default: ''
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual variant that controls row styling.'
+      default: 'default'
+    stickyHeader:
+      type: boolean
+      title: Sticky Header
+      description: 'When true, the header row stays fixed while the table body scrolls.'
+      default: false
+    fullWidth:
+      type: boolean
+      title: Full Width
+      description: 'When true, the table expands to fill 100% of its container width.'
+      default: true
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `hx-thead`, `hx-tbody`, and `hx-tfoot` sub-components.'
+  caption:
+    title: Caption
+    description: 'Custom caption content rendered inside the `<caption>` element.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-table/hx-table.css
+++ b/packages/hx-library/drupal/components/hx-table/hx-table.css
@@ -1,0 +1,20 @@
+/**
+ * HX Table component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-table-border-color: Cell border color. (default: var(--hx-color-neutral-200, #e2e8f0))
+ * --hx-table-header-bg: Header row background. (default: var(--hx-color-neutral-50, #f8fafc))
+ * --hx-table-header-color: Header text color. (default: var(--hx-color-neutral-700, #334155))
+ * --hx-table-cell-color: Cell text color. (default: var(--hx-color-neutral-900, #0f172a))
+ * --hx-table-row-hover-bg: Row hover background. (default: var(--hx-color-neutral-50, #f8fafc))
+ * --hx-table-stripe-bg: Striped row background. (default: var(--hx-color-neutral-50, #f8fafc))
+ */
+
+/* Component host styles */
+hx-table {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-table/hx-table.js
+++ b/packages/hx-library/drupal/components/hx-table/hx-table.js
@@ -1,0 +1,11 @@
+/**
+ * HX Table - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-table';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-table');
+}

--- a/packages/hx-library/drupal/components/hx-table/hx-table.twig
+++ b/packages/hx-library/drupal/components/hx-table/hx-table.twig
@@ -1,0 +1,28 @@
+{#
+ /**
+ * @file
+ * HX Table component template.
+ *
+ * A semantic table container with variant styling and accessibility support.
+ * Compose with `hx-thead`, `hx-tbody`, `hx-tfoot`, `hx-tr`, `hx-th`, and `hx-td`.
+ *
+ * Available variables:
+ * - label: string - Accessible name for the table (WCAG 4.1.2 requirement). Exposed via `aria-label` on the `<table>` element.
+ * - caption: string - Visible caption text. When set, renders a `<caption>` element. Use the `caption` slot for richer caption content.
+ * - variant: object - Visual variant that controls row styling.
+ * - stickyHeader: boolean - When true, the header row stays fixed while the table body scrolls.
+ * - fullWidth: boolean - When true, the table expands to fill 100% of its container width.
+ */
+#}
+<hx-table
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if caption is defined and caption is not empty %}caption="{{ caption }}"{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if stickyHeader %}sticky-header{% endif %}
+  {% if fullWidth %}full-width{% endif %}
+>
+  {% if slots.caption is defined %}
+    <slot name="caption">{{ slots.caption }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-table>

--- a/packages/hx-library/drupal/components/hx-tabs/README.md
+++ b/packages/hx-library/drupal/components/hx-tabs/README.md
@@ -1,0 +1,69 @@
+# HX Tabs
+
+A tabbed content organizer that manages a set of `<hx-tab>` and `<hx-tab-panel>` children.
+Supports horizontal and vertical orientations, automatic and manual activation modes,
+and full keyboard navigation per the ARIA Authoring Practices Guide.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tabs' with {
+  orientation: 'horizontal',
+  activation: 'automatic',
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| orientation | object | horizontal | The layout orientation of the tabs. |
+| activation | object | automatic | Controls how keyboard navigation activates tabs.
+In `automatic` mode, focus also activates the tab.
+In `manual` mode, focus moves independently; Space or Enter activates. |
+| label | string |  | Accessible label for the tablist. Rendered as `aria-label` on the tablist container.
+Provide a brief description of what the tabs represent (e.g., "Patient record sections"). |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| tab | Slot for `<hx-tab>` elements. Rendered inside the tablist. |
+| (default) | Default slot for `<hx-tab-panel>` elements. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-tab-change | Dispatched when the active tab changes. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-tabs-border-color | var(--hx-color-neutral-200, #e9ecef) | Tablist border color. |
+| --hx-tabs-border-width | 1px | Tablist border width. |
+| --hx-tabs-vertical-width | 12rem | Width of the tablist in vertical orientation. |
+| --hx-tabs-gap | 0 | Gap between the tablist and panels container. |
+| --hx-tabs-tab-color | var(--hx-color-neutral-600, #495057) | Inactive tab text color. |
+| --hx-tabs-tab-active-color | var(--hx-color-primary-600, #1d4ed8) | Active tab text color. |
+| --hx-tabs-tab-hover-color | var(--hx-color-neutral-800, #212529) | Tab hover text color. |
+| --hx-tabs-tab-hover-bg | var(--hx-color-neutral-50, #f8f9fa) | Tab hover background. |
+| --hx-tabs-tab-font-size | var(--hx-font-size-md, 1rem) | Tab font size. |
+| --hx-tabs-tab-font-weight | var(--hx-font-weight-medium, 500) | Tab font weight. |
+| --hx-tabs-tab-active-font-weight | var(--hx-font-weight-semibold, 600) | Active tab font weight. |
+| --hx-tabs-tab-padding-x | var(--hx-space-4, 1rem) | Horizontal tab padding. |
+| --hx-tabs-tab-padding-y | var(--hx-space-2, 0.5rem) | Vertical tab padding. |
+| --hx-tabs-indicator-color | var(--hx-color-primary-500, #2563eb) | Active indicator color. |
+| --hx-tabs-indicator-size | 2px | Active indicator thickness. |
+| --hx-tabs-focus-ring-color | var(--hx-focus-ring-color, #2563eb) | Focus ring color for tabs and panels. |
+| --hx-tabs-panel-padding | var(--hx-space-4, 1rem) | Panel inner padding. |
+| --hx-tabs-panel-color | var(--hx-color-neutral-700, #343a40) | Panel text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| tablist | The tablist container element. |
+| panels | The panel content container element. |

--- a/packages/hx-library/drupal/components/hx-tabs/hx-tabs.component.yml
+++ b/packages/hx-library/drupal/components/hx-tabs/hx-tabs.component.yml
@@ -1,0 +1,31 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tabs
+status: experimental
+group: HELiX
+description: 'A tabbed content organizer that manages a set of `<hx-tab>` and `<hx-tab-panel>` children. Supports horizontal and vertical orientations, automatic and manual activation modes, and full keyboard navigation per the ARIA Authoring Practices Guide.'
+props:
+  type: object
+  properties:
+    orientation:
+      type: object
+      title: Orientation
+      description: 'The layout orientation of the tabs.'
+      default: 'horizontal'
+    activation:
+      type: object
+      title: Activation
+      description: 'Controls how keyboard navigation activates tabs. In `automatic` mode, focus also activates the tab. In `manual` mode, focus moves independently; Space or Enter activates.'
+      default: 'automatic'
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label for the tablist. Rendered as `aria-label` on the tablist container. Provide a brief description of what the tabs represent (e.g., "Patient record sections").'
+      default: ''
+slots:
+  tab:
+    title: Tab
+    description: 'Slot for `<hx-tab>` elements. Rendered inside the tablist.'
+  default:
+    title: Default
+    description: 'Default slot for `<hx-tab-panel>` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tabs/hx-tabs.css
+++ b/packages/hx-library/drupal/components/hx-tabs/hx-tabs.css
@@ -1,0 +1,32 @@
+/**
+ * HX Tabs component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-tabs-border-color: Tablist border color. (default: var(--hx-color-neutral-200, #e9ecef))
+ * --hx-tabs-border-width: Tablist border width. (default: 1px)
+ * --hx-tabs-vertical-width: Width of the tablist in vertical orientation. (default: 12rem)
+ * --hx-tabs-gap: Gap between the tablist and panels container. (default: 0)
+ * --hx-tabs-tab-color: Inactive tab text color. (default: var(--hx-color-neutral-600, #495057))
+ * --hx-tabs-tab-active-color: Active tab text color. (default: var(--hx-color-primary-600, #1d4ed8))
+ * --hx-tabs-tab-hover-color: Tab hover text color. (default: var(--hx-color-neutral-800, #212529))
+ * --hx-tabs-tab-hover-bg: Tab hover background. (default: var(--hx-color-neutral-50, #f8f9fa))
+ * --hx-tabs-tab-font-size: Tab font size. (default: var(--hx-font-size-md, 1rem))
+ * --hx-tabs-tab-font-weight: Tab font weight. (default: var(--hx-font-weight-medium, 500))
+ * --hx-tabs-tab-active-font-weight: Active tab font weight. (default: var(--hx-font-weight-semibold, 600))
+ * --hx-tabs-tab-padding-x: Horizontal tab padding. (default: var(--hx-space-4, 1rem))
+ * --hx-tabs-tab-padding-y: Vertical tab padding. (default: var(--hx-space-2, 0.5rem))
+ * --hx-tabs-indicator-color: Active indicator color. (default: var(--hx-color-primary-500, #2563eb))
+ * --hx-tabs-indicator-size: Active indicator thickness. (default: 2px)
+ * --hx-tabs-focus-ring-color: Focus ring color for tabs and panels. (default: var(--hx-focus-ring-color, #2563eb))
+ * --hx-tabs-panel-padding: Panel inner padding. (default: var(--hx-space-4, 1rem))
+ * --hx-tabs-panel-color: Panel text color. (default: var(--hx-color-neutral-700, #343a40))
+ */
+
+/* Component host styles */
+hx-tabs {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tabs/hx-tabs.js
+++ b/packages/hx-library/drupal/components/hx-tabs/hx-tabs.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tabs - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tabs';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tabs');
+}

--- a/packages/hx-library/drupal/components/hx-tabs/hx-tabs.twig
+++ b/packages/hx-library/drupal/components/hx-tabs/hx-tabs.twig
@@ -1,0 +1,25 @@
+{#
+ /**
+ * @file
+ * HX Tabs component template.
+ *
+ * A tabbed content organizer that manages a set of `<hx-tab>` and `<hx-tab-panel>` children.
+ * Supports horizontal and vertical orientations, automatic and manual activation modes,
+ * and full keyboard navigation per the ARIA Authoring Practices Guide.
+ *
+ * Available variables:
+ * - orientation: object - The layout orientation of the tabs.
+ * - activation: object - Controls how keyboard navigation activates tabs. In `automatic` mode, focus also activates the tab. In `manual` mode, focus moves independently; Space or Enter activates.
+ * - label: string - Accessible label for the tablist. Rendered as `aria-label` on the tablist container. Provide a brief description of what the tabs represent (e.g., "Patient record sections").
+ */
+#}
+<hx-tabs
+  {% if orientation is defined and orientation is not empty %}orientation="{{ orientation }}"{% endif %}
+  {% if activation is defined and activation is not empty %}activation="{{ activation }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if slots.tab is defined %}
+    <slot name="tab">{{ slots.tab }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tabs>

--- a/packages/hx-library/drupal/components/hx-tag/README.md
+++ b/packages/hx-library/drupal/components/hx-tag/README.md
@@ -1,0 +1,64 @@
+# HX Tag
+
+A compact label for categorization, filtering, and selection.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tag' with {
+  variant: 'default',
+  size: 'md',
+  pill: false,
+  removable: false,
+  disabled: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | default | Visual style variant of the tag. |
+| size | object | md | Size of the tag. |
+| pill | boolean | false | Whether the tag uses fully rounded (pill) styling. |
+| removable | boolean | false | Whether the tag renders a dismiss button. |
+| disabled | boolean | false | Whether the tag is disabled. When disabled, interactions are suppressed. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for tag label text. |
+| prefix | Icon or avatar rendered before the label. |
+| suffix | Content rendered after the label. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-remove | Dispatched when the user clicks the remove button. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-tag-bg | var(--hx-color-neutral-100) | Tag background color. |
+| --hx-tag-color | var(--hx-color-neutral-700) | Tag text color. |
+| --hx-tag-border-color | var(--hx-color-neutral-200) | Tag border color. |
+| --hx-tag-font-size | - | Tag font size (set per size variant). |
+| --hx-tag-font-weight | var(--hx-font-weight-medium) | Tag font weight. |
+| --hx-tag-font-family | var(--hx-font-family-sans) | Tag font family. |
+| --hx-tag-border-radius | var(--hx-border-radius-sm) | Tag border radius (non-pill mode). |
+| --hx-tag-border-radius-pill | var(--hx-border-radius-full) | Border radius in pill mode. Independent of --hx-tag-border-radius so consumer overrides don't break pill shape. |
+| --hx-tag-padding-x | - | Tag horizontal padding (set per size variant). |
+| --hx-tag-padding-y | - | Tag vertical padding (set per size variant). |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The root tag element. |
+| prefix | The prefix slot wrapper. |
+| label | The label slot wrapper. |
+| suffix | The suffix slot wrapper. |
+| remove-button | The remove/dismiss button. |

--- a/packages/hx-library/drupal/components/hx-tag/hx-tag.component.yml
+++ b/packages/hx-library/drupal/components/hx-tag/hx-tag.component.yml
@@ -1,0 +1,44 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tag
+status: experimental
+group: HELiX
+description: 'A compact label for categorization, filtering, and selection.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the tag.'
+      default: 'default'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the tag.'
+      default: 'md'
+    pill:
+      type: boolean
+      title: Pill
+      description: 'Whether the tag uses fully rounded (pill) styling.'
+      default: false
+    removable:
+      type: boolean
+      title: Removable
+      description: 'Whether the tag renders a dismiss button.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the tag is disabled. When disabled, interactions are suppressed.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for tag label text.'
+  prefix:
+    title: Prefix
+    description: 'Icon or avatar rendered before the label.'
+  suffix:
+    title: Suffix
+    description: 'Content rendered after the label.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tag/hx-tag.css
+++ b/packages/hx-library/drupal/components/hx-tag/hx-tag.css
@@ -1,0 +1,24 @@
+/**
+ * HX Tag component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-tag-bg: Tag background color. (default: var(--hx-color-neutral-100))
+ * --hx-tag-color: Tag text color. (default: var(--hx-color-neutral-700))
+ * --hx-tag-border-color: Tag border color. (default: var(--hx-color-neutral-200))
+ * --hx-tag-font-size: Tag font size (set per size variant).
+ * --hx-tag-font-weight: Tag font weight. (default: var(--hx-font-weight-medium))
+ * --hx-tag-font-family: Tag font family. (default: var(--hx-font-family-sans))
+ * --hx-tag-border-radius: Tag border radius (non-pill mode). (default: var(--hx-border-radius-sm))
+ * --hx-tag-border-radius-pill: Border radius in pill mode. Independent of --hx-tag-border-radius so consumer overrides don't break pill shape. (default: var(--hx-border-radius-full))
+ * --hx-tag-padding-x: Tag horizontal padding (set per size variant).
+ * --hx-tag-padding-y: Tag vertical padding (set per size variant).
+ */
+
+/* Component host styles */
+hx-tag {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tag/hx-tag.js
+++ b/packages/hx-library/drupal/components/hx-tag/hx-tag.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tag - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tag';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tag');
+}

--- a/packages/hx-library/drupal/components/hx-tag/hx-tag.twig
+++ b/packages/hx-library/drupal/components/hx-tag/hx-tag.twig
@@ -1,0 +1,30 @@
+{#
+ /**
+ * @file
+ * HX Tag component template.
+ *
+ * A compact label for categorization, filtering, and selection.
+ *
+ * Available variables:
+ * - variant: object - Visual style variant of the tag.
+ * - size: object - Size of the tag.
+ * - pill: boolean - Whether the tag uses fully rounded (pill) styling.
+ * - removable: boolean - Whether the tag renders a dismiss button.
+ * - disabled: boolean - Whether the tag is disabled. When disabled, interactions are suppressed.
+ */
+#}
+<hx-tag
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if pill %}pill{% endif %}
+  {% if removable %}removable{% endif %}
+  {% if disabled %}disabled{% endif %}
+>
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tag>

--- a/packages/hx-library/drupal/components/hx-tbody/README.md
+++ b/packages/hx-library/drupal/components/hx-tbody/README.md
@@ -1,0 +1,23 @@
+# HX Tbody
+
+Semantic table body section. Must be a direct child of `hx-table`.
+Contains `hx-tr` rows with `hx-td` data cells.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tbody' with {
+} %}
+```
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `hx-tr` elements. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| tbody | The `<tbody>` element. |

--- a/packages/hx-library/drupal/components/hx-tbody/hx-tbody.component.yml
+++ b/packages/hx-library/drupal/components/hx-tbody/hx-tbody.component.yml
@@ -1,0 +1,10 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tbody
+status: experimental
+group: HELiX
+description: 'Semantic table body section. Must be a direct child of `hx-table`. Contains `hx-tr` rows with `hx-td` data cells.'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `hx-tr` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tbody/hx-tbody.css
+++ b/packages/hx-library/drupal/components/hx-tbody/hx-tbody.css
@@ -1,0 +1,12 @@
+/**
+ * HX Tbody component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-tbody {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tbody/hx-tbody.js
+++ b/packages/hx-library/drupal/components/hx-tbody/hx-tbody.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tbody - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tbody';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tbody');
+}

--- a/packages/hx-library/drupal/components/hx-tbody/hx-tbody.twig
+++ b/packages/hx-library/drupal/components/hx-tbody/hx-tbody.twig
@@ -1,0 +1,12 @@
+{#
+ /**
+ * @file
+ * HX Tbody component template.
+ *
+ * Semantic table body section. Must be a direct child of `hx-table`.
+ * Contains `hx-tr` rows with `hx-td` data cells.
+ */
+#}
+<hx-tbody>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tbody>

--- a/packages/hx-library/drupal/components/hx-td/README.md
+++ b/packages/hx-library/drupal/components/hx-td/README.md
@@ -1,0 +1,43 @@
+# HX Td
+
+Semantic table data cell. Must be a child of `hx-tr`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-td' with {
+  align: 'left',
+  colspan: 0,
+  rowspan: 0,
+  label: '',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| align | object | left | Horizontal alignment for cell content. |
+| colspan | number | 0 | Number of columns this cell spans. |
+| rowspan | number | 0 | Number of rows this cell spans. |
+| label | string |  | Column header label for this cell. Forwarded as `data-label` on the native `<td>` for
+the mobile card layout (`td::before { content: attr(data-label) }`) and as `aria-label`
+so screen readers identify the column when the header row is hidden. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for cell content. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-table-cell-color | var(--hx-color-neutral-900, #0f172a) | Cell text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| cell | The `<td>` element. |

--- a/packages/hx-library/drupal/components/hx-td/hx-td.component.yml
+++ b/packages/hx-library/drupal/components/hx-td/hx-td.component.yml
@@ -1,0 +1,33 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Td
+status: experimental
+group: HELiX
+description: 'Semantic table data cell. Must be a child of `hx-tr`.'
+props:
+  type: object
+  properties:
+    align:
+      type: object
+      title: Align
+      description: 'Horizontal alignment for cell content.'
+      default: 'left'
+    colspan:
+      type: number
+      title: Colspan
+      description: 'Number of columns this cell spans.'
+      default: 0
+    rowspan:
+      type: number
+      title: Rowspan
+      description: 'Number of rows this cell spans.'
+      default: 0
+    label:
+      type: string
+      title: Label
+      description: 'Column header label for this cell. Forwarded as `data-label` on the native `<td>` for the mobile card layout (`td::before { content: attr(data-label) }`) and as `aria-label` so screen readers identify the column when the header row is hidden.'
+      default: ''
+slots:
+  default:
+    title: Default
+    description: 'Default slot for cell content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-td/hx-td.css
+++ b/packages/hx-library/drupal/components/hx-td/hx-td.css
@@ -1,0 +1,15 @@
+/**
+ * HX Td component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-table-cell-color: Cell text color. (default: var(--hx-color-neutral-900, #0f172a))
+ */
+
+/* Component host styles */
+hx-td {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-td/hx-td.js
+++ b/packages/hx-library/drupal/components/hx-td/hx-td.js
@@ -1,0 +1,11 @@
+/**
+ * HX Td - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-td';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-td');
+}

--- a/packages/hx-library/drupal/components/hx-td/hx-td.twig
+++ b/packages/hx-library/drupal/components/hx-td/hx-td.twig
@@ -1,0 +1,22 @@
+{#
+ /**
+ * @file
+ * HX Td component template.
+ *
+ * Semantic table data cell. Must be a child of `hx-tr`.
+ *
+ * Available variables:
+ * - align: object - Horizontal alignment for cell content.
+ * - colspan: number - Number of columns this cell spans.
+ * - rowspan: number - Number of rows this cell spans.
+ * - label: string - Column header label for this cell. Forwarded as `data-label` on the native `<td>` for the mobile card layout (`td::before { content: attr(data-label) }`) and as `aria-label` so screen readers identify the column when the header row is hidden.
+ */
+#}
+<hx-td
+  {% if align is defined and align is not empty %}align="{{ align }}"{% endif %}
+  {% if colspan is defined and colspan is not empty %}colspan="{{ colspan }}"{% endif %}
+  {% if rowspan is defined and rowspan is not empty %}rowspan="{{ rowspan }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-td>

--- a/packages/hx-library/drupal/components/hx-text-input/README.md
+++ b/packages/hx-library/drupal/components/hx-text-input/README.md
@@ -1,0 +1,95 @@
+# HX Text Input
+
+A text input component with label, validation, and form association.
+Supports accessible labeling via `label` property, `aria-label` attribute, or the `label` slot.
+Uses `aria-invalid` and `aria-describedby` on the native input for screen reader support. Native `required` provides implicit aria-required mapping per HTML-AAM.
+Error messages are announced via `role="alert"`. Keyboard navigation follows native input behavior.
+
+## Usage
+
+```twig
+{% include 'helix:hx-text-input' with {
+  label: '',
+  placeholder: '',
+  value: '',
+  type: 'text',
+  required: false,
+  disabled: false,
+  error: '',
+  helpText: '',
+  name: '',
+  ariaLabel: 'null',
+  readonly: false,
+  minlength: 'undefined',
+  maxlength: 'undefined',
+  pattern: '',
+  autocomplete: '',
+  requiredMessage: 'This field is required.',
+  size: 'md',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | The visible label text for the input. |
+| placeholder | string |  | Placeholder text shown when the input is empty. |
+| value | string |  | The current value of the input. |
+| type | object | text | The type of the native input element. |
+| required | boolean | false | Whether the input is required for form submission. |
+| disabled | boolean | false | Whether the input is disabled. |
+| error | string |  | Error message to display. When set, the input enters an error state. |
+| helpText | string |  | Help text displayed below the input for guidance. |
+| name | string |  | The name of the input, used for form submission. |
+| ariaLabel | object | null | Accessible name for screen readers, if different from the visible label. |
+| readonly | boolean | false | Whether the input is read-only. |
+| minlength | object | undefined | Minimum number of characters allowed. |
+| maxlength | object | undefined | Maximum number of characters allowed. |
+| pattern | string |  | A regular expression pattern the value must match for form validation. |
+| autocomplete | string |  | Hint for the browser's autocomplete feature. Accepts standard HTML autocomplete values. |
+| requiredMessage | string | This field is required. | Validation message shown when the field is required but empty. |
+| size | object | md | Visual size of the input field. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Custom label content (overrides the label property). Use for Drupal Form API rendered labels. |
+| prefix | Content rendered before the input (e.g., icon). |
+| suffix | Content rendered after the input (e.g., icon or button). |
+| help-text | Custom help text content (overrides the helpText property). |
+| error | Custom error content (overrides the error property). Use for Drupal Form API rendered errors. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-input | Dispatched on every keystroke as the user types. |
+| hx-change | Dispatched when the input loses focus after its value changed. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-input-bg | var(--hx-color-neutral-0) | Input background color. |
+| --hx-input-color | var(--hx-color-neutral-800) | Input text color. |
+| --hx-input-border-color | var(--hx-color-neutral-300) | Input border color. |
+| --hx-input-border-radius | var(--hx-border-radius-md) | Input border radius. |
+| --hx-input-font-family | var(--hx-font-family-sans) | Input font family. |
+| --hx-input-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-input-error-color | var(--hx-color-error-500) | Error state color. |
+| --hx-input-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-input-sm-font-size | 0.875rem | Font size for the sm size variant. |
+| --hx-input-lg-font-size | 1.125rem | Font size for the lg size variant. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| field | The outer field container. |
+| label | The label element. |
+| input-wrapper | The wrapper around prefix, input, and suffix. |
+| input | The native input element. |
+| help-text | The help text container. |
+| error | The error message container. |

--- a/packages/hx-library/drupal/components/hx-text-input/hx-text-input.component.yml
+++ b/packages/hx-library/drupal/components/hx-text-input/hx-text-input.component.yml
@@ -1,0 +1,110 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Text Input
+status: experimental
+group: HELiX
+description: 'A text input component with label, validation, and form association. Supports accessible labeling via `label` property, `aria-label` attribute, or the `label` slot. Uses `aria-invalid` and `aria-describedby` on the native input for screen reader support. Native `required` provides implicit aria-required mapping per HTML-AAM. Error messages are announced via `role="alert"`. Keyboard navigation follows native input behavior.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the input.'
+      default: ''
+    placeholder:
+      type: string
+      title: Placeholder
+      description: 'Placeholder text shown when the input is empty.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The current value of the input.'
+      default: ''
+    type:
+      type: object
+      title: Type
+      description: 'The type of the native input element.'
+      default: 'text'
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the input is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the input is disabled.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the input enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the input for guidance.'
+      default: ''
+    name:
+      type: string
+      title: Name
+      description: 'The name of the input, used for form submission.'
+      default: ''
+    ariaLabel:
+      type: object
+      title: Aria Label
+      description: 'Accessible name for screen readers, if different from the visible label.'
+      default: 'null'
+    readonly:
+      type: boolean
+      title: Readonly
+      description: 'Whether the input is read-only.'
+      default: false
+    minlength:
+      type: object
+      title: Minlength
+      description: 'Minimum number of characters allowed.'
+      default: 'undefined'
+    maxlength:
+      type: object
+      title: Maxlength
+      description: 'Maximum number of characters allowed.'
+      default: 'undefined'
+    pattern:
+      type: string
+      title: Pattern
+      description: 'A regular expression pattern the value must match for form validation.'
+      default: ''
+    autocomplete:
+      type: string
+      title: Autocomplete
+      description: "Hint for the browser's autocomplete feature. Accepts standard HTML autocomplete values."
+      default: ''
+    requiredMessage:
+      type: string
+      title: Required Message
+      description: 'Validation message shown when the field is required but empty.'
+      default: 'This field is required.'
+    size:
+      type: object
+      title: Size
+      description: 'Visual size of the input field.'
+      default: 'md'
+slots:
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property). Use for Drupal Form API rendered labels.'
+  prefix:
+    title: Prefix
+    description: 'Content rendered before the input (e.g., icon).'
+  suffix:
+    title: Suffix
+    description: 'Content rendered after the input (e.g., icon or button).'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property). Use for Drupal Form API rendered errors.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-text-input/hx-text-input.css
+++ b/packages/hx-library/drupal/components/hx-text-input/hx-text-input.css
@@ -1,0 +1,24 @@
+/**
+ * HX Text Input component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-input-bg: Input background color. (default: var(--hx-color-neutral-0))
+ * --hx-input-color: Input text color. (default: var(--hx-color-neutral-800))
+ * --hx-input-border-color: Input border color. (default: var(--hx-color-neutral-300))
+ * --hx-input-border-radius: Input border radius. (default: var(--hx-border-radius-md))
+ * --hx-input-font-family: Input font family. (default: var(--hx-font-family-sans))
+ * --hx-input-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-input-error-color: Error state color. (default: var(--hx-color-error-500))
+ * --hx-input-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-input-sm-font-size: Font size for the sm size variant. (default: 0.875rem)
+ * --hx-input-lg-font-size: Font size for the lg size variant. (default: 1.125rem)
+ */
+
+/* Component host styles */
+hx-text-input {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-text-input/hx-text-input.js
+++ b/packages/hx-library/drupal/components/hx-text-input/hx-text-input.js
@@ -1,0 +1,11 @@
+/**
+ * HX Text Input - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-text-input';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-text-input');
+}

--- a/packages/hx-library/drupal/components/hx-text-input/hx-text-input.twig
+++ b/packages/hx-library/drupal/components/hx-text-input/hx-text-input.twig
@@ -1,0 +1,65 @@
+{#
+ /**
+ * @file
+ * HX Text Input component template.
+ *
+ * A text input component with label, validation, and form association.
+ * Supports accessible labeling via `label` property, `aria-label` attribute, or the `label` slot.
+ * Uses `aria-invalid` and `aria-describedby` on the native input for screen reader support. Native `required` provides implicit aria-required mapping per HTML-AAM.
+ * Error messages are announced via `role="alert"`. Keyboard navigation follows native input behavior.
+ *
+ * Available variables:
+ * - label: string - The visible label text for the input.
+ * - placeholder: string - Placeholder text shown when the input is empty.
+ * - value: string - The current value of the input.
+ * - type: object - The type of the native input element.
+ * - required: boolean - Whether the input is required for form submission.
+ * - disabled: boolean - Whether the input is disabled.
+ * - error: string - Error message to display. When set, the input enters an error state.
+ * - helpText: string - Help text displayed below the input for guidance.
+ * - name: string - The name of the input, used for form submission.
+ * - ariaLabel: object - Accessible name for screen readers, if different from the visible label.
+ * - readonly: boolean - Whether the input is read-only.
+ * - minlength: object - Minimum number of characters allowed.
+ * - maxlength: object - Maximum number of characters allowed.
+ * - pattern: string - A regular expression pattern the value must match for form validation.
+ * - autocomplete: string - Hint for the browser's autocomplete feature. Accepts standard HTML autocomplete values.
+ * - requiredMessage: string - Validation message shown when the field is required but empty.
+ * - size: object - Visual size of the input field.
+ */
+#}
+<hx-text-input
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if placeholder is defined and placeholder is not empty %}placeholder="{{ placeholder }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if type is defined and type is not empty %}type="{{ type }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if ariaLabel is defined and ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
+  {% if readonly %}readonly{% endif %}
+  {% if minlength is defined and minlength is not empty %}minlength="{{ minlength }}"{% endif %}
+  {% if maxlength is defined and maxlength is not empty %}maxlength="{{ maxlength }}"{% endif %}
+  {% if pattern is defined and pattern is not empty %}pattern="{{ pattern }}"{% endif %}
+  {% if autocomplete is defined and autocomplete is not empty %}autocomplete="{{ autocomplete }}"{% endif %}
+  {% if requiredMessage is defined and requiredMessage is not empty %}required-message="{{ requiredMessage }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+</hx-text-input>

--- a/packages/hx-library/drupal/components/hx-text/README.md
+++ b/packages/hx-library/drupal/components/hx-text/README.md
@@ -1,0 +1,61 @@
+# HX Text
+
+A semantic typography wrapper that applies consistent text styles using design tokens.
+
+## Usage
+
+```twig
+{% include 'helix:hx-text' with {
+  variant: 'body',
+  weight: 'undefined',
+  color: 'default',
+  truncate: false,
+  lines: 0,
+  as: 'span',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | body | Typography variant controlling font size, line height, and letter spacing.
+
+Note: The public variant set (body / body-sm / body-lg / label / label-sm / caption / code /
+overline) intentionally extends the original audit spec (body / lead / small / caption /
+overline). `lead` and `small` were replaced with the more granular `body-lg`, `body-sm`,
+`label`, `label-sm`, and `code` variants to better serve healthcare UI density requirements.
+There are no `lead` or `small` variants — consumers must use `body-lg` and `body-sm`
+respectively. |
+| weight | object | undefined | Font weight override. When unset, the variant's default weight is used. |
+| color | object | default | Semantic color intent. |
+| truncate | boolean | false | When true, clips text to a single line with an ellipsis overflow. |
+| lines | number | 0 | Maximum number of lines to display before clamping with ellipsis.
+When set, overrides `truncate`. Set to 0 to disable. |
+| as | object | span | The HTML element to render as the inner base element.
+Use to produce semantically appropriate markup (e.g., `p`, `strong`, `em`).
+Defaults to `span` for inline usage.
+
+In Drupal Twig: `<hx-text as="p" variant="body">...</hx-text>` |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for text content. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-text-font-size | - | Font size (set per variant). |
+| --hx-text-font-weight | - | Font weight (overridden by weight prop). |
+| --hx-text-line-height | - | Line height (set per variant). |
+| --hx-text-letter-spacing | - | Letter spacing (set per variant). |
+| --hx-text-color | - | Text color (set per color prop). |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner element (tag determined by the `as` property). |

--- a/packages/hx-library/drupal/components/hx-text/hx-text.component.yml
+++ b/packages/hx-library/drupal/components/hx-text/hx-text.component.yml
@@ -1,0 +1,43 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Text
+status: experimental
+group: HELiX
+description: 'A semantic typography wrapper that applies consistent text styles using design tokens.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Typography variant controlling font size, line height, and letter spacing.  Note: The public variant set (body / body-sm / body-lg / label / label-sm / caption / code / overline) intentionally extends the original audit spec (body / lead / small / caption / overline). `lead` and `small` were replaced with the more granular `body-lg`, `body-sm`, `label`, `label-sm`, and `code` variants to better serve healthcare UI density requirements. There are no `lead` or `small` variants — consumers must use `body-lg` and `body-sm` respectively.'
+      default: 'body'
+    weight:
+      type: object
+      title: Weight
+      description: "Font weight override. When unset, the variant's default weight is used."
+      default: 'undefined'
+    color:
+      type: object
+      title: Color
+      description: 'Semantic color intent.'
+      default: 'default'
+    truncate:
+      type: boolean
+      title: Truncate
+      description: 'When true, clips text to a single line with an ellipsis overflow.'
+      default: false
+    lines:
+      type: number
+      title: Lines
+      description: 'Maximum number of lines to display before clamping with ellipsis. When set, overrides `truncate`. Set to 0 to disable.'
+      default: 0
+    as:
+      type: object
+      title: As
+      description: 'The HTML element to render as the inner base element. Use to produce semantically appropriate markup (e.g., `p`, `strong`, `em`). Defaults to `span` for inline usage.  In Drupal Twig: `<hx-text as="p" variant="body">...</hx-text>`'
+      default: 'span'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for text content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-text/hx-text.css
+++ b/packages/hx-library/drupal/components/hx-text/hx-text.css
@@ -1,0 +1,19 @@
+/**
+ * HX Text component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-text-font-size: Font size (set per variant).
+ * --hx-text-font-weight: Font weight (overridden by weight prop).
+ * --hx-text-line-height: Line height (set per variant).
+ * --hx-text-letter-spacing: Letter spacing (set per variant).
+ * --hx-text-color: Text color (set per color prop).
+ */
+
+/* Component host styles */
+hx-text {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-text/hx-text.js
+++ b/packages/hx-library/drupal/components/hx-text/hx-text.js
@@ -1,0 +1,11 @@
+/**
+ * HX Text - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-text';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-text');
+}

--- a/packages/hx-library/drupal/components/hx-text/hx-text.twig
+++ b/packages/hx-library/drupal/components/hx-text/hx-text.twig
@@ -1,0 +1,26 @@
+{#
+ /**
+ * @file
+ * HX Text component template.
+ *
+ * A semantic typography wrapper that applies consistent text styles using design tokens.
+ *
+ * Available variables:
+ * - variant: object - Typography variant controlling font size, line height, and letter spacing.  Note: The public variant set (body / body-sm / body-lg / label / label-sm / caption / code / overline) intentionally extends the original audit spec (body / lead / small / caption / overline). `lead` and `small` were replaced with the more granular `body-lg`, `body-sm`, `label`, `label-sm`, and `code` variants to better serve healthcare UI density requirements. There are no `lead` or `small` variants — consumers must use `body-lg` and `body-sm` respectively.
+ * - weight: object - Font weight override. When unset, the variant's default weight is used.
+ * - color: object - Semantic color intent.
+ * - truncate: boolean - When true, clips text to a single line with an ellipsis overflow.
+ * - lines: number - Maximum number of lines to display before clamping with ellipsis. When set, overrides `truncate`. Set to 0 to disable.
+ * - as: object - The HTML element to render as the inner base element. Use to produce semantically appropriate markup (e.g., `p`, `strong`, `em`). Defaults to `span` for inline usage.  In Drupal Twig: `<hx-text as="p" variant="body">...</hx-text>`
+ */
+#}
+<hx-text
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if weight is defined and weight is not empty %}weight="{{ weight }}"{% endif %}
+  {% if color is defined and color is not empty %}color="{{ color }}"{% endif %}
+  {% if truncate %}truncate{% endif %}
+  {% if lines is defined and lines is not empty %}lines="{{ lines }}"{% endif %}
+  {% if as is defined and as is not empty %}as="{{ as }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-text>

--- a/packages/hx-library/drupal/components/hx-textarea/README.md
+++ b/packages/hx-library/drupal/components/hx-textarea/README.md
@@ -1,0 +1,97 @@
+# HX Textarea
+
+A multi-line text area component with label, validation, and form association.
+
+Uses `aria-invalid` to convey error state and `aria-describedby` to link
+error/help text to the textarea. Label association is handled through
+`aria-labelledby` (for slotted labels) or the standard `<label for>` pattern.
+Supports `aria-label` for cases where a visible label is not present.
+Validation errors are announced via `role="alert"` (assertive live region).
+
+## Usage
+
+```twig
+{% include 'helix:hx-textarea' with {
+  label: '',
+  placeholder: '',
+  value: '',
+  required: false,
+  disabled: false,
+  error: '',
+  helpText: '',
+  name: '',
+  rows: 4,
+  minlength: '',
+  maxlength: '',
+  readonly: false,
+  resize: 'vertical',
+  showCount: false,
+  requiredMessage: 'This field is required.',
+  ariaLabel: 'null',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | The visible label text for the textarea. |
+| placeholder | string |  | Placeholder text shown when the textarea is empty. |
+| value | string |  | The current value of the textarea. |
+| required | boolean | false | Whether the textarea is required for form submission. |
+| disabled | boolean | false | Whether the textarea is disabled. |
+| error | string |  | Error message to display. When set, the textarea enters an error state. |
+| helpText | string |  | Help text displayed below the textarea for guidance. |
+| name | string |  | The name of the textarea, used for form submission. |
+| rows | number | 4 | The number of visible text rows. Must be a positive integer (minimum 1).
+Invalid values are clamped to the nearest valid value. |
+| minlength | object | - | Minimum number of characters required. |
+| maxlength | object | - | Maximum number of characters allowed. |
+| readonly | boolean | false | Whether the textarea is read-only. Read-only fields are visible but
+cannot be edited by the user. Common in healthcare for displaying
+non-editable patient data inline with editable fields. |
+| resize | object | vertical | Controls how the textarea can be resized. Use 'auto' for auto-grow behavior. |
+| showCount | boolean | false | Whether to show a character count below the textarea. |
+| requiredMessage | string | This field is required. | Validation message shown when the field is required but empty. |
+| ariaLabel | object | null | Accessible name for screen readers, if different from the visible label. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Custom label content (overrides the label property). Use for Drupal Form API rendered labels. |
+| help-text | Custom help text content (overrides the helpText property). |
+| error | Custom error content (overrides the error property). Use for Drupal Form API rendered errors. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-input | Dispatched on every keystroke as the user types. |
+| hx-change | Dispatched when the textarea loses focus after its value changed. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-input-bg | var(--hx-color-neutral-0) | Input background color. |
+| --hx-input-color | var(--hx-color-neutral-800) | Input text color. |
+| --hx-input-border-color | var(--hx-color-neutral-300) | Input border color. |
+| --hx-input-border-radius | var(--hx-border-radius-md) | Input border radius. |
+| --hx-input-font-family | var(--hx-font-family-sans) | Input font family. |
+| --hx-input-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-input-error-color | var(--hx-color-error-500) | Error state color. |
+| --hx-input-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-textarea-min-height | var(--hx-size-20, 5rem) | Minimum textarea height. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| field | The outer field container. |
+| label | The label element. |
+| textarea-wrapper | The wrapper around the textarea. |
+| textarea | The native textarea element. |
+| counter | The character count display. |
+| help-text | The help text container. |
+| error | The error message container. |

--- a/packages/hx-library/drupal/components/hx-textarea/hx-textarea.component.yml
+++ b/packages/hx-library/drupal/components/hx-textarea/hx-textarea.component.yml
@@ -1,0 +1,97 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Textarea
+status: experimental
+group: HELiX
+description: 'A multi-line text area component with label, validation, and form association.  Uses `aria-invalid` to convey error state and `aria-describedby` to link error/help text to the textarea. Label association is handled through `aria-labelledby` (for slotted labels) or the standard `<label for>` pattern. Supports `aria-label` for cases where a visible label is not present. Validation errors are announced via `role="alert"` (assertive live region).'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the textarea.'
+      default: ''
+    placeholder:
+      type: string
+      title: Placeholder
+      description: 'Placeholder text shown when the textarea is empty.'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The current value of the textarea.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the textarea is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the textarea is disabled.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the textarea enters an error state.'
+      default: ''
+    helpText:
+      type: string
+      title: Help Text
+      description: 'Help text displayed below the textarea for guidance.'
+      default: ''
+    name:
+      type: string
+      title: Name
+      description: 'The name of the textarea, used for form submission.'
+      default: ''
+    rows:
+      type: number
+      title: Rows
+      description: 'The number of visible text rows. Must be a positive integer (minimum 1). Invalid values are clamped to the nearest valid value.'
+      default: 4
+    minlength:
+      type: object
+      title: Minlength
+      description: 'Minimum number of characters required.'
+    maxlength:
+      type: object
+      title: Maxlength
+      description: 'Maximum number of characters allowed.'
+    readonly:
+      type: boolean
+      title: Readonly
+      description: 'Whether the textarea is read-only. Read-only fields are visible but cannot be edited by the user. Common in healthcare for displaying non-editable patient data inline with editable fields.'
+      default: false
+    resize:
+      type: object
+      title: Resize
+      description: "Controls how the textarea can be resized. Use 'auto' for auto-grow behavior."
+      default: 'vertical'
+    showCount:
+      type: boolean
+      title: Show Count
+      description: 'Whether to show a character count below the textarea.'
+      default: false
+    requiredMessage:
+      type: string
+      title: Required Message
+      description: 'Validation message shown when the field is required but empty.'
+      default: 'This field is required.'
+    ariaLabel:
+      type: object
+      title: Aria Label
+      description: 'Accessible name for screen readers, if different from the visible label.'
+      default: 'null'
+slots:
+  label:
+    title: Label
+    description: 'Custom label content (overrides the label property). Use for Drupal Form API rendered labels.'
+  help-text:
+    title: Help Text
+    description: 'Custom help text content (overrides the helpText property).'
+  error:
+    title: Error
+    description: 'Custom error content (overrides the error property). Use for Drupal Form API rendered errors.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-textarea/hx-textarea.css
+++ b/packages/hx-library/drupal/components/hx-textarea/hx-textarea.css
@@ -1,0 +1,23 @@
+/**
+ * HX Textarea component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-input-bg: Input background color. (default: var(--hx-color-neutral-0))
+ * --hx-input-color: Input text color. (default: var(--hx-color-neutral-800))
+ * --hx-input-border-color: Input border color. (default: var(--hx-color-neutral-300))
+ * --hx-input-border-radius: Input border radius. (default: var(--hx-border-radius-md))
+ * --hx-input-font-family: Input font family. (default: var(--hx-font-family-sans))
+ * --hx-input-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-input-error-color: Error state color. (default: var(--hx-color-error-500))
+ * --hx-input-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-textarea-min-height: Minimum textarea height. (default: var(--hx-size-20, 5rem))
+ */
+
+/* Component host styles */
+hx-textarea {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-textarea/hx-textarea.js
+++ b/packages/hx-library/drupal/components/hx-textarea/hx-textarea.js
@@ -1,0 +1,11 @@
+/**
+ * HX Textarea - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-textarea';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-textarea');
+}

--- a/packages/hx-library/drupal/components/hx-textarea/hx-textarea.twig
+++ b/packages/hx-library/drupal/components/hx-textarea/hx-textarea.twig
@@ -1,0 +1,60 @@
+{#
+ /**
+ * @file
+ * HX Textarea component template.
+ *
+ * A multi-line text area component with label, validation, and form association.
+ * 
+ * Uses `aria-invalid` to convey error state and `aria-describedby` to link
+ * error/help text to the textarea. Label association is handled through
+ * `aria-labelledby` (for slotted labels) or the standard `<label for>` pattern.
+ * Supports `aria-label` for cases where a visible label is not present.
+ * Validation errors are announced via `role="alert"` (assertive live region).
+ *
+ * Available variables:
+ * - label: string - The visible label text for the textarea.
+ * - placeholder: string - Placeholder text shown when the textarea is empty.
+ * - value: string - The current value of the textarea.
+ * - required: boolean - Whether the textarea is required for form submission.
+ * - disabled: boolean - Whether the textarea is disabled.
+ * - error: string - Error message to display. When set, the textarea enters an error state.
+ * - helpText: string - Help text displayed below the textarea for guidance.
+ * - name: string - The name of the textarea, used for form submission.
+ * - rows: number - The number of visible text rows. Must be a positive integer (minimum 1). Invalid values are clamped to the nearest valid value.
+ * - minlength: object - Minimum number of characters required.
+ * - maxlength: object - Maximum number of characters allowed.
+ * - readonly: boolean - Whether the textarea is read-only. Read-only fields are visible but cannot be edited by the user. Common in healthcare for displaying non-editable patient data inline with editable fields.
+ * - resize: object - Controls how the textarea can be resized. Use 'auto' for auto-grow behavior.
+ * - showCount: boolean - Whether to show a character count below the textarea.
+ * - requiredMessage: string - Validation message shown when the field is required but empty.
+ * - ariaLabel: object - Accessible name for screen readers, if different from the visible label.
+ */
+#}
+<hx-textarea
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if placeholder is defined and placeholder is not empty %}placeholder="{{ placeholder }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if helpText is defined and helpText is not empty %}help-text="{{ helpText }}"{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if rows is defined and rows is not empty %}rows="{{ rows }}"{% endif %}
+  {% if minlength is defined and minlength is not empty %}minlength="{{ minlength }}"{% endif %}
+  {% if maxlength is defined and maxlength is not empty %}maxlength="{{ maxlength }}"{% endif %}
+  {% if readonly %}readonly{% endif %}
+  {% if resize is defined and resize is not empty %}resize="{{ resize }}"{% endif %}
+  {% if showCount %}show-count{% endif %}
+  {% if requiredMessage is defined and requiredMessage is not empty %}required-message="{{ requiredMessage }}"{% endif %}
+  {% if ariaLabel is defined and ariaLabel is not empty %}aria-label="{{ ariaLabel }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+</hx-textarea>

--- a/packages/hx-library/drupal/components/hx-tfoot/README.md
+++ b/packages/hx-library/drupal/components/hx-tfoot/README.md
@@ -1,0 +1,23 @@
+# HX Tfoot
+
+Semantic table foot section. Must be a direct child of `hx-table`.
+Typically contains summary or totals rows.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tfoot' with {
+} %}
+```
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `hx-tr` elements. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| tfoot | The `<tfoot>` element. |

--- a/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.component.yml
+++ b/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.component.yml
@@ -1,0 +1,10 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tfoot
+status: experimental
+group: HELiX
+description: 'Semantic table foot section. Must be a direct child of `hx-table`. Typically contains summary or totals rows.'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `hx-tr` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.css
+++ b/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.css
@@ -1,0 +1,12 @@
+/**
+ * HX Tfoot component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-tfoot {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.js
+++ b/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tfoot - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tfoot';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tfoot');
+}

--- a/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.twig
+++ b/packages/hx-library/drupal/components/hx-tfoot/hx-tfoot.twig
@@ -1,0 +1,12 @@
+{#
+ /**
+ * @file
+ * HX Tfoot component template.
+ *
+ * Semantic table foot section. Must be a direct child of `hx-table`.
+ * Typically contains summary or totals rows.
+ */
+#}
+<hx-tfoot>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tfoot>

--- a/packages/hx-library/drupal/components/hx-th/README.md
+++ b/packages/hx-library/drupal/components/hx-th/README.md
@@ -1,0 +1,45 @@
+# HX Th
+
+Semantic table header cell. Must be a child of `hx-tr`.
+Supports sortable columns with accessible sort state.
+
+## Usage
+
+```twig
+{% include 'helix:hx-th' with {
+  sortable: false,
+  sortDirection: 'none',
+  scope: 'col',
+  colspan: 0,
+  rowspan: 0,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| sortable | boolean | false | When true, the header renders a sort button and emits `hx-sort` on activation. |
+| sortDirection | object | none | Current sort direction. Reflected for CSS targeting. |
+| scope | object | col | The `scope` attribute for the underlying `<th>` element. |
+| colspan | number | 0 | Number of columns this header spans. |
+| rowspan | number | 0 | Number of rows this header spans. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for header label content. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-sort | Dispatched when a sortable header is activated. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| header | The `<th>` element. |
+| sort-icon | The sort indicator icon `<span>` inside sortable headers. |

--- a/packages/hx-library/drupal/components/hx-th/hx-th.component.yml
+++ b/packages/hx-library/drupal/components/hx-th/hx-th.component.yml
@@ -1,0 +1,38 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Th
+status: experimental
+group: HELiX
+description: 'Semantic table header cell. Must be a child of `hx-tr`. Supports sortable columns with accessible sort state.'
+props:
+  type: object
+  properties:
+    sortable:
+      type: boolean
+      title: Sortable
+      description: 'When true, the header renders a sort button and emits `hx-sort` on activation.'
+      default: false
+    sortDirection:
+      type: object
+      title: Sort Direction
+      description: 'Current sort direction. Reflected for CSS targeting.'
+      default: 'none'
+    scope:
+      type: object
+      title: Scope
+      description: 'The `scope` attribute for the underlying `<th>` element.'
+      default: 'col'
+    colspan:
+      type: number
+      title: Colspan
+      description: 'Number of columns this header spans.'
+      default: 0
+    rowspan:
+      type: number
+      title: Rowspan
+      description: 'Number of rows this header spans.'
+      default: 0
+slots:
+  default:
+    title: Default
+    description: 'Default slot for header label content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-th/hx-th.css
+++ b/packages/hx-library/drupal/components/hx-th/hx-th.css
@@ -1,0 +1,12 @@
+/**
+ * HX Th component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-th {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-th/hx-th.js
+++ b/packages/hx-library/drupal/components/hx-th/hx-th.js
@@ -1,0 +1,11 @@
+/**
+ * HX Th - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-th';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-th');
+}

--- a/packages/hx-library/drupal/components/hx-th/hx-th.twig
+++ b/packages/hx-library/drupal/components/hx-th/hx-th.twig
@@ -1,0 +1,25 @@
+{#
+ /**
+ * @file
+ * HX Th component template.
+ *
+ * Semantic table header cell. Must be a child of `hx-tr`.
+ * Supports sortable columns with accessible sort state.
+ *
+ * Available variables:
+ * - sortable: boolean - When true, the header renders a sort button and emits `hx-sort` on activation.
+ * - sortDirection: object - Current sort direction. Reflected for CSS targeting.
+ * - scope: object - The `scope` attribute for the underlying `<th>` element.
+ * - colspan: number - Number of columns this header spans.
+ * - rowspan: number - Number of rows this header spans.
+ */
+#}
+<hx-th
+  {% if sortable %}sortable{% endif %}
+  {% if sortDirection is defined and sortDirection is not empty %}sort-direction="{{ sortDirection }}"{% endif %}
+  {% if scope is defined and scope is not empty %}scope="{{ scope }}"{% endif %}
+  {% if colspan is defined and colspan is not empty %}colspan="{{ colspan }}"{% endif %}
+  {% if rowspan is defined and rowspan is not empty %}rowspan="{{ rowspan }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-th>

--- a/packages/hx-library/drupal/components/hx-thead/README.md
+++ b/packages/hx-library/drupal/components/hx-thead/README.md
@@ -1,0 +1,23 @@
+# HX Thead
+
+Semantic table head section. Must be a direct child of `hx-table`.
+Contains `hx-tr` rows with `hx-th` header cells.
+
+## Usage
+
+```twig
+{% include 'helix:hx-thead' with {
+} %}
+```
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `hx-tr` elements. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| thead | The `<thead>` element. |

--- a/packages/hx-library/drupal/components/hx-thead/hx-thead.component.yml
+++ b/packages/hx-library/drupal/components/hx-thead/hx-thead.component.yml
@@ -1,0 +1,10 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Thead
+status: experimental
+group: HELiX
+description: 'Semantic table head section. Must be a direct child of `hx-table`. Contains `hx-tr` rows with `hx-th` header cells.'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `hx-tr` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-thead/hx-thead.css
+++ b/packages/hx-library/drupal/components/hx-thead/hx-thead.css
@@ -1,0 +1,12 @@
+/**
+ * HX Thead component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-thead {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-thead/hx-thead.js
+++ b/packages/hx-library/drupal/components/hx-thead/hx-thead.js
@@ -1,0 +1,11 @@
+/**
+ * HX Thead - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-thead';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-thead');
+}

--- a/packages/hx-library/drupal/components/hx-thead/hx-thead.twig
+++ b/packages/hx-library/drupal/components/hx-thead/hx-thead.twig
@@ -1,0 +1,12 @@
+{#
+ /**
+ * @file
+ * HX Thead component template.
+ *
+ * Semantic table head section. Must be a direct child of `hx-table`.
+ * Contains `hx-tr` rows with `hx-th` header cells.
+ */
+#}
+<hx-thead>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-thead>

--- a/packages/hx-library/drupal/components/hx-theme/README.md
+++ b/packages/hx-library/drupal/components/hx-theme/README.md
@@ -1,0 +1,52 @@
+# HX Theme
+
+A theme provider that injects CSS custom property tokens for a named theme
+onto a scoped root element. Wrapping content with this component scopes
+all `--hx-*` design tokens to the selected theme.
+
+This is a pure infrastructure component with `display: contents` — it does
+not affect layout. Use it to apply a theme to a subtree of components.
+
+Supported themes:
+- `"light"` — standard light-mode token set (default)
+- `"dark"` — dark-mode semantic overrides applied on top of light primitives
+- `"high-contrast"` — WCAG 7:1+ contrast token set for low-vision accessibility
+- `"auto"` — follows the OS `prefers-color-scheme` media query (light or dark)
+
+## Usage
+
+```twig
+{% include 'helix:hx-theme' with {
+  theme: 'light',
+  system: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| theme | object | light | The theme to apply. Determines which set of --hx-* tokens are injected.
+- `"light"` (default): standard light-mode tokens
+- `"dark"`: dark-mode semantic overrides applied on top of light primitives
+- `"high-contrast"`: WCAG 7:1+ contrast tokens for low-vision users
+- `"auto"`: follows OS `prefers-color-scheme`; resolves to `"light"` or `"dark"` at runtime |
+| system | boolean | false |  |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for themed content. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-* | - | All design tokens for the selected theme are injected as CSS custom properties on the host element. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner slot wrapper element. `display: contents` — no layout effect. |

--- a/packages/hx-library/drupal/components/hx-theme/hx-theme.component.yml
+++ b/packages/hx-library/drupal/components/hx-theme/hx-theme.component.yml
@@ -1,0 +1,22 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Theme
+status: experimental
+group: HELiX
+description: 'A theme provider that injects CSS custom property tokens for a named theme onto a scoped root element. Wrapping content with this component scopes all `--hx-*` design tokens to the selected theme.  This is a pure infrastructure component with `display: contents` — it does not affect layout. Use it to apply a theme to a subtree of components.  Supported themes: - `"light"` — standard light-mode token set (default) - `"dark"` — dark-mode semantic overrides applied on top of light primitives - `"high-contrast"` — WCAG 7:1+ contrast token set for low-vision accessibility - `"auto"` — follows the OS `prefers-color-scheme` media query (light or dark)'
+props:
+  type: object
+  properties:
+    theme:
+      type: object
+      title: Theme
+      description: 'The theme to apply. Determines which set of --hx-* tokens are injected. - `"light"` (default): standard light-mode tokens - `"dark"`: dark-mode semantic overrides applied on top of light primitives - `"high-contrast"`: WCAG 7:1+ contrast tokens for low-vision users - `"auto"`: follows OS `prefers-color-scheme`; resolves to `"light"` or `"dark"` at runtime'
+      default: 'light'
+    system:
+      type: boolean
+      title: System
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for themed content.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-theme/hx-theme.css
+++ b/packages/hx-library/drupal/components/hx-theme/hx-theme.css
@@ -1,0 +1,15 @@
+/**
+ * HX Theme component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-*: All design tokens for the selected theme are injected as CSS custom properties on the host element.
+ */
+
+/* Component host styles */
+hx-theme {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-theme/hx-theme.js
+++ b/packages/hx-library/drupal/components/hx-theme/hx-theme.js
@@ -1,0 +1,11 @@
+/**
+ * HX Theme - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-theme';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-theme');
+}

--- a/packages/hx-library/drupal/components/hx-theme/hx-theme.twig
+++ b/packages/hx-library/drupal/components/hx-theme/hx-theme.twig
@@ -1,0 +1,29 @@
+{#
+ /**
+ * @file
+ * HX Theme component template.
+ *
+ * A theme provider that injects CSS custom property tokens for a named theme
+ * onto a scoped root element. Wrapping content with this component scopes
+ * all `--hx-*` design tokens to the selected theme.
+ * 
+ * This is a pure infrastructure component with `display: contents` — it does
+ * not affect layout. Use it to apply a theme to a subtree of components.
+ * 
+ * Supported themes:
+ * - `"light"` — standard light-mode token set (default)
+ * - `"dark"` — dark-mode semantic overrides applied on top of light primitives
+ * - `"high-contrast"` — WCAG 7:1+ contrast token set for low-vision accessibility
+ * - `"auto"` — follows the OS `prefers-color-scheme` media query (light or dark)
+ *
+ * Available variables:
+ * - theme: object - The theme to apply. Determines which set of --hx-* tokens are injected. - `"light"` (default): standard light-mode tokens - `"dark"`: dark-mode semantic overrides applied on top of light primitives - `"high-contrast"`: WCAG 7:1+ contrast tokens for low-vision users - `"auto"`: follows OS `prefers-color-scheme`; resolves to `"light"` or `"dark"` at runtime
+ * - system: boolean - 
+ */
+#}
+<hx-theme
+  {% if theme is defined and theme is not empty %}theme="{{ theme }}"{% endif %}
+  {% if system %}system{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-theme>

--- a/packages/hx-library/drupal/components/hx-time-picker/README.md
+++ b/packages/hx-library/drupal/components/hx-time-picker/README.md
@@ -1,0 +1,82 @@
+# HX Time Picker
+
+A time-picker component with a combobox pattern: a text input with format
+masking and a dropdown listbox of pre-generated time slots.
+
+## Usage
+
+```twig
+{% include 'helix:hx-time-picker' with {
+  name: '',
+  value: '',
+  min: '00:00',
+  max: '23:59',
+  step: 30,
+  label: '',
+  required: false,
+  disabled: false,
+  error: '',
+  format: '12h',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| name | string |  | The name submitted with the form. Value is always HH:MM (24-hour). |
+| value | string |  | The current value in HH:MM (24-hour) format. |
+| min | string | 00:00 | The earliest selectable time in HH:MM format. |
+| max | string | 23:59 | The latest selectable time in HH:MM format. |
+| step | number | 30 | Step interval between dropdown options, in minutes. Defaults to 30. |
+| label | string |  | The visible label text for the field. |
+| required | boolean | false | Whether the field is required for form submission. |
+| disabled | boolean | false | Whether the field is disabled. |
+| error | string |  | Error message to display. When set, the field enters an error state. |
+| format | object | 12h | Display format for the time input. '12h' shows AM/PM; '24h' is bare HH:MM. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| label | Custom label content; overrides the rendered label element when used. |
+| help-text | Help text displayed below the field. |
+| error | Custom error content; overrides the `error` property. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-change | Dispatched when the selected time changes. Detail value is HH:MM (24h). |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-time-picker-bg | var(--hx-color-neutral-0) | Input background color. |
+| --hx-time-picker-color | var(--hx-color-neutral-800) | Input text color. |
+| --hx-time-picker-border-color | var(--hx-color-neutral-300) | Border color. |
+| --hx-time-picker-border-radius | var(--hx-border-radius-md) | Border radius. |
+| --hx-time-picker-font-family | var(--hx-font-family-sans) | Font family. |
+| --hx-time-picker-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-time-picker-error-color | var(--hx-color-error-500) | Error state color. |
+| --hx-time-picker-label-color | var(--hx-color-neutral-700) | Label text color. |
+| --hx-time-picker-chevron-color | var(--hx-color-neutral-500) | Toggle chevron color. |
+| --hx-time-picker-listbox-bg | var(--hx-color-neutral-0) | Listbox background. |
+| --hx-time-picker-listbox-max-height | 16rem | Maximum height of the dropdown. |
+| --hx-time-picker-listbox-shadow | 0 4px 16px color-mix(in srgb, var(--hx-color-neutral-900) 12%, transparent) | Box shadow for the dropdown listbox. |
+| --hx-time-picker-option-color | var(--hx-color-neutral-800) | Option text color. |
+| --hx-time-picker-option-hover-bg | var(--hx-color-primary-50) | Option hover background. |
+| --hx-time-picker-option-hover-color | var(--hx-color-primary-700) | Option hover text color. |
+| --hx-time-picker-option-selected-bg | var(--hx-color-primary-100) | Selected option background. |
+| --hx-time-picker-option-selected-color | var(--hx-color-primary-800) | Selected option text color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| label | The label element. |
+| input | The text input element. |
+| toggle | The clock icon toggle button. |
+| listbox | The dropdown `<ul>` element. |
+| option | Each `<li>` option in the listbox. |

--- a/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.component.yml
+++ b/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.component.yml
@@ -1,0 +1,69 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Time Picker
+status: experimental
+group: HELiX
+description: 'A time-picker component with a combobox pattern: a text input with format masking and a dropdown listbox of pre-generated time slots.'
+props:
+  type: object
+  properties:
+    name:
+      type: string
+      title: Name
+      description: 'The name submitted with the form. Value is always HH:MM (24-hour).'
+      default: ''
+    value:
+      type: string
+      title: Value
+      description: 'The current value in HH:MM (24-hour) format.'
+      default: ''
+    min:
+      type: string
+      title: Min
+      description: 'The earliest selectable time in HH:MM format.'
+      default: '00:00'
+    max:
+      type: string
+      title: Max
+      description: 'The latest selectable time in HH:MM format.'
+      default: '23:59'
+    step:
+      type: number
+      title: Step
+      description: 'Step interval between dropdown options, in minutes. Defaults to 30.'
+      default: 30
+    label:
+      type: string
+      title: Label
+      description: 'The visible label text for the field.'
+      default: ''
+    required:
+      type: boolean
+      title: Required
+      description: 'Whether the field is required for form submission.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the field is disabled.'
+      default: false
+    error:
+      type: string
+      title: Error
+      description: 'Error message to display. When set, the field enters an error state.'
+      default: ''
+    format:
+      type: object
+      title: Format
+      description: "Display format for the time input. '12h' shows AM/PM; '24h' is bare HH:MM."
+      default: '12h'
+slots:
+  label:
+    title: Label
+    description: 'Custom label content; overrides the rendered label element when used.'
+  help-text:
+    title: Help Text
+    description: 'Help text displayed below the field.'
+  error:
+    title: Error
+    description: 'Custom error content; overrides the `error` property.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.css
+++ b/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.css
@@ -1,0 +1,31 @@
+/**
+ * HX Time Picker component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-time-picker-bg: Input background color. (default: var(--hx-color-neutral-0))
+ * --hx-time-picker-color: Input text color. (default: var(--hx-color-neutral-800))
+ * --hx-time-picker-border-color: Border color. (default: var(--hx-color-neutral-300))
+ * --hx-time-picker-border-radius: Border radius. (default: var(--hx-border-radius-md))
+ * --hx-time-picker-font-family: Font family. (default: var(--hx-font-family-sans))
+ * --hx-time-picker-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-time-picker-error-color: Error state color. (default: var(--hx-color-error-500))
+ * --hx-time-picker-label-color: Label text color. (default: var(--hx-color-neutral-700))
+ * --hx-time-picker-chevron-color: Toggle chevron color. (default: var(--hx-color-neutral-500))
+ * --hx-time-picker-listbox-bg: Listbox background. (default: var(--hx-color-neutral-0))
+ * --hx-time-picker-listbox-max-height: Maximum height of the dropdown. (default: 16rem)
+ * --hx-time-picker-listbox-shadow: Box shadow for the dropdown listbox. (default: 0 4px 16px color-mix(in srgb, var(--hx-color-neutral-900) 12%, transparent))
+ * --hx-time-picker-option-color: Option text color. (default: var(--hx-color-neutral-800))
+ * --hx-time-picker-option-hover-bg: Option hover background. (default: var(--hx-color-primary-50))
+ * --hx-time-picker-option-hover-color: Option hover text color. (default: var(--hx-color-primary-700))
+ * --hx-time-picker-option-selected-bg: Selected option background. (default: var(--hx-color-primary-100))
+ * --hx-time-picker-option-selected-color: Selected option text color. (default: var(--hx-color-primary-800))
+ */
+
+/* Component host styles */
+hx-time-picker {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.js
+++ b/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.js
@@ -1,0 +1,11 @@
+/**
+ * HX Time Picker - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-time-picker';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-time-picker');
+}

--- a/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.twig
+++ b/packages/hx-library/drupal/components/hx-time-picker/hx-time-picker.twig
@@ -1,0 +1,43 @@
+{#
+ /**
+ * @file
+ * HX Time Picker component template.
+ *
+ * A time-picker component with a combobox pattern: a text input with format
+ * masking and a dropdown listbox of pre-generated time slots.
+ *
+ * Available variables:
+ * - name: string - The name submitted with the form. Value is always HH:MM (24-hour).
+ * - value: string - The current value in HH:MM (24-hour) format.
+ * - min: string - The earliest selectable time in HH:MM format.
+ * - max: string - The latest selectable time in HH:MM format.
+ * - step: number - Step interval between dropdown options, in minutes. Defaults to 30.
+ * - label: string - The visible label text for the field.
+ * - required: boolean - Whether the field is required for form submission.
+ * - disabled: boolean - Whether the field is disabled.
+ * - error: string - Error message to display. When set, the field enters an error state.
+ * - format: object - Display format for the time input. '12h' shows AM/PM; '24h' is bare HH:MM.
+ */
+#}
+<hx-time-picker
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if min is defined and min is not empty %}min="{{ min }}"{% endif %}
+  {% if max is defined and max is not empty %}max="{{ max }}"{% endif %}
+  {% if step is defined and step is not empty %}step="{{ step }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if required %}required{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if error is defined and error is not empty %}error="{{ error }}"{% endif %}
+  {% if format is defined and format is not empty %}format="{{ format }}"{% endif %}
+>
+  {% if slots.label is defined %}
+    <slot name="label">{{ slots.label }}</slot>
+  {% endif %}
+  {% if slots.help-text is defined %}
+    <slot name="help-text">{{ slots.help-text }}</slot>
+  {% endif %}
+  {% if slots.error is defined %}
+    <slot name="error">{{ slots.error }}</slot>
+  {% endif %}
+</hx-time-picker>

--- a/packages/hx-library/drupal/components/hx-toast-stack/README.md
+++ b/packages/hx-library/drupal/components/hx-toast-stack/README.md
@@ -1,0 +1,38 @@
+# HX Toast Stack
+
+A fixed-position container that stacks `hx-toast` elements at the specified
+corner of the viewport. Enforces a maximum visible toast count via `stack-limit`.
+
+## Usage
+
+```twig
+{% include 'helix:hx-toast-stack' with {
+  placement: 'bottom-end',
+  stackLimit: 3,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| placement | object | bottom-end | Corner of the viewport where toasts appear. |
+| stackLimit | number | 3 | Maximum number of simultaneously visible toasts. 0 = unlimited. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Accepts `hx-toast` elements. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-z-index-toast | 9000 | Z-index for the fixed stack. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner stack container div. |

--- a/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.component.yml
+++ b/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.component.yml
@@ -1,0 +1,23 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Toast Stack
+status: experimental
+group: HELiX
+description: 'A fixed-position container that stacks `hx-toast` elements at the specified corner of the viewport. Enforces a maximum visible toast count via `stack-limit`.'
+props:
+  type: object
+  properties:
+    placement:
+      type: object
+      title: Placement
+      description: 'Corner of the viewport where toasts appear.'
+      default: 'bottom-end'
+    stackLimit:
+      type: number
+      title: Stack Limit
+      description: 'Maximum number of simultaneously visible toasts. 0 = unlimited.'
+      default: 3
+slots:
+  default:
+    title: Default
+    description: 'Accepts `hx-toast` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.css
+++ b/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.css
@@ -1,0 +1,15 @@
+/**
+ * HX Toast Stack component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-z-index-toast: Z-index for the fixed stack. (default: 9000)
+ */
+
+/* Component host styles */
+hx-toast-stack {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.js
+++ b/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.js
@@ -1,0 +1,11 @@
+/**
+ * HX Toast Stack - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-toast-stack';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-toast-stack');
+}

--- a/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.twig
+++ b/packages/hx-library/drupal/components/hx-toast-stack/hx-toast-stack.twig
@@ -1,0 +1,19 @@
+{#
+ /**
+ * @file
+ * HX Toast Stack component template.
+ *
+ * A fixed-position container that stacks `hx-toast` elements at the specified
+ * corner of the viewport. Enforces a maximum visible toast count via `stack-limit`.
+ *
+ * Available variables:
+ * - placement: object - Corner of the viewport where toasts appear.
+ * - stackLimit: number - Maximum number of simultaneously visible toasts. 0 = unlimited.
+ */
+#}
+<hx-toast-stack
+  {% if placement is defined and placement is not empty %}placement="{{ placement }}"{% endif %}
+  {% if stackLimit is defined and stackLimit is not empty %}stack-limit="{{ stackLimit }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-toast-stack>

--- a/packages/hx-library/drupal/components/hx-toast/README.md
+++ b/packages/hx-library/drupal/components/hx-toast/README.md
@@ -1,0 +1,63 @@
+# HX Toast
+
+A transient notification message that auto-dismisses after a configurable duration.
+Supports multiple visual variants, a closable button, icon/action slots, and full
+ARIA live region semantics for screen readers.
+
+## Usage
+
+```twig
+{% include 'helix:hx-toast' with {
+  variant: 'default',
+  duration: 3000,
+  closable: false,
+  open: false,
+  closeLabel: 'Dismiss notification',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| variant | object | default | Visual style variant. |
+| duration | number | 3000 | Auto-dismiss duration in milliseconds. Set to 0 for persistent toasts. |
+| closable | boolean | false | Whether to show a close button. |
+| open | boolean | false | Whether the toast is currently visible. |
+| closeLabel | string | Dismiss notification | Accessible label for the close button. Override for localization. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the notification message. |
+| icon | Optional icon rendered before the message. |
+| action | Optional action button rendered after the message. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-show | Dispatched when the toast becomes visible. |
+| hx-hide | Dispatched when the toast begins hiding. |
+| hx-after-hide | Dispatched after the hide animation completes. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-toast-bg | var(--hx-color-neutral-900) | Toast background color. |
+| --hx-toast-color | var(--hx-color-neutral-0) | Toast text color. |
+| --hx-toast-border-radius | var(--hx-border-radius-md) | Toast border radius. |
+| --hx-toast-shadow | - | Toast box shadow. |
+| --hx-toast-width | 20rem | Toast width. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner toast container div. |
+| icon | The icon slot wrapper. |
+| message | The message slot wrapper. |
+| close-button | The dismiss button (only when closable). |
+| action | The action slot wrapper. |

--- a/packages/hx-library/drupal/components/hx-toast/hx-toast.component.yml
+++ b/packages/hx-library/drupal/components/hx-toast/hx-toast.component.yml
@@ -1,0 +1,44 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Toast
+status: experimental
+group: HELiX
+description: 'A transient notification message that auto-dismisses after a configurable duration. Supports multiple visual variants, a closable button, icon/action slots, and full ARIA live region semantics for screen readers.'
+props:
+  type: object
+  properties:
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant.'
+      default: 'default'
+    duration:
+      type: number
+      title: Duration
+      description: 'Auto-dismiss duration in milliseconds. Set to 0 for persistent toasts.'
+      default: 3000
+    closable:
+      type: boolean
+      title: Closable
+      description: 'Whether to show a close button.'
+      default: false
+    open:
+      type: boolean
+      title: Open
+      description: 'Whether the toast is currently visible.'
+      default: false
+    closeLabel:
+      type: string
+      title: Close Label
+      description: 'Accessible label for the close button. Override for localization.'
+      default: 'Dismiss notification'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the notification message.'
+  icon:
+    title: Icon
+    description: 'Optional icon rendered before the message.'
+  action:
+    title: Action
+    description: 'Optional action button rendered after the message.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-toast/hx-toast.css
+++ b/packages/hx-library/drupal/components/hx-toast/hx-toast.css
@@ -1,0 +1,19 @@
+/**
+ * HX Toast component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-toast-bg: Toast background color. (default: var(--hx-color-neutral-900))
+ * --hx-toast-color: Toast text color. (default: var(--hx-color-neutral-0))
+ * --hx-toast-border-radius: Toast border radius. (default: var(--hx-border-radius-md))
+ * --hx-toast-shadow: Toast box shadow.
+ * --hx-toast-width: Toast width. (default: 20rem)
+ */
+
+/* Component host styles */
+hx-toast {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-toast/hx-toast.js
+++ b/packages/hx-library/drupal/components/hx-toast/hx-toast.js
@@ -1,0 +1,11 @@
+/**
+ * HX Toast - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-toast';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-toast');
+}

--- a/packages/hx-library/drupal/components/hx-toast/hx-toast.twig
+++ b/packages/hx-library/drupal/components/hx-toast/hx-toast.twig
@@ -1,0 +1,32 @@
+{#
+ /**
+ * @file
+ * HX Toast component template.
+ *
+ * A transient notification message that auto-dismisses after a configurable duration.
+ * Supports multiple visual variants, a closable button, icon/action slots, and full
+ * ARIA live region semantics for screen readers.
+ *
+ * Available variables:
+ * - variant: object - Visual style variant.
+ * - duration: number - Auto-dismiss duration in milliseconds. Set to 0 for persistent toasts.
+ * - closable: boolean - Whether to show a close button.
+ * - open: boolean - Whether the toast is currently visible.
+ * - closeLabel: string - Accessible label for the close button. Override for localization.
+ */
+#}
+<hx-toast
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if duration is defined and duration is not empty %}duration="{{ duration }}"{% endif %}
+  {% if closable %}closable{% endif %}
+  {% if open %}open{% endif %}
+  {% if closeLabel is defined and closeLabel is not empty %}close-label="{{ closeLabel }}"{% endif %}
+>
+  {% if slots.icon is defined %}
+    <slot name="icon">{{ slots.icon }}</slot>
+  {% endif %}
+  {% if slots.action is defined %}
+    <slot name="action">{{ slots.action }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-toast>

--- a/packages/hx-library/drupal/components/hx-toggle-button/README.md
+++ b/packages/hx-library/drupal/components/hx-toggle-button/README.md
@@ -1,0 +1,73 @@
+# HX Toggle Button
+
+A two-state toggle button that communicates a pressed/unpressed status to
+assistive technology via `aria-pressed`. Supports multiple visual variants
+and sizes, prefix/suffix slots, full ElementInternals form association, and
+a distinct pressed visual state for every variant.
+
+## Usage
+
+```twig
+{% include 'helix:hx-toggle-button' with {
+  pressed: false,
+  variant: 'secondary',
+  size: 'md',
+  disabled: false,
+  name: 'undefined',
+  value: 'undefined',
+  label: 'undefined',
+  required: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| pressed | boolean | false | Whether the toggle button is in the pressed state.
+Reflected as an attribute so CSS selectors like `:host([pressed])` work. |
+| variant | object | secondary | Visual style variant of the button. |
+| size | object | md | Size of the button. |
+| disabled | boolean | false | Whether the button is disabled. Prevents all interaction and form actions. |
+| name | object | undefined | Form field name submitted via ElementInternals when the button is pressed. |
+| value | object | undefined | Form field value submitted via ElementInternals when the button is pressed. |
+| label | object | undefined | Accessible label forwarded to the inner `<button>` as `aria-label`.
+Required for icon-only toggle buttons where no visible text is present. |
+| required | boolean | false | When true, the button must be in the pressed state for the form to be submitted. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the button label text or content. |
+| prefix | Icon or content rendered before the label. |
+| suffix | Icon or content rendered after the label. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-toggle | Dispatched when the toggle state changes. Not dispatched when the button is disabled. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-toggle-button-bg | var(--hx-color-primary-500) | Button background color. |
+| --hx-toggle-button-color | var(--hx-color-neutral-0) | Button text color. |
+| --hx-toggle-button-border-color | transparent | Button border color. |
+| --hx-toggle-button-border-radius | var(--hx-border-radius-md) | Button border radius. |
+| --hx-toggle-button-font-family | var(--hx-font-family-sans) | Button font family. |
+| --hx-toggle-button-font-weight | var(--hx-font-weight-semibold) | Button font weight. |
+| --hx-toggle-button-focus-ring-color | var(--hx-focus-ring-color) | Focus ring color. |
+| --hx-toggle-button-pressed-bg | var(--hx-color-primary-500) | Background when pressed (variant-specific fallback applies). |
+| --hx-toggle-button-pressed-color | var(--hx-color-neutral-0) | Text color when pressed (variant-specific fallback applies). |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| button | The native `<button>` element. |
+| label | The label text wrapper span. |
+| prefix | The prefix slot container span. |
+| suffix | The suffix slot container span. |

--- a/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.component.yml
+++ b/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.component.yml
@@ -1,0 +1,59 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Toggle Button
+status: experimental
+group: HELiX
+description: 'A two-state toggle button that communicates a pressed/unpressed status to assistive technology via `aria-pressed`. Supports multiple visual variants and sizes, prefix/suffix slots, full ElementInternals form association, and a distinct pressed visual state for every variant.'
+props:
+  type: object
+  properties:
+    pressed:
+      type: boolean
+      title: Pressed
+      description: 'Whether the toggle button is in the pressed state. Reflected as an attribute so CSS selectors like `:host([pressed])` work.'
+      default: false
+    variant:
+      type: object
+      title: Variant
+      description: 'Visual style variant of the button.'
+      default: 'secondary'
+    size:
+      type: object
+      title: Size
+      description: 'Size of the button.'
+      default: 'md'
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the button is disabled. Prevents all interaction and form actions.'
+      default: false
+    name:
+      type: object
+      title: Name
+      description: 'Form field name submitted via ElementInternals when the button is pressed.'
+      default: 'undefined'
+    value:
+      type: object
+      title: Value
+      description: 'Form field value submitted via ElementInternals when the button is pressed.'
+      default: 'undefined'
+    label:
+      type: object
+      title: Label
+      description: 'Accessible label forwarded to the inner `<button>` as `aria-label`. Required for icon-only toggle buttons where no visible text is present.'
+      default: 'undefined'
+    required:
+      type: boolean
+      title: Required
+      description: 'When true, the button must be in the pressed state for the form to be submitted.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the button label text or content.'
+  prefix:
+    title: Prefix
+    description: 'Icon or content rendered before the label.'
+  suffix:
+    title: Suffix
+    description: 'Icon or content rendered after the label.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.css
+++ b/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.css
@@ -1,0 +1,23 @@
+/**
+ * HX Toggle Button component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-toggle-button-bg: Button background color. (default: var(--hx-color-primary-500))
+ * --hx-toggle-button-color: Button text color. (default: var(--hx-color-neutral-0))
+ * --hx-toggle-button-border-color: Button border color. (default: transparent)
+ * --hx-toggle-button-border-radius: Button border radius. (default: var(--hx-border-radius-md))
+ * --hx-toggle-button-font-family: Button font family. (default: var(--hx-font-family-sans))
+ * --hx-toggle-button-font-weight: Button font weight. (default: var(--hx-font-weight-semibold))
+ * --hx-toggle-button-focus-ring-color: Focus ring color. (default: var(--hx-focus-ring-color))
+ * --hx-toggle-button-pressed-bg: Background when pressed (variant-specific fallback applies). (default: var(--hx-color-primary-500))
+ * --hx-toggle-button-pressed-color: Text color when pressed (variant-specific fallback applies). (default: var(--hx-color-neutral-0))
+ */
+
+/* Component host styles */
+hx-toggle-button {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.js
+++ b/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.js
@@ -1,0 +1,11 @@
+/**
+ * HX Toggle Button - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-toggle-button';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-toggle-button');
+}

--- a/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.twig
+++ b/packages/hx-library/drupal/components/hx-toggle-button/hx-toggle-button.twig
@@ -1,0 +1,39 @@
+{#
+ /**
+ * @file
+ * HX Toggle Button component template.
+ *
+ * A two-state toggle button that communicates a pressed/unpressed status to
+ * assistive technology via `aria-pressed`. Supports multiple visual variants
+ * and sizes, prefix/suffix slots, full ElementInternals form association, and
+ * a distinct pressed visual state for every variant.
+ *
+ * Available variables:
+ * - pressed: boolean - Whether the toggle button is in the pressed state. Reflected as an attribute so CSS selectors like `:host([pressed])` work.
+ * - variant: object - Visual style variant of the button.
+ * - size: object - Size of the button.
+ * - disabled: boolean - Whether the button is disabled. Prevents all interaction and form actions.
+ * - name: object - Form field name submitted via ElementInternals when the button is pressed.
+ * - value: object - Form field value submitted via ElementInternals when the button is pressed.
+ * - label: object - Accessible label forwarded to the inner `<button>` as `aria-label`. Required for icon-only toggle buttons where no visible text is present.
+ * - required: boolean - When true, the button must be in the pressed state for the form to be submitted.
+ */
+#}
+<hx-toggle-button
+  {% if pressed %}pressed{% endif %}
+  {% if variant is defined and variant is not empty %}variant="{{ variant }}"{% endif %}
+  {% if size is defined and size is not empty %}size="{{ size }}"{% endif %}
+  {% if disabled %}disabled{% endif %}
+  {% if name is defined and name is not empty %}name="{{ name }}"{% endif %}
+  {% if value is defined and value is not empty %}value="{{ value }}"{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if required %}required{% endif %}
+>
+  {% if slots.prefix is defined %}
+    <slot name="prefix">{{ slots.prefix }}</slot>
+  {% endif %}
+  {% if slots.suffix is defined %}
+    <slot name="suffix">{{ slots.suffix }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-toggle-button>

--- a/packages/hx-library/drupal/components/hx-tooltip/README.md
+++ b/packages/hx-library/drupal/components/hx-tooltip/README.md
@@ -1,0 +1,52 @@
+# HX Tooltip
+
+A tooltip that displays contextual help text on hover or focus.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tooltip' with {
+  placement: 'top',
+  showDelay: 300,
+  hideDelay: 100,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| placement | object | top | Preferred placement of the tooltip relative to the trigger.
+Supports all Floating UI placement values including alignment variants
+(e.g. 'top-start', 'bottom-end') and 'auto'. |
+| showDelay | number | 300 | Delay in milliseconds before the tooltip is shown. |
+| hideDelay | number | 100 | Delay in milliseconds before the tooltip is hidden. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the trigger element. |
+| content | Tooltip content to display. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-tooltip-bg | var(--hx-color-neutral-900) | Tooltip background color. |
+| --hx-tooltip-color | var(--hx-color-neutral-50) | Tooltip text color. |
+| --hx-tooltip-font-size | var(--hx-font-size-xs) | Tooltip font size. |
+| --hx-tooltip-max-width | 280px | Maximum tooltip width. |
+| --hx-tooltip-padding | - | Tooltip padding. |
+| --hx-tooltip-border-radius | var(--hx-border-radius-sm) | Tooltip border radius. |
+| --hx-tooltip-shadow | - | Tooltip box shadow. |
+| --hx-tooltip-z-index | 9999 | Tooltip z-index. |
+| --hx-tooltip-transition-duration | 0.15s | Show/hide transition duration. |
+| --hx-tooltip-arrow-size | 8px | Size of the arrow indicator. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| tooltip | The tooltip container element. |
+| arrow | The arrow indicator element. |

--- a/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.component.yml
+++ b/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.component.yml
@@ -1,0 +1,31 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tooltip
+status: experimental
+group: HELiX
+description: 'A tooltip that displays contextual help text on hover or focus.'
+props:
+  type: object
+  properties:
+    placement:
+      type: object
+      title: Placement
+      description: "Preferred placement of the tooltip relative to the trigger. Supports all Floating UI placement values including alignment variants (e.g. 'top-start', 'bottom-end') and 'auto'."
+      default: 'top'
+    showDelay:
+      type: number
+      title: Show Delay
+      description: 'Delay in milliseconds before the tooltip is shown.'
+      default: 300
+    hideDelay:
+      type: number
+      title: Hide Delay
+      description: 'Delay in milliseconds before the tooltip is hidden.'
+      default: 100
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the trigger element.'
+  content:
+    title: Content
+    description: 'Tooltip content to display.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.css
+++ b/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.css
@@ -1,0 +1,24 @@
+/**
+ * HX Tooltip component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-tooltip-bg: Tooltip background color. (default: var(--hx-color-neutral-900))
+ * --hx-tooltip-color: Tooltip text color. (default: var(--hx-color-neutral-50))
+ * --hx-tooltip-font-size: Tooltip font size. (default: var(--hx-font-size-xs))
+ * --hx-tooltip-max-width: Maximum tooltip width. (default: 280px)
+ * --hx-tooltip-padding: Tooltip padding.
+ * --hx-tooltip-border-radius: Tooltip border radius. (default: var(--hx-border-radius-sm))
+ * --hx-tooltip-shadow: Tooltip box shadow.
+ * --hx-tooltip-z-index: Tooltip z-index. (default: 9999)
+ * --hx-tooltip-transition-duration: Show/hide transition duration. (default: 0.15s)
+ * --hx-tooltip-arrow-size: Size of the arrow indicator. (default: 8px)
+ */
+
+/* Component host styles */
+hx-tooltip {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.js
+++ b/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tooltip - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tooltip';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tooltip');
+}

--- a/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.twig
+++ b/packages/hx-library/drupal/components/hx-tooltip/hx-tooltip.twig
@@ -1,0 +1,23 @@
+{#
+ /**
+ * @file
+ * HX Tooltip component template.
+ *
+ * A tooltip that displays contextual help text on hover or focus.
+ *
+ * Available variables:
+ * - placement: object - Preferred placement of the tooltip relative to the trigger. Supports all Floating UI placement values including alignment variants (e.g. 'top-start', 'bottom-end') and 'auto'.
+ * - showDelay: number - Delay in milliseconds before the tooltip is shown.
+ * - hideDelay: number - Delay in milliseconds before the tooltip is hidden.
+ */
+#}
+<hx-tooltip
+  {% if placement is defined and placement is not empty %}placement="{{ placement }}"{% endif %}
+  {% if showDelay is defined and showDelay is not empty %}show-delay="{{ showDelay }}"{% endif %}
+  {% if hideDelay is defined and hideDelay is not empty %}hide-delay="{{ hideDelay }}"{% endif %}
+>
+  {% if slots.content is defined %}
+    <slot name="content">{{ slots.content }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tooltip>

--- a/packages/hx-library/drupal/components/hx-top-nav/README.md
+++ b/packages/hx-library/drupal/components/hx-top-nav/README.md
@@ -1,0 +1,58 @@
+# HX Top Nav
+
+Top-of-page site navigation bar with logo, menu items, and utility area.
+Supports sticky positioning, responsive hamburger menu, and full slot-driven
+content composition for Drupal and other CMS consumers.
+
+## Usage
+
+```twig
+{% include 'helix:hx-top-nav' with {
+  sticky: false,
+  label: 'Site Navigation',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| sticky | boolean | false | When true, the navigation bar sticks to the top of the viewport during scroll. |
+| label | string | Site Navigation | Accessible label applied to the `<nav>` element via `aria-label`. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| logo | Brand area rendered on the left side. |
+| (default) | Default slot for primary navigation items rendered in the center. IMPORTANT: Do NOT place a `<nav>` element in this slot — the component already renders a `<nav>` landmark internally. Use a `<div>` or bare links. |
+| actions | Utility area rendered on the right side (search, user menu, etc.). |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-mobile-toggle | Dispatched when the hamburger button is toggled. Detail contains the new open state. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-top-nav-bg | var(--hx-color-neutral-0) | Navigation bar background color. |
+| --hx-top-nav-color | var(--hx-color-neutral-800) | Navigation bar text color. |
+| --hx-top-nav-border-color | var(--hx-color-neutral-200) | Bottom border color. |
+| --hx-top-nav-height | var(--hx-space-16) | Navigation bar height. |
+| --hx-top-nav-padding-x | var(--hx-space-6) | Horizontal padding. |
+| --hx-top-nav-z-index | var(--hx-z-index-sticky) | Z-index for sticky mode. |
+| --hx-top-nav-toggle-color | var(--hx-color-neutral-700) | Hamburger icon color. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| header | The outer `<header>` landmark element. |
+| nav | The `<nav>` element inside the header. |
+| logo | The logo slot container. |
+| menu | The primary navigation slot container. |
+| actions | The actions slot container. |
+| mobile-toggle | The hamburger toggle button. |

--- a/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.component.yml
+++ b/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.component.yml
@@ -1,0 +1,29 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Top Nav
+status: experimental
+group: HELiX
+description: 'Top-of-page site navigation bar with logo, menu items, and utility area. Supports sticky positioning, responsive hamburger menu, and full slot-driven content composition for Drupal and other CMS consumers.'
+props:
+  type: object
+  properties:
+    sticky:
+      type: boolean
+      title: Sticky
+      description: 'When true, the navigation bar sticks to the top of the viewport during scroll.'
+      default: false
+    label:
+      type: string
+      title: Label
+      description: 'Accessible label applied to the `<nav>` element via `aria-label`.'
+      default: 'Site Navigation'
+slots:
+  logo:
+    title: Logo
+    description: 'Brand area rendered on the left side.'
+  default:
+    title: Default
+    description: 'Default slot for primary navigation items rendered in the center. IMPORTANT: Do NOT place a `<nav>` element in this slot — the component already renders a `<nav>` landmark internally. Use a `<div>` or bare links.'
+  actions:
+    title: Actions
+    description: 'Utility area rendered on the right side (search, user menu, etc.).'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.css
+++ b/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.css
@@ -1,0 +1,21 @@
+/**
+ * HX Top Nav component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-top-nav-bg: Navigation bar background color. (default: var(--hx-color-neutral-0))
+ * --hx-top-nav-color: Navigation bar text color. (default: var(--hx-color-neutral-800))
+ * --hx-top-nav-border-color: Bottom border color. (default: var(--hx-color-neutral-200))
+ * --hx-top-nav-height: Navigation bar height. (default: var(--hx-space-16))
+ * --hx-top-nav-padding-x: Horizontal padding. (default: var(--hx-space-6))
+ * --hx-top-nav-z-index: Z-index for sticky mode. (default: var(--hx-z-index-sticky))
+ * --hx-top-nav-toggle-color: Hamburger icon color. (default: var(--hx-color-neutral-700))
+ */
+
+/* Component host styles */
+hx-top-nav {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.js
+++ b/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.js
@@ -1,0 +1,11 @@
+/**
+ * HX Top Nav - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-top-nav';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-top-nav');
+}

--- a/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.twig
+++ b/packages/hx-library/drupal/components/hx-top-nav/hx-top-nav.twig
@@ -1,0 +1,26 @@
+{#
+ /**
+ * @file
+ * HX Top Nav component template.
+ *
+ * Top-of-page site navigation bar with logo, menu items, and utility area.
+ * Supports sticky positioning, responsive hamburger menu, and full slot-driven
+ * content composition for Drupal and other CMS consumers.
+ *
+ * Available variables:
+ * - sticky: boolean - When true, the navigation bar sticks to the top of the viewport during scroll.
+ * - label: string - Accessible label applied to the `<nav>` element via `aria-label`.
+ */
+#}
+<hx-top-nav
+  {% if sticky %}sticky{% endif %}
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+>
+  {% if slots.logo is defined %}
+    <slot name="logo">{{ slots.logo }}</slot>
+  {% endif %}
+  {% if slots.actions is defined %}
+    <slot name="actions">{{ slots.actions }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-top-nav>

--- a/packages/hx-library/drupal/components/hx-tr/README.md
+++ b/packages/hx-library/drupal/components/hx-tr/README.md
@@ -1,0 +1,32 @@
+# HX Tr
+
+Semantic table row. Must be a child of `hx-thead`, `hx-tbody`, or `hx-tfoot`.
+Contains `hx-th` or `hx-td` cells.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tr' with {
+  selected: false,
+  disabled: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| selected | boolean | false | When true, marks the row as selected and applies selected styling. |
+| disabled | boolean | false | When true, the row is visually disabled and non-interactive. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for `hx-th` and `hx-td` elements. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| row | The `<tr>` element. |

--- a/packages/hx-library/drupal/components/hx-tr/hx-tr.component.yml
+++ b/packages/hx-library/drupal/components/hx-tr/hx-tr.component.yml
@@ -1,0 +1,23 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tr
+status: experimental
+group: HELiX
+description: 'Semantic table row. Must be a child of `hx-thead`, `hx-tbody`, or `hx-tfoot`. Contains `hx-th` or `hx-td` cells.'
+props:
+  type: object
+  properties:
+    selected:
+      type: boolean
+      title: Selected
+      description: 'When true, marks the row as selected and applies selected styling.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'When true, the row is visually disabled and non-interactive.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for `hx-th` and `hx-td` elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tr/hx-tr.css
+++ b/packages/hx-library/drupal/components/hx-tr/hx-tr.css
@@ -1,0 +1,12 @@
+/**
+ * HX Tr component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-tr {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tr/hx-tr.js
+++ b/packages/hx-library/drupal/components/hx-tr/hx-tr.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tr - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tr';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tr');
+}

--- a/packages/hx-library/drupal/components/hx-tr/hx-tr.twig
+++ b/packages/hx-library/drupal/components/hx-tr/hx-tr.twig
@@ -1,0 +1,19 @@
+{#
+ /**
+ * @file
+ * HX Tr component template.
+ *
+ * Semantic table row. Must be a child of `hx-thead`, `hx-tbody`, or `hx-tfoot`.
+ * Contains `hx-th` or `hx-td` cells.
+ *
+ * Available variables:
+ * - selected: boolean - When true, marks the row as selected and applies selected styling.
+ * - disabled: boolean - When true, the row is visually disabled and non-interactive.
+ */
+#}
+<hx-tr
+  {% if selected %}selected{% endif %}
+  {% if disabled %}disabled{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tr>

--- a/packages/hx-library/drupal/components/hx-tree-item/README.md
+++ b/packages/hx-library/drupal/components/hx-tree-item/README.md
@@ -1,0 +1,58 @@
+# HX Tree Item
+
+A tree item used within an hx-tree-view component.
+Supports expand/collapse, selection, keyboard navigation, and icon/children slots.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tree-item' with {
+  expanded: false,
+  selected: false,
+  disabled: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| expanded | boolean | false | Whether the item is expanded (showing children). |
+| selected | boolean | false | Whether the item is selected. |
+| disabled | boolean | false | Whether the item is disabled (non-interactive). |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for the item label content. This text is also used to label the children group. |
+| icon | Custom icon shown before the label. |
+| children | Nested hx-tree-item elements for sub-tree. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-tree-item-select | Dispatched when this item is clicked or activated via keyboard. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-tree-item-color | var(--hx-color-neutral-900) | Item text color. |
+| --hx-tree-item-hover-bg | var(--hx-color-neutral-100) | Hover background color. |
+| --hx-tree-item-selected-bg | var(--hx-color-primary-100) | Selected background color. |
+| --hx-tree-item-selected-color | var(--hx-color-primary-800) | Selected text color. |
+| --hx-tree-item-padding-x | var(--hx-space-2) | Horizontal padding. |
+| --hx-tree-item-padding-y | var(--hx-space-1) | Vertical padding. |
+| --hx-tree-indent-size | 1.5rem | Indentation size per level. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| item | The outer item container. |
+| row | The interactive item row (contains expand icon, icon slot, and label). |
+| expand-icon | The expand/collapse toggle button. |
+| label | The label text content area. |
+| children | The children container. |

--- a/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.component.yml
+++ b/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.component.yml
@@ -1,0 +1,34 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tree Item
+status: experimental
+group: HELiX
+description: 'A tree item used within an hx-tree-view component. Supports expand/collapse, selection, keyboard navigation, and icon/children slots.'
+props:
+  type: object
+  properties:
+    expanded:
+      type: boolean
+      title: Expanded
+      description: 'Whether the item is expanded (showing children).'
+      default: false
+    selected:
+      type: boolean
+      title: Selected
+      description: 'Whether the item is selected.'
+      default: false
+    disabled:
+      type: boolean
+      title: Disabled
+      description: 'Whether the item is disabled (non-interactive).'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'Default slot for the item label content. This text is also used to label the children group.'
+  icon:
+    title: Icon
+    description: 'Custom icon shown before the label.'
+  children:
+    title: Children
+    description: 'Nested hx-tree-item elements for sub-tree.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.css
+++ b/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.css
@@ -1,0 +1,21 @@
+/**
+ * HX Tree Item component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-tree-item-color: Item text color. (default: var(--hx-color-neutral-900))
+ * --hx-tree-item-hover-bg: Hover background color. (default: var(--hx-color-neutral-100))
+ * --hx-tree-item-selected-bg: Selected background color. (default: var(--hx-color-primary-100))
+ * --hx-tree-item-selected-color: Selected text color. (default: var(--hx-color-primary-800))
+ * --hx-tree-item-padding-x: Horizontal padding. (default: var(--hx-space-2))
+ * --hx-tree-item-padding-y: Vertical padding. (default: var(--hx-space-1))
+ * --hx-tree-indent-size: Indentation size per level. (default: 1.5rem)
+ */
+
+/* Component host styles */
+hx-tree-item {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.js
+++ b/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tree Item - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tree-item';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tree-item');
+}

--- a/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.twig
+++ b/packages/hx-library/drupal/components/hx-tree-item/hx-tree-item.twig
@@ -1,0 +1,27 @@
+{#
+ /**
+ * @file
+ * HX Tree Item component template.
+ *
+ * A tree item used within an hx-tree-view component.
+ * Supports expand/collapse, selection, keyboard navigation, and icon/children slots.
+ *
+ * Available variables:
+ * - expanded: boolean - Whether the item is expanded (showing children).
+ * - selected: boolean - Whether the item is selected.
+ * - disabled: boolean - Whether the item is disabled (non-interactive).
+ */
+#}
+<hx-tree-item
+  {% if expanded %}expanded{% endif %}
+  {% if selected %}selected{% endif %}
+  {% if disabled %}disabled{% endif %}
+>
+  {% if slots.icon is defined %}
+    <slot name="icon">{{ slots.icon }}</slot>
+  {% endif %}
+  {% if slots.children is defined %}
+    <slot name="children">{{ slots.children }}</slot>
+  {% endif %}
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tree-item>

--- a/packages/hx-library/drupal/components/hx-tree-view/README.md
+++ b/packages/hx-library/drupal/components/hx-tree-view/README.md
@@ -1,0 +1,62 @@
+# HX Tree View
+
+A hierarchical tree component for navigating nested data structures.
+Used in healthcare applications for org charts, ICD-10 code hierarchies, and department navigation.
+
+Implements WAI-ARIA tree view pattern with `role="tree"` on the container
+and `role="treeitem"` on each item. Supports `aria-label` via the `label` property
+for screen reader identification. Full keyboard navigation: Arrow keys for movement,
+Enter/Space for selection, Home/End for first/last item.
+
+## Scale Limits
+
+This component renders all tree items simultaneously in the DOM. It is suitable for
+trees with up to ~500 visible items. For large taxonomies (e.g., ICD-10 with 70,000+
+codes), use async/lazy loading: only render top-level nodes initially and populate
+child nodes on `hx-select` or expand events. The component exposes the `expanded`
+property on `hx-tree-item` for programmatic control of subtrees, enabling consumer-level
+virtualization strategies without requiring changes to this component.
+
+## Usage
+
+```twig
+{% include 'helix:hx-tree-view' with {
+  label: '',
+  selection: 'none',
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| label | string |  | Accessible label for the tree. Applied as `aria-label` on the tree container.
+Provides context to screen readers about the tree's purpose. |
+| selection | object | none | Selection mode for the tree.
+- `none` — items cannot be selected
+- `single` — only one item can be selected at a time
+- `multiple` — multiple items can be selected |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | Default slot for hx-tree-item elements. |
+
+## Events
+
+| Event | Description |
+|-------|-------------|
+| hx-select | Dispatched when a tree item is selected or deselected. |
+
+## CSS Custom Properties
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| --hx-tree-font-family | var(--hx-font-family-sans) | Tree font family. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| tree | The tree container element with role="tree". |

--- a/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.component.yml
+++ b/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.component.yml
@@ -1,0 +1,23 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Tree View
+status: experimental
+group: HELiX
+description: 'A hierarchical tree component for navigating nested data structures. Used in healthcare applications for org charts, ICD-10 code hierarchies, and department navigation.  Implements WAI-ARIA tree view pattern with `role="tree"` on the container and `role="treeitem"` on each item. Supports `aria-label` via the `label` property for screen reader identification. Full keyboard navigation: Arrow keys for movement, Enter/Space for selection, Home/End for first/last item.  ## Scale Limits  This component renders all tree items simultaneously in the DOM. It is suitable for trees with up to ~500 visible items. For large taxonomies (e.g., ICD-10 with 70,000+ codes), use async/lazy loading: only render top-level nodes initially and populate child nodes on `hx-select` or expand events. The component exposes the `expanded` property on `hx-tree-item` for programmatic control of subtrees, enabling consumer-level virtualization strategies without requiring changes to this component.'
+props:
+  type: object
+  properties:
+    label:
+      type: string
+      title: Label
+      description: "Accessible label for the tree. Applied as `aria-label` on the tree container. Provides context to screen readers about the tree's purpose."
+      default: ''
+    selection:
+      type: object
+      title: Selection
+      description: 'Selection mode for the tree. - `none` — items cannot be selected - `single` — only one item can be selected at a time - `multiple` — multiple items can be selected'
+      default: 'none'
+slots:
+  default:
+    title: Default
+    description: 'Default slot for hx-tree-item elements.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.css
+++ b/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.css
@@ -1,0 +1,15 @@
+/**
+ * HX Tree View component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ *
+ * CSS Custom Properties:
+ * --hx-tree-font-family: Tree font family. (default: var(--hx-font-family-sans))
+ */
+
+/* Component host styles */
+hx-tree-view {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.js
+++ b/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.js
@@ -1,0 +1,11 @@
+/**
+ * HX Tree View - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-tree-view';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-tree-view');
+}

--- a/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.twig
+++ b/packages/hx-library/drupal/components/hx-tree-view/hx-tree-view.twig
@@ -1,0 +1,33 @@
+{#
+ /**
+ * @file
+ * HX Tree View component template.
+ *
+ * A hierarchical tree component for navigating nested data structures.
+ * Used in healthcare applications for org charts, ICD-10 code hierarchies, and department navigation.
+ * 
+ * Implements WAI-ARIA tree view pattern with `role="tree"` on the container
+ * and `role="treeitem"` on each item. Supports `aria-label` via the `label` property
+ * for screen reader identification. Full keyboard navigation: Arrow keys for movement,
+ * Enter/Space for selection, Home/End for first/last item.
+ * 
+ * ## Scale Limits
+ * 
+ * This component renders all tree items simultaneously in the DOM. It is suitable for
+ * trees with up to ~500 visible items. For large taxonomies (e.g., ICD-10 with 70,000+
+ * codes), use async/lazy loading: only render top-level nodes initially and populate
+ * child nodes on `hx-select` or expand events. The component exposes the `expanded`
+ * property on `hx-tree-item` for programmatic control of subtrees, enabling consumer-level
+ * virtualization strategies without requiring changes to this component.
+ *
+ * Available variables:
+ * - label: string - Accessible label for the tree. Applied as `aria-label` on the tree container. Provides context to screen readers about the tree's purpose.
+ * - selection: object - Selection mode for the tree. - `none` — items cannot be selected - `single` — only one item can be selected at a time - `multiple` — multiple items can be selected
+ */
+#}
+<hx-tree-view
+  {% if label is defined and label is not empty %}label="{{ label }}"{% endif %}
+  {% if selection is defined and selection is not empty %}selection="{{ selection }}"{% endif %}
+>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-tree-view>

--- a/packages/hx-library/drupal/components/hx-visually-hidden/README.md
+++ b/packages/hx-library/drupal/components/hx-visually-hidden/README.md
@@ -1,0 +1,34 @@
+# HX Visually Hidden
+
+A utility component that hides content visually while keeping it
+accessible to screen readers. Uses the standard visually-hidden CSS
+technique — does NOT use `visibility: hidden` or `display: none`,
+which would also hide content from assistive technologies.
+
+## Usage
+
+```twig
+{% include 'helix:hx-visually-hidden' with {
+  focusable: false,
+} %}
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| focusable | boolean | false | When true, the component becomes visible when a focusable child
+(such as a skip link) receives focus. This enables the standard
+"skip to content" accessibility pattern. |
+
+## Slots
+
+| Slot | Description |
+|------|-------------|
+| (default) | The content to hide visually but expose to screen readers. |
+
+## CSS Parts
+
+| Part | Description |
+|------|-------------|
+| base | The inner wrapper element containing the slotted content. |

--- a/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.component.yml
+++ b/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.component.yml
@@ -1,0 +1,18 @@
+$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'
+name: HX Visually Hidden
+status: experimental
+group: HELiX
+description: 'A utility component that hides content visually while keeping it accessible to screen readers. Uses the standard visually-hidden CSS technique — does NOT use `visibility: hidden` or `display: none`, which would also hide content from assistive technologies.'
+props:
+  type: object
+  properties:
+    focusable:
+      type: boolean
+      title: Focusable
+      description: 'When true, the component becomes visible when a focusable child (such as a skip link) receives focus. This enables the standard "skip to content" accessibility pattern.'
+      default: false
+slots:
+  default:
+    title: Default
+    description: 'The content to hide visually but expose to screen readers.'
+libraryOverrides: {}

--- a/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.css
+++ b/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.css
@@ -1,0 +1,12 @@
+/**
+ * HX Visually Hidden component styles.
+ *
+ * This component uses the @helixui/adopted-stylesheets pattern.
+ * The JS file initializes AdoptedStylesheetsController which
+ * handles stylesheet adoption into the shadow DOM.
+ */
+
+/* Component host styles */
+hx-visually-hidden {
+  display: block;
+}

--- a/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.js
+++ b/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.js
@@ -1,0 +1,11 @@
+/**
+ * HX Visually Hidden - Drupal SDC integration.
+ * Registers the custom element and initializes adopted stylesheets.
+ */
+import '@helixui/library/components/hx-visually-hidden';
+
+// Initialize adopted stylesheets for shadow DOM style injection
+// @see https://www.drupal.org/project/adopted_stylesheets
+if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {
+  new window.AdoptedStylesheetsController('hx-visually-hidden');
+}

--- a/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.twig
+++ b/packages/hx-library/drupal/components/hx-visually-hidden/hx-visually-hidden.twig
@@ -1,0 +1,17 @@
+{#
+ /**
+ * @file
+ * HX Visually Hidden component template.
+ *
+ * A utility component that hides content visually while keeping it
+ * accessible to screen readers. Uses the standard visually-hidden CSS
+ * technique — does NOT use `visibility: hidden` or `display: none`,
+ * which would also hide content from assistive technologies.
+ *
+ * Available variables:
+ * - focusable: boolean - When true, the component becomes visible when a focusable child (such as a skip link) receives focus. This enables the standard "skip to content" accessibility pattern.
+ */
+#}
+<hx-visually-hidden {% if focusable %}focusable{% endif %}>
+  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}
+</hx-visually-hidden>

--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -29,6 +29,8 @@
   "scripts": {
     "dev": "vite build --watch",
     "generate:barrel": "node scripts/generate-barrel.js",
+    "generate:sdc": "tsx scripts/generate-sdc.ts",
+    "test:scripts": "vitest run --config vitest.config.scripts.ts",
     "prepare": "node scripts/generate-barrel.js",
     "prebuild": "node scripts/generate-barrel.js",
     "build": "vite build && pnpm run cem",

--- a/packages/hx-library/scripts/__tests__/generate-sdc.test.ts
+++ b/packages/hx-library/scripts/__tests__/generate-sdc.test.ts
@@ -1,0 +1,673 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  parseArgs,
+  mapCemTypeToJsonSchema,
+  transformDeclaration,
+  generateComponentYml,
+  generateTwig,
+  generateCss,
+  generateJs,
+  generateReadme,
+  toTitleCase,
+  toKebabCase,
+  toHumanName,
+  escapeYamlString,
+  extractComponents,
+} from '../generate-sdc.js';
+import type {
+  CemDeclaration,
+  Cem,
+  SdcComponent,
+} from '../generate-sdc.js';
+
+// ---------------------------------------------------------------------------
+// Shared mock data
+// ---------------------------------------------------------------------------
+
+const mockButtonDeclaration: CemDeclaration = {
+  kind: 'class',
+  name: 'HelixButton',
+  tagName: 'hx-button',
+  description: 'A versatile button component for user interactions.',
+  members: [
+    {
+      kind: 'field',
+      name: 'variant',
+      type: { text: 'string' },
+      default: '"primary"',
+      description: 'The button visual style.',
+      attribute: 'variant',
+      reflects: true,
+    },
+    {
+      kind: 'field',
+      name: 'disabled',
+      type: { text: 'boolean' },
+      default: 'false',
+      description: 'Whether the button is disabled.',
+      attribute: 'disabled',
+      reflects: true,
+    },
+    {
+      kind: 'field',
+      name: 'size',
+      type: { text: 'number' },
+      default: '16',
+      description: 'Internal size hint.',
+      attribute: 'size',
+    },
+    {
+      kind: 'method',
+      name: 'focus',
+      description: 'Focuses the button.',
+    },
+    {
+      kind: 'field',
+      name: '_internalState',
+      type: { text: 'string' },
+      description: 'Private internal state.',
+      attribute: '_internalState',
+    },
+    {
+      kind: 'field',
+      name: 'internals',
+      type: { text: 'object' },
+      description: 'ElementInternals.',
+    },
+  ],
+  slots: [
+    { name: '', description: 'Default slot for button label.' },
+    { name: 'prefix', description: 'Content placed before the label.' },
+  ],
+  events: [
+    {
+      name: 'hx-click',
+      description: 'Fires when the button is clicked.',
+      type: { text: 'CustomEvent' },
+    },
+  ],
+  cssProperties: [
+    {
+      name: '--hx-button-bg',
+      description: 'Button background color.',
+      default: 'var(--hx-color-primary)',
+    },
+  ],
+  cssParts: [{ name: 'button', description: 'The inner button element.' }],
+};
+
+const mockCardDeclaration: CemDeclaration = {
+  kind: 'class',
+  name: 'HelixCard',
+  tagName: 'hx-card',
+  description: 'A card container component.',
+  members: [],
+  slots: [],
+  events: [],
+  cssProperties: [],
+  cssParts: [],
+};
+
+const mockDeprecatedDeclaration: CemDeclaration = {
+  kind: 'class',
+  name: 'HelixLegacy',
+  tagName: 'hx-legacy',
+  description: 'Old component.',
+  deprecated: 'Use hx-button instead.',
+  members: [],
+  slots: [],
+  events: [],
+  cssProperties: [],
+  cssParts: [],
+};
+
+const mockCem: Cem = {
+  schemaVersion: '1.0.0',
+  modules: [
+    {
+      kind: 'javascript-module',
+      path: 'src/components/hx-button/hx-button.ts',
+      declarations: [mockButtonDeclaration],
+    },
+    {
+      kind: 'javascript-module',
+      path: 'src/components/hx-card/hx-card.ts',
+      declarations: [mockCardDeclaration],
+    },
+    {
+      // Non-component module — should be skipped
+      kind: 'javascript-module',
+      path: 'src/utils/helpers.ts',
+      declarations: [
+        { kind: 'variable', name: 'CONSTANT', type: { text: 'string' } },
+      ],
+    },
+    {
+      // Explicitly non-javascript-module — should be skipped
+      kind: 'css-module',
+      path: 'src/tokens.css',
+      declarations: [],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// parseArgs
+// ---------------------------------------------------------------------------
+
+describe('parseArgs', () => {
+  it('returns defaults when no args provided', () => {
+    const args = parseArgs([]);
+    expect(args.cem).toBe('./custom-elements.json');
+    expect(args.output).toBe('./drupal/components');
+    expect(args.component).toBeNull();
+    expect(args.help).toBe(false);
+  });
+
+  it('parses --cem flag', () => {
+    const args = parseArgs(['--cem', '/path/to/cem.json']);
+    expect(args.cem).toBe('/path/to/cem.json');
+  });
+
+  it('parses --output flag', () => {
+    const args = parseArgs(['--output', '/tmp/drupal']);
+    expect(args.output).toBe('/tmp/drupal');
+  });
+
+  it('parses --component flag', () => {
+    const args = parseArgs(['--component', 'hx-button']);
+    expect(args.component).toBe('hx-button');
+  });
+
+  it('parses --help flag', () => {
+    expect(parseArgs(['--help']).help).toBe(true);
+    expect(parseArgs(['-h']).help).toBe(true);
+  });
+
+  it('parses all flags together', () => {
+    const args = parseArgs([
+      '--cem', './cem.json',
+      '--output', './out',
+      '--component', 'hx-card',
+    ]);
+    expect(args.cem).toBe('./cem.json');
+    expect(args.output).toBe('./out');
+    expect(args.component).toBe('hx-card');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mapCemTypeToJsonSchema
+// ---------------------------------------------------------------------------
+
+describe('mapCemTypeToJsonSchema', () => {
+  it('maps boolean', () => {
+    expect(mapCemTypeToJsonSchema('boolean')).toBe('boolean');
+    expect(mapCemTypeToJsonSchema('Boolean')).toBe('boolean');
+  });
+
+  it('maps number', () => {
+    expect(mapCemTypeToJsonSchema('number')).toBe('number');
+    expect(mapCemTypeToJsonSchema('NUMBER')).toBe('number');
+  });
+
+  it('maps string', () => {
+    expect(mapCemTypeToJsonSchema('string')).toBe('string');
+    expect(mapCemTypeToJsonSchema('STRING')).toBe('string');
+  });
+
+  it('maps union types to object', () => {
+    expect(mapCemTypeToJsonSchema("'primary' | 'secondary'")).toBe('object');
+    expect(mapCemTypeToJsonSchema('1 | 2 | 3')).toBe('object');
+  });
+
+  it('maps unknown types to object', () => {
+    expect(mapCemTypeToJsonSchema('HTMLElement')).toBe('object');
+    expect(mapCemTypeToJsonSchema('')).toBe('object');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractComponents
+// ---------------------------------------------------------------------------
+
+describe('extractComponents', () => {
+  it('extracts only class declarations with tagName', () => {
+    const components = extractComponents(mockCem);
+    expect(components).toHaveLength(2);
+    expect(components[0].tagName).toBe('hx-button');
+    expect(components[1].tagName).toBe('hx-card');
+  });
+
+  it('skips non-javascript-module kinds', () => {
+    const components = extractComponents(mockCem);
+    const tags = components.map((c) => c.tagName);
+    // css-module should not appear
+    expect(tags).not.toContain(undefined);
+  });
+
+  it('skips declarations without tagName', () => {
+    const components = extractComponents(mockCem);
+    // helpers.ts variable has no tagName
+    expect(components.every((c) => c.tagName !== undefined)).toBe(true);
+  });
+
+  it('returns empty array for empty CEM', () => {
+    const emptyCem: Cem = { schemaVersion: '1.0.0', modules: [] };
+    expect(extractComponents(emptyCem)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// transformDeclaration
+// ---------------------------------------------------------------------------
+
+describe('transformDeclaration', () => {
+  let component: SdcComponent;
+
+  beforeEach(() => {
+    component = transformDeclaration(mockButtonDeclaration);
+  });
+
+  it('sets tagName and name', () => {
+    expect(component.tagName).toBe('hx-button');
+    expect(component.name).toBe('HX Button');
+  });
+
+  it('sets description', () => {
+    expect(component.description).toBe('A versatile button component for user interactions.');
+  });
+
+  it('includes public attribute fields as props', () => {
+    const names = component.props.map((p) => p.name);
+    expect(names).toContain('variant');
+    expect(names).toContain('disabled');
+    expect(names).toContain('size');
+  });
+
+  it('excludes method members', () => {
+    const names = component.props.map((p) => p.name);
+    expect(names).not.toContain('focus');
+  });
+
+  it('excludes members without attribute property', () => {
+    // internals has no attribute property
+    const names = component.props.map((p) => p.name);
+    expect(names).not.toContain('internals');
+  });
+
+  it('excludes members starting with underscore', () => {
+    const names = component.props.map((p) => p.name);
+    expect(names).not.toContain('_internalState');
+  });
+
+  it('correctly maps boolean default', () => {
+    const disabledProp = component.props.find((p) => p.name === 'disabled');
+    expect(disabledProp?.type).toBe('boolean');
+    expect(disabledProp?.default).toBe(false);
+  });
+
+  it('correctly maps string default (strips quotes)', () => {
+    const variantProp = component.props.find((p) => p.name === 'variant');
+    expect(variantProp?.type).toBe('string');
+    expect(variantProp?.default).toBe('primary');
+  });
+
+  it('correctly maps number default', () => {
+    const sizeProp = component.props.find((p) => p.name === 'size');
+    expect(sizeProp?.type).toBe('number');
+    expect(sizeProp?.default).toBe(16);
+  });
+
+  it('maps slots correctly', () => {
+    expect(component.slots).toHaveLength(2);
+    const defaultSlot = component.slots.find((s) => s.name === '');
+    expect(defaultSlot?.title).toBe('Default');
+    const prefixSlot = component.slots.find((s) => s.name === 'prefix');
+    expect(prefixSlot?.title).toBe('Prefix');
+  });
+
+  it('passes through events', () => {
+    expect(component.events).toHaveLength(1);
+    expect(component.events[0].name).toBe('hx-click');
+  });
+
+  it('passes through cssProperties', () => {
+    expect(component.cssProperties).toHaveLength(1);
+    expect(component.cssProperties[0].name).toBe('--hx-button-bg');
+  });
+
+  it('passes through cssParts', () => {
+    expect(component.cssParts).toHaveLength(1);
+    expect(component.cssParts[0].name).toBe('button');
+  });
+
+  it('handles deprecated flag as string', () => {
+    const legacy = transformDeclaration(mockDeprecatedDeclaration);
+    expect(legacy.deprecated).toBe('Use hx-button instead.');
+  });
+
+  it('handles component with no members', () => {
+    const card = transformDeclaration(mockCardDeclaration);
+    expect(card.props).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateComponentYml
+// ---------------------------------------------------------------------------
+
+describe('generateComponentYml', () => {
+  let component: SdcComponent;
+  let yml: string;
+
+  beforeEach(() => {
+    component = transformDeclaration(mockButtonDeclaration);
+    yml = generateComponentYml(component);
+  });
+
+  it('includes $schema header', () => {
+    expect(yml).toContain('$schema:');
+    expect(yml).toContain('drupalcode.org');
+  });
+
+  it('includes component name', () => {
+    expect(yml).toContain('name: HX Button');
+  });
+
+  it('includes status and group', () => {
+    expect(yml).toContain('status: experimental');
+    expect(yml).toContain('group: HELiX');
+  });
+
+  it('includes props section', () => {
+    expect(yml).toContain('props:');
+    expect(yml).toContain('type: object');
+    expect(yml).toContain('properties:');
+    expect(yml).toContain('variant:');
+    expect(yml).toContain('disabled:');
+  });
+
+  it('includes slots section', () => {
+    expect(yml).toContain('slots:');
+    expect(yml).toContain('default:');
+    expect(yml).toContain('prefix:');
+  });
+
+  it('includes libraryOverrides', () => {
+    expect(yml).toContain('libraryOverrides: {}');
+  });
+
+  it('adds deprecated field for deprecated components', () => {
+    const legacy = transformDeclaration(mockDeprecatedDeclaration);
+    const legacyYml = generateComponentYml(legacy);
+    expect(legacyYml).toContain('deprecated:');
+    expect(legacyYml).toContain('Use hx-button instead.');
+  });
+
+  it('omits props section when no props', () => {
+    const card = transformDeclaration(mockCardDeclaration);
+    const cardYml = generateComponentYml(card);
+    expect(cardYml).not.toContain('props:');
+  });
+
+  it('omits slots section when no slots', () => {
+    const card = transformDeclaration(mockCardDeclaration);
+    const cardYml = generateComponentYml(card);
+    expect(cardYml).not.toContain('slots:');
+  });
+
+  it('writes boolean defaults without quotes', () => {
+    expect(yml).toContain('default: false');
+  });
+
+  it('writes string defaults with quotes', () => {
+    expect(yml).toContain("default: 'primary'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateTwig
+// ---------------------------------------------------------------------------
+
+describe('generateTwig', () => {
+  let component: SdcComponent;
+  let twig: string;
+
+  beforeEach(() => {
+    component = transformDeclaration(mockButtonDeclaration);
+    twig = generateTwig(component);
+  });
+
+  it('includes file docblock', () => {
+    expect(twig).toContain('{#');
+    expect(twig).toContain('@file');
+    expect(twig).toContain('HX Button');
+  });
+
+  it('opens the correct tag', () => {
+    expect(twig).toContain('<hx-button');
+  });
+
+  it('closes the correct tag', () => {
+    expect(twig).toContain('</hx-button>');
+  });
+
+  it('renders boolean attributes without value', () => {
+    expect(twig).toContain('{% if disabled %}disabled{% endif %}');
+  });
+
+  it('renders string attributes with value binding', () => {
+    expect(twig).toContain('variant="{{ variant }}"');
+  });
+
+  it('renders named slots with conditionals', () => {
+    expect(twig).toContain('{% if slots.prefix is defined %}');
+    expect(twig).toContain('<slot name="prefix">{{ slots.prefix }}</slot>');
+  });
+
+  it('renders default slot fallback', () => {
+    expect(twig).toContain('{% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}');
+  });
+
+  it('adds deprecation comment for deprecated components', () => {
+    const legacy = transformDeclaration(mockDeprecatedDeclaration);
+    const legacyTwig = generateTwig(legacy);
+    expect(legacyTwig).toContain('{# DEPRECATED:');
+  });
+
+  it('generates valid twig for component with no props or slots', () => {
+    const card = transformDeclaration(mockCardDeclaration);
+    const cardTwig = generateTwig(card);
+    expect(cardTwig).toContain('<hx-card>');
+    expect(cardTwig).toContain('</hx-card>');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateCss
+// ---------------------------------------------------------------------------
+
+describe('generateCss', () => {
+  let component: SdcComponent;
+  let css: string;
+
+  beforeEach(() => {
+    component = transformDeclaration(mockButtonDeclaration);
+    css = generateCss(component);
+  });
+
+  it('includes component name in header', () => {
+    expect(css).toContain('HX Button');
+  });
+
+  it('mentions adopted-stylesheets pattern', () => {
+    expect(css).toContain('@helixui/adopted-stylesheets');
+    expect(css).toContain('AdoptedStylesheetsController');
+  });
+
+  it('documents CSS custom properties', () => {
+    expect(css).toContain('--hx-button-bg');
+  });
+
+  it('includes host selector block', () => {
+    expect(css).toContain('hx-button {');
+    expect(css).toContain('display: block;');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateJs
+// ---------------------------------------------------------------------------
+
+describe('generateJs', () => {
+  let component: SdcComponent;
+  let js: string;
+
+  beforeEach(() => {
+    component = transformDeclaration(mockButtonDeclaration);
+    js = generateJs(component);
+  });
+
+  it('imports the component from @helixui/library', () => {
+    expect(js).toContain("import '@helixui/library/components/hx-button'");
+  });
+
+  it('checks for AdoptedStylesheetsController', () => {
+    expect(js).toContain('window.AdoptedStylesheetsController');
+  });
+
+  it('instantiates controller with tag name', () => {
+    expect(js).toContain("new window.AdoptedStylesheetsController('hx-button')");
+  });
+
+  it('guards against non-browser environments', () => {
+    expect(js).toContain("typeof window !== 'undefined'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateReadme
+// ---------------------------------------------------------------------------
+
+describe('generateReadme', () => {
+  let component: SdcComponent;
+  let readme: string;
+
+  beforeEach(() => {
+    component = transformDeclaration(mockButtonDeclaration);
+    readme = generateReadme(component);
+  });
+
+  it('has H1 heading with component name', () => {
+    expect(readme).toContain('# HX Button');
+  });
+
+  it('includes description', () => {
+    expect(readme).toContain('A versatile button component for user interactions.');
+  });
+
+  it('includes twig usage example', () => {
+    expect(readme).toContain("{% include 'helix:hx-button'");
+  });
+
+  it('includes props table', () => {
+    expect(readme).toContain('## Props');
+    expect(readme).toContain('| variant |');
+    expect(readme).toContain('| disabled |');
+  });
+
+  it('includes slots table', () => {
+    expect(readme).toContain('## Slots');
+    expect(readme).toContain('| (default) |');
+    expect(readme).toContain('| prefix |');
+  });
+
+  it('includes events table', () => {
+    expect(readme).toContain('## Events');
+    expect(readme).toContain('| hx-click |');
+  });
+
+  it('includes CSS custom properties table', () => {
+    expect(readme).toContain('## CSS Custom Properties');
+    expect(readme).toContain('| --hx-button-bg |');
+  });
+
+  it('includes CSS parts table', () => {
+    expect(readme).toContain('## CSS Parts');
+    expect(readme).toContain('| button |');
+  });
+
+  it('adds deprecation notice for deprecated components', () => {
+    const legacy = transformDeclaration(mockDeprecatedDeclaration);
+    const legacyReadme = generateReadme(legacy);
+    expect(legacyReadme).toContain('**Deprecated:**');
+    expect(legacyReadme).toContain('Use hx-button instead.');
+  });
+
+  it('omits empty sections', () => {
+    const card = transformDeclaration(mockCardDeclaration);
+    const cardReadme = generateReadme(card);
+    expect(cardReadme).not.toContain('## Props');
+    expect(cardReadme).not.toContain('## Slots');
+    expect(cardReadme).not.toContain('## Events');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+describe('toTitleCase', () => {
+  it('converts camelCase', () => {
+    expect(toTitleCase('backgroundColor')).toBe('Background Color');
+  });
+
+  it('converts kebab-case', () => {
+    expect(toTitleCase('my-prop-name')).toBe('My Prop Name');
+  });
+
+  it('handles single word', () => {
+    expect(toTitleCase('variant')).toBe('Variant');
+  });
+
+  it('handles snake_case', () => {
+    expect(toTitleCase('my_prop')).toBe('My Prop');
+  });
+});
+
+describe('toKebabCase', () => {
+  it('converts camelCase to kebab-case', () => {
+    expect(toKebabCase('backgroundColor')).toBe('background-color');
+  });
+
+  it('leaves already-kebab strings unchanged', () => {
+    expect(toKebabCase('variant')).toBe('variant');
+  });
+
+  it('handles leading capitals', () => {
+    expect(toKebabCase('MyProp')).toBe('my-prop');
+  });
+});
+
+describe('toHumanName', () => {
+  it('converts hx- tag to human name with HX prefix', () => {
+    expect(toHumanName('hx-button')).toBe('HX Button');
+    expect(toHumanName('hx-accordion-item')).toBe('HX Accordion Item');
+    expect(toHumanName('hx-text-input')).toBe('HX Text Input');
+  });
+});
+
+describe('escapeYamlString', () => {
+  it('escapes single quotes by doubling them', () => {
+    expect(escapeYamlString("it's a test")).toBe("it''s a test");
+  });
+
+  it('collapses newlines to spaces', () => {
+    expect(escapeYamlString('line one\nline two')).toBe('line one line two');
+  });
+
+  it('handles strings with no special chars', () => {
+    expect(escapeYamlString('normal string')).toBe('normal string');
+  });
+});

--- a/packages/hx-library/scripts/generate-sdc.ts
+++ b/packages/hx-library/scripts/generate-sdc.ts
@@ -1,0 +1,738 @@
+#!/usr/bin/env node
+/**
+ * generate-sdc.ts
+ *
+ * Reads the HELiX Custom Elements Manifest (custom-elements.json) and generates
+ * complete Drupal Single Directory Component (SDC) directories for each component.
+ *
+ * Usage:
+ *   tsx scripts/generate-sdc.ts [options]
+ *
+ * Options:
+ *   --cem <path>         Path to custom-elements.json (default: ./custom-elements.json)
+ *   --output <path>      Output directory (default: ./drupal/components)
+ *   --component <name>   Generate only a specific component by tag name (optional)
+ *   --help               Show help
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// CEM type definitions
+// ---------------------------------------------------------------------------
+
+export interface CemTypeRef {
+  text: string;
+}
+
+export interface CemMember {
+  kind: 'field' | 'method';
+  name: string;
+  type?: CemTypeRef;
+  default?: string;
+  description?: string;
+  attribute?: string;
+  reflects?: boolean;
+  deprecated?: boolean | string;
+  privacy?: 'private' | 'protected' | 'public';
+  static?: boolean;
+}
+
+export interface CemSlot {
+  name: string;
+  description?: string;
+}
+
+export interface CemEvent {
+  name: string;
+  description?: string;
+  type?: CemTypeRef;
+}
+
+export interface CemCssProperty {
+  name: string;
+  description?: string;
+  default?: string;
+}
+
+export interface CemCssPart {
+  name: string;
+  description?: string;
+}
+
+export interface CemDeclaration {
+  kind: string;
+  name: string;
+  tagName?: string;
+  description?: string;
+  summary?: string;
+  members?: CemMember[];
+  slots?: CemSlot[];
+  events?: CemEvent[];
+  cssProperties?: CemCssProperty[];
+  cssParts?: CemCssPart[];
+  deprecated?: boolean | string;
+}
+
+export interface CemModule {
+  kind: string;
+  path: string;
+  declarations?: CemDeclaration[];
+}
+
+export interface Cem {
+  schemaVersion: string;
+  modules: CemModule[];
+}
+
+// ---------------------------------------------------------------------------
+// SDC intermediate representation
+// ---------------------------------------------------------------------------
+
+export interface SdcProp {
+  name: string;
+  type: 'string' | 'boolean' | 'number' | 'object';
+  title: string;
+  description: string;
+  default: string | boolean | number | null;
+}
+
+export interface SdcSlot {
+  name: string;
+  title: string;
+  description: string;
+}
+
+export interface SdcComponent {
+  tagName: string;
+  name: string;
+  description: string;
+  deprecated: boolean | string;
+  props: SdcProp[];
+  slots: SdcSlot[];
+  events: CemEvent[];
+  cssProperties: CemCssProperty[];
+  cssParts: CemCssPart[];
+}
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+export interface CliArgs {
+  cem: string;
+  output: string;
+  component: string | null;
+  help: boolean;
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  const args: CliArgs = {
+    cem: './custom-elements.json',
+    output: './drupal/components',
+    component: null,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      args.help = true;
+    } else if (arg === '--cem' && argv[i + 1]) {
+      args.cem = argv[++i];
+    } else if (arg === '--output' && argv[i + 1]) {
+      args.output = argv[++i];
+    } else if (arg === '--component' && argv[i + 1]) {
+      args.component = argv[++i];
+    }
+  }
+
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// CEM parsing
+// ---------------------------------------------------------------------------
+
+export function loadCem(cemPath: string): Cem {
+  const raw = readFileSync(cemPath, 'utf-8');
+  return JSON.parse(raw) as Cem;
+}
+
+export function extractComponents(cem: Cem): CemDeclaration[] {
+  const components: CemDeclaration[] = [];
+
+  for (const module of cem.modules) {
+    if (module.kind !== 'javascript-module') continue;
+    if (!module.declarations) continue;
+
+    for (const decl of module.declarations) {
+      if (decl.kind !== 'class') continue;
+      if (!decl.tagName) continue;
+      components.push(decl);
+    }
+  }
+
+  return components;
+}
+
+// ---------------------------------------------------------------------------
+// Type mapping
+// ---------------------------------------------------------------------------
+
+export function mapCemTypeToJsonSchema(
+  typeText: string,
+): 'string' | 'boolean' | 'number' | 'object' {
+  const t = typeText.trim().toLowerCase();
+  if (t === 'boolean') return 'boolean';
+  if (t === 'number') return 'number';
+  if (t === 'string') return 'string';
+  return 'object';
+}
+
+// ---------------------------------------------------------------------------
+// Component → SdcComponent transformation
+// ---------------------------------------------------------------------------
+
+export function transformDeclaration(decl: CemDeclaration): SdcComponent {
+  const tagName = decl.tagName!;
+
+  // Build props from members that are public fields with an attribute binding.
+  const props: SdcProp[] = [];
+  for (const member of decl.members ?? []) {
+    if (member.kind !== 'field') continue;
+    if (!member.attribute) continue;
+    if (member.name === 'internals') continue;
+    if (member.name.startsWith('_')) continue;
+    if (member.privacy === 'private' || member.privacy === 'protected') continue;
+    if (member.static) continue;
+
+    const jsonSchemaType = mapCemTypeToJsonSchema(member.type?.text ?? 'string');
+    const rawDefault = member.default ?? null;
+
+    let parsedDefault: string | boolean | number | null = null;
+    if (rawDefault !== null) {
+      if (jsonSchemaType === 'boolean') {
+        parsedDefault = rawDefault === 'true';
+      } else if (jsonSchemaType === 'number') {
+        const n = parseFloat(rawDefault);
+        parsedDefault = isNaN(n) ? null : n;
+      } else if (jsonSchemaType === 'string') {
+        // Strip surrounding quotes if present
+        parsedDefault = rawDefault.replace(/^['"]|['"]$/g, '');
+      } else {
+        // object — keep as string representation
+        parsedDefault = rawDefault.replace(/^['"]|['"]$/g, '');
+      }
+    }
+
+    props.push({
+      name: member.name,
+      type: jsonSchemaType,
+      title: toTitleCase(member.name),
+      description: member.description ?? '',
+      default: parsedDefault,
+    });
+  }
+
+  // Build slots
+  const slots: SdcSlot[] = (decl.slots ?? []).map((slot) => ({
+    name: slot.name,
+    title: slot.name === '' ? 'Default' : toTitleCase(slot.name),
+    description: slot.description ?? '',
+  }));
+
+  return {
+    tagName,
+    name: toHumanName(tagName),
+    description: decl.description ?? decl.summary ?? '',
+    deprecated: decl.deprecated ?? false,
+    props,
+    slots,
+    events: decl.events ?? [],
+    cssProperties: decl.cssProperties ?? [],
+    cssParts: decl.cssParts ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// File generators
+// ---------------------------------------------------------------------------
+
+export function generateComponentYml(component: SdcComponent): string {
+  const lines: string[] = [];
+
+  lines.push(
+    `$schema: 'https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json'`,
+  );
+  lines.push(`name: ${component.name}`);
+  lines.push(`status: experimental`);
+  lines.push(`group: HELiX`);
+
+  if (component.deprecated) {
+    const msg =
+      typeof component.deprecated === 'string'
+        ? component.deprecated
+        : 'This component is deprecated.';
+    lines.push(`deprecated: '${escapeYamlString(msg)}'`);
+  }
+
+  if (component.description) {
+    lines.push(`description: '${escapeYamlString(component.description)}'`);
+  }
+
+  // Props
+  if (component.props.length > 0) {
+    lines.push(`props:`);
+    lines.push(`  type: object`);
+    lines.push(`  properties:`);
+
+    for (const prop of component.props) {
+      lines.push(`    ${prop.name}:`);
+      lines.push(`      type: ${prop.type}`);
+      lines.push(`      title: ${prop.title}`);
+      if (prop.description) {
+        lines.push(`      description: '${escapeYamlString(prop.description)}'`);
+      }
+      if (prop.default !== null) {
+        if (prop.type === 'boolean') {
+          lines.push(`      default: ${prop.default}`);
+        } else if (prop.type === 'number') {
+          lines.push(`      default: ${prop.default}`);
+        } else {
+          lines.push(`      default: '${escapeYamlString(String(prop.default))}'`);
+        }
+      }
+    }
+  }
+
+  // Slots
+  if (component.slots.length > 0) {
+    lines.push(`slots:`);
+    for (const slot of component.slots) {
+      const slotKey = slot.name === '' ? 'default' : slot.name;
+      lines.push(`  ${slotKey}:`);
+      lines.push(`    title: ${slot.title}`);
+      if (slot.description) {
+        lines.push(`    description: '${escapeYamlString(slot.description)}'`);
+      }
+    }
+  }
+
+  lines.push(`libraryOverrides: {}`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export function generateTwig(component: SdcComponent): string {
+  const lines: string[] = [];
+
+  // File docblock
+  lines.push(`{#`);
+  lines.push(` /**`);
+  lines.push(` * @file`);
+  lines.push(` * ${component.name} component template.`);
+  if (component.description) {
+    lines.push(` *`);
+    const descLines = component.description.split('\n');
+    for (const dl of descLines) {
+      lines.push(` * ${dl}`);
+    }
+  }
+  if (component.props.length > 0) {
+    lines.push(` *`);
+    lines.push(` * Available variables:`);
+    for (const prop of component.props) {
+      const singleLineDesc = prop.description.replace(/\n/g, ' ').trim();
+      lines.push(` * - ${prop.name}: ${prop.type} - ${singleLineDesc}`);
+    }
+  }
+  lines.push(` */`);
+  lines.push(`#}`);
+
+  // Deprecation notice
+  if (component.deprecated) {
+    const msg =
+      typeof component.deprecated === 'string'
+        ? component.deprecated
+        : 'This component is deprecated and will be removed in a future release.';
+    lines.push(`{# DEPRECATED: ${msg} #}`);
+  }
+
+  // Opening tag with attributes
+  const hasMultipleProps = component.props.length > 1;
+  if (hasMultipleProps) {
+    lines.push(`<${component.tagName}`);
+    for (const prop of component.props) {
+      if (prop.type === 'boolean') {
+        lines.push(`  {% if ${prop.name} %}${toKebabCase(prop.name)}{% endif %}`);
+      } else {
+        lines.push(
+          `  {% if ${prop.name} is defined and ${prop.name} is not empty %}${toKebabCase(prop.name)}="{{ ${prop.name} }}"{% endif %}`,
+        );
+      }
+    }
+    lines.push(`>`);
+  } else if (component.props.length === 1) {
+    const prop = component.props[0];
+    if (prop.type === 'boolean') {
+      lines.push(
+        `<${component.tagName} {% if ${prop.name} %}${toKebabCase(prop.name)}{% endif %}>`,
+      );
+    } else {
+      lines.push(
+        `<${component.tagName} {% if ${prop.name} is defined and ${prop.name} is not empty %}${toKebabCase(prop.name)}="{{ ${prop.name} }}"{% endif %}>`,
+      );
+    }
+  } else {
+    lines.push(`<${component.tagName}>`);
+  }
+
+  // Named slots
+  const namedSlots = component.slots.filter((s) => s.name !== '');
+  for (const slot of namedSlots) {
+    lines.push(`  {% if slots.${slot.name} is defined %}`);
+    lines.push(`    <slot name="${slot.name}">{{ slots.${slot.name} }}</slot>`);
+    lines.push(`  {% endif %}`);
+  }
+
+  // Default slot / content
+  const hasDefaultSlot = component.slots.some((s) => s.name === '');
+  if (hasDefaultSlot) {
+    lines.push(`  {% if content is defined %}{{ content }}{% else %}<slot></slot>{% endif %}`);
+  }
+
+  lines.push(`</${component.tagName}>`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export function generateCss(component: SdcComponent): string {
+  const lines: string[] = [];
+
+  lines.push(`/**`);
+  lines.push(` * ${component.name} component styles.`);
+  lines.push(` *`);
+  lines.push(` * This component uses the @helixui/adopted-stylesheets pattern.`);
+  lines.push(` * The JS file initializes AdoptedStylesheetsController which`);
+  lines.push(` * handles stylesheet adoption into the shadow DOM.`);
+
+  if (component.cssProperties.length > 0) {
+    lines.push(` *`);
+    lines.push(` * CSS Custom Properties:`);
+    for (const prop of component.cssProperties) {
+      const defaultNote = prop.default ? ` (default: ${prop.default})` : '';
+      lines.push(` * ${prop.name}: ${prop.description ?? ''}${defaultNote}`);
+    }
+  }
+
+  lines.push(` */`);
+  lines.push('');
+  lines.push(`/* Component host styles */`);
+  lines.push(`${component.tagName} {`);
+  lines.push(`  display: block;`);
+  lines.push(`}`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export function generateJs(component: SdcComponent): string {
+  const lines: string[] = [];
+
+  lines.push(`/**`);
+  lines.push(` * ${component.name} - Drupal SDC integration.`);
+  lines.push(` * Registers the custom element and initializes adopted stylesheets.`);
+  lines.push(` */`);
+  lines.push(`import '@helixui/library/components/${component.tagName}';`);
+  lines.push('');
+  lines.push(`// Initialize adopted stylesheets for shadow DOM style injection`);
+  lines.push(`// @see https://www.drupal.org/project/adopted_stylesheets`);
+  lines.push(`if (typeof window !== 'undefined' && window.AdoptedStylesheetsController) {`);
+  lines.push(`  new window.AdoptedStylesheetsController('${component.tagName}');`);
+  lines.push(`}`);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+export function generateReadme(component: SdcComponent): string {
+  const lines: string[] = [];
+
+  lines.push(`# ${component.name}`);
+  lines.push('');
+
+  if (component.deprecated) {
+    const msg =
+      typeof component.deprecated === 'string'
+        ? component.deprecated
+        : 'This component is deprecated and will be removed in a future release.';
+    lines.push(`> **Deprecated:** ${msg}`);
+    lines.push('');
+  }
+
+  if (component.description) {
+    lines.push(component.description);
+    lines.push('');
+  }
+
+  // Usage example
+  lines.push(`## Usage`);
+  lines.push('');
+  lines.push('```twig');
+  lines.push(`{% include 'helix:${component.tagName}' with {`);
+  for (const prop of component.props) {
+    const val =
+      prop.type === 'boolean'
+        ? (prop.default ?? false)
+        : prop.type === 'number'
+          ? (prop.default ?? 0)
+          : `'${prop.default ?? ''}'`;
+    lines.push(`  ${prop.name}: ${val},`);
+  }
+  lines.push(`} %}`);
+  lines.push('```');
+  lines.push('');
+
+  // Props table
+  if (component.props.length > 0) {
+    lines.push(`## Props`);
+    lines.push('');
+    lines.push(`| Prop | Type | Default | Description |`);
+    lines.push(`|------|------|---------|-------------|`);
+    for (const prop of component.props) {
+      const def = prop.default !== null ? String(prop.default) : '-';
+      lines.push(`| ${prop.name} | ${prop.type} | ${def} | ${prop.description} |`);
+    }
+    lines.push('');
+  }
+
+  // Slots table
+  if (component.slots.length > 0) {
+    lines.push(`## Slots`);
+    lines.push('');
+    lines.push(`| Slot | Description |`);
+    lines.push(`|------|-------------|`);
+    for (const slot of component.slots) {
+      const slotLabel = slot.name === '' ? '(default)' : slot.name;
+      lines.push(`| ${slotLabel} | ${slot.description} |`);
+    }
+    lines.push('');
+  }
+
+  // Events table
+  if (component.events.length > 0) {
+    lines.push(`## Events`);
+    lines.push('');
+    lines.push(`| Event | Description |`);
+    lines.push(`|-------|-------------|`);
+    for (const event of component.events) {
+      lines.push(`| ${event.name} | ${event.description ?? ''} |`);
+    }
+    lines.push('');
+  }
+
+  // CSS Custom Properties table
+  if (component.cssProperties.length > 0) {
+    lines.push(`## CSS Custom Properties`);
+    lines.push('');
+    lines.push(`| Property | Default | Description |`);
+    lines.push(`|----------|---------|-------------|`);
+    for (const prop of component.cssProperties) {
+      lines.push(`| ${prop.name} | ${prop.default ?? '-'} | ${prop.description ?? ''} |`);
+    }
+    lines.push('');
+  }
+
+  // CSS Parts table
+  if (component.cssParts.length > 0) {
+    lines.push(`## CSS Parts`);
+    lines.push('');
+    lines.push(`| Part | Description |`);
+    lines.push(`|------|-------------|`);
+    for (const part of component.cssParts) {
+      lines.push(`| ${part.name} | ${part.description ?? ''} |`);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Directory writer
+// ---------------------------------------------------------------------------
+
+export function writeComponentFiles(outputDir: string, component: SdcComponent): void {
+  const dir = join(outputDir, component.tagName);
+  mkdirSync(dir, { recursive: true });
+
+  writeFileSync(
+    join(dir, `${component.tagName}.component.yml`),
+    generateComponentYml(component),
+    'utf-8',
+  );
+  writeFileSync(join(dir, `${component.tagName}.twig`), generateTwig(component), 'utf-8');
+  writeFileSync(join(dir, `${component.tagName}.css`), generateCss(component), 'utf-8');
+  writeFileSync(join(dir, `${component.tagName}.js`), generateJs(component), 'utf-8');
+  writeFileSync(join(dir, 'README.md'), generateReadme(component), 'utf-8');
+}
+
+// ---------------------------------------------------------------------------
+// Utility helpers
+// ---------------------------------------------------------------------------
+
+export function toTitleCase(str: string): string {
+  return str
+    .replace(/([A-Z])/g, ' $1')
+    .replace(/[-_]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function toKebabCase(str: string): string {
+  return str
+    .replace(/([A-Z])/g, '-$1')
+    .toLowerCase()
+    .replace(/^-/, '');
+}
+
+export function toHumanName(tagName: string): string {
+  // e.g. "hx-accordion-item" → "HX Accordion Item"
+  return tagName
+    .split('-')
+    .map((part) => {
+      if (part === 'hx') return 'HX';
+      return part.charAt(0).toUpperCase() + part.slice(1);
+    })
+    .join(' ');
+}
+
+export function escapeYamlString(str: string): string {
+  return str.replace(/'/g, "''").replace(/\n/g, ' ');
+}
+
+// ---------------------------------------------------------------------------
+// Help text
+// ---------------------------------------------------------------------------
+
+function printHelp(): void {
+  console.log(`
+generate-sdc — HELiX SDC Generator
+
+Reads the Custom Elements Manifest and generates Drupal Single Directory
+Component (SDC) directories for each web component.
+
+Usage:
+  tsx scripts/generate-sdc.ts [options]
+
+Options:
+  --cem <path>         Path to custom-elements.json
+                       (default: ./custom-elements.json)
+  --output <path>      Output directory for generated SDC components
+                       (default: ./drupal/components)
+  --component <name>   Generate only the specified component by tag name
+                       e.g. --component hx-button
+  --help               Show this help message
+
+Examples:
+  tsx scripts/generate-sdc.ts
+  tsx scripts/generate-sdc.ts --cem ./custom-elements.json --output ./drupal/components
+  tsx scripts/generate-sdc.ts --component hx-button
+`);
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const args = parseArgs(argv);
+
+  if (args.help) {
+    printHelp();
+    process.exit(0);
+  }
+
+  // Resolve CEM path relative to cwd if not absolute
+  const cemPath = args.cem.startsWith('/') ? args.cem : join(process.cwd(), args.cem);
+  const outputPath = args.output.startsWith('/') ? args.output : join(process.cwd(), args.output);
+
+  if (!existsSync(cemPath)) {
+    console.error(`Error: CEM file not found at ${cemPath}`);
+    console.error(`Run \`pnpm run cem\` first to generate the Custom Elements Manifest.`);
+    process.exit(1);
+  }
+
+  console.log(`Reading CEM from: ${cemPath}`);
+  console.log(`Writing SDC components to: ${outputPath}`);
+
+  let cem: Cem;
+  try {
+    cem = loadCem(cemPath);
+  } catch (err) {
+    console.error(
+      `Error: Failed to parse CEM file: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exit(1);
+  }
+
+  const allDeclarations = extractComponents(cem);
+
+  if (allDeclarations.length === 0) {
+    console.warn('Warning: No components with tagName found in CEM.');
+    process.exit(0);
+  }
+
+  // Filter by --component if specified
+  const declarations =
+    args.component !== null
+      ? allDeclarations.filter((d) => d.tagName === args.component)
+      : allDeclarations;
+
+  if (args.component !== null && declarations.length === 0) {
+    console.error(`Error: Component '${args.component}' not found in CEM.`);
+    console.error(`Available components: ${allDeclarations.map((d) => d.tagName).join(', ')}`);
+    process.exit(1);
+  }
+
+  mkdirSync(outputPath, { recursive: true });
+
+  let generated = 0;
+  let skipped = 0;
+
+  for (const decl of declarations) {
+    try {
+      const component = transformDeclaration(decl);
+      writeComponentFiles(outputPath, component);
+      const deprecatedNote = component.deprecated ? ' (deprecated)' : '';
+      console.log(`  Generated: ${component.tagName}${deprecatedNote}`);
+      generated++;
+    } catch (err) {
+      console.error(
+        `  Error generating ${decl.tagName}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      skipped++;
+    }
+  }
+
+  console.log('');
+  console.log(
+    `Done. Generated ${generated} component(s).${skipped > 0 ? ` Skipped ${skipped} due to errors.` : ''}`,
+  );
+}
+
+// Run main only when executed directly (not imported for tests)
+const isMain =
+  process.argv[1] &&
+  fileURLToPath(import.meta.url).endsWith(process.argv[1].split('/').pop() ?? '');
+
+if (isMain) {
+  main();
+}

--- a/packages/hx-library/vitest.config.scripts.ts
+++ b/packages/hx-library/vitest.config.scripts.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest configuration for scripts/ unit tests.
+ *
+ * These tests run in a Node.js environment (not browser mode) because they
+ * test pure TypeScript utilities — file I/O, string manipulation, CEM parsing —
+ * that have no browser dependency.
+ */
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['scripts/__tests__/**/*.test.ts'],
+    exclude: ['node_modules/**'],
+    reporters: ['verbose'],
+    globals: true,
+    testTimeout: 15000,
+  },
+});


### PR DESCRIPTION
## Summary

Build a tool that reads the HELiX Custom Elements Manifest (custom-elements.json) and generates complete Drupal SDC directories for each component.

**For each HELiX component (e.g., hx-button), generate:**

```
components/hx-button/
├── hx-button.component.yml    # SDC manifest (props from CEM, slots, metadata)
├── hx-button.twig             # Twig template rendering <hx-button> with variables
├── hx-button.css              # Extracted component styles + adopted stylesheet setup
├── hx-button.j...

---
*Recovered automatically by Automaker post-agent hook*