### PR TITLE
fix(hx-counter): semantic role, accessible name, live region, input guards

### DIFF
--- a/.changeset/fix-hx-counter-semantic-1447.md
+++ b/.changeset/fix-hx-counter-semantic-1447.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-counter): add role=status on counter, enforce accessible name, include label in live region, guard invalid easing/duration

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -10,21 +10,27 @@ describe('hx-counter', () => {
 
   describe('Rendering', () => {
     it('renders with shadow DOM', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       expect(el.shadowRoot).toBeTruthy();
     });
 
     it('renders a span with the counter part', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
       expect(counter).toBeTruthy();
       expect(counter?.tagName.toLowerCase()).toBe('span');
     });
 
     it('applies default size=md class', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--md')).toBe(true);
+    });
+
+    it('sets role="status" on the counter element', async () => {
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="42"></hx-counter>');
+      const counter = shadowQuery(el, '[part~="counter"]');
+      expect(counter?.getAttribute('role')).toBe('status');
     });
   });
 
@@ -46,32 +52,38 @@ describe('hx-counter', () => {
 
   describe('Property: size', () => {
     it('applies sm class via hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter hx-size="sm" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" hx-size="sm" value="5"></hx-counter>',
+      );
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--sm')).toBe(true);
     });
 
     it('applies md class via hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter hx-size="md" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" hx-size="md" value="5"></hx-counter>',
+      );
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--md')).toBe(true);
     });
 
     it('applies lg class via hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter hx-size="lg" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" hx-size="lg" value="5"></hx-counter>',
+      );
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--lg')).toBe(true);
     });
 
     it('backward compat: legacy size attribute maps to hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter size="sm" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" size="sm" value="5"></hx-counter>');
       await el.updateComplete;
       expect(el.size).toBe('sm');
     });
 
     it('hx-size takes precedence over legacy size attribute', async () => {
       const el = await fixture<HelixCounter>(
-        '<hx-counter size="sm" hx-size="lg" value="5"></hx-counter>',
+        '<hx-counter label="Count" size="sm" hx-size="lg" value="5"></hx-counter>',
       );
       await el.updateComplete;
       expect(el.size).toBe('lg');
@@ -137,7 +149,7 @@ describe('hx-counter', () => {
     it('accepts all easing values', async () => {
       for (const easing of ['linear', 'ease-in', 'ease-out', 'ease-in-out']) {
         const el = await fixture<HelixCounter>(
-          `<hx-counter easing="${easing}" value="10"></hx-counter>`,
+          `<hx-counter label="Count" easing="${easing}" value="10"></hx-counter>`,
         );
         expect(el.easing).toBe(easing);
         el.remove();
@@ -167,7 +179,7 @@ describe('hx-counter', () => {
         return originalMatchMedia(query);
       });
 
-      const el = await fixture<HelixCounter>('<hx-counter value="500"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="500"></hx-counter>');
       await el.updateComplete;
 
       const counter = shadowQuery(el, '[part~="counter"]');
@@ -280,7 +292,7 @@ describe('hx-counter', () => {
 
   describe('CSS Parts', () => {
     it('exposes "counter" part', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="10"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="10"></hx-counter>');
       expect(shadowQuery(el, '[part~="counter"]')).toBeTruthy();
     });
   });
@@ -292,7 +304,7 @@ describe('hx-counter', () => {
       // WCAG 4.1.2: role="status" implies aria-live="polite", but the visible counter span
       // carries aria-live="off" to suppress per-frame announcements during animation.
       // A separate off-screen live region announces the final value once at animation end.
-      const el = await fixture<HelixCounter>('<hx-counter value="42"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="42"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
       // Visible counter carries aria-live="off" to suppress implicit live behavior of role="status"
       expect(counter?.getAttribute('aria-live')).toBe('off');
@@ -303,7 +315,7 @@ describe('hx-counter', () => {
 
     it('has aria-atomic="true" on the off-screen live region (not on the visible counter)', async () => {
       // WCAG 4.1.2 fix: aria-atomic moved from the visible counter span to a hidden live region
-      const el = await fixture<HelixCounter>('<hx-counter value="42"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="42"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
       // Visible counter must NOT carry aria-atomic
       expect(counter?.getAttribute('aria-atomic')).toBeNull();
@@ -312,8 +324,17 @@ describe('hx-counter', () => {
       expect(liveRegion?.getAttribute('aria-atomic')).toBe('true');
     });
 
-    it('has no axe violations in default state', async () => {
+    it('warns in dev mode when no label is provided', async () => {
+      // Intentionally mounts without label to cover the devWarn path (WCAG 4.1.2 enforcement)
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      await el.updateComplete;
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('has no axe violations in default state', async () => {
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
@@ -321,7 +342,7 @@ describe('hx-counter', () => {
     it('has no axe violations across all sizes', async () => {
       for (const size of ['sm', 'md', 'lg']) {
         const el = await fixture<HelixCounter>(
-          `<hx-counter hx-size="${size}" value="42"></hx-counter>`,
+          `<hx-counter label="Count" hx-size="${size}" value="42"></hx-counter>`,
         );
         const { violations } = await checkA11y(el);
         expect(violations, `hx-size="${size}" should have no violations`).toEqual([]);
@@ -335,7 +356,7 @@ describe('hx-counter', () => {
   describe('Lifecycle', () => {
     it('cancels animation on disconnect', async () => {
       const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       el.remove();
       // cancelAnimationFrame should have been called during disconnectedCallback
       expect(cancelSpy).toHaveBeenCalled();

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -288,14 +288,15 @@ describe('hx-counter', () => {
   // ─── Accessibility (3) ───
 
   describe('Accessibility', () => {
-    it('has aria-live="polite" on the off-screen live region (not on the visible counter)', async () => {
-      // WCAG 4.1.2 fix: aria-live moved from the visible counter span to a hidden live region
-      // so screen readers only announce once at animation end, not on every frame.
+    it('has aria-live="polite" on the off-screen live region; counter span has aria-live="off"', async () => {
+      // WCAG 4.1.2: role="status" implies aria-live="polite", but the visible counter span
+      // carries aria-live="off" to suppress per-frame announcements during animation.
+      // A separate off-screen live region announces the final value once at animation end.
       const el = await fixture<HelixCounter>('<hx-counter value="42"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
-      // Visible counter must NOT carry aria-live (prevents per-frame announcements)
-      expect(counter?.getAttribute('aria-live')).toBeNull();
-      // The off-screen .sr-only span carries aria-live instead
+      // Visible counter carries aria-live="off" to suppress implicit live behavior of role="status"
+      expect(counter?.getAttribute('aria-live')).toBe('off');
+      // The off-screen .sr-only span carries aria-live="polite" for end-of-animation announcements
       const liveRegion = el.shadowRoot?.querySelector<HTMLElement>('.sr-only');
       expect(liveRegion?.getAttribute('aria-live')).toBe('polite');
     });

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -136,6 +136,43 @@ describe('hx-counter', () => {
       const el = await fixture<HelixCounter>('<hx-counter duration="2000"></hx-counter>');
       expect(el.duration).toBe(2000);
     });
+
+    it('clamps duration <= 0 and still completes animation', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const originalMatchMedia = window.matchMedia;
+      vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+        if (query === '(prefers-reduced-motion: reduce)') {
+          return {
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          } as MediaQueryList;
+        }
+        return originalMatchMedia(query);
+      });
+
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" duration="0" value="42"></hx-counter>',
+      );
+
+      // Wait for rAF-based animation to complete (clamped to 1ms, finishes in 1-2 frames)
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      await el.updateComplete;
+
+      const counter = shadowQuery(el, '[part~="counter"]');
+      expect(counter?.textContent?.trim()).toBe('42');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] duration must be > 0 (received 0). Clamping to 1ms.',
+      );
+
+      vi.restoreAllMocks();
+    });
   });
 
   // ─── Property: easing (2) ───
@@ -154,6 +191,37 @@ describe('hx-counter', () => {
         expect(el.easing).toBe(easing);
         el.remove();
       }
+    });
+
+    it('falls back to linear for invalid easing and emits devWarn', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const originalMatchMedia = window.matchMedia;
+      vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+        if (query === '(prefers-reduced-motion: reduce)') {
+          return {
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          } as MediaQueryList;
+        }
+        return originalMatchMedia(query);
+      });
+
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" easing="bogus" value="50"></hx-counter>',
+      );
+      await el.updateComplete;
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] Unrecognized easing value "bogus". Falling back to "linear". Valid values: ease-in, ease-out, ease-in-out, linear.',
+      );
+
+      vi.restoreAllMocks();
     });
   });
 
@@ -329,8 +397,49 @@ describe('hx-counter', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
       await el.updateComplete;
-      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
+      );
       warnSpy.mockRestore();
+    });
+
+    it('treats whitespace-only label as empty and warns', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const el = await fixture<HelixCounter>('<hx-counter label="   " value="100"></hx-counter>');
+      await el.updateComplete;
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('includes label in sr-only announcement when label is set', async () => {
+      const originalMatchMedia = window.matchMedia;
+      vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+        if (query === '(prefers-reduced-motion: reduce)') {
+          return {
+            matches: true,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          } as MediaQueryList;
+        }
+        return originalMatchMedia(query);
+      });
+
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Total patients" value="1284"></hx-counter>',
+      );
+      await el.updateComplete;
+
+      const liveRegion = el.shadowRoot?.querySelector<HTMLElement>('.sr-only');
+      expect(liveRegion?.textContent).toBe('Total patients: 1,284');
+
+      vi.restoreAllMocks();
     });
 
     it('has no axe violations in default state', async () => {

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -38,12 +38,12 @@ describe('hx-counter', () => {
 
   describe('Property: value', () => {
     it('defaults to 0', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.value).toBe(0);
     });
 
     it('accepts numeric value attribute', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="500"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="500"></hx-counter>');
       expect(el.value).toBe(500);
     });
   });
@@ -94,13 +94,13 @@ describe('hx-counter', () => {
 
   describe('Property: format', () => {
     it('defaults to integer format', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.format).toBe('integer');
     });
 
     it('accepts decimal format', async () => {
       const el = await fixture<HelixCounter>(
-        '<hx-counter format="decimal" value="0"></hx-counter>',
+        '<hx-counter label="Count" format="decimal" value="0"></hx-counter>',
       );
       expect(el.format).toBe('decimal');
     });
@@ -110,14 +110,14 @@ describe('hx-counter', () => {
 
   describe('Property: prefix and suffix', () => {
     it('defaults prefix and suffix to empty string', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.prefix).toBe('');
       expect(el.suffix).toBe('');
     });
 
     it('accepts prefix and suffix attributes', async () => {
       const el = await fixture<HelixCounter>(
-        '<hx-counter prefix="$" suffix="%" value="50"></hx-counter>',
+        '<hx-counter label="Price" prefix="$" suffix="%" value="50"></hx-counter>',
       );
       expect(el.prefix).toBe('$');
       expect(el.suffix).toBe('%');
@@ -128,12 +128,12 @@ describe('hx-counter', () => {
 
   describe('Property: duration', () => {
     it('defaults to 1000ms', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.duration).toBe(1000);
     });
 
     it('accepts custom duration', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter duration="2000"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" duration="2000"></hx-counter>');
       expect(el.duration).toBe(2000);
     });
 
@@ -179,7 +179,7 @@ describe('hx-counter', () => {
 
   describe('Property: easing', () => {
     it('defaults to ease-out', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.easing).toBe('ease-out');
     });
 
@@ -281,7 +281,7 @@ describe('hx-counter', () => {
       });
 
       const el = await fixture<HelixCounter>(
-        '<hx-counter format="integer" value="1000"></hx-counter>',
+        '<hx-counter label="Count" format="integer" value="1000"></hx-counter>',
       );
       await el.updateComplete;
 
@@ -312,7 +312,7 @@ describe('hx-counter', () => {
       });
 
       const el = await fixture<HelixCounter>(
-        '<hx-counter prefix="$" suffix="+" value="99"></hx-counter>',
+        '<hx-counter label="Price" prefix="$" suffix="+" value="99"></hx-counter>',
       );
       await el.updateComplete;
 
@@ -342,7 +342,7 @@ describe('hx-counter', () => {
       });
 
       const el = await fixture<HelixCounter>(
-        '<hx-counter format="decimal" value="42"></hx-counter>',
+        '<hx-counter label="Score" format="decimal" value="42"></hx-counter>',
       );
       await el.updateComplete;
 

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -111,12 +111,20 @@ export class HelixCounter extends LitElement {
   private _prefersReducedMotion = false;
   /** @internal */
   private _motionMql: MediaQueryList | null = null;
+  /**
+   * Normalized easing value after validation. Set once per animation start
+   * to avoid repeated devWarn calls on every requestAnimationFrame tick.
+   * @internal
+   */
+  private _resolvedEasing: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out' = 'ease-out';
   /** @internal */
   private readonly _handleMotionChange = (e: MediaQueryListEvent): void => {
     this._prefersReducedMotion = e.matches;
     if (this._prefersReducedMotion) {
       this._cancelAnimation();
       this._displayValue = this.value;
+      this._announcedValue = this._buildAnnouncement();
+      this.requestUpdate();
     }
   };
 
@@ -190,9 +198,33 @@ export class HelixCounter extends LitElement {
     }
   }
 
+  /**
+   * Validates `this.easing` once per animation start and stores the result in
+   * `_resolvedEasing`. This prevents devWarn from firing on every rAF tick for
+   * an invalid easing value — the warning is emitted at most once per call.
+   * @internal
+   */
+  private _normalizeEasing(): void {
+    const validEasings: Array<'linear' | 'ease-in' | 'ease-out' | 'ease-in-out'> = [
+      'linear',
+      'ease-in',
+      'ease-out',
+      'ease-in-out',
+    ];
+    if (validEasings.includes(this.easing)) {
+      this._resolvedEasing = this.easing;
+    } else {
+      devWarn(
+        'hx-counter',
+        `Unrecognized easing value "${this.easing as string}". Falling back to "ease-out". Valid values: ease-in, ease-out, ease-in-out, linear.`,
+      );
+      this._resolvedEasing = 'ease-out';
+    }
+  }
+
   /** @internal */
   private _applyEasing(t: number): number {
-    switch (this.easing) {
+    switch (this._resolvedEasing) {
       case 'linear':
         return t;
       case 'ease-in':
@@ -201,18 +233,13 @@ export class HelixCounter extends LitElement {
         return t * (2 - t);
       case 'ease-in-out':
         return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
-      default:
-        devWarn(
-          'hx-counter',
-          `Unrecognized easing value "${this.easing as string}". Falling back to linear. Valid values: ease-in, ease-out, ease-in-out, linear.`,
-        );
-        return t;
     }
   }
 
   /** @internal */
   private _startAnimation(): void {
     this._cancelAnimation();
+    this._normalizeEasing();
 
     const effectiveDuration =
       this.duration <= 0

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -141,7 +141,8 @@ export class HelixCounter extends LitElement {
     }
 
     // WCAG 4.1.2: a numeric value without context is meaningless to screen readers.
-    if (!this.label) {
+    // Normalize: whitespace-only labels are treated as empty.
+    if (!(this.label || '').trim()) {
       devWarn(
         'hx-counter',
         'hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
@@ -216,9 +217,9 @@ export class HelixCounter extends LitElement {
     } else {
       devWarn(
         'hx-counter',
-        `Unrecognized easing value "${this.easing as string}". Falling back to "ease-out". Valid values: ease-in, ease-out, ease-in-out, linear.`,
+        `Unrecognized easing value "${this.easing as string}". Falling back to "linear". Valid values: ease-in, ease-out, ease-in-out, linear.`,
       );
-      this._resolvedEasing = 'ease-out';
+      this._resolvedEasing = 'linear';
     }
   }
 
@@ -295,8 +296,14 @@ export class HelixCounter extends LitElement {
    * @internal
    */
   private _buildAnnouncement(): string {
+    const normalizedLabel = (this.label || '').trim();
+    if (!normalizedLabel) {
+      // No label means the number lacks context — return empty to prevent
+      // announcing a context-free number to screen readers.
+      return '';
+    }
     const formatted = this._formatValue();
-    return this.label ? `${this.label}: ${formatted}` : formatted;
+    return `${normalizedLabel}: ${formatted}`;
   }
 
   // ─── Render ───
@@ -313,7 +320,9 @@ export class HelixCounter extends LitElement {
         role="status"
         aria-live="off"
         class=${classMap(classes)}
-        aria-label=${this.label ? `${this.label}: ${this._formatValue()}` : nothing}
+        aria-label=${(this.label || '').trim()
+          ? `${(this.label || '').trim()}: ${this._formatValue()}`
+          : nothing}
       >
         ${this._formatValue()}
       </span>

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -132,6 +132,14 @@ export class HelixCounter extends LitElement {
       this.size = legacySize as CounterSize;
     }
 
+    // WCAG 4.1.2: a numeric value without context is meaningless to screen readers.
+    if (!this.label) {
+      devWarn(
+        'hx-counter',
+        'hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
+      );
+    }
+
     // Guard for SSR — window.matchMedia and requestAnimationFrame are unavailable server-side
     if (typeof window === 'undefined') {
       this._displayValue = this.value;
@@ -145,7 +153,7 @@ export class HelixCounter extends LitElement {
 
     if (this._prefersReducedMotion) {
       this._displayValue = this.value;
-      this._announcedValue = this._formatValue();
+      this._announcedValue = this._buildAnnouncement();
     } else {
       this._startAnimation();
     }
@@ -163,7 +171,7 @@ export class HelixCounter extends LitElement {
     if (changedProps.has('value') && changedProps.get('value') !== undefined) {
       if (this._prefersReducedMotion) {
         this._displayValue = this.value;
-        this._announcedValue = this._formatValue();
+        this._announcedValue = this._buildAnnouncement();
       } else {
         this._startValue = this._displayValue;
         this._startTime = null;
@@ -193,6 +201,12 @@ export class HelixCounter extends LitElement {
         return t * (2 - t);
       case 'ease-in-out':
         return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+      default:
+        devWarn(
+          'hx-counter',
+          `Unrecognized easing value "${this.easing as string}". Falling back to linear. Valid values: ease-in, ease-out, ease-in-out, linear.`,
+        );
+        return t;
     }
   }
 
@@ -200,13 +214,22 @@ export class HelixCounter extends LitElement {
   private _startAnimation(): void {
     this._cancelAnimation();
 
+    const effectiveDuration =
+      this.duration <= 0
+        ? (devWarn(
+            'hx-counter',
+            `duration must be > 0 (received ${this.duration}). Clamping to 1ms.`,
+          ),
+          1)
+        : this.duration;
+
     const step = (timestamp: number): void => {
       if (this._startTime === null) {
         this._startTime = timestamp;
       }
 
       const elapsed = timestamp - this._startTime;
-      const rawProgress = Math.min(elapsed / this.duration, 1);
+      const rawProgress = Math.min(elapsed / effectiveDuration, 1);
       const easedProgress = this._applyEasing(rawProgress);
 
       this._displayValue = this._startValue + (this.value - this._startValue) * easedProgress;
@@ -219,7 +242,7 @@ export class HelixCounter extends LitElement {
         // WCAG 4.1.2: announce the final value only once, at animation end.
         // _announcedValue feeds the off-screen live region so screen readers
         // hear a single announcement rather than one per animation frame.
-        this._announcedValue = this._formatValue();
+        this._announcedValue = this._buildAnnouncement();
       }
     };
 
@@ -238,6 +261,17 @@ export class HelixCounter extends LitElement {
     return `${this.prefix}${num.toLocaleString()}${this.suffix}`;
   }
 
+  /**
+   * Builds the string announced to screen readers at animation end.
+   * Includes label context when present so users hear "Total patients: 1,284"
+   * rather than a bare number with no semantic context.
+   * @internal
+   */
+  private _buildAnnouncement(): string {
+    const formatted = this._formatValue();
+    return this.label ? `${this.label}: ${formatted}` : formatted;
+  }
+
   // ─── Render ───
 
   override render() {
@@ -249,6 +283,8 @@ export class HelixCounter extends LitElement {
     return html`
       <span
         part="counter"
+        role="status"
+        aria-live="off"
         class=${classMap(classes)}
         aria-label=${this.label ? `${this.label}: ${this._formatValue()}` : nothing}
       >

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -242,14 +242,13 @@ export class HelixCounter extends LitElement {
     this._cancelAnimation();
     this._normalizeEasing();
 
-    const effectiveDuration =
-      this.duration <= 0
-        ? (devWarn(
-            'hx-counter',
-            `duration must be > 0 (received ${this.duration}). Clamping to 1ms.`,
-          ),
-          1)
-        : this.duration;
+    let effectiveDuration: number;
+    if (this.duration <= 0) {
+      devWarn('hx-counter', `duration must be > 0 (received ${this.duration}). Clamping to 1ms.`);
+      effectiveDuration = 1;
+    } else {
+      effectiveDuration = this.duration;
+    }
 
     const step = (timestamp: number): void => {
       if (this._startTime === null) {
@@ -314,15 +313,15 @@ export class HelixCounter extends LitElement {
       [`counter--${this.size}`]: true,
     };
 
+    const trimmedLabel = (this.label || '').trim();
+
     return html`
       <span
         part="counter"
         role="status"
         aria-live="off"
         class=${classMap(classes)}
-        aria-label=${(this.label || '').trim()
-          ? `${(this.label || '').trim()}: ${this._formatValue()}`
-          : nothing}
+        aria-label=${trimmedLabel ? `${trimmedLabel}: ${this._formatValue()}` : nothing}
       >
         ${this._formatValue()}
       </span>


### PR DESCRIPTION
## Summary

Fixes P0 accessibility and DX blockers from 3.0.0 production readiness audit (issue #1447). hx-counter was the lowest-scoring component in the fleet.

- Add \`role="status"\` to counter \`<span>\` for semantic context, with \`aria-live="off"\` to suppress implicit live behavior during animation frames
- Add \`devWarn()\` when label is empty (screen reader users hear bare numbers without context)
- Include label in live region announcements: "Total Patients: 1,284" instead of bare "1,284"
- Add \`_buildAnnouncement()\` helper that composes label + formatted value for all three announcement sites
- Guard unrecognized easing values with devWarn + linear fallback (runtime safety for HTML attribute values)
- Guard \`duration <= 0\` to prevent infinite animation loop, clamps to 1ms with devWarn

Closes #1447

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved counter accessibility: added status role and adjusted live-region behavior for reliable screen reader output.
  * Live announcements now include the component label for clearer context.
  * Added runtime warnings and safe fallbacks for missing labels, zero/invalid durations, and invalid easing to prevent broken animations.

* **Tests**
  * Expanded test coverage for accessibility semantics, live-region text, and dev-warning behaviors for label, duration, and easing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->