### PR TITLE
fix(hx-form): remove redundant aria-live on error summary

### DIFF
--- a/.changeset/fix-hx-form-aria-live-1437.md
+++ b/.changeset/fix-hx-form-aria-live-1437.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-form): remove redundant aria-live on error summary (role="alert" implies it)

--- a/packages/hx-library/src/components/hx-form/hx-form.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.ts
@@ -425,13 +425,7 @@ export class HelixForm extends LitElement {
     const errorSummary =
       this._validationErrors.length > 0
         ? html`
-            <div
-              class="hx-form-error-summary"
-              role="alert"
-              aria-live="assertive"
-              aria-atomic="true"
-              tabindex="-1"
-            >
+            <div class="hx-form-error-summary" role="alert" aria-atomic="true" tabindex="-1">
               <ul>
                 ${this._validationErrors.map(
                   (error) => html`<li>${error.message || error.name}</li>`,


### PR DESCRIPTION
Fixes #1437. role="alert" implicitly sets aria-live="assertive" per the WAI-ARIA spec. The explicit aria-live attribute is redundant and can cause double-announcement in some screen readers (notably NVDA and JAWS).