### PR TITLE
promote: remove orphaned changeset blocking publish

### DIFF
--- a/.changeset/fix-storybook-browser-disconnect-ci.md
+++ b/.changeset/fix-storybook-browser-disconnect-ci.md
@@ -1,5 +1,0 @@
----
-'@helixui/storybook': patch
----
-
-fix(ci): prevent storybook browser disconnection by running story files sequentially in CI

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 # ============================================================================
 # Publish Pipeline — wc-2026 Enterprise Healthcare Web Component Library
 # ============================================================================
-# Triggers on push to main. If unreleased changesets exist, bumps versions
+# Triggers on push to main or manual dispatch. If unreleased changesets exist, bumps versions
 # and publishes to npm directly. Version bump is pushed back via a PR.
 #
 # Tests are NOT re-run here — CI (ci.yml + ci-matrix.yml) already validates


### PR DESCRIPTION
Removes orphaned changeset for private package @helixui/storybook that was blocking the publish pipeline. Private packages are skipped by changeset version, but the file caused the action to enter version-PR mode instead of publish mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed a release metadata entry related to Storybook.
* **Documentation**
  * Clarified workflow trigger wording to reflect both push and manual dispatch options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->