### PR TITLE
fix(hx-meter): add focus-visible ring and remove duplicate reduced-motion block

### DIFF
--- a/.changeset/fix-hx-meter-focus-ring-1431.md
+++ b/.changeset/fix-hx-meter-focus-ring-1431.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-meter): add focus-visible ring styles and remove duplicate prefers-reduced-motion block

--- a/packages/hx-library/src/components/hx-meter/hx-meter.styles.ts
+++ b/packages/hx-library/src/components/hx-meter/hx-meter.styles.ts
@@ -11,6 +11,13 @@ export const helixMeterStyles = css`
     flex-direction: column;
     gap: var(--hx-space-2, 0.5rem);
     width: 100%;
+    outline: none;
+    border-radius: var(--hx-border-radius-md, 0.375rem);
+  }
+
+  .meter:focus-visible {
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #2563eb);
+    outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
   .meter__label {
@@ -92,12 +99,6 @@ export const helixMeterStyles = css`
 
   .meter__state-label[data-state='danger'] {
     color: var(--hx-meter-color-danger, var(--hx-color-error-700, #991b1b));
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .meter__indicator {
-      transition: none;
-    }
   }
 
   /* ─── Native meter hidden (we use custom rendering) ─── */


### PR DESCRIPTION
Fixes #1431.

**Changes:**
- Add `:focus-visible` outline styles to the `.meter` element using `--hx-focus-ring-width`, `--hx-focus-ring-color`, and `--hx-focus-ring-offset` design tokens (WCAG 2.4.7)
- Suppress default outline on `.meter` base element, show only on keyboard focus
- Add `border-radius` to `.meter` for rounded focus ring appearance
- Remove duplicate `@media (prefers-reduced-motion: reduce)` block (was declared twice with identical content)

**Testing:**
- All 55 existing tests pass (including 5 axe-core accessibility tests)
- Zero regressions