### PR TITLE
fix(hx-popover, hx-popup): use Lit nothing sentinel for conditional rendering

### DIFF
--- a/.changeset/fix-nothing-sentinel-1428.md
+++ b/.changeset/fix-nothing-sentinel-1428.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-popover, hx-popup): use Lit nothing sentinel instead of empty string for conditional rendering

--- a/packages/hx-library/src/components/hx-popover/hx-popover.ts
+++ b/packages/hx-library/src/components/hx-popover/hx-popover.ts
@@ -543,7 +543,7 @@ export class HelixPopover extends LitElement {
         @mouseleave=${this._handleBodyMouseLeave}
       >
         <slot></slot>
-        ${this.arrow ? html`<div part="arrow"></div>` : ''}
+        ${this.arrow ? html`<div part="arrow"></div>` : nothing}
       </div>
     `;
   }

--- a/packages/hx-library/src/components/hx-popup/hx-popup.ts
+++ b/packages/hx-library/src/components/hx-popup/hx-popup.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, type PropertyValues } from 'lit';
+import { LitElement, html, nothing, type PropertyValues } from 'lit';
 import '../../utilities/document-token-adoption.js';
 import { customElement, property } from 'lit/decorators.js';
 import {
@@ -521,7 +521,7 @@ export class HelixPopup extends LitElement {
       <slot name="anchor" @slotchange=${this._handleAnchorSlotChange}></slot>
       <div part="popup" ?inert=${!this.active}>
         <slot></slot>
-        ${this.arrow ? html`<div part="arrow"></div>` : ''}
+        ${this.arrow ? html`<div part="arrow"></div>` : nothing}
       </div>
     `;
   }


### PR DESCRIPTION
Fixes #1428. Replaces empty string conditionals with Lit's `nothing` sentinel to avoid unnecessary empty text nodes in the DOM.

## Changes

- **hx-popover**: Replace `''` with `nothing` in arrow conditional render (line 546). `nothing` was already imported but unused for this expression.
- **hx-popup**: Add `nothing` to the `lit` import and replace `''` with `nothing` in arrow conditional render (line 524).
- Add changeset for patch release.