### PR TITLE
fix(hx-card): correct devWarn attribute name reference

### DIFF
--- a/.changeset/fix-hx-card-devwarn-1434.md
+++ b/.changeset/fix-hx-card-devwarn-1434.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-card): correct devWarn attribute reference from "hx-aria-label" to "hx-label"

--- a/packages/hx-library/src/components/hx-card/README.drupal.md
+++ b/packages/hx-library/src/components/hx-card/README.drupal.md
@@ -71,7 +71,7 @@ When `hx-href` is set, the card becomes a clickable navigation element. It fires
 
 ### Accessible Labels for Interactive Cards
 
-Always provide `hx-aria-label` when using `hx-href`. The label should describe the card's purpose, not expose the raw URL:
+Always provide `hx-label` when using `hx-href`. The label should describe the card's purpose, not expose the raw URL:
 
 ```twig
 {# Wrong — exposes raw URL to screen readers #}
@@ -80,7 +80,7 @@ Always provide `hx-aria-label` when using `hx-href`. The label should describe t
 {# Correct — meaningful description #}
 <hx-card
   hx-href="/node/1234"
-  hx-aria-label="View chart for Margaret Thompson"
+  hx-label="View chart for Margaret Thompson"
 >
   <h3 slot="heading">Margaret Thompson</h3>
   ...
@@ -91,7 +91,7 @@ Always provide `hx-aria-label` when using `hx-href`. The label should describe t
 {# Drupal field mapping example #}
 <hx-card
   hx-href="{{ node.url }}"
-  hx-aria-label="{{ 'View @title'|t({'@title': node.title}) }}"
+  hx-label="{{ 'View @title'|t({'@title': node.title}) }}"
 >
   <h3 slot="heading">{{ node.title }}</h3>
   {{ node.body.summary }}
@@ -132,7 +132,7 @@ Do NOT use `hx-href` and `slot="actions"` together on the same card. This create
 </hx-card>
 
 {# CORRECT — Use either hx-href OR actions, not both #}
-<hx-card hx-href="/node/1234" hx-aria-label="View Margaret Thompson">
+<hx-card hx-href="/node/1234" hx-label="View Margaret Thompson">
   <h3 slot="heading">Margaret Thompson</h3>
 </hx-card>
 
@@ -163,7 +163,7 @@ Do NOT use `hx-href` and `slot="actions"` together on the same card. This create
 | `variant`       | Yes          | String. `default`, `featured`, or `compact`.                               |
 | `elevation`     | Yes          | String. `flat`, `raised`, or `floating`.                                   |
 | `hx-href`       | Yes          | Custom attribute with `hx-` prefix. Valid HTML. Use `attributes.setAttribute('hx-href', url)` in PHP. |
-| `hx-aria-label` | Yes          | String. Required when `hx-href` is set. Provides meaningful label for AT.  |
+| `hx-label` | Yes          | String. Required when `hx-href` is set. Provides meaningful label for AT.  |
 
 ## Drupal Views Integration
 
@@ -178,7 +178,7 @@ For rendering a Views result as cards:
       variant="default"
       elevation="raised"
       hx-href="{{ patient.url }}"
-      hx-aria-label="{{ 'View chart for @name'|t({'@name': patient.title}) }}"
+      hx-label="{{ 'View chart for @name'|t({'@name': patient.title}) }}"
     >
       <h3 slot="heading">{{ patient.title }}</h3>
       <p>{{ patient.field_summary }}</p>

--- a/packages/hx-library/src/components/hx-card/hx-card.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.ts
@@ -145,7 +145,7 @@ export class HelixCard extends LitElement {
     ) {
       devWarn(
         'hx-card',
-        "Interactive card (hx-href is set) is missing an accessible name. Set `hx-aria-label` to describe the card's destination or purpose (WCAG 4.1.2).",
+        "Interactive card (hx-href is set) is missing an accessible name. Set `hx-label` to describe the card's destination or purpose (WCAG 4.1.2).",
       );
     }
   }

--- a/packages/hx-library/src/components/hx-card/hx-card.twig
+++ b/packages/hx-library/src/components/hx-card/hx-card.twig
@@ -11,7 +11,7 @@
     - hx-href:       Optional URL. When set, the card becomes interactive/clickable.
                      Note: Do NOT use hx-href together with slot="actions". Interactive
                      controls nested inside role="link" violates ARIA spec.
-    - hx-aria-label: Accessible label for interactive cards. Required when hx-href is
+    - hx-label:      Accessible label for interactive cards. Required when hx-href is
                      set — provide a meaningful description of the card's purpose
                      (e.g., "View chart for Margaret Thompson") rather than the raw URL.
 
@@ -37,7 +37,7 @@
   elevation="{{ elevation|default('flat') }}"
   {% if href is defined and href %}
     hx-href="{{ href }}"
-    hx-aria-label="{{ aria_label }}"
+    hx-label="{{ aria_label }}"
   {% endif %}
 >
   {% if image is defined and image %}


### PR DESCRIPTION
Fixes #1434.

The `devWarn` message in `hx-card` incorrectly referenced `hx-aria-label` as the attribute name for providing an accessible label on interactive cards. The actual attribute defined on the component is `hx-label` (line 77: `@property({ type: String, attribute: 'hx-label' })`).

**Changes:**
- `hx-card.ts`: Updated devWarn message from `hx-aria-label` to `hx-label`
- `hx-card.twig`: Corrected attribute name in Twig template comment and output
- `README.drupal.md`: Corrected all references from `hx-aria-label` to `hx-label`