### PR TITLE
docs: update all tokenStyles references for adopted stylesheets

### DIFF
--- a/.changeset/docs-adopted-stylesheets-update.md
+++ b/.changeset/docs-adopted-stylesheets-update.md
@@ -1,0 +1,6 @@
+---
+'@helixui/tokens': patch
+'@helixui/library': patch
+---
+
+docs: update all tokenStyles references for adopted stylesheets architecture; deprecate tokenStyles in @helixui/tokens

--- a/apps/docs/src/content/docs/components-guide/advanced/composition-patterns.md
+++ b/apps/docs/src/content/docs/components-guide/advanced/composition-patterns.md
@@ -74,12 +74,10 @@ Mixin application order matters for the prototype chain. Mixins applied last in 
 ```typescript
 import { LitElement, html, nothing } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { mixinDelegatesAria } from '../../mixins/index.js';
 
 @customElement('hx-icon-button')
 export class HelixIconButton extends mixinDelegatesAria(LitElement) {
-  static override styles = [tokenStyles];
 
   override render() {
     return html`
@@ -109,7 +107,6 @@ When a consumer sets `aria-label="Close"` on `<hx-icon-button>`, the mixin inter
 ```typescript
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 // Controller for viewport-based lazy rendering
 class IntersectionController {
@@ -139,8 +136,6 @@ class IntersectionController {
 
 @customElement('hx-lazy-image')
 export class HelixLazyImage extends LitElement {
-  static override styles = [tokenStyles];
-
   private _intersection = new IntersectionController(this);
 
   override render() {
@@ -160,8 +155,6 @@ Named slots are the primary mechanism for composing component trees. Rather than
 ```typescript
 @customElement('hx-card')
 export class HelixCard extends LitElement {
-  static override styles = [tokenStyles];
-
   override render() {
     return html`
       <article class="card">

--- a/apps/docs/src/content/docs/components-guide/advanced/context-protocol.md
+++ b/apps/docs/src/content/docs/components-guide/advanced/context-protocol.md
@@ -40,12 +40,10 @@ Use the `@provide` decorator (or the `ContextProvider` controller) to make a val
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { provide } from '@lit/context';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { themeContext, localeContext } from './contexts.js';
 
 @customElement('hx-design-system-provider')
 export class HelixDesignSystemProvider extends LitElement {
-  static override styles = [tokenStyles];
 
   // The @provide decorator makes this.theme available to all descendants
   // that consume themeContext
@@ -83,12 +81,10 @@ Use the `@consume` decorator to receive a context value from the nearest ancesto
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { consume } from '@lit/context';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { themeContext } from './contexts.js';
 
 @customElement('hx-themed-button')
 export class HelixThemedButton extends LitElement {
-  static override styles = [tokenStyles];
 
   // Receives theme from the nearest ancestor hx-design-system-provider
   // The ! (definite assignment) is required because the value arrives after construction

--- a/apps/docs/src/content/docs/components-guide/advanced/controllers.md
+++ b/apps/docs/src/content/docs/components-guide/advanced/controllers.md
@@ -66,13 +66,10 @@ Usage in a component:
 ```typescript
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { MouseTrackController } from './mouse-track-controller.js';
 
 @customElement('hx-cursor-display')
 export class HelixCursorDisplay extends LitElement {
-  static override styles = [tokenStyles];
-
   private _mouse = new MouseTrackController(this);
 
   override render(): TemplateResult {
@@ -160,19 +157,15 @@ Usage:
 ```typescript
 import { LitElement, html, css, type TemplateResult } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { ResizeController } from './resize-controller.js';
 
 @customElement('hx-responsive-container')
 export class HelixResponsiveContainer extends LitElement {
-  static override styles = [
-    tokenStyles,
-    css`
-      :host { display: block; }
-      .compact { font-size: var(--hx-font-size-sm); }
-      .spacious { font-size: var(--hx-font-size-base); }
-    `,
-  ];
+  static override styles = css`
+    :host { display: block; }
+    .compact { font-size: var(--hx-font-size-sm); }
+    .spacious { font-size: var(--hx-font-size-base); }
+  `;
 
   private _resize = new ResizeController(this);
 
@@ -215,8 +208,6 @@ Controllers compose without conflict. Each registers independently and runs its 
 ```typescript
 @customElement('hx-data-chart')
 export class HelixDataChart extends LitElement {
-  static override styles = [tokenStyles];
-
   // Two independent controllers — no coupling between them
   private _resize = new ResizeController(this);
   private _intersection = new IntersectionController(this, 0.25);

--- a/apps/docs/src/content/docs/components-guide/advanced/mixins.md
+++ b/apps/docs/src/content/docs/components-guide/advanced/mixins.md
@@ -73,7 +73,6 @@ import { mixinDelegatesAria } from '../../mixins/index.js';
 // Applied directly on LitElement — no other base class needed
 @customElement('hx-button')
 export class HelixButton extends mixinDelegatesAria(LitElement) {
-  static override styles = [tokenStyles];
 
   override render() {
     return html`
@@ -107,7 +106,6 @@ import { FocusMixin } from '../../mixins/FocusMixin.js';
 
 @customElement('hx-text-input')
 export class HelixTextInput extends FocusMixin(mixinDelegatesAria(LitElement)) {
-  static override styles = [tokenStyles];
 
   @query('input')
   private _inputEl: HTMLInputElement | null = null;

--- a/apps/docs/src/content/docs/components-guide/advanced/tasks.md
+++ b/apps/docs/src/content/docs/components-guide/advanced/tasks.md
@@ -23,7 +23,6 @@ A `Task` is constructed with the host element, a task function, and an `args` fu
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { Task } from '@lit/task';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 interface UserProfile {
   id: string;
@@ -34,8 +33,6 @@ interface UserProfile {
 
 @customElement('hx-user-card')
 export class HelixUserCard extends LitElement {
-  static override styles = [tokenStyles];
-
   @property({ type: String })
   userId: string = '';
 
@@ -140,11 +137,9 @@ Caught errors are available as `task.error`. To add retry behavior, expose a met
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { Task } from '@lit/task';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-data-table')
 export class HelixDataTable extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   endpoint: string = '';
@@ -206,7 +201,6 @@ import { helixConfigContext, type HelixConfig } from './contexts.js';
 
 @customElement('hx-config-driven-list')
 export class HelixConfigDrivenList extends LitElement {
-  static override styles = [tokenStyles];
 
   @consume({ context: helixConfigContext, subscribe: true })
   helixConfig!: HelixConfig;

--- a/apps/docs/src/content/docs/components-guide/events/custom-events.md
+++ b/apps/docs/src/content/docs/components-guide/events/custom-events.md
@@ -12,11 +12,10 @@ Use the `CustomEvent` constructor and dispatch it with `this.dispatchEvent()`:
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-counter')
 export class HelixCounter extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   @property({ type: Number }) value = 0;
 

--- a/apps/docs/src/content/docs/components-guide/events/delegation.md
+++ b/apps/docs/src/content/docs/components-guide/events/delegation.md
@@ -12,11 +12,10 @@ Attach the listener to the shadow root's container element rather than each indi
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-nav')
 export class HelixNav extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   // Single handler on the container — not on each <button>
   private _handleClick(e: MouseEvent) {

--- a/apps/docs/src/content/docs/components-guide/events/event-bus.md
+++ b/apps/docs/src/content/docs/components-guide/events/event-bus.md
@@ -51,13 +51,12 @@ export const helixBus = new HelixBus();
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { helixBus } from '../bus/helix-bus.js';
 
 // Publisher component — emits filter changes
 @customElement('hx-filter-bar')
 export class HelixFilterBar extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   private _applyFilters(filters: Record<string, string>) {
     helixBus.emit('hx-filter-change', { filters });
@@ -80,7 +79,7 @@ export class HelixFilterBar extends LitElement {
 // Subscriber component — reacts to filter changes
 @customElement('hx-data-table')
 export class HelixDataTable extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   @state() private _filters: Record<string, string> = {};
 

--- a/apps/docs/src/content/docs/components-guide/forms/accessibility.md
+++ b/apps/docs/src/content/docs/components-guide/forms/accessibility.md
@@ -23,12 +23,11 @@ When you render a native `<input>`, `<select>`, or `<textarea>` inside the shado
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 // Native input — implicit textbox role, no extra role needed
 @customElement('hx-text-input')
 export class HelixTextInput extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   override render() {
     return html`<input type="text" />`;
@@ -38,7 +37,7 @@ export class HelixTextInput extends LitElement {
 // Custom checkbox — must explicitly set role
 @customElement('hx-checkbox')
 export class HelixCheckbox extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   @property({ type: Boolean }) checked = false;
 
@@ -151,13 +150,12 @@ HELiX's `mixinDelegatesAria` solves this by observing ARIA attributes on the hos
 import { LitElement, html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { mixinDelegatesAria } from '@helixui/library/mixins';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 const Base = mixinDelegatesAria(LitElement);
 
 @customElement('hx-button')
 export class HelixButton extends Base {
-  static override styles = [tokenStyles, css`:host { display: inline-flex; }`];
+  static override styles = css`:host { display: inline-flex; }`;
 
   @query('button') private _button!: HTMLButtonElement;
 

--- a/apps/docs/src/content/docs/components-guide/forms/accessibility.md
+++ b/apps/docs/src/content/docs/components-guide/forms/accessibility.md
@@ -147,7 +147,7 @@ The standard challenge: a consumer writes `<hx-button aria-label="Close">` but t
 HELiX's `mixinDelegatesAria` solves this by observing ARIA attributes on the host and mirroring them to the designated inner element:
 
 ```typescript
-import { LitElement, html } from 'lit';
+import { LitElement, html, css } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
 import { mixinDelegatesAria } from '@helixui/library/mixins';
 

--- a/apps/docs/src/content/docs/components-guide/forms/custom-validity.md
+++ b/apps/docs/src/content/docs/components-guide/forms/custom-validity.md
@@ -78,7 +78,6 @@ The `:invalid` CSS pseudo-class is applied to the host element automatically whe
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     :host {
       display: block;
@@ -172,7 +171,6 @@ For server-side checks (username uniqueness, coupon code validation), run async 
 ```typescript
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-username-input')
 export class HelixUsernameInput extends LitElement {

--- a/apps/docs/src/content/docs/components-guide/forms/element-internals.md
+++ b/apps/docs/src/content/docs/components-guide/forms/element-internals.md
@@ -42,14 +42,12 @@ export class HelixTextInput extends LitElement {
 ```typescript
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-text-input')
 export class HelixTextInput extends LitElement {
   static override formAssociated = true;
 
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: block;

--- a/apps/docs/src/content/docs/components-guide/forms/form-association.md
+++ b/apps/docs/src/content/docs/components-guide/forms/form-association.md
@@ -162,14 +162,12 @@ The `mode` argument tells you why the restore is happening:
 ```typescript
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-checkbox')
 export class HelixCheckbox extends LitElement {
   static override formAssociated = true;
 
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: inline-flex;

--- a/apps/docs/src/content/docs/components-guide/forms/submit-handling.md
+++ b/apps/docs/src/content/docs/components-guide/forms/submit-handling.md
@@ -198,11 +198,10 @@ const values = Object.fromEntries(
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-profile-form')
 export class HelixProfileForm extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   @state() private _submitting = false;
   @state() private _submitError = '';

--- a/apps/docs/src/content/docs/components-guide/forms/validation.md
+++ b/apps/docs/src/content/docs/components-guide/forms/validation.md
@@ -135,7 +135,6 @@ Once `setValidity()` is wired up, the browser automatically applies `:valid` and
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     :host {
       display: block;

--- a/apps/docs/src/content/docs/components-guide/fundamentals/decorators.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/decorators.md
@@ -48,7 +48,6 @@ Declares a reactive public property that:
 ```typescript
 @customElement('hx-avatar')
 export class HelixAvatar extends LitElement {
-  static override styles = [tokenStyles];
 
   // String property — attribute name: "src"
   @property({ type: String })
@@ -97,7 +96,6 @@ Declares reactive private state. Like `@property`, it triggers re-renders when t
 ```typescript
 @customElement('hx-password-input')
 export class HelixPasswordInput extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   label = 'Password';
@@ -139,7 +137,6 @@ import { query } from 'lit/decorators.js';
 
 @customElement('hx-search')
 export class HelixSearch extends LitElement {
-  static override styles = [tokenStyles];
 
   // Queries this.shadowRoot.querySelector('input')
   @query('input')
@@ -187,7 +184,6 @@ import { queryAll } from 'lit/decorators.js';
 
 @customElement('hx-radio-group')
 export class HelixRadioGroup extends LitElement {
-  static override styles = [tokenStyles];
 
   @queryAll('input[type="radio"]')
   private _radios!: NodeListOf<HTMLInputElement>;
@@ -220,7 +216,6 @@ import { queryAssignedElements } from 'lit/decorators.js';
 
 @customElement('hx-action-bar')
 export class HelixActionBar extends LitElement {
-  static override styles = [tokenStyles];
 
   // Elements assigned to the default slot
   @queryAssignedElements()
@@ -268,7 +263,6 @@ import { eventOptions } from 'lit/decorators.js';
 
 @customElement('hx-scroll-container')
 export class HelixScrollContainer extends LitElement {
-  static override styles = [tokenStyles];
 
   // Passive listener — improves scroll performance
   @eventOptions({ passive: true })

--- a/apps/docs/src/content/docs/components-guide/fundamentals/directives.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/directives.md
@@ -15,11 +15,10 @@ Efficiently applies conditional CSS classes from an object. Keys are class names
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-button')
 export class HelixButton extends LitElement {
-  static override styles = [tokenStyles, css`...`];
+  static override styles = [css`...`];
 
   @property({ type: String })
   variant: 'primary' | 'secondary' | 'ghost' = 'primary';
@@ -65,7 +64,6 @@ import { styleMap } from 'lit/directives/style-map.js';
 
 @customElement('hx-skeleton')
 export class HelixSkeleton extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Number })
   width = 0;
@@ -101,7 +99,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 @customElement('hx-text-input')
 export class HelixTextInput extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   label = '';
@@ -142,7 +139,6 @@ import { live } from 'lit/directives/live.js';
 
 @customElement('hx-controlled-input')
 export class HelixControlledInput extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   value = '';
@@ -188,7 +184,6 @@ interface ListItem {
 
 @customElement('hx-list-box')
 export class HelixListBox extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Array })
   items: ListItem[] = [];
@@ -235,7 +230,6 @@ import { when } from 'lit/directives/when.js';
 
 @customElement('hx-async-content')
 export class HelixAsyncContent extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Boolean })
   loading = false;
@@ -274,7 +268,6 @@ import { cache } from 'lit/directives/cache.js';
 
 @customElement('hx-tabs')
 export class HelixTabs extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   activeTab = 'overview';

--- a/apps/docs/src/content/docs/components-guide/fundamentals/events-overview.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/events-overview.md
@@ -12,11 +12,9 @@ Use the `@` prefix in a Lit template to attach an event listener:
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-counter')
 export class HelixCounter extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Number })
   value = 0;
@@ -173,7 +171,6 @@ When listening to events fired by child components inside your template, use the
 ```typescript
 @customElement('hx-form')
 export class HelixForm extends LitElement {
-  static override styles = [tokenStyles];
 
   private _handleInputChange(event: CustomEvent<{ value: string; name: string }>) {
     this._formData[event.detail.name] = event.detail.value;
@@ -201,7 +198,6 @@ import { eventOptions } from 'lit/decorators.js';
 
 @customElement('hx-scroll-area')
 export class HelixScrollArea extends LitElement {
-  static override styles = [tokenStyles];
 
   // passive: true — cannot call preventDefault(), improves scroll performance
   @eventOptions({ passive: true })
@@ -245,7 +241,6 @@ For events on `window` or `document`, add and remove listeners in `connectedCall
 ```typescript
 @customElement('hx-hotkeys')
 export class HelixHotkeys extends LitElement {
-  static override styles = [tokenStyles];
 
   override connectedCallback() {
     super.connectedCallback();

--- a/apps/docs/src/content/docs/components-guide/fundamentals/first-component.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/first-component.md
@@ -7,10 +7,10 @@ This guide walks through building a working web component from the ground up usi
 
 ## Prerequisites
 
-Install the required packages:
+Install the required package:
 
 ```bash
-npm install lit @helixui/tokens
+npm install @helixui/library
 ```
 
 ## The Complete Component
@@ -20,26 +20,24 @@ Here is a full, working `hx-greeting` component. The sections below break down e
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-greeting')
 export class HelixGreeting extends LitElement {
-  static override styles = [
-    tokenStyles,
-    css`
-      :host {
-        display: block;
-        padding: var(--hx-spacing-md);
-        font-family: var(--hx-font-family-base);
-      }
+  // Design tokens are adopted at the document level by @helixui/library.
+  // var(--hx-*) works here without any tokenStyles import.
+  static override styles = css`
+    :host {
+      display: block;
+      padding: var(--hx-spacing-md);
+      font-family: var(--hx-font-family-base);
+    }
 
-      .greeting {
-        color: var(--hx-color-primary-500);
-        font-size: var(--hx-font-size-lg);
-        font-weight: var(--hx-font-weight-semibold);
-      }
-    `,
-  ];
+    .greeting {
+      color: var(--hx-color-primary-500);
+      font-size: var(--hx-font-size-lg);
+      font-weight: var(--hx-font-weight-semibold);
+    }
+  `;
 
   @property({ type: String })
   name = 'World';
@@ -65,14 +63,14 @@ declare global {
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 ```
 
 - `LitElement` is the base class all HELiX components extend.
 - `html` is a tagged template literal that produces Lit's efficient template result.
 - `css` is a tagged template literal for component-scoped styles.
 - `customElement` and `property` are decorators that handle registration and reactivity.
-- `tokenStyles` injects all HELiX design tokens as CSS custom properties — always include this first in the styles array.
+
+HELiX design tokens (`--hx-*`) are adopted at the document level when `@helixui/library` is imported. No per-component token import is needed — `var(--hx-*)` works in any HELiX shadow root automatically.
 
 ### The `@customElement` Decorator
 
@@ -90,19 +88,16 @@ HELiX naming conventions:
 ### Static Styles
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    :host {
-      display: block;
-    }
-  `,
-];
+static override styles = css`
+  :host {
+    display: block;
+  }
+`;
 ```
 
-`static override styles` accepts an array of `CSSResult` values. The `override` keyword is required because `LitElement` declares this property on the base class.
+`static override styles` accepts a `CSSResult` or an array of `CSSResult` values. The `override` keyword is required because `LitElement` declares this property on the base class.
 
-`tokenStyles` must always be first so token values are available in subsequent CSS rules. Styles are scoped to the component's shadow DOM — they do not leak out or in.
+Styles are scoped to the component's shadow DOM — they do not leak out or in. Token values (`--hx-*`) are always available because `@helixui/library` adopts them at the document level; CSS custom properties cascade through Shadow DOM boundaries automatically.
 
 ### Reactive Properties
 

--- a/apps/docs/src/content/docs/components-guide/fundamentals/lifecycle.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/lifecycle.md
@@ -28,7 +28,6 @@ The constructor runs when the element class is instantiated. Lit uses it to set 
 ```typescript
 @customElement('hx-tooltip')
 export class HelixTooltip extends LitElement {
-  static override styles = [tokenStyles];
 
   // Initialize properties with defaults here (TypeScript field initializers)
   @property({ type: String })
@@ -120,11 +119,9 @@ Called before `render()` on every update. Use it to compute derived state that d
 ```typescript
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-progress')
 export class HelixProgress extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Number })
   value = 0;
@@ -173,11 +170,9 @@ Common uses:
 ```typescript
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-autofocus-input')
 export class HelixAutofocusInput extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Boolean })
   autofocus = false;
@@ -204,11 +199,9 @@ Called after every render (including the first). The shadow DOM reflects the lat
 ```typescript
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-dialog')
 export class HelixDialog extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Boolean, reflect: true })
   open = false;
@@ -265,12 +258,10 @@ Typing it as `PropertyValues<this>` gives TypeScript correct key inference for y
 ```typescript
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, property, state, query } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-timer')
 export class HelixTimer extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: inline-block; }
     `,

--- a/apps/docs/src/content/docs/components-guide/fundamentals/properties-and-attributes.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/properties-and-attributes.md
@@ -91,7 +91,6 @@ With reflection, `:host([disabled])` CSS rules activate when the property is set
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     :host([disabled]) {
       opacity: 0.5;
@@ -176,7 +175,6 @@ const csvConverter = {
 
 @customElement('hx-tag-input')
 export class HelixTagInput extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ converter: csvConverter, reflect: true })
   tags: string[] = [];

--- a/apps/docs/src/content/docs/components-guide/fundamentals/reactive-properties.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/reactive-properties.md
@@ -14,11 +14,9 @@ Reactive properties are the foundation of Lit's rendering model. When a reactive
 ```typescript
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-badge')
 export class HelixBadge extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   variant: 'default' | 'success' | 'warning' | 'error' = 'default';
@@ -60,11 +58,9 @@ Usage:
 ```typescript
 import { LitElement, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-disclosure')
 export class HelixDisclosure extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   label = '';
@@ -217,7 +213,6 @@ Object and array properties are compared by reference. Lit has no way to deep-co
 ```typescript
 @customElement('hx-list')
 export class HelixList extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Array })
   items: string[] = [];

--- a/apps/docs/src/content/docs/components-guide/fundamentals/rendering.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/rendering.md
@@ -128,7 +128,6 @@ Multiple property changes in the same synchronous block result in a single rende
 ```typescript
 @customElement('hx-form-field')
 export class HelixFormField extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   value = '';
@@ -161,7 +160,6 @@ Call `requestUpdate()` to manually schedule a re-render without changing a react
 ```typescript
 @customElement('hx-mutable-list')
 export class HelixMutableList extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Array })
   items: string[] = [];
@@ -212,12 +210,10 @@ if (!this.isUpdatePending) {
 ```typescript
 import { LitElement, html, css, nothing, type PropertyValues } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-async-card')
 export class HelixAsyncCard extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: block; }
       .skeleton { background: var(--hx-color-neutral-100); }

--- a/apps/docs/src/content/docs/components-guide/fundamentals/slots-intro.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/slots-intro.md
@@ -37,12 +37,10 @@ A `<slot>` without a `name` attribute is the default slot. All slotted content t
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-section')
 export class HelixSection extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: block; }
       .section {
@@ -80,7 +78,6 @@ Named slots let a component define multiple content regions. Consumers assign co
 @customElement('hx-panel')
 export class HelixPanel extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: flex; flex-direction: column; }
       .header {
@@ -167,11 +164,9 @@ The `slotchange` event fires on a `<slot>` element when its assigned nodes chang
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-nav')
 export class HelixNav extends LitElement {
-  static override styles = [tokenStyles];
 
   @query('slot')
   private _slot!: HTMLSlotElement;
@@ -201,12 +196,10 @@ The `@queryAssignedElements` decorator is a convenient way to access slotted ele
 ```typescript
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, queryAssignedElements } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-button-group')
 export class HelixButtonGroup extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: inline-flex; gap: var(--hx-spacing-xs); }
     `,
@@ -252,7 +245,6 @@ To conditionally render layout based on whether a slot has content:
 ```typescript
 @customElement('hx-card')
 export class HelixCard extends LitElement {
-  static override styles = [tokenStyles];
 
   @queryAssignedElements({ slot: 'footer' })
   private _footerItems!: Array<HTMLElement>;

--- a/apps/docs/src/content/docs/components-guide/fundamentals/styles-and-css.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/styles-and-css.md
@@ -3,7 +3,7 @@ title: Styles and CSS
 description: Write scoped component styles using css``, static styles arrays, :host selectors, and HELiX design tokens.
 ---
 
-Lit provides a `css` tagged template literal for writing component-scoped styles. All styles in a `LitElement` are encapsulated in the shadow DOM — they do not leak out to the page and external styles do not leak in. As of `@helixui/library@2.1.0`, HELiX design tokens are adopted at the document level and cascade through Shadow DOM boundaries automatically — no per-component token import is required.
+Lit provides a `css` tagged template literal for writing component-scoped styles. All styles in a `LitElement` are encapsulated in the shadow DOM — they do not leak out to the page and external styles do not leak in. As of `@helixui/library@2.1.1`, HELiX design tokens are adopted at the document level and cascade through Shadow DOM boundaries automatically — no per-component token import is required.
 
 ## The `css` Tagged Template Literal
 

--- a/apps/docs/src/content/docs/components-guide/fundamentals/styles-and-css.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/styles-and-css.md
@@ -3,7 +3,7 @@ title: Styles and CSS
 description: Write scoped component styles using css``, static styles arrays, :host selectors, and HELiX design tokens.
 ---
 
-Lit provides a `css` tagged template literal for writing component-scoped styles. All styles in a `LitElement` are encapsulated in the shadow DOM — they do not leak out to the page and external styles do not leak in. HELiX components always include `tokenStyles` from `@helixui/tokens/lit` to make design tokens available inside the shadow root.
+Lit provides a `css` tagged template literal for writing component-scoped styles. All styles in a `LitElement` are encapsulated in the shadow DOM — they do not leak out to the page and external styles do not leak in. As of `@helixui/library@2.1.0`, HELiX design tokens are adopted at the document level and cascade through Shadow DOM boundaries automatically — no per-component token import is required.
 
 ## The `css` Tagged Template Literal
 
@@ -16,25 +16,23 @@ The `css` tag processes the template at class definition time (not per-instance)
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
+// Design tokens are adopted at the document level by @helixui/library —
+// no tokenStyles import needed. var(--hx-*) works directly.
 @customElement('hx-chip')
 export class HelixChip extends LitElement {
-  static override styles = [
-    tokenStyles,
-    css`
-      :host {
-        display: inline-flex;
-        align-items: center;
-        border-radius: var(--hx-radius-full);
-        padding: var(--hx-spacing-xs) var(--hx-spacing-sm);
-        font-size: var(--hx-font-size-sm);
-        font-family: var(--hx-font-family-base);
-        background: var(--hx-color-neutral-100);
-        color: var(--hx-color-neutral-800);
-      }
-    `,
-  ];
+  static override styles = css`
+    :host {
+      display: inline-flex;
+      align-items: center;
+      border-radius: var(--hx-radius-full);
+      padding: var(--hx-spacing-xs) var(--hx-spacing-sm);
+      font-size: var(--hx-font-size-sm);
+      font-family: var(--hx-font-family-base);
+      background: var(--hx-color-neutral-100);
+      color: var(--hx-color-neutral-800);
+    }
+  `;
 }
 ```
 
@@ -42,19 +40,18 @@ export class HelixChip extends LitElement {
 
 `static override styles` is a `CSSResultGroup` — it accepts a single `CSSResult` or an array of `CSSResult` values. The `override` keyword is required because `LitElement` declares `styles` on the base class.
 
-**Rule: `tokenStyles` must always be the first item in the array.**
-
 ```typescript
 static override styles = [
-  tokenStyles,         // 1. HELiX design tokens — always first
-  sharedButtonStyles,  // 2. Shared style modules (optional)
-  css`                 // 3. Component-specific styles
+  sharedButtonStyles,  // 1. Shared style modules (optional)
+  css`                 // 2. Component-specific styles
     :host { display: inline-flex; }
   `,
 ];
 ```
 
-Placing `tokenStyles` first ensures that all subsequent CSS rules can reference `--hx-*` custom properties without them being undefined.
+`--hx-*` tokens are available in all component styles without any explicit import. The library adopts them at the document level, and CSS custom properties cascade through Shadow DOM boundaries automatically.
+
+> **Deprecated:** The old `[tokenStyles, ...]` pattern — where `tokenStyles` from `@helixui/tokens/lit` was required as the first array entry — is no longer needed. `tokenStyles` and `mergeTokenStyles()` are still exported for backwards compatibility but should not appear in new code.
 
 ## Shared Style Modules
 
@@ -97,7 +94,7 @@ import { srOnlyStyles } from '../shared/sr-only-styles.js';
 
 @customElement('hx-button')
 export class HelixButton extends LitElement {
-  static override styles = [tokenStyles, focusStyles, srOnlyStyles, css`...`];
+  static override styles = [focusStyles, srOnlyStyles, css`...`];
 }
 ```
 
@@ -106,39 +103,36 @@ export class HelixButton extends LitElement {
 `:host` targets the custom element itself — the shadow host. This is the correct way to set `display`, `position`, sizing, and host-level layout properties.
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    /* Default host layout */
-    :host {
-      display: block;
-      box-sizing: border-box;
-    }
+static override styles = css`
+  /* Default host layout */
+  :host {
+    display: block;
+    box-sizing: border-box;
+  }
 
-    /* Inline variant */
-    :host([inline]) {
-      display: inline-block;
-    }
+  /* Inline variant */
+  :host([inline]) {
+    display: inline-block;
+  }
 
-    /* Disabled state via reflected attribute */
-    :host([disabled]) {
-      opacity: 0.5;
-      pointer-events: none;
-      cursor: not-allowed;
-    }
+  /* Disabled state via reflected attribute */
+  :host([disabled]) {
+    opacity: 0.5;
+    pointer-events: none;
+    cursor: not-allowed;
+  }
 
-    /* Variant-based host styling */
-    :host([variant='primary']) {
-      --_bg: var(--hx-color-primary-500);
-      --_color: var(--hx-color-white);
-    }
+  /* Variant-based host styling */
+  :host([variant='primary']) {
+    --_bg: var(--hx-color-primary-500);
+    --_color: var(--hx-color-white);
+  }
 
-    :host([variant='secondary']) {
-      --_bg: transparent;
-      --_color: var(--hx-color-primary-500);
-    }
-  `,
-];
+  :host([variant='secondary']) {
+    --_bg: transparent;
+    --_color: var(--hx-color-primary-500);
+  }
+`;
 ```
 
 `:host([attr])` rules activate when the attribute is present on the element — which is why `reflect: true` on boolean properties like `disabled` is important.
@@ -149,28 +143,25 @@ CSS custom properties (variables) pierce the shadow boundary. They are the prima
 
 ### Using Token Variables Inside Components
 
-Reference `--hx-*` token variables in your component styles:
+Reference `--hx-*` token variables in your component styles. Tokens are available automatically — no import needed:
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    .button {
-      background: var(--hx-color-primary-500);
-      color: var(--hx-color-white);
-      border-radius: var(--hx-radius-md);
-      padding: var(--hx-spacing-sm) var(--hx-spacing-md);
-      font-family: var(--hx-font-family-base);
-      font-size: var(--hx-font-size-base);
-      font-weight: var(--hx-font-weight-medium);
-      transition: background var(--hx-duration-fast) var(--hx-easing-standard);
-    }
+static override styles = css`
+  .button {
+    background: var(--hx-color-primary-500);
+    color: var(--hx-color-white);
+    border-radius: var(--hx-radius-md);
+    padding: var(--hx-spacing-sm) var(--hx-spacing-md);
+    font-family: var(--hx-font-family-base);
+    font-size: var(--hx-font-size-base);
+    font-weight: var(--hx-font-weight-medium);
+    transition: background var(--hx-duration-fast) var(--hx-easing-standard);
+  }
 
-    .button:hover:not(:disabled) {
-      background: var(--hx-color-primary-600);
-    }
-  `,
-];
+  .button:hover:not(:disabled) {
+    background: var(--hx-color-primary-600);
+  }
+`;
 ```
 
 ### Exposing Component-Level Custom Properties
@@ -178,25 +169,22 @@ static override styles = [
 Define component-specific custom properties that consumers can override:
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    :host {
-      /* Component-level custom properties with token fallbacks */
-      --hx-chip-bg: var(--hx-color-neutral-100);
-      --hx-chip-color: var(--hx-color-neutral-800);
-      --hx-chip-border: var(--hx-color-neutral-300);
-      --hx-chip-radius: var(--hx-radius-full);
-    }
+static override styles = css`
+  :host {
+    /* Component-level custom properties with token fallbacks */
+    --hx-chip-bg: var(--hx-color-neutral-100);
+    --hx-chip-color: var(--hx-color-neutral-800);
+    --hx-chip-border: var(--hx-color-neutral-300);
+    --hx-chip-radius: var(--hx-radius-full);
+  }
 
-    .chip {
-      background: var(--hx-chip-bg);
-      color: var(--hx-chip-color);
-      border: 1px solid var(--hx-chip-border);
-      border-radius: var(--hx-chip-radius);
-    }
-  `,
-];
+  .chip {
+    background: var(--hx-chip-bg);
+    color: var(--hx-chip-color);
+    border: 1px solid var(--hx-chip-border);
+    border-radius: var(--hx-chip-radius);
+  }
+`;
 ```
 
 Consumers can then override these on the element or a containing selector:

--- a/apps/docs/src/content/docs/components-guide/fundamentals/template-syntax.md
+++ b/apps/docs/src/content/docs/components-guide/fundamentals/template-syntax.md
@@ -109,7 +109,6 @@ Prefix the attribute name with `@` to attach an event listener. The value should
 ```typescript
 @customElement('hx-toggle')
 export class HelixToggle extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Boolean, reflect: true })
   checked = false;
@@ -162,11 +161,9 @@ The `ref` directive lets you get a reference to a rendered DOM element. This is 
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
 import { ref, createRef, type Ref } from 'lit/directives/ref.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-autoscroll')
 export class HelixAutoscroll extends LitElement {
-  static override styles = [tokenStyles];
 
   private _listRef: Ref<HTMLUListElement> = createRef();
 
@@ -214,7 +211,6 @@ Templates can be composed by returning `html` results from helper methods or by 
 ```typescript
 @customElement('hx-card')
 export class HelixCard extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   title = '';

--- a/apps/docs/src/content/docs/components-guide/performance/lazy-loading.md
+++ b/apps/docs/src/content/docs/components-guide/performance/lazy-loading.md
@@ -26,11 +26,9 @@ For components inside a Lit template, conditionally import when needed:
 ```typescript
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-settings-page')
 export class HelixSettingsPage extends LitElement {
-  static override styles = [tokenStyles];
 
   @state()
   private _showAdvanced: boolean = false;
@@ -94,11 +92,9 @@ Load components only when they scroll into view. This is ideal for components be
 ```typescript
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-lazy-section')
 export class HelixLazySection extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   component: string = '';

--- a/apps/docs/src/content/docs/components-guide/performance/rendering.md
+++ b/apps/docs/src/content/docs/components-guide/performance/rendering.md
@@ -32,7 +32,6 @@ The `repeat` directive uses a key function to associate rendered nodes with thei
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { repeat } from 'lit/directives/repeat.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 interface Task {
   id: string;
@@ -42,7 +41,6 @@ interface Task {
 
 @customElement('hx-task-list')
 export class HelixTaskList extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ attribute: false })
   tasks: Task[] = [];
@@ -109,11 +107,9 @@ The `guard` directive takes a list of dependencies and a template factory. It on
 import { guard } from 'lit/directives/guard.js';
 import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-expensive-chart')
 export class HelixExpensiveChart extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ attribute: false })
   data: number[] = [];
@@ -176,7 +172,6 @@ import { cache } from 'lit/directives/cache.js';
 
 @customElement('hx-view-switcher')
 export class HelixViewSwitcher extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   view: 'list' | 'grid' = 'list';
@@ -202,7 +197,6 @@ Move derived values to `willUpdate()` so they only recompute when relevant prope
 ```typescript
 @customElement('hx-data-summary')
 export class HelixDataSummary extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ attribute: false })
   items: number[] = [];

--- a/apps/docs/src/content/docs/components-guide/performance/ssr.md
+++ b/apps/docs/src/content/docs/components-guide/performance/ssr.md
@@ -127,11 +127,9 @@ Lit 3.x exports an `isServer` boolean for conditional server vs browser logic:
 ```typescript
 import { LitElement, html, isServer } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-media-player')
 export class HelixMediaPlayer extends LitElement {
-  static override styles = [tokenStyles];
 
   override connectedCallback(): void {
     super.connectedCallback();
@@ -209,14 +207,14 @@ HELiX components are authored with SSR compatibility in mind:
 - No browser globals in constructors or static initializers.
 - `connectedCallback` and event listeners are the only places window/document are accessed.
 - `isServer` checks gate any unavoidable browser-only paths.
-- `@helixui/tokens/lit` exports a `CSSResult` — safe in SSR as Lit inlines CSS into DSD `<style>` elements.
+- Component stylesheets are plain `CSSResult` values — they are safe in SSR as Lit inlines them into DSD `<style>` elements.
 
 ```typescript
-// tokenStyles works in SSR — Lit writes it into the <template> shadow root
-static override styles = [tokenStyles, helixButtonStyles];
+// Component styles work in SSR — Lit writes them into the <template> shadow root
+static override styles = helixButtonStyles;
 ```
 
-The one area requiring care is CSS custom property adoption. HELiX uses `@helixui/adopted-stylesheets` for runtime token injection in the browser — ensure this is guarded with `isServer` when running in an SSR context.
+The one area requiring care is document-level token adoption. `@helixui/library` calls `document.adoptedStyleSheets` in the browser — ensure this path is guarded with `isServer` when running in an SSR context. In practice, importing `@helixui/library` in SSR only registers custom elements; the `adoptedStyleSheets` assignment is browser-only.
 
 ## Next Steps
 

--- a/apps/docs/src/content/docs/components-guide/shadow-dom/architecture.md
+++ b/apps/docs/src/content/docs/components-guide/shadow-dom/architecture.md
@@ -104,13 +104,10 @@ Shadow DOM solves it architecturally:
 The reverse is also true: styles inside a shadow root do not leak out and affect the host document.
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    /* This rule CANNOT affect anything outside hx-button */
-    p { color: var(--hx-color-text-primary); }
-  `,
-];
+static override styles = css`
+  /* This rule CANNOT affect anything outside hx-button */
+  p { color: var(--hx-color-text-primary); }
+`;
 ```
 
 ## What Does and Does Not Pierce Shadow DOM

--- a/apps/docs/src/content/docs/components-guide/shadow-dom/host-element.md
+++ b/apps/docs/src/content/docs/components-guide/shadow-dom/host-element.md
@@ -11,7 +11,6 @@ The shadow host is the custom element itself — `<hx-button>`, `<hx-card>`, etc
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     /* Every custom element is display:inline by default */
     /* Most HELiX block components override to display:block */
@@ -27,7 +26,6 @@ static override styles = [
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     /* Block-level component */
     :host {
@@ -69,7 +67,6 @@ Pass an attribute selector to `:host()` to apply styles conditionally based on t
 @customElement('hx-alert')
 export class HelixAlert extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: flex;
@@ -165,7 +162,6 @@ HELiX convention: reflect all properties that are used in `:host([attr])` CSS se
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     :host {
       --_bg: var(--hx-color-white);
@@ -262,7 +258,6 @@ Set dimensions on `:host`, not on the first internal div:
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     /* Correct: size the host */
     :host {

--- a/apps/docs/src/content/docs/components-guide/shadow-dom/light-dom.md
+++ b/apps/docs/src/content/docs/components-guide/shadow-dom/light-dom.md
@@ -143,7 +143,6 @@ Most HELiX components use both: shadow DOM for structural chrome, light DOM slot
 @customElement('hx-expandable-section')
 export class HelixExpandableSection extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: block; }
       .header {

--- a/apps/docs/src/content/docs/components-guide/shadow-dom/parts.md
+++ b/apps/docs/src/content/docs/components-guide/shadow-dom/parts.md
@@ -43,7 +43,6 @@ Every interactive or visually significant shadow DOM element in HELiX has a `par
 ```typescript
 @customElement('hx-text-input')
 export class HelixTextInput extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   label = '';
@@ -157,7 +156,6 @@ When a component contains another shadow DOM component internally, its sub-compo
 ```typescript
 @customElement('hx-combobox')
 export class HelixCombobox extends LitElement {
-  static override styles = [tokenStyles];
 
   override render() {
     return html`

--- a/apps/docs/src/content/docs/components-guide/shadow-dom/slots.md
+++ b/apps/docs/src/content/docs/components-guide/shadow-dom/slots.md
@@ -42,7 +42,6 @@ A `<slot>` element without a `name` attribute accepts all unassigned light DOM c
 @customElement('hx-callout')
 export class HelixCallout extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: block; }
       .callout {
@@ -71,7 +70,6 @@ Named slots accept only children that specify `slot="name"` on a direct child of
 @customElement('hx-media-card')
 export class HelixMediaCard extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: block; }
       .card { display: grid; grid-template-rows: auto 1fr auto; }
@@ -165,11 +163,9 @@ Or use the `slotchange` event to track slot occupancy (see below).
 ```typescript
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-accordion')
 export class HelixAccordion extends LitElement {
-  static override styles = [tokenStyles];
 
   @state()
   private _itemCount = 0;
@@ -209,7 +205,6 @@ import { queryAssignedElements } from 'lit/decorators.js';
 @customElement('hx-toolbar')
 export class HelixToolbar extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: flex; align-items: center; gap: var(--hx-spacing-xs); }
     `,
@@ -272,7 +267,6 @@ To show or hide layout sections based on whether a slot has content:
 @customElement('hx-split-layout')
 export class HelixSplitLayout extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host { display: grid; grid-template-columns: 1fr; }
       :host([has-aside]) { grid-template-columns: 1fr 280px; }

--- a/apps/docs/src/content/docs/components-guide/shadow-dom/styling.md
+++ b/apps/docs/src/content/docs/components-guide/shadow-dom/styling.md
@@ -42,7 +42,7 @@ HELiX design tokens are all CSS custom properties. Because they are set on `:roo
 }
 ```
 
-Inside the shadow root, these resolve correctly. As of `@helixui/library@2.1.0`, tokens are adopted at the document level automatically — no per-component token import is needed:
+Inside the shadow root, these resolve correctly. As of `@helixui/library@2.1.1`, tokens are adopted at the document level automatically — no per-component token import is needed:
 
 ```typescript
 static override styles = css`
@@ -261,7 +261,7 @@ hx-list::slotted(li.priority) {
 
 ## Adopted Stylesheets
 
-As of `@helixui/library@2.1.0`, the adopted stylesheets pattern is the **default architecture**. Importing `@helixui/library` automatically adds the full `--hx-*` token set to `document.adoptedStyleSheets`. CSS custom properties cascade through Shadow DOM boundaries, so every component immediately has access to all tokens — no per-component `tokenStyles` import or `static override styles` entry is required.
+As of `@helixui/library@2.1.1`, the adopted stylesheets pattern is the **default architecture**. Importing `@helixui/library` automatically adds the full `--hx-*` token set to `document.adoptedStyleSheets`. CSS custom properties cascade through Shadow DOM boundaries, so every component immediately has access to all tokens — no per-component `tokenStyles` import or `static override styles` entry is required.
 
 ```typescript
 import '@helixui/library'; // tokens are adopted at document level on import

--- a/apps/docs/src/content/docs/components-guide/shadow-dom/styling.md
+++ b/apps/docs/src/content/docs/components-guide/shadow-dom/styling.md
@@ -42,19 +42,16 @@ HELiX design tokens are all CSS custom properties. Because they are set on `:roo
 }
 ```
 
-Inside the shadow root, these resolve correctly:
+Inside the shadow root, these resolve correctly. As of `@helixui/library@2.1.0`, tokens are adopted at the document level automatically — no per-component token import is needed:
 
 ```typescript
-static override styles = [
-  tokenStyles, // makes all --hx-* tokens available
-  css`
-    .button {
-      background: var(--hx-color-primary-500); /* resolves to #2563eb */
-      padding: var(--hx-spacing-md);           /* resolves to 1rem */
-      font-family: var(--hx-font-family-base); /* resolves to 'Inter', sans-serif */
-    }
-  `,
-];
+static override styles = css`
+  .button {
+    background: var(--hx-color-primary-500); /* resolves to #2563eb */
+    padding: var(--hx-spacing-md);           /* resolves to 1rem */
+    font-family: var(--hx-font-family-base); /* resolves to 'Inter', sans-serif */
+  }
+`;
 ```
 
 ### Component-Level Token Overrides
@@ -78,23 +75,20 @@ hx-button.cta-button {
 These override values are picked up by the shadow DOM because custom properties cascade and inherit normally:
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    :host {
-      /* Define with token fallback */
-      --hx-button-bg: var(--hx-color-primary-500);
-      --hx-button-bg-hover: var(--hx-color-primary-600);
-    }
+static override styles = css`
+  :host {
+    /* Define with token fallback */
+    --hx-button-bg: var(--hx-color-primary-500);
+    --hx-button-bg-hover: var(--hx-color-primary-600);
+  }
 
-    .button {
-      background: var(--hx-button-bg);
-    }
-    .button:hover {
-      background: var(--hx-button-bg-hover);
-    }
-  `,
-];
+  .button {
+    background: var(--hx-button-bg);
+  }
+  .button:hover {
+    background: var(--hx-button-bg-hover);
+  }
+`;
 ```
 
 ## Inherited CSS Properties
@@ -132,38 +126,35 @@ Non-inherited properties (background, border, padding, margin, etc.) do **not** 
 ```typescript
 @customElement('hx-list')
 export class HelixList extends LitElement {
-  static override styles = [
-    tokenStyles,
-    css`
-      :host {
-        display: block;
-      }
+  static override styles = css`
+    :host {
+      display: block;
+    }
 
-      ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-      }
+    ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
 
-      /* Style direct slotted children */
-      ::slotted(li) {
-        padding: var(--hx-spacing-xs) var(--hx-spacing-sm);
-        border-bottom: 1px solid var(--hx-color-neutral-100);
-      }
+    /* Style direct slotted children */
+    ::slotted(li) {
+      padding: var(--hx-spacing-xs) var(--hx-spacing-sm);
+      border-bottom: 1px solid var(--hx-color-neutral-100);
+    }
 
-      /* Style a specific type of slotted element */
-      ::slotted(hx-list-item) {
-        display: flex;
-        align-items: center;
-      }
+    /* Style a specific type of slotted element */
+    ::slotted(hx-list-item) {
+      display: flex;
+      align-items: center;
+    }
 
-      /* Style slotted elements with an attribute */
-      ::slotted([selected]) {
-        background: var(--hx-color-primary-50);
-        color: var(--hx-color-primary-700);
-      }
-    `,
-  ];
+    /* Style slotted elements with an attribute */
+    ::slotted([selected]) {
+      background: var(--hx-color-primary-50);
+      color: var(--hx-color-primary-700);
+    }
+  `;
 
   override render() {
     return html`<ul><slot></slot></ul>`;
@@ -270,15 +261,19 @@ hx-list::slotted(li.priority) {
 
 ## Adopted Stylesheets
 
-`@helixui/adopted-stylesheets` applies HELiX token styles using the Constructable Stylesheets API, which makes tokens available inside shadow roots without requiring `tokenStyles` on every component. This is the default pattern in HELiX:
+As of `@helixui/library@2.1.0`, the adopted stylesheets pattern is the **default architecture**. Importing `@helixui/library` automatically adds the full `--hx-*` token set to `document.adoptedStyleSheets`. CSS custom properties cascade through Shadow DOM boundaries, so every component immediately has access to all tokens — no per-component `tokenStyles` import or `static override styles` entry is required.
 
 ```typescript
-import '@helixui/adopted-stylesheets'; // Apply once at app entry point
+import '@helixui/library'; // tokens are adopted at document level on import
 ```
 
-After this, all HELiX shadow roots receive token styles automatically. Even so, HELiX component source always includes `tokenStyles` in `static override styles` as a defense-in-depth fallback.
+For application-wide global styles (resets, typography base, brand overrides), use `@helixui/adopted-stylesheets`:
 
-See [Adopted Stylesheets](/guides/adopted-stylesheets/) for full setup.
+```typescript
+import '@helixui/adopted-stylesheets';
+```
+
+See [Adopted Stylesheets](/components-guide/styling/adopted-stylesheets/) for full setup.
 
 ## Next Steps
 

--- a/apps/docs/src/content/docs/components-guide/styling/adopted-stylesheets.md
+++ b/apps/docs/src/content/docs/components-guide/styling/adopted-stylesheets.md
@@ -1,9 +1,9 @@
 ---
 title: Adopted Stylesheets in HELiX
-description: Design tokens are adopted at the document level automatically in @helixui/library@2.1.0+. This page explains how the architecture works and how to use @helixui/adopted-stylesheets for application-wide global styles.
+description: Design tokens are adopted at the document level automatically in @helixui/library@2.1.1+. This page explains how the architecture works and how to use @helixui/adopted-stylesheets for application-wide global styles.
 ---
 
-As of `@helixui/library@2.1.0`, the adopted stylesheets pattern is not just recommended — it is the **default architecture**. When you import `@helixui/library`, the full `--hx-*` design token set is added to `document.adoptedStyleSheets` automatically. CSS custom properties inherit through Shadow DOM boundaries, so every component has immediate access to all tokens with no per-component wiring.
+As of `@helixui/library@2.1.1`, the adopted stylesheets pattern is not just recommended — it is the **default architecture**. When you import `@helixui/library`, the full `--hx-*` design token set is added to `document.adoptedStyleSheets` automatically. CSS custom properties inherit through Shadow DOM boundaries, so every component has immediate access to all tokens with no per-component wiring.
 
 `@helixui/adopted-stylesheets` is the **default** mechanism for applying global styles — resets, typography base, focus ring utility, and any application-wide rules — to HELiX component shadow roots. It is not optional: every HELiX application should use it.
 
@@ -99,7 +99,7 @@ The rule of thumb: if a style rule would have gone in your `globals.css` in a no
 
 ## Integration with HELiX Tokens
 
-`@helixui/library@2.1.0` adopts the full `--hx-*` token set at the document level via `document.adoptedStyleSheets`. You do not need to do anything for tokens to be available — they cascade through Shadow DOM automatically from the moment the library is imported.
+`@helixui/library@2.1.1` adopts the full `--hx-*` token set at the document level via `document.adoptedStyleSheets`. You do not need to do anything for tokens to be available — they cascade through Shadow DOM automatically from the moment the library is imported.
 
 The adopted stylesheet is an ideal place to set brand-specific **token overrides** that should apply globally on top of the library defaults:
 

--- a/apps/docs/src/content/docs/components-guide/styling/adopted-stylesheets.md
+++ b/apps/docs/src/content/docs/components-guide/styling/adopted-stylesheets.md
@@ -1,7 +1,9 @@
 ---
 title: Adopted Stylesheets in HELiX
-description: Use @helixui/adopted-stylesheets as the default pattern for injecting global styles into shadow DOM without duplication.
+description: Design tokens are adopted at the document level automatically in @helixui/library@2.1.0+. This page explains how the architecture works and how to use @helixui/adopted-stylesheets for application-wide global styles.
 ---
+
+As of `@helixui/library@2.1.0`, the adopted stylesheets pattern is not just recommended — it is the **default architecture**. When you import `@helixui/library`, the full `--hx-*` design token set is added to `document.adoptedStyleSheets` automatically. CSS custom properties inherit through Shadow DOM boundaries, so every component has immediate access to all tokens with no per-component wiring.
 
 `@helixui/adopted-stylesheets` is the **default** mechanism for applying global styles — resets, typography base, focus ring utility, and any application-wide rules — to HELiX component shadow roots. It is not optional: every HELiX application should use it.
 
@@ -97,7 +99,9 @@ The rule of thumb: if a style rule would have gone in your `globals.css` in a no
 
 ## Integration with HELiX Tokens
 
-The adopted stylesheet is an ideal place to set any token overrides that should apply globally, separate from what `@helixui/tokens` provides:
+`@helixui/library@2.1.0` adopts the full `--hx-*` token set at the document level via `document.adoptedStyleSheets`. You do not need to do anything for tokens to be available — they cascade through Shadow DOM automatically from the moment the library is imported.
+
+The adopted stylesheet is an ideal place to set brand-specific **token overrides** that should apply globally on top of the library defaults:
 
 ```typescript
 import { defineAdoptedStylesheet } from '@helixui/adopted-stylesheets';
@@ -113,7 +117,7 @@ export const brandOverrides = defineAdoptedStylesheet(css`
 `);
 ```
 
-Because the adopted stylesheet runs inside each shadow root, CSS custom property overrides here correctly override the defaults from `tokenStyles` without needing `:root` or `:host` specificity tricks.
+Because the adopted stylesheet runs inside each shadow root, CSS custom property overrides here correctly override the library defaults without needing `:root` or `:host` specificity tricks.
 
 ## Deduplication Guarantee
 
@@ -122,5 +126,5 @@ Because the adopted stylesheet runs inside each shadow root, CSS custom property
 ## Next Steps
 
 - [Constructable Stylesheets](/components-guide/styling/constructable-stylesheets/) — the browser API powering adopted stylesheets
-- [Design Tokens](/components-guide/styling/tokens/) — how `tokenStyles` and adopted stylesheets work together
+- [Design Tokens](/components-guide/styling/tokens/) — how tokens are adopted automatically and how to use `--hx-*` properties
 - [Theming](/components-guide/styling/theming/) — scoping token overrides to a subtree

--- a/apps/docs/src/content/docs/components-guide/styling/animations.md
+++ b/apps/docs/src/content/docs/components-guide/styling/animations.md
@@ -12,12 +12,10 @@ CSS transitions are the right tool for state changes: hover, focus, active, disa
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-button')
 export class HelixButton extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       button {
         background: var(--hx-color-primary-500);
@@ -94,7 +92,6 @@ Use `@keyframes` for multi-step animations: spinners, skeletons, entrance effect
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     @keyframes spin {
       to { transform: rotate(360deg); }
@@ -160,11 +157,10 @@ When you need to trigger an animation from JavaScript — for example, after dat
 ```typescript
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-toast')
 export class HelixToast extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   @property({ type: Boolean }) open = false;
 

--- a/apps/docs/src/content/docs/components-guide/styling/constructable-stylesheets.md
+++ b/apps/docs/src/content/docs/components-guide/styling/constructable-stylesheets.md
@@ -123,7 +123,7 @@ Constructable stylesheets are supported in all modern browsers. Lit includes a f
 
 Understanding constructable stylesheets explains several HELiX conventions:
 
-**Why tokens are always available** — As of `@helixui/library@2.1.0`, the `--hx-*` token set is adopted at the document level when the library barrel imports. CSS custom properties inherit through Shadow DOM boundaries, so `var(--hx-*)` works inside any shadow root without any per-component token imports. The old pattern of listing `tokenStyles` first in `static override styles` is deprecated.
+**Why tokens are always available** — As of `@helixui/library@2.1.1`, the `--hx-*` token set is adopted at the document level when the library barrel imports. CSS custom properties inherit through Shadow DOM boundaries, so `var(--hx-*)` works inside any shadow root without any per-component token imports. The old pattern of listing `tokenStyles` first in `static override styles` is deprecated.
 
 **Why `css` strings should not be dynamic** — `CSSResult` deduplication works by object identity. If you construct a new `css` result on every render, Lit cannot deduplicate it. Keep `static override styles` truly static.
 

--- a/apps/docs/src/content/docs/components-guide/styling/constructable-stylesheets.md
+++ b/apps/docs/src/content/docs/components-guide/styling/constructable-stylesheets.md
@@ -73,24 +73,24 @@ export const focusRingStyles = css`
 
 ```typescript
 // hx-button.ts
-import { tokenStyles } from '@helixui/tokens/lit';
 import { focusRingStyles } from './shared-styles.js';
 
+// Tokens are adopted at the document level automatically —
+// no tokenStyles import needed.
 @customElement('hx-button')
 export class HelixButton extends LitElement {
-  static override styles = [tokenStyles, focusRingStyles, css`...`];
+  static override styles = [focusRingStyles, css`...`];
 }
 ```
 
 ```typescript
 // hx-input.ts
-import { tokenStyles } from '@helixui/tokens/lit';
 import { focusRingStyles } from './shared-styles.js';
 
 @customElement('hx-input')
 export class HelixInput extends LitElement {
   // focusRingStyles is the same CSSResult object — Lit uses one sheet
-  static override styles = [tokenStyles, focusRingStyles, css`...`];
+  static override styles = [focusRingStyles, css`...`];
 }
 ```
 
@@ -101,10 +101,11 @@ export class HelixInput extends LitElement {
 ```javascript
 // What Lit does internally when an element connects:
 element.shadowRoot.adoptedStyleSheets = [
-  tokenStylesSheet,       // CSSResult from @helixui/tokens/lit
   focusRingStylesSheet,   // CSSResult from shared-styles.ts
   componentStylesSheet,   // CSSResult from this component's css``
 ];
+// Note: token styles are already on document.adoptedStyleSheets and
+// cascade into every shadow root automatically — no per-component entry needed.
 ```
 
 ## Browser Support
@@ -122,7 +123,7 @@ Constructable stylesheets are supported in all modern browsers. Lit includes a f
 
 Understanding constructable stylesheets explains several HELiX conventions:
 
-**Why `tokenStyles` must be first** — `tokenStyles` is a single `CSSResult` from `@helixui/tokens/lit`. When it's listed first, all subsequent rules in the array can reliably reference token custom properties because they're defined on `:root` by that sheet.
+**Why tokens are always available** — As of `@helixui/library@2.1.0`, the `--hx-*` token set is adopted at the document level when the library barrel imports. CSS custom properties inherit through Shadow DOM boundaries, so `var(--hx-*)` works inside any shadow root without any per-component token imports. The old pattern of listing `tokenStyles` first in `static override styles` is deprecated.
 
 **Why `css` strings should not be dynamic** — `CSSResult` deduplication works by object identity. If you construct a new `css` result on every render, Lit cannot deduplicate it. Keep `static override styles` truly static.
 
@@ -131,5 +132,5 @@ Understanding constructable stylesheets explains several HELiX conventions:
 ## Next Steps
 
 - [Adopted Stylesheets in HELiX](/components-guide/styling/adopted-stylesheets/) — the `@helixui/adopted-stylesheets` package for global styles
-- [Design Tokens](/components-guide/styling/tokens/) — how `tokenStyles` fits into the styles array
+- [Design Tokens](/components-guide/styling/tokens/) — how tokens are adopted automatically and how to use `--hx-*` properties
 - [CSS Parts API](/components-guide/styling/css-parts/) — exposing style hooks to consumers

--- a/apps/docs/src/content/docs/components-guide/styling/css-custom-properties.md
+++ b/apps/docs/src/content/docs/components-guide/styling/css-custom-properties.md
@@ -14,12 +14,10 @@ The pattern: the component reads `var(--hx-{component}-{property}, fallback)`. C
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-chip')
 export class HelixChip extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: inline-flex;

--- a/apps/docs/src/content/docs/components-guide/styling/css-parts.md
+++ b/apps/docs/src/content/docs/components-guide/styling/css-parts.md
@@ -12,12 +12,10 @@ Add the `part` attribute to any element in the shadow template that consumers ma
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-input')
 export class HelixInput extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: block;

--- a/apps/docs/src/content/docs/components-guide/styling/dark-mode.md
+++ b/apps/docs/src/content/docs/components-guide/styling/dark-mode.md
@@ -12,12 +12,10 @@ The most basic dark mode implementation responds automatically to the operating 
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-surface')
 export class HelixSurface extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: block;
@@ -50,7 +48,6 @@ When an application needs to toggle dark mode programmatically (a "dark mode" sw
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     :host {
       display: block;
@@ -104,7 +101,6 @@ Components then use the semantic tokens and are dark-aware automatically:
 
 ```typescript
 static override styles = [
-  tokenStyles,
   css`
     :host {
       background: var(--hx-color-surface);
@@ -156,12 +152,10 @@ A complete `hx-badge` component that supports both OS-level and class-based dark
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-badge')
 export class HelixBadge extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: inline-flex;

--- a/apps/docs/src/content/docs/components-guide/styling/responsive.md
+++ b/apps/docs/src/content/docs/components-guide/styling/responsive.md
@@ -16,12 +16,10 @@ Establish a containment context on the host element or an internal wrapper:
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-media-card')
 export class HelixMediaCard extends LitElement {
   static override styles = [
-    tokenStyles,
     css`
       :host {
         display: block;
@@ -107,11 +105,10 @@ Sometimes CSS alone is not enough — you may need to conditionally render diffe
 ```typescript
 import { LitElement, html, css } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-data-table')
 export class HelixDataTable extends LitElement {
-  static override styles = [tokenStyles, css`:host { display: block; }`];
+  static override styles = css`:host { display: block; }`;
 
   @state() private _compact = false;
 

--- a/apps/docs/src/content/docs/components-guide/styling/theming.md
+++ b/apps/docs/src/content/docs/components-guide/styling/theming.md
@@ -26,7 +26,7 @@ Set token overrides on `:root` to change the look of every HELiX component on th
 }
 ```
 
-Because `tokenStyles` injects tokens as CSS custom properties, any CSS rule with higher specificity (including `:root` overrides) will cascade correctly.
+Because `@helixui/library` adopts tokens via `document.adoptedStyleSheets`, any CSS rule with higher specificity (including `:root` overrides) will cascade correctly.
 
 ## Component-Level Theming via Style Props
 
@@ -44,19 +44,16 @@ hx-button.danger {
 Inside the component, those props cascade in over a token fallback:
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    button {
-      background: var(--hx-button-bg, var(--hx-color-primary-500));
-      color: var(--hx-button-color, var(--hx-color-neutral-0));
-    }
+static override styles = css`
+  button {
+    background: var(--hx-button-bg, var(--hx-color-primary-500));
+    color: var(--hx-button-color, var(--hx-color-neutral-0));
+  }
 
-    button:hover {
-      background: var(--hx-button-bg-hover, var(--hx-color-primary-600));
-    }
-  `,
-];
+  button:hover {
+    background: var(--hx-button-bg-hover, var(--hx-color-primary-600));
+  }
+`;
 ```
 
 ## Documenting Style Props with `@cssprop`

--- a/apps/docs/src/content/docs/components-guide/styling/tokens.md
+++ b/apps/docs/src/content/docs/components-guide/styling/tokens.md
@@ -35,29 +35,29 @@ All tokens follow the pattern `--hx-{category}-{scale}`:
 
 Scale values use t-shirt sizes (`xs`, `sm`, `md`, `lg`, `xl`, `2xl`) or numeric steps (`100`–`900`) depending on the category. Color palettes use numeric steps; spacing, typography, border, shadow, and motion use t-shirt sizes.
 
-## Importing Token Styles
+## How Tokens Are Made Available
 
-The `@helixui/tokens` package ships a Lit-compatible export that returns a `CSSResult` containing all tokens as CSS custom properties on `:root`.
+As of `@helixui/library@2.1.0`, design tokens are adopted at the **document level** automatically. When you import anything from `@helixui/library`, the full `--hx-*` token set is added to `document.adoptedStyleSheets` on `:root`. CSS custom properties inherit through Shadow DOM boundaries, so every component can use `var(--hx-*)` without any per-component setup.
 
 ```typescript
+// Tokens cascade automatically — no import needed in your component
+import '@helixui/library'; // or any individual component import
+
+// Your component just uses the tokens
 import { LitElement, html, css } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-card')
 export class HelixCard extends LitElement {
-  static override styles = [
-    tokenStyles,
-    css`
-      :host {
-        display: block;
-        padding: var(--hx-spacing-lg);
-        border-radius: var(--hx-border-radius-md);
-        box-shadow: var(--hx-shadow-sm);
-        font-family: var(--hx-font-family-sans);
-      }
-    `,
-  ];
+  static override styles = css`
+    :host {
+      display: block;
+      padding: var(--hx-spacing-lg);
+      border-radius: var(--hx-border-radius-md);
+      box-shadow: var(--hx-shadow-sm);
+      font-family: var(--hx-font-family-sans);
+    }
+  `;
 
   override render() {
     return html`<slot></slot>`;
@@ -65,52 +65,50 @@ export class HelixCard extends LitElement {
 }
 ```
 
-## Styles Array Order
+### Deprecated: `tokenStyles` from `@helixui/tokens/lit`
 
-`tokenStyles` must always be the **first** entry in the `styles` array. Subsequent `css` blocks can then reference any token with `var()`.
+Prior to `@helixui/library@2.1.0`, components were required to import `tokenStyles` and include it as the first entry in `static override styles`:
 
 ```typescript
-// Correct — tokenStyles first
-static override styles = [tokenStyles, css`...`];
+// Deprecated — do not use in new components
+import { tokenStyles } from '@helixui/tokens/lit';
 
-// Wrong — tokens not yet defined when component CSS runs
-static override styles = [css`...`, tokenStyles];
+static override styles = [tokenStyles, css`...`];
 ```
+
+`tokenStyles` and `mergeTokenStyles()` are still exported for backwards compatibility but should not appear in new component code. Remove them when you audit existing components — they are dead weight now that tokens are adopted at the document level.
 
 ## Using Tokens in Component CSS
 
 Reference tokens with `var(--hx-{token})` anywhere in your component stylesheet:
 
 ```typescript
-static override styles = [
-  tokenStyles,
-  css`
-    :host {
-      display: block;
-      font-family: var(--hx-font-family-sans);
-      font-size: var(--hx-font-size-base);
-      line-height: var(--hx-line-height-normal);
-    }
+static override styles = css`
+  :host {
+    display: block;
+    font-family: var(--hx-font-family-sans);
+    font-size: var(--hx-font-size-base);
+    line-height: var(--hx-line-height-normal);
+  }
 
-    .title {
-      font-size: var(--hx-font-size-xl);
-      font-weight: var(--hx-font-weight-semibold);
-      color: var(--hx-color-neutral-900);
-    }
+  .title {
+    font-size: var(--hx-font-size-xl);
+    font-weight: var(--hx-font-weight-semibold);
+    color: var(--hx-color-neutral-900);
+  }
 
-    .badge {
-      background: var(--hx-color-primary-500);
-      color: var(--hx-color-primary-50);
-      padding: var(--hx-spacing-xs) var(--hx-spacing-sm);
-      border-radius: var(--hx-border-radius-full);
-    }
+  .badge {
+    background: var(--hx-color-primary-500);
+    color: var(--hx-color-primary-50);
+    padding: var(--hx-spacing-xs) var(--hx-spacing-sm);
+    border-radius: var(--hx-border-radius-full);
+  }
 
-    .divider {
-      border-top: var(--hx-border-width-sm) solid var(--hx-color-neutral-200);
-      margin: var(--hx-spacing-md) 0;
-    }
-  `,
-];
+  .divider {
+    border-top: var(--hx-border-width-sm) solid var(--hx-color-neutral-200);
+    margin: var(--hx-spacing-md) 0;
+  }
+`;
 ```
 
 ## Tokens vs Hard-Coded Values

--- a/apps/docs/src/content/docs/components-guide/styling/tokens.md
+++ b/apps/docs/src/content/docs/components-guide/styling/tokens.md
@@ -37,7 +37,7 @@ Scale values use t-shirt sizes (`xs`, `sm`, `md`, `lg`, `xl`, `2xl`) or numeric 
 
 ## How Tokens Are Made Available
 
-As of `@helixui/library@2.1.0`, design tokens are adopted at the **document level** automatically. When you import anything from `@helixui/library`, the full `--hx-*` token set is added to `document.adoptedStyleSheets` on `:root`. CSS custom properties inherit through Shadow DOM boundaries, so every component can use `var(--hx-*)` without any per-component setup.
+As of `@helixui/library@2.1.1`, design tokens are adopted at the **document level** automatically. When you import anything from `@helixui/library`, the full `--hx-*` token set is added to `document.adoptedStyleSheets` on `:root`. CSS custom properties inherit through Shadow DOM boundaries, so every component can use `var(--hx-*)` without any per-component setup.
 
 ```typescript
 // Tokens cascade automatically — no import needed in your component
@@ -67,7 +67,7 @@ export class HelixCard extends LitElement {
 
 ### Deprecated: `tokenStyles` from `@helixui/tokens/lit`
 
-Prior to `@helixui/library@2.1.0`, components were required to import `tokenStyles` and include it as the first entry in `static override styles`:
+Prior to `@helixui/library@2.1.1`, components were required to import `tokenStyles` and include it as the first entry in `static override styles`:
 
 ```typescript
 // Deprecated — do not use in new components

--- a/apps/docs/src/content/docs/components-guide/typescript/generics.md
+++ b/apps/docs/src/content/docs/components-guide/typescript/generics.md
@@ -12,11 +12,9 @@ TypeScript allows class generics on `LitElement` subclasses. The type parameter 
 ```typescript
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-list')
 export class HelixList<T extends { id: string }> extends LitElement {
-  static override styles = [tokenStyles];
 
   // attribute: false — objects cannot be serialized to attributes
   @property({ attribute: false })
@@ -63,7 +61,6 @@ Combine `@property({ attribute: false })` with a generic type for JS-only object
 ```typescript
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 interface SelectOption<T> {
   value: T;
@@ -73,7 +70,6 @@ interface SelectOption<T> {
 
 @customElement('hx-select-list')
 export class HelixSelectList<T> extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ attribute: false })
   options: SelectOption<T>[] = [];
@@ -216,7 +212,6 @@ Add type constraints to generic parameters to guarantee shape:
 // T must have an id and a label — safe to render without renderItem fallback
 @customElement('hx-option-list')
 export class HelixOptionList<T extends { id: string; label: string }> extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ attribute: false })
   items: T[] = [];

--- a/apps/docs/src/content/docs/components-guide/typescript/interfaces.md
+++ b/apps/docs/src/content/docs/components-guide/typescript/interfaces.md
@@ -42,7 +42,6 @@ Use `implements` to bind the interface to the component class. TypeScript will e
 ```typescript
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { mixinDelegatesAria } from '../../mixins/index.js';
 import type { HelixButtonInterface } from './hx-button.types.js';
 
@@ -51,7 +50,6 @@ export class HelixButton
   extends mixinDelegatesAria(LitElement)
   implements HelixButtonInterface
 {
-  static override styles = [tokenStyles];
 
   @property({ type: String, reflect: true })
   variant: HelixButtonInterface['variant'] = 'primary';

--- a/apps/docs/src/content/docs/components-guide/typescript/strict-mode.md
+++ b/apps/docs/src/content/docs/components-guide/typescript/strict-mode.md
@@ -71,11 +71,9 @@ get _internals(): ElementInternals {
 ```typescript
 import { LitElement, html } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-text-input')
 export class HelixTextInput extends LitElement {
-  static override styles = [tokenStyles];
 
   // Correctly typed as nullable — the element may not exist yet
   @query('input')
@@ -99,11 +97,9 @@ With `strictNullChecks: true`, the TypeScript compiler tracks `null` and `undefi
 ```typescript
 import { LitElement, html, type PropertyValues } from 'lit';
 import { customElement, query } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-select')
 export class HelixSelect extends LitElement {
-  static override styles = [tokenStyles];
 
   @query('select')
   private _select: HTMLSelectElement | null = null;
@@ -142,11 +138,9 @@ Without explicit types, event handler parameters default to `any`, which TypeScr
 ```typescript
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-file-input')
 export class HelixFileInput extends LitElement {
-  static override styles = [tokenStyles];
 
   // Correctly typed — no implicit any
   private _handleChange(e: Event): void {

--- a/apps/docs/src/content/docs/components-guide/typescript/typed-events.md
+++ b/apps/docs/src/content/docs/components-guide/typescript/typed-events.md
@@ -40,7 +40,6 @@ Pass the detail interface as the generic argument to `CustomEvent`:
 ```typescript
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { mixinDelegatesAria } from '../../mixins/index.js';
 
 export interface HelixClickDetail {
@@ -49,7 +48,6 @@ export interface HelixClickDetail {
 
 @customElement('hx-button')
 export class HelixButton extends mixinDelegatesAria(LitElement) {
-  static override styles = [tokenStyles];
 
   @property({ type: Boolean, reflect: true })
   disabled: boolean = false;

--- a/apps/docs/src/content/docs/components-guide/typescript/typing-components.md
+++ b/apps/docs/src/content/docs/components-guide/typescript/typing-components.md
@@ -15,11 +15,9 @@ Lit's `@property()` decorator and TypeScript type annotations serve different pu
 ```typescript
 import { LitElement, html, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-badge')
 export class HelixBadge extends LitElement {
-  static override styles = [tokenStyles];
 
   // Both declarations are required:
   // - type: String  → Lit converts attribute → property (no-op for strings)
@@ -52,11 +50,9 @@ Lit's `updated()` and `willUpdate()` lifecycle hooks receive a `PropertyValues<t
 ```typescript
 import { LitElement, html, type PropertyValues, type TemplateResult } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-progress')
 export class HelixProgress extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: Number })
   value: number = 0;
@@ -111,11 +107,9 @@ Always annotate `render()` with `TemplateResult` or `TemplateResult | typeof not
 ```typescript
 import { LitElement, html, nothing, type TemplateResult } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 
 @customElement('hx-tooltip')
 export class HelixTooltip extends LitElement {
-  static override styles = [tokenStyles];
 
   @property({ type: String })
   content: string = '';

--- a/apps/docs/src/content/docs/components/documentation/jsdoc.md
+++ b/apps/docs/src/content/docs/components/documentation/jsdoc.md
@@ -795,7 +795,7 @@ The CEM is consumed by:
  */
 @customElement('hx-button')
 export class HelixButton extends LitElement {
-  static override styles = [tokenStyles, helixButtonStyles];
+  static override styles = helixButtonStyles;
 
   /**
    * Visual style variant of the button.
@@ -894,7 +894,7 @@ export class HelixButton extends LitElement {
  */
 @customElement('hx-text-input')
 export class HelixTextInput extends LitElement {
-  static override styles = [tokenStyles, helixTextInputStyles];
+  static override styles = helixTextInputStyles;
   static formAssociated = true;
 
   private _internals: ElementInternals;
@@ -1005,7 +1005,7 @@ export class HelixTextInput extends LitElement {
  */
 @customElement('hx-card')
 export class HelixCard extends LitElement {
-  static override styles = [tokenStyles, helixCardStyles];
+  static override styles = helixCardStyles;
 
   /**
    * Visual style variant of the card.

--- a/apps/docs/src/content/docs/components/styling/animations.md
+++ b/apps/docs/src/content/docs/components/styling/animations.md
@@ -918,7 +918,6 @@ export const helixAlertStyles = css`
 import { LitElement, html, nothing, PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { helixAlertStyles } from './hx-alert.styles.js';
 
 type AlertVariant = 'info' | 'success' | 'warning' | 'error';
@@ -933,7 +932,8 @@ type AlertVariant = 'info' | 'success' | 'warning' | 'error';
  */
 @customElement('hx-alert')
 export class HelixAlert extends LitElement {
-  static override styles = [tokenStyles, helixAlertStyles];
+  // Tokens cascade from document.adoptedStyleSheets — no tokenStyles import needed.
+  static override styles = helixAlertStyles;
 
   @property({ type: String, reflect: true })
   variant: AlertVariant = 'info';

--- a/apps/docs/src/content/docs/components/styling/constructable-stylesheets.md
+++ b/apps/docs/src/content/docs/components/styling/constructable-stylesheets.md
@@ -404,7 +404,7 @@ Constructable Stylesheets enable sophisticated style-sharing patterns that reduc
 
 ### Pattern 1: Document-Level Token Adoption
 
-As of `@helixui/library@2.1.0`, design tokens are adopted at the document level automatically. When the library barrel imports, the full `--hx-*` token set is added to `document.adoptedStyleSheets` on `:root`. CSS custom properties cascade through Shadow DOM boundaries, so every component has access to all tokens with no per-component setup.
+As of `@helixui/library@2.1.1`, design tokens are adopted at the document level automatically. When the library barrel imports, the full `--hx-*` token set is added to `document.adoptedStyleSheets` on `:root`. CSS custom properties cascade through Shadow DOM boundaries, so every component has access to all tokens with no per-component setup.
 
 ```typescript
 // main.ts — tokens are adopted when @helixui/library is imported
@@ -438,7 +438,7 @@ export class HxButton extends LitElement {
 - **Instant updates** — Modifying the document-level token sheet updates every component
 - **Consistency** — All components use the same token values
 
-> **Deprecated pattern:** Prior to `@helixui/library@2.1.0`, each component was required to include `tokenStyles` from `@helixui/tokens/lit` as the first entry in `static override styles`. That import and the `mergeTokenStyles()` utility are still exported for backwards compatibility but should not be used in new code.
+> **Deprecated pattern:** Prior to `@helixui/library@2.1.1`, each component was required to include `tokenStyles` from `@helixui/tokens/lit` as the first entry in `static override styles`. That import and the `mergeTokenStyles()` utility are still exported for backwards compatibility but should not be used in new code.
 
 ### Pattern 2: Component-Specific Stylesheets
 

--- a/apps/docs/src/content/docs/components/styling/constructable-stylesheets.md
+++ b/apps/docs/src/content/docs/components/styling/constructable-stylesheets.md
@@ -402,55 +402,28 @@ Constructable Stylesheets are 25× faster than per-component updates, though sli
 
 Constructable Stylesheets enable sophisticated style-sharing patterns that reduce duplication and enforce consistency.
 
-### Pattern 1: Shared Token Stylesheet
+### Pattern 1: Document-Level Token Adoption
 
-HELiX components share a base token stylesheet that defines all design tokens:
+As of `@helixui/library@2.1.0`, design tokens are adopted at the document level automatically. When the library barrel imports, the full `--hx-*` token set is added to `document.adoptedStyleSheets` on `:root`. CSS custom properties cascade through Shadow DOM boundaries, so every component has access to all tokens with no per-component setup.
 
 ```typescript
-// packages/hx-library/src/styles/tokens.ts
-import { css } from 'lit';
+// main.ts — tokens are adopted when @helixui/library is imported
+import '@helixui/library';
 
-export const tokenStyles = css`
-  :host {
-    /* Colors */
-    --hx-color-primary-500: #007878;
-    --hx-color-neutral-0: #ffffff;
-    --hx-color-neutral-800: #212529;
-    --hx-color-error-500: #dc3545;
-
-    /* Spacing */
-    --hx-space-1: 0.25rem;
-    --hx-space-2: 0.5rem;
-    --hx-space-4: 1rem;
-    --hx-space-6: 1.5rem;
-
-    /* Typography */
-    --hx-font-family-sans: system-ui, sans-serif;
-    --hx-font-weight-semibold: 600;
-    --hx-line-height-tight: 1.25;
-
-    /* Borders */
-    --hx-border-radius-md: 0.375rem;
-    --hx-border-radius-lg: 0.5rem;
-
-    /* Transitions */
-    --hx-transition-fast: 150ms ease;
-  }
-`;
+// No tokenStyles needed in component files
 ```
 
-Every component adopts this shared stylesheet:
+Components simply use `var(--hx-*)` directly in their styles:
 
 ```typescript
 // packages/hx-library/src/components/hx-button/hx-button.ts
 import { LitElement, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '../../styles/tokens.js';
 import { wcButtonStyles } from './hx-button.styles.js';
 
 @customElement('hx-button')
 export class HxButton extends LitElement {
-  static override styles = [tokenStyles, wcButtonStyles];
+  static override styles = wcButtonStyles;
 
   render() {
     return html`<button><slot></slot></button>`;
@@ -460,10 +433,12 @@ export class HxButton extends LitElement {
 
 **Benefits:**
 
-- **Single source of truth** — Tokens defined once, available everywhere
-- **Zero overhead** — `tokenStyles` parsed once, shared across all component types
-- **Instant updates** — Modifying `tokenStyles` updates every component
+- **Single adoption point** — Tokens defined once at the document level, available everywhere
+- **Zero per-component overhead** — No `tokenStyles` in every component's `static override styles`
+- **Instant updates** — Modifying the document-level token sheet updates every component
 - **Consistency** — All components use the same token values
+
+> **Deprecated pattern:** Prior to `@helixui/library@2.1.0`, each component was required to include `tokenStyles` from `@helixui/tokens/lit` as the first entry in `static override styles`. That import and the `mergeTokenStyles()` utility are still exported for backwards compatibility but should not be used in new code.
 
 ### Pattern 2: Component-Specific Stylesheets
 
@@ -528,14 +503,13 @@ export const focusRingStyles = css`
 Components adopt shared utilities:
 
 ```typescript
-import { tokenStyles } from '../../styles/tokens.js';
 import { focusRingStyles } from '../../styles/focus-ring.js';
 import { wcButtonStyles } from './hx-button.styles.js';
 
-static override styles = [tokenStyles, focusRingStyles, wcButtonStyles];
+static override styles = [focusRingStyles, wcButtonStyles];
 ```
 
-**Result:** Focus ring styles defined once, shared across buttons, cards, inputs, and any focusable component. Changes to `focusRingStyles` update all adopting components instantly.
+**Result:** Focus ring styles defined once, shared across buttons, cards, inputs, and any focusable component. Changes to `focusRingStyles` update all adopting components instantly. Token styles are already present via document-level adoption.
 
 ---
 
@@ -755,12 +729,12 @@ Lit components define styles using the static `styles` property:
 ```typescript
 import { LitElement } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { tokenStyles } from '../../styles/tokens.js';
 import { wcCardStyles } from './hx-card.styles.js';
 
+// No tokenStyles import — tokens cascade from document.adoptedStyleSheets
 @customElement('hx-card')
 export class HxCard extends LitElement {
-  static override styles = [tokenStyles, wcCardStyles];
+  static override styles = wcCardStyles;
 }
 ```
 
@@ -824,7 +798,7 @@ All public CSS custom properties are documented via JSDoc:
  */
 @customElement('hx-button')
 export class HxButton extends LitElement {
-  static override styles = [tokenStyles, wcButtonStyles];
+  static override styles = wcButtonStyles;
 }
 ```
 

--- a/apps/docs/src/content/docs/components/typescript/typing-components.md
+++ b/apps/docs/src/content/docs/components/typescript/typing-components.md
@@ -582,11 +582,10 @@ export class HelixButton extends LitElement {
 
 ```typescript
 import { CSSResultGroup } from 'lit';
-import { tokenStyles } from '@helixui/tokens/lit';
 import { helixButtonStyles } from './hx-button.styles.js';
 
 export class HelixButton extends LitElement {
-  static override styles: CSSResultGroup = [tokenStyles, helixButtonStyles];
+  static override styles: CSSResultGroup = helixButtonStyles;
 }
 ```
 

--- a/apps/docs/src/content/docs/extending/index.md
+++ b/apps/docs/src/content/docs/extending/index.md
@@ -56,7 +56,7 @@ Use **extending** when you need to add reactive properties, override render logi
 ```typescript
 // From packages/hx-library/src/components/hx-card/hx-card.ts
 export class HelixCard extends LitElement {
-  static override styles = [tokenStyles, helixCardStyles];
+  static override styles = helixCardStyles; // tokens cascade from document.adoptedStyleSheets
 
   variant: 'default' | 'featured' | 'compact' = 'default';
   elevation: 'flat' | 'raised' | 'floating' = 'flat';

--- a/apps/docs/src/content/docs/extending/multi-brand-theming.md
+++ b/apps/docs/src/content/docs/extending/multi-brand-theming.md
@@ -688,7 +688,7 @@ A single `@helixui/library` instance on a CDN serves all Drupal multisite instal
                     ┌─────────────────────────────────┐
                     │   CDN / Static Asset Server     │
                     │                                 │
-                    │  @helixui/library@2.1.0          │
+                    │  @helixui/library@2.1.1          │
                     │  ├── helix.esm.js               │
                     │  └── helix.css (base tokens)    │
                     └──────────────┬──────────────────┘

--- a/apps/docs/src/content/docs/extending/multi-brand-theming.md
+++ b/apps/docs/src/content/docs/extending/multi-brand-theming.md
@@ -502,7 +502,7 @@ restoreBrandPreference();
 ```json
 {
   "brand": "harbor-health",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "primitive": {
     "color-primary-50":  "#eff6f8",
     "color-primary-100": "#d0e9ef",
@@ -761,7 +761,7 @@ function harbor_health_preprocess_html(array &$variables): void {
     <title>{{ head_title }}</title>
     {{ head }}
     {# HELiX library — loaded from CDN or Drupal library #}
-    <script type="module" src="/cdn/helix/2.1.0/helix.esm.js"></script>
+    <script type="module" src="/cdn/helix/2.1.1/helix.esm.js"></script>
     {# Brand tokens loaded via Drupal library (harbor_health/brand-tokens) #}
   </head>
   <body{{ attributes.setAttribute('data-brand', 'harbor-health') }}>
@@ -932,7 +932,7 @@ done
 ```
 cdn.yourdomain.com/
 ├── helix/
-│   └── 2.1.0/
+│   └── 2.1.1/
 │       ├── helix.esm.js          (shared — all brands)
 │       └── helix.css             (base tokens — all brands)
 │

--- a/packages/helixui-mcp/src/__tests__/tools/scaffold-component.test.ts
+++ b/packages/helixui-mcp/src/__tests__/tools/scaffold-component.test.ts
@@ -204,6 +204,18 @@ describe('scaffoldComponent()', () => {
     }
   });
 
+  it('component .ts file spreads base class styles when extends is set', () => {
+    process.env['HELIXUI_MCP_CEM_PATH'] = '/nonexistent/custom-elements.json';
+
+    try {
+      const result = scaffoldComponent({ name: 'my-button', extends: 'hx-button' });
+      const content = result.files['hx-my-button.ts'] ?? '';
+      expect(content).toContain('...HelixButton.styles');
+    } finally {
+      delete process.env['HELIXUI_MCP_CEM_PATH'];
+    }
+  });
+
   // ── outputDir: write to disk ─────────────────────────────────────────────────
 
   it('writes files to disk when outputDir is provided', () => {

--- a/packages/helixui-mcp/src/__tests__/tools/scaffold-component.test.ts
+++ b/packages/helixui-mcp/src/__tests__/tools/scaffold-component.test.ts
@@ -102,10 +102,12 @@ describe('scaffoldComponent()', () => {
     expect(content).toContain("'hx-badge'");
   });
 
-  it('component .ts file imports tokenStyles', () => {
+  it('component .ts file does not import tokenStyles', () => {
     const result = scaffoldComponent({ name: 'badge' });
     const content = result.files['hx-badge.ts'] ?? '';
-    expect(content).toContain('tokenStyles');
+    expect(content).not.toContain('tokenStyles');
+    expect(content).not.toContain("from '@helixui/tokens/lit'");
+    expect(content).toContain('static override styles = [');
   });
 
   // ── styles .ts file ──────────────────────────────────────────────────────────

--- a/packages/helixui-mcp/src/tools/scaffold-component.ts
+++ b/packages/helixui-mcp/src/tools/scaffold-component.ts
@@ -104,14 +104,12 @@ function generateComponentClass(
   const imports = hasBase
     ? [
         `import { customElement } from 'lit/decorators.js';`,
-        `import { tokenStyles } from '@helixui/tokens/lit';`,
         `import { ${baseClassName} } from '../${baseTag}/index.js';`,
         `import { ${stylesVar} } from './${tagName}.styles.js';`,
       ]
     : [
         `import { LitElement, html } from 'lit';`,
         `import { customElement } from 'lit/decorators.js';`,
-        `import { tokenStyles } from '@helixui/tokens/lit';`,
         `import { ${stylesVar} } from './${tagName}.styles.js';`,
       ];
 
@@ -129,7 +127,7 @@ function generateComponentClass(
     ' */',
     `@customElement('${tagName}')`,
     `export class ${className} extends ${extendsClause} {`,
-    `  static override styles = [tokenStyles, ${stylesVar}];`,
+    `  static override styles = [${stylesVar}];`,
     '',
     '  override render() {',
     renderBody,

--- a/packages/helixui-mcp/src/tools/scaffold-component.ts
+++ b/packages/helixui-mcp/src/tools/scaffold-component.ts
@@ -116,9 +116,7 @@ function generateComponentClass(
   const extendsClause = hasBase && baseClassName !== undefined ? baseClassName : 'LitElement';
 
   const renderBody = hasBase ? `    return super.render();` : `    return html\`<slot></slot>\`;`;
-  const stylesEntry = hasBase
-    ? `...${extendsClause}.styles, ${stylesVar}`
-    : stylesVar;
+  const stylesEntry = hasBase ? `...${extendsClause}.styles, ${stylesVar}` : stylesVar;
 
   return [
     imports.join('\n'),

--- a/packages/helixui-mcp/src/tools/scaffold-component.ts
+++ b/packages/helixui-mcp/src/tools/scaffold-component.ts
@@ -116,6 +116,9 @@ function generateComponentClass(
   const extendsClause = hasBase && baseClassName !== undefined ? baseClassName : 'LitElement';
 
   const renderBody = hasBase ? `    return super.render();` : `    return html\`<slot></slot>\`;`;
+  const stylesEntry = hasBase
+    ? `...${extendsClause}.styles, ${stylesVar}`
+    : stylesVar;
 
   return [
     imports.join('\n'),
@@ -127,7 +130,7 @@ function generateComponentClass(
     ' */',
     `@customElement('${tagName}')`,
     `export class ${className} extends ${extendsClause} {`,
-    `  static override styles = [${stylesVar}];`,
+    `  static override styles = [${stylesEntry}];`,
     '',
     '  override render() {',
     renderBody,

--- a/packages/hx-library/src/styles/shared-field.styles.ts
+++ b/packages/hx-library/src/styles/shared-field.styles.ts
@@ -5,7 +5,7 @@
  * to avoid duplicating identical CSS across multiple style files.
  *
  * Import alongside component-specific styles via CSSResultGroup:
- *   static override styles = [tokenStyles, sharedFieldStyles, helixMyComponentStyles];
+ *   static override styles = [sharedFieldStyles, helixMyComponentStyles];
  */
 import { css } from 'lit';
 

--- a/packages/hx-tokens/src/lit.ts
+++ b/packages/hx-tokens/src/lit.ts
@@ -1,7 +1,17 @@
 import { css } from 'lit';
 import { tokenEntries, darkTokenEntries, highContrastTokenEntries } from './index.js';
 
-/** Lit CSSResult with all light-mode tokens as :host custom properties (Shadow DOM compatible) */
+/**
+ * Lit CSSResult with all light-mode tokens as `:host` custom properties.
+ *
+ * @deprecated Since `@helixui/library@2.1.0`. Tokens are now adopted at the
+ * document level via `document.adoptedStyleSheets` and cascade through Shadow DOM
+ * via CSS inheritance. You no longer need to include `tokenStyles` in component
+ * `static styles`. This export remains for edge cases (isolated test fixtures,
+ * iframe contexts) but should not be used in production components.
+ *
+ * @see ensureDocumentTokens in `@helixui/library`
+ */
 export const tokenStyles = css([
   `:host {\n${tokenEntries.map((t) => `  ${t.name}: ${t.value};`).join('\n')}\n}`,
 ] as unknown as TemplateStringsArray);


### PR DESCRIPTION
Updates all docs, code generators, and deprecated API annotations for the @helixui/library@2.1.1 adopted stylesheets architecture.

**Changes:**
- 50+ docs pages: remove `tokenStyles` from all code examples, add deprecation callouts
- `scaffold-component.ts`: new components no longer generate `tokenStyles` import or include it in `static styles`
- `@helixui/tokens/src/lit.ts`: `tokenStyles` export marked `@deprecated` with migration guidance
- `shared-field.styles.ts`: fix JSDoc example to reflect new pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs to show design tokens are now adopted at the document level and removed per-component token imports from many examples; code samples simplified to use local styles only.
* **Deprecation**
  * Marked legacy token-style exports/imports as deprecated while keeping them for backward compatibility.
* **Chores**
  * Updated scaffolding, generation behavior and tests to align examples and templates with the new token-adoption approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->