### PR TITLE
fix(cem): add missing @csspart jsdoc for hx-drawer, hx-slider, hx-time-picker

### DIFF
--- a/.changeset/fix-cem-css-parts-missing-1775004637.md
+++ b/.changeset/fix-cem-css-parts-missing-1775004637.md
@@ -1,0 +1,14 @@
+---
+'@helixui/library': patch
+---
+
+fix(cem): add missing @csspart JSDoc annotations to hx-drawer, hx-slider, hx-time-picker
+
+Resolves 14 CEM API Diff validation errors caused by CSS parts declared in
+component templates (`part="..."`) that were not documented in `@csspart` JSDoc
+blocks, causing the manifest to omit them from `cssParts`.
+
+Components fixed:
+- `hx-drawer`: added `@csspart close-btn` (visually-hidden close button rendered when `noHeader` is true)
+- `hx-slider`: added `@csspart help-text` (help text element below the slider)
+- `hx-time-picker`: added `@csspart field`, `@csspart error`, `@csspart help-text`


### PR DESCRIPTION
## Summary

- Adds patch changeset documenting 14 CEM validation errors caused by CSS parts declared in component templates (`part="..."`) that lacked `@csspart` JSDoc annotations
- The source fixes were applied in a prior commit (`bc9033b9`); this PR formalizes the change through the changeset pipeline

**Components fixed:**
- `hx-drawer`: `@csspart close-btn` — visually-hidden close button rendered when `noHeader` is true
- `hx-slider`: `@csspart help-text` — help text element below the slider
- `hx-time-picker`: `@csspart field`, `@csspart error`, `@csspart help-text`

**Verification:**
```
pnpm run cem && node scripts/validate-cem.mjs
→ All 102 component(s) passed CEM validation.
```

## Test plan
- [ ] CI passes `cem` job: `pnpm run cem` exits 0, `validate-cem.mjs` confirms all 102 components pass
- [ ] CEM API Diff job runs without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored missing CSS part documentation for component styling: added entries for the drawer close button, the slider help text, and the time-picker field, error, and help-text parts so these parts appear in CSS customization manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->