### PR TITLE
fix(components): restore @query getter for hx-number-input and hx-slider

### DIFF
--- a/.changeset/fix-query-declare-shadowing.md
+++ b/.changeset/fix-query-declare-shadowing.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+fix(hx-number-input, hx-slider): use `declare` on @query fields to prevent instance initializer from shadowing Lit's prototype getter

--- a/packages/hx-library/src/components/hx-number-input/hx-number-input.ts
+++ b/packages/hx-library/src/components/hx-number-input/hx-number-input.ts
@@ -194,7 +194,7 @@ export class HelixNumberInput extends LitElement {
 
   /** @internal */
   @query('.field__input')
-  private _input: HTMLInputElement | null = null;
+  declare private _input: HTMLInputElement | null;
 
   // ─── Internal State ───
 

--- a/packages/hx-library/src/components/hx-slider/hx-slider.ts
+++ b/packages/hx-library/src/components/hx-slider/hx-slider.ts
@@ -184,7 +184,7 @@ export class HelixSlider extends LitElement {
    * @internal
    */
   @query('.slider__input')
-  private _input: HTMLInputElement | null = null;
+  declare private _input: HTMLInputElement | null;
 
   // ─── Unique IDs ───
 


### PR DESCRIPTION
## Summary

- `@query('.field__input') private _input: HTMLInputElement | null = null` — the `= null` instance initializer shadows Lit's `@query` getter on the prototype, causing `_input` to always return `null`
- This broke `hx-number-input` and `hx-slider`: focus, select, and all internal input access silently failed
- Regression introduced in `02460b314` (CodeRabbit feedback remediation in #1389)
- Fix: `declare private _input: HTMLInputElement | null` — TypeScript `declare` modifier prevents an initializer from being emitted, preserving the `@query` getter

## Test plan

- [ ] `pnpm run test:smart` — hx-number-input and hx-slider test suites pass (particularly `reflects numeric value on the native input` which was timing out)
- [ ] `pnpm run type-check` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)