### PR TITLE
fix: resolve component bugs across hx-alert, hx-badge, hx-action-bar

### DIFF
--- a/.changeset/fix-component-bugs-batch-20260412.md
+++ b/.changeset/fix-component-bugs-batch-20260412.md
@@ -1,0 +1,18 @@
+---
+'@helixui/library': patch
+---
+
+fix(hx-alert): consolidate duplicate icon/showIcon Storybook control — the icon
+argType now correctly binds to the component's showIcon property via show-icon
+attribute
+
+fix(hx-badge): strengthen dot-mode CSS guards to prevent prefix slot from
+rendering in dot indicator mode; add slot projection assertions to
+RemovableWithCount story; refactor --hx-badge-pulse-color to use private
+--_pulse-color variable so consumers can override via the public custom property
+
+fix(hx-action-bar): **BREAKING** replace ariaLabel property that shadowed native
+HTMLElement.ariaLabel with accessibleLabel property (accessible-label attribute).
+The component continues to accept the standard aria-label HTML attribute for
+backward compatibility. Consumers using the JS property el.ariaLabel should
+migrate to el.accessibleLabel or set the aria-label attribute directly.

--- a/packages/hx-library/src/components/hx-action-bar/hx-action-bar.stories.ts
+++ b/packages/hx-library/src/components/hx-action-bar/hx-action-bar.stories.ts
@@ -58,13 +58,14 @@ const meta = {
     size: 'md',
     variant: 'default',
     position: 'top',
+    accessibleLabel: 'Toolbar',
   },
   render: (args) => html`
     <hx-action-bar
       size=${args.size}
       variant=${args.variant}
       position=${args.position}
-      aria-label="Toolbar"
+      accessible-label=${args.accessibleLabel}
       style="border: 1px dashed var(--hx-color-neutral-200, #e5e7eb);"
     >
       <button

--- a/packages/hx-library/src/components/hx-action-bar/hx-action-bar.stories.ts
+++ b/packages/hx-library/src/components/hx-action-bar/hx-action-bar.stories.ts
@@ -43,10 +43,10 @@ const meta = {
         type: { summary: "'top' | 'bottom' | 'sticky'" },
       },
     },
-    ariaLabel: {
+    accessibleLabel: {
       control: 'text',
       description:
-        'Accessible label for the toolbar. Required when multiple toolbars appear on the same page.',
+        'Accessible label for the toolbar. Required when multiple toolbars appear on the same page. Also accepts the standard `aria-label` HTML attribute.',
       table: {
         category: 'Accessibility',
         defaultValue: { summary: 'Actions' },

--- a/packages/hx-library/src/components/hx-action-bar/hx-action-bar.ts
+++ b/packages/hx-library/src/components/hx-action-bar/hx-action-bar.ts
@@ -32,8 +32,9 @@ export type ActionBarSize = 'sm' | 'md' | 'lg';
  * @cssprop [--hx-action-bar-gap=var(--hx-space-2,0.5rem)] - Gap between slotted items.
  * @cssprop [--hx-action-bar-z-index=10] - Z-index when sticky or bottom position.
  *
- * @attr {string} aria-label - Required. Identifies the toolbar to assistive technology.
+ * @attr {string} accessible-label - Identifies the toolbar to assistive technology.
  *   When multiple toolbars appear on the same page, each must have a unique, descriptive label.
+ *   Falls back to the native `aria-label` attribute if not set.
  *
  * @example
  * ```html
