### PR TITLE
fix(a11y): remove invalid role from hx-step and add aria-live announcements

### DIFF
--- a/.changeset/a11y-hx-steps-remove-invalid-role-1743120000.md
+++ b/.changeset/a11y-hx-steps-remove-invalid-role-1743120000.md
@@ -1,0 +1,9 @@
+---
+'@helixui/library': patch
+---
+
+fix invalid role="button" on hx-step inner div and add aria-live status announcements
+
+- STEPS-001: remove role="button" from the inner .step div — the host element already has role="listitem" and tabindex="0"; the inner div is purely presentational and the duplicate role caused role/focus mismatch for screen readers
+- STEPS-003: add aria-live="polite" region in hx-step shadow DOM that announces status transitions to "complete" or "error" so screen readers are notified when step status changes programmatically
+- STEPS-002: add devWarn in hx-steps connectedCallback() when aria-label is null or empty, guiding developers to provide an accessible name for the steps list (WCAG 2.1 SC 4.1.2)

--- a/packages/hx-library/src/components/hx-steps/hx-step.ts
+++ b/packages/hx-library/src/components/hx-steps/hx-step.ts
@@ -1,5 +1,5 @@
 import { LitElement, html, type PropertyValues } from 'lit';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { tokenStyles } from '@helixui/tokens/lit';
 import { helixStepStyles } from './hx-step.styles.js';
 
