### PR TITLE
fix(ci): move security audit to soft-fail gate (npm retired v1 endpoint)

### DIFF
--- a/.changeset/fix-ci-audit-endpoint-1469.md
+++ b/.changeset/fix-ci-audit-endpoint-1469.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(ci): move security audit to soft-fail gate (npm retired v1 endpoint)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,7 +748,8 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - name: Security audit
-        run: pnpm audit --audit-level=critical
+        run: pnpm audit --audit-level=critical 2>&1 || echo "::warning::pnpm audit failed (npm audit endpoint may be unavailable)"
+        continue-on-error: true
 
   # ── Storybook Interaction Tests ─────────────────────────────────────────
   # Runs all 83 component story play functions as Vitest browser mode tests.
@@ -875,7 +876,7 @@ jobs:
 
           FAIL=0
 
-          for gate in secret-scan lint format type-check build audit; do
+          for gate in secret-scan lint format type-check build; do
             result="${{ needs.lint.result }}"
             case "$gate" in
               secret-scan) result="${{ needs.secret-scan.result }}" ;;
@@ -883,7 +884,6 @@ jobs:
               format)      result="${{ needs.format.result }}" ;;
               type-check)  result="${{ needs.type-check.result }}" ;;
               build)       result="${{ needs.build.result }}" ;;
-              audit)       result="${{ needs.audit.result }}" ;;
             esac
             if [[ "$result" != "success" ]]; then
               echo "::error::Gate '$gate' did not succeed: $result"
@@ -920,6 +920,11 @@ jobs:
           # React wrapper tests are informational until the suite is stabilized
           if [[ "${{ needs.test-react.result }}" != "success" && "${{ needs.test-react.result }}" != "skipped" ]]; then
             echo "::warning::React wrapper tests did not pass — informational only"
+          fi
+
+          # Security audit is informational until npm audit endpoint is stabilized
+          if [[ "${{ needs.audit.result }}" != "success" && "${{ needs.audit.result }}" != "skipped" ]]; then
+            echo "::warning::Security audit did not pass — npm audit endpoint may be retired. See https://api-docs.npmjs.com/#tag/Audit"
           fi
 
           if [[ "$FAIL" -eq 1 ]]; then


### PR DESCRIPTION
npm retired the v1 audit endpoint (HTTP 410), causing `pnpm audit` to fail on all PRs and blocking Quality Gates.

**Changes:**
- Add `continue-on-error: true` to the audit step so the job does not hard-fail
- Move `audit` from the hard-fail gate loop to an informational warning (same pattern as a11y-audit, storybook-tests, and test-react)
- `secret-scan` remains in the hard-fail loop — secret detection is unaffected

**Impact:** Unblocks all PRs currently stuck on the audit gate failure.