@@ -98,10 +99,35 @@ export class HelixActionBar extends LitElement {
   /**
    * Accessible label for the toolbar.
    * Required when multiple toolbars appear on the same page.
-   * @attr aria-label
+   *
+   * Accepts both `accessible-label` and the standard `aria-label` HTML attribute.
+   * The `accessible-label` attribute takes precedence when both are set.
+   *
+   * Previously this was exposed as the `ariaLabel` JS property, which shadowed
+   * the native `HTMLElement.ariaLabel`. That shadowing is removed; use
+   * `accessibleLabel` or the HTML attributes instead.
+   *
+   * @attr accessible-label
+   */
+  @property({ attribute: 'accessible-label' })
+  accessibleLabel: string = '';
+
+  /**
+   * Observed mirror of the host's `aria-label` attribute so Lit re-renders
+   * when consumers set `aria-label` (the standard HTML pattern).
+   * @internal
    */
   @property({ attribute: 'aria-label' })
-  ariaLabel: string = 'Actions';
+  private _ariaLabelAttr: string = '';
+
+  /**
+   * Returns the effective label for the toolbar, checking accessible-label first,
+   * then the aria-label attribute, falling back to 'Actions'.
+   * @internal
+   */
+  private get _effectiveLabel(): string {
+    return this.accessibleLabel || this._ariaLabelAttr || 'Actions';
+  }
 
   /** Cached list of focusable items — invalidated on slot change. */
   /** @internal */
@@ -285,7 +311,7 @@ export class HelixActionBar extends LitElement {
       <div
         part="base"
         role="toolbar"
-        aria-label=${this.ariaLabel}
+        aria-label=${this._effectiveLabel}
         aria-orientation="horizontal"
         class="base base--${this.size} base--${this.variant}${positionClass}"
       >

--- a/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.stories.ts
@@ -41,12 +41,13 @@ const meta = {
         type: { summary: 'boolean' },
       },
     },
-    icon: {
+    showIcon: {
       control: 'boolean',
-      description: 'Whether to show the default variant icon. Set to false to hide the icon.',
+      description:
+        'Whether to show the default variant icon. Add the `show-icon` attribute to display the icon.',
       table: {
         category: 'Visual',
-        defaultValue: { summary: 'true' },
+        defaultValue: { summary: 'false' },
         type: { summary: 'boolean' },
       },
     },
@@ -78,16 +79,6 @@ const meta = {
         type: { summary: 'string | null' },
       },
     },
-    showIcon: {
-      control: 'boolean',
-      description:
-        'Whether to show the default variant icon. Add the `show-icon` attribute to display the icon.',
-      table: {
-        category: 'Visual',
-        defaultValue: { summary: 'false' },
-        type: { summary: 'boolean' },
-      },
-    },
     severityLabel: {
       control: 'text',
       description:
@@ -112,7 +103,7 @@ const meta = {
     variant: 'info',
     dismissible: false,
     open: true,
-    icon: true,
+    showIcon: true,
     accent: false,
     'return-focus-to': '',
     message: 'Your session will expire in 15 minutes. Please save your work.',
@@ -122,7 +113,7 @@ const meta = {
       variant=${args.variant}
       ?dismissible=${args.dismissible}
       ?open=${args.open}
-      ?show-icon=${args.icon}
+      ?show-icon=${args.showIcon}
       ?accent=${args.accent}
       return-focus-to=${ifDefined(args['return-focus-to'] || undefined)}
     >

--- a/packages/hx-library/src/components/hx-badge/hx-badge.stories.ts
+++ b/packages/hx-library/src/components/hx-badge/hx-badge.stories.ts
@@ -424,15 +424,33 @@ export const RemovableWithCount: Story = {
       await expect(btn).toBeTruthy();
     }
 
-    // Verify prefix labels appear alongside counts (light DOM check)
+    // Verify prefix labels appear alongside counts
     const firstBadge = badges[0];
     const firstLabel = firstBadge.querySelector('[slot="prefix"]');
     await expect(firstLabel?.textContent?.trim()).toBe('ICU');
+
+    // Verify prefix slot is actually projected in shadow DOM (not silently dropped)
+    const firstPrefixSlot = firstBadge.shadowRoot?.querySelector(
+      'slot[name="prefix"]',
+    ) as HTMLSlotElement | null;
+    await expect(firstPrefixSlot).toBeTruthy();
+    const firstAssigned = firstPrefixSlot?.assignedElements({ flatten: true });
+    await expect(firstAssigned?.length).toBeGreaterThan(0);
+    await expect(firstAssigned?.[0]?.textContent?.trim()).toBe('ICU');
 
     // Last badge: count=107, max=99 → "99+"
     const lastBadge = badges[4];
     const lastLabel = lastBadge.querySelector('[slot="prefix"]');
     await expect(lastLabel?.textContent?.trim()).toBe('Discharged');
+    const lastPrefixSlot = lastBadge.shadowRoot?.querySelector(
+      'slot[name="prefix"]',
+    ) as HTMLSlotElement | null;
+    await expect(lastPrefixSlot).toBeTruthy();
+    const lastAssigned = lastPrefixSlot?.assignedElements({ flatten: true });
+    await expect(lastAssigned?.length).toBeGreaterThan(0);
+    await expect(lastAssigned?.[0]?.textContent?.trim()).toBe('Discharged');
+
+    // Count display is correct
     const span = lastBadge.shadowRoot?.querySelector('[part="badge"]');
     await expect(span?.textContent?.trim()).toBe('99+');
   },

--- a/packages/hx-library/src/components/hx-badge/hx-badge.styles.ts
+++ b/packages/hx-library/src/components/hx-badge/hx-badge.styles.ts
@@ -46,43 +46,49 @@ export const helixBadgeStyles = css`
   .badge--primary {
     --hx-badge-bg: var(--hx-color-primary-500, #2563eb);
     --hx-badge-color: var(--hx-color-neutral-0, #ffffff);
-    --hx-badge-pulse-color: var(--hx-color-primary-500, #2563eb);
+    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-primary-500, #2563eb));
   }
 
   .badge--secondary {
     --hx-badge-bg: var(--hx-badge-secondary-bg, var(--hx-color-neutral-100, #f3f4f6));
     --hx-badge-color: var(--hx-badge-secondary-color, var(--hx-color-neutral-700, #374151));
-    --hx-badge-pulse-color: var(--hx-badge-secondary-bg, var(--hx-color-neutral-100, #f3f4f6));
+    --_pulse-color: var(
+      --hx-badge-pulse-color,
+      var(--hx-badge-secondary-bg, var(--hx-color-neutral-100, #f3f4f6))
+    );
   }
 
   .badge--success {
     --hx-badge-bg: var(--hx-color-success-700, #15803d);
     --hx-badge-color: var(--hx-color-neutral-0, #ffffff);
-    --hx-badge-pulse-color: var(--hx-color-success-700, #15803d);
+    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-success-700, #15803d));
   }
 
   .badge--warning {
     --hx-badge-bg: var(--hx-color-warning-500, #eab308);
     --hx-badge-color: var(--hx-color-neutral-900, #1a1a1a);
-    --hx-badge-pulse-color: var(--hx-color-warning-500, #eab308);
+    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-warning-500, #eab308));
   }
 
   .badge--error {
     --hx-badge-bg: var(--hx-color-error-500, #dc2626);
     --hx-badge-color: var(--hx-color-neutral-0, #ffffff);
-    --hx-badge-pulse-color: var(--hx-color-error-500, #dc2626);
+    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-error-500, #dc2626));
   }
 
   .badge--neutral {
     --hx-badge-bg: var(--hx-color-neutral-200, #e5e7eb);
     --hx-badge-color: var(--hx-color-neutral-700, #374151);
-    --hx-badge-pulse-color: var(--hx-color-neutral-200, #e5e7eb);
+    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-neutral-200, #e5e7eb));
   }
 
   .badge--info {
     --hx-badge-bg: var(--hx-badge-info-bg, var(--hx-color-info-700, #0369a1));
     --hx-badge-color: var(--hx-badge-info-color, var(--hx-color-neutral-0, #ffffff));
-    --hx-badge-pulse-color: var(--hx-badge-info-bg, var(--hx-color-info-700, #0369a1));
+    --_pulse-color: var(
+      --hx-badge-pulse-color,
+      var(--hx-badge-info-bg, var(--hx-color-info-700, #0369a1))
+    );
   }
 
   /* ─── Semantic Variant Label (WCAG 1.4.1) ─── */
@@ -116,13 +122,11 @@ export const helixBadgeStyles = css`
     border-radius: var(--hx-border-radius-full, 9999px);
   }
 
-  /* Guard: hide prefix slot and slotted content in dot mode to prevent overflow */
-  .badge--dot ::slotted(*) {
-    display: none;
-  }
-
+  /* Guard: hide all inner content in dot mode — the dot is purely visual */
+  .badge--dot ::slotted(*),
+  .badge--dot slot,
   .badge--dot slot[name='prefix'] {
-    display: none;
+    display: none !important;
   }
 
   /* ─── Pulse Animation ─── */
@@ -131,7 +135,7 @@ export const helixBadgeStyles = css`
     0%,
     100% {
       opacity: 1;
-      box-shadow: 0 0 0 2px var(--hx-badge-pulse-color, currentColor);
+      box-shadow: 0 0 0 2px var(--_pulse-color, currentColor);
     }
     50% {
       opacity: var(--hx-opacity-75, 0.75);

--- a/packages/hx-library/src/components/hx-badge/hx-badge.styles.ts
+++ b/packages/hx-library/src/components/hx-badge/hx-badge.styles.ts
@@ -46,13 +46,16 @@ export const helixBadgeStyles = css`
   .badge--primary {
     --hx-badge-bg: var(--hx-color-primary-500, #2563eb);
     --hx-badge-color: var(--hx-color-neutral-0, #ffffff);
-    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-primary-500, #2563eb));
+    --hx-badge-pulse-color-internal: var(
+      --hx-badge-pulse-color,
+      var(--hx-color-primary-500, #2563eb)
+    );
   }
 
   .badge--secondary {
     --hx-badge-bg: var(--hx-badge-secondary-bg, var(--hx-color-neutral-100, #f3f4f6));
     --hx-badge-color: var(--hx-badge-secondary-color, var(--hx-color-neutral-700, #374151));
-    --_pulse-color: var(
+    --hx-badge-pulse-color-internal: var(
       --hx-badge-pulse-color,
       var(--hx-badge-secondary-bg, var(--hx-color-neutral-100, #f3f4f6))
     );
@@ -61,31 +64,43 @@ export const helixBadgeStyles = css`
   .badge--success {
     --hx-badge-bg: var(--hx-color-success-700, #15803d);
     --hx-badge-color: var(--hx-color-neutral-0, #ffffff);
-    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-success-700, #15803d));
+    --hx-badge-pulse-color-internal: var(
+      --hx-badge-pulse-color,
+      var(--hx-color-success-700, #15803d)
+    );
   }
 
   .badge--warning {
     --hx-badge-bg: var(--hx-color-warning-500, #eab308);
     --hx-badge-color: var(--hx-color-neutral-900, #1a1a1a);
-    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-warning-500, #eab308));
+    --hx-badge-pulse-color-internal: var(
+      --hx-badge-pulse-color,
+      var(--hx-color-warning-500, #eab308)
+    );
   }
 
   .badge--error {
     --hx-badge-bg: var(--hx-color-error-500, #dc2626);
     --hx-badge-color: var(--hx-color-neutral-0, #ffffff);
-    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-error-500, #dc2626));
+    --hx-badge-pulse-color-internal: var(
+      --hx-badge-pulse-color,
+      var(--hx-color-error-500, #dc2626)
+    );
   }
 
   .badge--neutral {
     --hx-badge-bg: var(--hx-color-neutral-200, #e5e7eb);
     --hx-badge-color: var(--hx-color-neutral-700, #374151);
-    --_pulse-color: var(--hx-badge-pulse-color, var(--hx-color-neutral-200, #e5e7eb));
+    --hx-badge-pulse-color-internal: var(
+      --hx-badge-pulse-color,
+      var(--hx-color-neutral-200, #e5e7eb)
+    );
   }
 
   .badge--info {
     --hx-badge-bg: var(--hx-badge-info-bg, var(--hx-color-info-700, #0369a1));
     --hx-badge-color: var(--hx-badge-info-color, var(--hx-color-neutral-0, #ffffff));
-    --_pulse-color: var(
+    --hx-badge-pulse-color-internal: var(
       --hx-badge-pulse-color,
       var(--hx-badge-info-bg, var(--hx-color-info-700, #0369a1))
     );
@@ -135,7 +150,7 @@ export const helixBadgeStyles = css`
     0%,
     100% {
       opacity: 1;
-      box-shadow: 0 0 0 2px var(--_pulse-color, currentColor);
+      box-shadow: 0 0 0 2px var(--hx-badge-pulse-color-internal, currentColor);
     }
     50% {
       opacity: var(--hx-opacity-75, 0.75);


### PR DESCRIPTION
## Summary

Batch 1 of the HELiX release cycle component bug fixes, covering 5 active fixes across 3 components:

- **hx-alert (#690):** Consolidate duplicate `icon`/`showIcon` Storybook argTypes — the icon control now correctly binds to the component's `showIcon` property via `show-icon` attribute
- **hx-badge (#711):** Strengthen dot-mode CSS guards (`!important`, additional selectors) to prevent the prefix slot from rendering in dot indicator mode
- **hx-badge (#710):** Add slot projection assertions to RemovableWithCount story to verify prefix labels render alongside counts
- **hx-badge (#709):** Refactor `--hx-badge-pulse-color` to use private `--_pulse-color` variable so the public custom property serves as a consumer override point
- **hx-action-bar (#705):** Replace `ariaLabel` property that shadowed native `HTMLElement.ariaLabel` with `accessibleLabel` (`accessible-label` attribute). The component continues to accept the standard `aria-label` HTML attribute for backward compatibility.

Tickets 6-7 (hx-avatar #696, #697) were already resolved on `dev` — `_imgError` reset is in `willUpdate()` and forced-colors styles are present.

### Breaking change (hx-action-bar)

The `ariaLabel` JS property is removed. Consumers should migrate to `accessibleLabel` or set the `aria-label` attribute directly.

## Test plan

- [x] `bash scripts/agent-verify.sh` passes (format, lint, type-check, tests)
- [x] All 39 hx-action-bar tests pass including keyboard navigation and axe-core
- [x] Pre-push quality gates pass (7 gates)
- [ ] CI Quality Gates pass
- [ ] CodeRabbit review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Alert: icon control now correctly toggles icon display in the component.
  * Badge: dot-mode no longer shows prefix slot content; pulse color now respects the public custom property for consumer overrides.
  * Action Bar: accessible label property renamed to accessibleLabel (breaking change); the standard aria-label attribute remains accepted for compatibility.

* **Tests**
  * Badge story: improved slot projection assertions to better validate rendered content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->