@@ -95,6 +95,10 @@ export class HelixStep extends LitElement {
   @property({ type: Number })
   index = 0;
 
+  /** Text for the aria-live region, updated when status transitions to complete or error. */
+  /** @internal */
+  @state() private _liveMessage = '';
+
   // ─── Lifecycle ───
 
   override connectedCallback(): void {
@@ -118,6 +122,18 @@ export class HelixStep extends LitElement {
         this.setAttribute('aria-current', 'step');
       } else {
         this.removeAttribute('aria-current');
+      }
+      // STEPS-003: announce status transitions to screen readers via aria-live region.
+      // Only announce on transitions (not initial render) by checking the previous value.
+      const prev = changedProperties.get('status');
+      if (prev !== undefined) {
+        if (this.status === 'complete') {
+          this._liveMessage = 'Complete';
+        } else if (this.status === 'error') {
+          this._liveMessage = 'Error';
+        } else {
+          this._liveMessage = '';
+        }
       }
     }
     if (changedProperties.has('disabled')) {
@@ -217,7 +233,7 @@ export class HelixStep extends LitElement {
 
   override render() {
     return html`
-      <div part="base" class="step" role="button" @click=${this._handleClick}>
+      <div part="base" class="step" @click=${this._handleClick}>
         <div class="step__track">
           <div part="indicator" class="step__indicator">${this._renderIndicatorContent()}</div>
           <div part="connector" class="step__connector" aria-hidden="true"></div>
@@ -231,6 +247,7 @@ export class HelixStep extends LitElement {
           </div>
         </div>
       </div>
+      <div aria-live="polite" aria-atomic="true" class="sr-only">${this._liveMessage}</div>
     `;
   }
 }

--- a/packages/hx-library/src/components/hx-steps/hx-steps.test.ts
+++ b/packages/hx-library/src/components/hx-steps/hx-steps.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { page } from '@vitest/browser/context';
 import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixSteps } from './hx-steps.js';
@@ -61,6 +61,27 @@ describe('hx-steps', () => {
     it('renders default size=md', async () => {
       const el = await fixture<HelixSteps>(THREE_STEPS_HTML);
       expect(el.size).toBe('md');
+    });
+
+    it('STEPS-002: warns in dev when aria-label is missing', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await fixture<HelixSteps>(
+        '<hx-steps><hx-step label="A" status="pending"></hx-step></hx-steps>',
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('aria-label'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('STEPS-002: does not warn when aria-label is provided', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      await fixture<HelixSteps>(THREE_STEPS_HTML);
+      const ariaLabelWarning = warnSpy.mock.calls.find((args) =>
+        String(args[0]).includes('aria-label'),
+      );
+      expect(ariaLabelWarning).toBeUndefined();
+      warnSpy.mockRestore();
     });
   });
 
@@ -261,6 +282,18 @@ describe('hx-step', () => {
       expect(connector?.getAttribute('aria-hidden')).toBe('true');
     });
 
+    it('STEPS-001: inner .step div does not have role="button"', async () => {
+      const el = await fixture<HelixStep>('<hx-step label="Test" status="pending"></hx-step>');
+      const base = shadowQuery(el, '[part~="base"]');
+      expect(base?.getAttribute('role')).toBeNull();
+    });
+
+    it('STEPS-003: renders an aria-live="polite" region in shadow DOM', async () => {
+      const el = await fixture<HelixStep>('<hx-step label="Test" status="pending"></hx-step>');
+      const live = el.shadowRoot?.querySelector('[aria-live="polite"]');
+      expect(live).toBeTruthy();
+    });
+
     it('displays step number (index + 1) when pending', async () => {
       const el = await fixture<HelixStep>('<hx-step label="Test" status="pending"></hx-step>');
       el.index = 2;
@@ -328,6 +361,31 @@ describe('hx-step', () => {
       const indicator = shadowQuery(el, '[part~="indicator"]');
       const srOnly = indicator?.querySelector('.sr-only');
       expect(srOnly?.textContent).toBe('Error');
+    });
+
+    it('STEPS-003: aria-live region announces "Complete" when status transitions to complete', async () => {
+      const el = await fixture<HelixStep>('<hx-step label="Test" status="active"></hx-step>');
+      await el.updateComplete;
+      el.status = 'complete';
+      await el.updateComplete;
+      const live = el.shadowRoot?.querySelector('[aria-live="polite"]');
+      expect(live?.textContent?.trim()).toBe('Complete');
+    });
+
+    it('STEPS-003: aria-live region announces "Error" when status transitions to error', async () => {
+      const el = await fixture<HelixStep>('<hx-step label="Test" status="active"></hx-step>');
+      await el.updateComplete;
+      el.status = 'error';
+      await el.updateComplete;
+      const live = el.shadowRoot?.querySelector('[aria-live="polite"]');
+      expect(live?.textContent?.trim()).toBe('Error');
+    });
+
+    it('STEPS-003: aria-live region is empty on initial render', async () => {
+      const el = await fixture<HelixStep>('<hx-step label="Test" status="complete"></hx-step>');
+      await el.updateComplete;
+      const live = el.shadowRoot?.querySelector('[aria-live="polite"]');
+      expect(live?.textContent?.trim()).toBe('');
     });
   });
 

--- a/packages/hx-library/src/components/hx-steps/hx-steps.ts
+++ b/packages/hx-library/src/components/hx-steps/hx-steps.ts
@@ -66,6 +66,14 @@ export class HelixSteps extends LitElement {
       devWarn('hx-steps', 'The "size" attribute is deprecated. Use "hx-size" instead.');
       this.size = legacySize as 'sm' | 'md' | 'lg';
     }
+    // STEPS-002: WCAG 2.1 SC 4.1.2 — the inner list must have an accessible name.
+    // Warn developers when aria-label is missing so the list is not anonymous.
+    if (!this.ariaLabel) {
+      devWarn(
+        'hx-steps',
+        'An "aria-label" attribute is required to provide an accessible name for the steps list (WCAG 2.1 SC 4.1.2).',
+      );
+    }
     // WCAG 4.1.2: suppress the host element's implicit ARIA role so only the
     // inner div[role="list"] is announced. Mirrors the hx-action-bar pattern.
     // Without this, the consumer's aria-label attribute on the host causes dual


### PR DESCRIPTION
## Summary

- **STEPS-001 (CRITICAL):** Remove `role="button"` from the inner `.step` div in `hx-step.ts`. The host element already has `role="listitem"` and `tabindex="0"`, making the inner div purely presentational. The duplicate role caused a role/focus mismatch where screen readers announced "button" but focus was on a listitem.
- **STEPS-003 (HIGH):** Add an `aria-live="polite"` region to `hx-step` shadow DOM. When status transitions to `complete` or `error` via JavaScript, the live region text is updated to announce the change — previously screen readers were only informed when the user manually navigated to that element.
- **STEPS-002 (HIGH):** Add `devWarn` in `hx-steps.connectedCallback()` when `aria-label` is null/empty, guiding developers to provide an accessible name for the steps list (WCAG 2.1 SC 4.1.2).

## Files changed

- `packages/hx-library/src/components/hx-steps/hx-step.ts` — remove `role="button"`, add `@state() _liveMessage`, update `updated()` to set live message on status transitions, add aria-live div in `render()`
- `packages/hx-library/src/components/hx-steps/hx-steps.ts` — add `devWarn` for missing `aria-label` in `connectedCallback()`
- `packages/hx-library/src/components/hx-steps/hx-steps.test.ts` — add tests for STEPS-001, STEPS-002, STEPS-003 findings

## Test plan

- [ ] Verify axe-core tests still pass (no new role violations since `role="button"` is removed)
- [ ] Verify STEPS-001: `[part~="base"]` div has no `role` attribute
- [ ] Verify STEPS-002: `console.warn` fires when `hx-steps` rendered without `aria-label`
- [ ] Verify STEPS-003: `[aria-live="polite"]` region announces `Complete`/`Error` on status transitions, empty on initial render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an invalid duplicate role on step items to improve semantic HTML and keyboard behavior.

* **New Features**
  * Added an aria-live announcement region to notify screen readers when a step becomes Complete or Error.

* **Chores**
  * Added a developer warning when a steps list is missing an accessible label.

* **Tests**
  * Added accessibility tests to verify announcements, role changes, and the developer warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->