### PR TITLE
fix(hx-link): add tabindex=0 to disabled span for keyboard accessibility

### DIFF
--- a/.changeset/audit-p0p1-link-skeleton-20260412.md
+++ b/.changeset/audit-p0p1-link-skeleton-20260412.md
@@ -1,0 +1,7 @@
+---
+'@helixui/library': patch
+---
+
+fix(hx-link): add missing tabindex="0" to disabled span — screen readers can
+now reach disabled links via keyboard navigation and announce the disabled state
+(P0-1 audit finding)

--- a/packages/hx-library/src/components/hx-link/hx-link.ts
+++ b/packages/hx-library/src/components/hx-link/hx-link.ts
@@ -162,6 +162,7 @@ export class HelixLink extends LitElement {
           class=${classMap(classes)}
           role="link"
           aria-disabled="true"
+          tabindex="0"
           @click=${this._handleClick}
         >
           <slot></slot>


### PR DESCRIPTION
## Summary
- Resolves P0-1 audit finding for hx-link (#800)
- Disabled links rendered as `<span>` were unreachable via keyboard — now have `tabindex="0"`
- Screen readers can reach disabled links and announce the disabled state
- Remaining P0/P1 items for hx-link and hx-skeleton were already remediated in prior audit cycles

## Audit coverage
- hx-link P0-1: **fixed** (this PR)
- hx-link P0-01, P0-2, P1-01 through P1-4: already resolved on dev
- hx-skeleton P0-01, P1-01 through P1-04: already resolved on dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility of disabled links to ensure they remain reachable through keyboard navigation and are properly announced by screen readers and assistive technologies, improving usability for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->