### PR TITLE
fix(hx-stat): add aria-live region, forced-colors styles, and devWarn

### DIFF
--- a/.changeset/fix-hx-stat-a11y-1443.md
+++ b/.changeset/fix-hx-stat-a11y-1443.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-stat): add aria-live region for dynamic value/trend updates, forced-colors support, and devWarn for empty state

--- a/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
@@ -121,7 +121,7 @@ export const helixStatStyles = css`
   /* ─── Forced Colors (Windows High Contrast Mode) ─── */
 
   @media (forced-colors: active) {
-    :host {
+    .stat__trend {
       forced-color-adjust: none;
     }
 

--- a/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
@@ -106,4 +106,51 @@ export const helixStatStyles = css`
   [hidden] {
     display: none !important;
   }
+
+  /* ─── Visually-hidden live region ─── */
+
+  .stat__live-region {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  /* ─── Forced Colors (Windows High Contrast Mode) ─── */
+
+  @media (forced-colors: active) {
+    :host {
+      forced-color-adjust: none;
+    }
+
+    .stat__value {
+      color: CanvasText;
+    }
+
+    .stat__label {
+      color: CanvasText;
+    }
+
+    .stat__icon {
+      color: CanvasText;
+    }
+
+    .stat__trend--up {
+      background: Highlight;
+      color: HighlightText;
+      border: 1px solid Highlight;
+    }
+
+    .stat__trend--down {
+      background: ButtonText;
+      color: ButtonFace;
+      border: 1px solid ButtonText;
+    }
+
+    .stat__trend-arrow {
+      color: currentColor;
+    }
+  }
 `;

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -183,12 +183,23 @@ describe('hx-stat', () => {
       expect(shadowQuery(el, '[part~="trend"]')).toBeTruthy();
     });
 
-    it('renders trend element with correct class for forced-colors targeting', async () => {
+    it('stylesheet includes forced-colors media query with distinct trend styles', async () => {
       const el = await fixture<HelixStat>('<hx-stat value="42" trend="up"></hx-stat>');
       await el.updateComplete;
+
+      // Verify the trend element renders with the correct class
       const trend = shadowQuery(el, '.stat__trend');
       expect(trend).toBeTruthy();
-      expect(trend!.classList.contains('stat__trend--up')).toBe(true);
+      expect(trend?.classList.contains('stat__trend--up')).toBe(true);
+
+      // Verify the component's adopted stylesheets contain forced-colors rules
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      const cssText = sheets.map((s) => [...s.cssRules].map((r) => r.cssText).join('\n')).join('\n');
+      expect(cssText).toContain('forced-colors: active');
+
+      // Verify up and down trends map to different border styles in the stylesheet
+      expect(cssText).toContain('.stat__trend--up');
+      expect(cssText).toContain('.stat__trend--down');
     });
   });
 

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -182,6 +182,14 @@ describe('hx-stat', () => {
       const el = await fixture<HelixStat>('<hx-stat value="42" trend="up"></hx-stat>');
       expect(shadowQuery(el, '[part~="trend"]')).toBeTruthy();
     });
+
+    it('renders trend element with correct class for forced-colors targeting', async () => {
+      const el = await fixture<HelixStat>('<hx-stat value="42" trend="up"></hx-stat>');
+      await el.updateComplete;
+      const trend = shadowQuery(el, '.stat__trend');
+      expect(trend).toBeTruthy();
+      expect(trend!.classList.contains('stat__trend--up')).toBe(true);
+    });
   });
 
   // ─── Slots (2) ───

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import { fixture, shadowQuery, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixStat } from './hx-stat.js';
 import './index.js';
@@ -249,6 +249,68 @@ describe('hx-stat', () => {
         expect(violations, `hx-size="${size}" should have no violations`).toEqual([]);
         el.remove();
       }
+    });
+  });
+
+  // ─── aria-live region (4) ───
+
+  describe('aria-live region', () => {
+    it('renders a visually-hidden live region element', async () => {
+      const el = await fixture<HelixStat>('<hx-stat label="Users" value="42"></hx-stat>');
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live).toBeTruthy();
+      expect(live?.getAttribute('aria-live')).toBe('polite');
+      expect(live?.getAttribute('aria-atomic')).toBe('true');
+    });
+
+    it('live region contains value and label text', async () => {
+      const el = await fixture<HelixStat>('<hx-stat label="Patients" value="1,234"></hx-stat>');
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live?.textContent).toContain('1,234');
+      expect(live?.textContent).toContain('Patients');
+    });
+
+    it('live region updates when value changes', async () => {
+      const el = await fixture<HelixStat>('<hx-stat label="Users" value="10"></hx-stat>');
+      el.value = '999';
+      await el.updateComplete;
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live?.textContent).toContain('999');
+    });
+
+    it('live region includes trend direction when set', async () => {
+      const el = await fixture<HelixStat>(
+        '<hx-stat label="Revenue" value="$5,000" trend="up"></hx-stat>',
+      );
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live?.textContent).toContain('up');
+    });
+  });
+
+  // ─── devWarn for empty state (2) ───
+
+  describe('devWarn for empty state', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('warns when both value and label are empty', async () => {
+      await fixture<HelixStat>('<hx-stat></hx-stat>');
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('unnamed hx-stat'),
+      );
+    });
+
+    it('does not warn about unnamed stat when value is provided', async () => {
+      await fixture<HelixStat>('<hx-stat value="42"></hx-stat>');
+      const unnamedCalls = (console.warn as ReturnType<typeof vi.spyOn>).mock.calls.filter(
+        (args) => String(args[0]).includes('unnamed hx-stat'),
+      );
+      expect(unnamedCalls).toHaveLength(0);
     });
   });
 });

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -324,6 +324,15 @@ describe('hx-stat', () => {
       );
     });
 
+    it('warns only once across multiple updates (_hasWarnedUnnamed guard)', async () => {
+      const el = await fixture<HelixStat>('<hx-stat></hx-stat>');
+      expect(console.warn).toHaveBeenCalledTimes(1);
+
+      el.requestUpdate();
+      await el.updateComplete;
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
     it('does not warn about unnamed stat when value is provided', async () => {
       await fixture<HelixStat>('<hx-stat value="42"></hx-stat>');
       const unnamedCalls = (console.warn as ReturnType<typeof vi.spyOn>).mock.calls.filter(

--- a/packages/hx-library/src/components/hx-stat/hx-stat.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.ts
@@ -100,14 +100,16 @@ export class HelixStat extends LitElement {
   override updated(changedProperties: Map<PropertyKey, unknown>): void {
     super.updated(changedProperties);
     const identityChanged = changedProperties.has('value') || changedProperties.has('label');
-    if (identityChanged && !this.value && !this.label && !this._hasWarnedUnnamed) {
+    const hasValue = this.value.trim().length > 0;
+    const hasLabel = this.label.trim().length > 0;
+    if (identityChanged && !hasValue && !hasLabel && !this._hasWarnedUnnamed) {
       this._hasWarnedUnnamed = true;
       devWarn(
         'hx-stat',
         'Rendering an unnamed hx-stat; provide at least value or label for screen reader accessibility.',
       );
     }
-    if (this.value || this.label) {
+    if (hasValue || hasLabel) {
       this._hasWarnedUnnamed = false;
     }
   }
@@ -186,9 +188,7 @@ export class HelixStat extends LitElement {
     // readers when any of those properties change programmatically.
     const liveParts: string[] = [];
     const primary =
-      this.label && this.value
-        ? `${this.label}: ${this.value}`
-        : this.value || this.label || '';
+      this.label && this.value ? `${this.label}: ${this.value}` : this.value || this.label || '';
     if (primary) liveParts.push(primary);
     if (hasTrend) liveParts.push(`${this.labelTrend}: ${this.trend}`);
     const liveText = liveParts.join(', ');

--- a/packages/hx-library/src/components/hx-stat/hx-stat.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.ts
@@ -94,6 +94,16 @@ export class HelixStat extends LitElement {
     }
   }
 
+  override updated(changedProperties: Map<PropertyKey, unknown>): void {
+    super.updated(changedProperties);
+    if (!this.value && !this.label) {
+      devWarn(
+        'hx-stat',
+        'Rendering an unnamed hx-stat; provide at least value or label for screen reader accessibility.',
+      );
+    }
+  }
+
   // ─── Slot Detection ───
 
   /** @internal */
@@ -164,6 +174,15 @@ export class HelixStat extends LitElement {
         ? `${this.value}: ${this.label}`
         : this.value || this.label || nothing;
 
+    // Live region text: announces value, label, and trend direction to screen
+    // readers when any of those properties change programmatically.
+    const liveText = [
+      this.label && this.value ? `${this.label}: ${this.value}` : this.value || this.label,
+      hasTrend ? `, ${this.labelTrend}: ${this.trend}` : '',
+    ]
+      .filter(Boolean)
+      .join('');
+
     return html`
       <div
         part="container"
@@ -171,6 +190,7 @@ export class HelixStat extends LitElement {
         role="group"
         aria-label=${groupLabel}
       >
+        <span class="stat__live-region" aria-live="polite" aria-atomic="true">${liveText}</span>
         <div part="header" class="stat__header">
           <span part="icon" class="stat__icon" ?hidden=${!this._hasIcon}>
             <slot name="icon" @slotchange=${this._onIconSlotChange}></slot>

--- a/packages/hx-library/src/components/hx-stat/hx-stat.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.ts
@@ -81,6 +81,9 @@ export class HelixStat extends LitElement {
    */
   @property({ attribute: 'label-trend' }) labelTrend = 'Trend';
 
+  /** @internal tracks whether the "unnamed" devWarn has already fired this lifecycle */
+  private _hasWarnedUnnamed = false;
+
   // ─── Lifecycle ───
 
   override connectedCallback(): void {
@@ -96,11 +99,16 @@ export class HelixStat extends LitElement {
 
   override updated(changedProperties: Map<PropertyKey, unknown>): void {
     super.updated(changedProperties);
-    if (!this.value && !this.label) {
+    const identityChanged = changedProperties.has('value') || changedProperties.has('label');
+    if (identityChanged && !this.value && !this.label && !this._hasWarnedUnnamed) {
+      this._hasWarnedUnnamed = true;
       devWarn(
         'hx-stat',
         'Rendering an unnamed hx-stat; provide at least value or label for screen reader accessibility.',
       );
+    }
+    if (this.value || this.label) {
+      this._hasWarnedUnnamed = false;
     }
   }
 
@@ -176,12 +184,14 @@ export class HelixStat extends LitElement {
 
     // Live region text: announces value, label, and trend direction to screen
     // readers when any of those properties change programmatically.
-    const liveText = [
-      this.label && this.value ? `${this.label}: ${this.value}` : this.value || this.label,
-      hasTrend ? `, ${this.labelTrend}: ${this.trend}` : '',
-    ]
-      .filter(Boolean)
-      .join('');
+    const liveParts: string[] = [];
+    const primary =
+      this.label && this.value
+        ? `${this.label}: ${this.value}`
+        : this.value || this.label || '';
+    if (primary) liveParts.push(primary);
+    if (hasTrend) liveParts.push(`${this.labelTrend}: ${this.trend}`);
+    const liveText = liveParts.join(', ');
 
     return html`
       <div


### PR DESCRIPTION
## Summary

Fixes P0 blockers from 3.0.0 production readiness audit (issue #1443). Clears HOLD designation on hx-stat.

- Add `aria-live="polite"` region so screen readers announce value/trend changes in healthcare dashboards
- Add `@media (forced-colors: active)` block differentiating trend-up and trend-down indicators in Windows High Contrast Mode
- Add `devWarn()` when both value and label are empty (unnamed group)

Closes #1443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows High Contrast / forced-colors support for the stat component.

* **New Features**
  * Live region announcements so screen readers are notified when stat values, trends, or labels change.

* **Chores**
  * Emit a developer warning when a stat is rendered without label or value to surface empty-state issues.

* **Tests**
  * Added tests validating live-region announcements, trend rendering, and the empty-state warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->