### PR TITLE
promote: dev → staging

### DIFF
--- a/.changeset/fix-ci-audit-endpoint-1469.md
+++ b/.changeset/fix-ci-audit-endpoint-1469.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(ci): move security audit to soft-fail gate (npm retired v1 endpoint)

--- a/.changeset/fix-hx-card-devwarn-1434.md
+++ b/.changeset/fix-hx-card-devwarn-1434.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-card): correct devWarn attribute reference from "hx-aria-label" to "hx-label"

--- a/.changeset/fix-hx-counter-semantic-1447.md
+++ b/.changeset/fix-hx-counter-semantic-1447.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-counter): add role=status on counter, enforce accessible name, include label in live region, guard invalid easing/duration

--- a/.changeset/fix-hx-file-upload-a11y-1444.md
+++ b/.changeset/fix-hx-file-upload-a11y-1444.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-file-upload): resolve 5 P0 accessibility blockers — aria-invalid, forced-colors, focus restoration, touch target, and mixinDelegatesAria

--- a/.changeset/fix-hx-form-aria-live-1437.md
+++ b/.changeset/fix-hx-form-aria-live-1437.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-form): remove redundant aria-live on error summary (role="alert" implies it)

--- a/.changeset/fix-hx-list-a11y-1446.md
+++ b/.changeset/fix-hx-list-a11y-1446.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-list): enforce accessible name on interactive listbox, add forced-colors support for selected/hover/disabled states

--- a/.changeset/fix-hx-meter-focus-ring-1431.md
+++ b/.changeset/fix-hx-meter-focus-ring-1431.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-meter): add focus-visible ring styles and remove duplicate prefers-reduced-motion block

--- a/.changeset/fix-hx-phi-field-phi-1445.md
+++ b/.changeset/fix-hx-phi-field-phi-1445.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-phi-field): hide masked value from screen readers (PHI exposure), prevent PHI in DOM attribute, add forced-colors support

--- a/.changeset/fix-hx-stat-a11y-1443.md
+++ b/.changeset/fix-hx-stat-a11y-1443.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-stat): add aria-live region for dynamic value/trend updates, forced-colors support, and devWarn for empty state

--- a/.changeset/fix-nothing-sentinel-1428.md
+++ b/.changeset/fix-nothing-sentinel-1428.md
@@ -1,0 +1,5 @@
+---
+"@helixui/library": patch
+---
+
+fix(hx-popover, hx-popup): use Lit nothing sentinel instead of empty string for conditional rendering

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,7 +748,8 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - name: Security audit
-        run: pnpm audit --audit-level=critical
+        run: pnpm audit --audit-level=critical 2>&1 || echo "::warning::pnpm audit failed (npm audit endpoint may be unavailable)"
+        continue-on-error: true
 
   # ── Storybook Interaction Tests ─────────────────────────────────────────
   # Runs all 83 component story play functions as Vitest browser mode tests.
@@ -875,7 +876,7 @@ jobs:
 
           FAIL=0
 
-          for gate in secret-scan lint format type-check build audit; do
+          for gate in secret-scan lint format type-check build; do
             result="${{ needs.lint.result }}"
             case "$gate" in
               secret-scan) result="${{ needs.secret-scan.result }}" ;;
@@ -883,7 +884,6 @@ jobs:
               format)      result="${{ needs.format.result }}" ;;
               type-check)  result="${{ needs.type-check.result }}" ;;
               build)       result="${{ needs.build.result }}" ;;
-              audit)       result="${{ needs.audit.result }}" ;;
             esac
             if [[ "$result" != "success" ]]; then
               echo "::error::Gate '$gate' did not succeed: $result"
@@ -920,6 +920,11 @@ jobs:
           # React wrapper tests are informational until the suite is stabilized
           if [[ "${{ needs.test-react.result }}" != "success" && "${{ needs.test-react.result }}" != "skipped" ]]; then
             echo "::warning::React wrapper tests did not pass — informational only"
+          fi
+
+          # Security audit is informational until npm audit endpoint is stabilized
+          if [[ "${{ needs.audit.result }}" != "success" && "${{ needs.audit.result }}" != "skipped" ]]; then
+            echo "::warning::Security audit did not pass — npm audit endpoint may be retired. See https://api-docs.npmjs.com/#tag/Audit"
           fi
 
           if [[ "$FAIL" -eq 1 ]]; then

--- a/bundle-budgets.json
+++ b/bundle-budgets.json
@@ -15,6 +15,10 @@
       "budget": 8192,
       "reason": "Calendar grid rendering, full keyboard nav, focus trap, date utilities, ElementInternals form association. JS-only: ~4324 gz."
     },
+    "hx-file-upload": {
+      "budget": 6144,
+      "reason": "Drag-and-drop file management with progress tracking, mixinDelegatesAria ARIA delegation, focus restoration after file removal, forced-colors support, and WCAG 2.5.5 touch targets. Baseline: ~4.64 KB gz; mandatory a11y fixes add ~1.1 KB."
+    },
     "hx-select": {
       "budget": 6144,
       "reason": "ARIA listbox, keyboard nav, multiple selection, ElementInternals form association, floating-ui positioning. JS-only: ~5.18 KB gz."

--- a/packages/hx-library/src/components/hx-card/README.drupal.md
+++ b/packages/hx-library/src/components/hx-card/README.drupal.md
@@ -71,7 +71,7 @@ When `hx-href` is set, the card becomes a clickable navigation element. It fires
 
 ### Accessible Labels for Interactive Cards
 
-Always provide `hx-aria-label` when using `hx-href`. The label should describe the card's purpose, not expose the raw URL:
+Always provide `hx-label` when using `hx-href`. The label should describe the card's purpose, not expose the raw URL:
 
 ```twig
 {# Wrong — exposes raw URL to screen readers #}
@@ -80,7 +80,7 @@ Always provide `hx-aria-label` when using `hx-href`. The label should describe t
 {# Correct — meaningful description #}
 <hx-card
   hx-href="/node/1234"
-  hx-aria-label="View chart for Margaret Thompson"
+  hx-label="View chart for Margaret Thompson"
 >
   <h3 slot="heading">Margaret Thompson</h3>
   ...
@@ -91,7 +91,7 @@ Always provide `hx-aria-label` when using `hx-href`. The label should describe t
 {# Drupal field mapping example #}
 <hx-card
   hx-href="{{ node.url }}"
-  hx-aria-label="{{ 'View @title'|t({'@title': node.title}) }}"
+  hx-label="{{ 'View @title'|t({'@title': node.title}) }}"
 >
   <h3 slot="heading">{{ node.title }}</h3>
   {{ node.body.summary }}
@@ -132,7 +132,7 @@ Do NOT use `hx-href` and `slot="actions"` together on the same card. This create
 </hx-card>
 
 {# CORRECT — Use either hx-href OR actions, not both #}
-<hx-card hx-href="/node/1234" hx-aria-label="View Margaret Thompson">
+<hx-card hx-href="/node/1234" hx-label="View Margaret Thompson">
   <h3 slot="heading">Margaret Thompson</h3>
 </hx-card>
 
@@ -163,7 +163,7 @@ Do NOT use `hx-href` and `slot="actions"` together on the same card. This create
 | `variant`       | Yes          | String. `default`, `featured`, or `compact`.                               |
 | `elevation`     | Yes          | String. `flat`, `raised`, or `floating`.                                   |
 | `hx-href`       | Yes          | Custom attribute with `hx-` prefix. Valid HTML. Use `attributes.setAttribute('hx-href', url)` in PHP. |
-| `hx-aria-label` | Yes          | String. Required when `hx-href` is set. Provides meaningful label for AT.  |
+| `hx-label` | Yes          | String. Required when `hx-href` is set. Provides meaningful label for AT.  |
 
 ## Drupal Views Integration
 
@@ -178,7 +178,7 @@ For rendering a Views result as cards:
       variant="default"
       elevation="raised"
       hx-href="{{ patient.url }}"
-      hx-aria-label="{{ 'View chart for @name'|t({'@name': patient.title}) }}"
+      hx-label="{{ 'View chart for @name'|t({'@name': patient.title}) }}"
     >
       <h3 slot="heading">{{ patient.title }}</h3>
       <p>{{ patient.field_summary }}</p>

--- a/packages/hx-library/src/components/hx-card/hx-card.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.ts
@@ -145,7 +145,7 @@ export class HelixCard extends LitElement {
     ) {
       devWarn(
         'hx-card',
-        "Interactive card (hx-href is set) is missing an accessible name. Set `hx-aria-label` to describe the card's destination or purpose (WCAG 4.1.2).",
+        "Interactive card (hx-href is set) is missing an accessible name. Set `hx-label` to describe the card's destination or purpose (WCAG 4.1.2).",
       );
     }
   }

--- a/packages/hx-library/src/components/hx-card/hx-card.twig
+++ b/packages/hx-library/src/components/hx-card/hx-card.twig
@@ -11,7 +11,7 @@
     - hx-href:       Optional URL. When set, the card becomes interactive/clickable.
                      Note: Do NOT use hx-href together with slot="actions". Interactive
                      controls nested inside role="link" violates ARIA spec.
-    - hx-aria-label: Accessible label for interactive cards. Required when hx-href is
+    - hx-label:      Accessible label for interactive cards. Required when hx-href is
                      set — provide a meaningful description of the card's purpose
                      (e.g., "View chart for Margaret Thompson") rather than the raw URL.
 
@@ -37,7 +37,7 @@
   elevation="{{ elevation|default('flat') }}"
   {% if href is defined and href %}
     hx-href="{{ href }}"
-    hx-aria-label="{{ aria_label }}"
+    hx-label="{{ aria_label }}"
   {% endif %}
 >
   {% if image is defined and image %}

--- a/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.ts
+++ b/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.ts
@@ -1,5 +1,6 @@
-import { LitElement, html, nothing, TemplateResult } from 'lit';
+import { html, nothing, TemplateResult } from 'lit';
 import '../../utilities/document-token-adoption.js';
+import { HelixElement } from '../../base/index.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { helixCodeSnippetStyles } from './hx-code-snippet.styles.js';
@@ -33,7 +34,7 @@ import { helixCodeSnippetStyles } from './hx-code-snippet.styles.js';
  * @cssprop [--hx-code-snippet-padding=var(--hx-space-4,1rem)] - Inner padding (block mode).
  */
 @customElement('hx-code-snippet')
-export class HelixCodeSnippet extends LitElement {
+export class HelixCodeSnippet extends HelixElement {
   static override styles = [helixCodeSnippetStyles];
 
   // ─── Public Properties ───

--- a/packages/hx-library/src/components/hx-color-picker/hx-color-picker.ts
+++ b/packages/hx-library/src/components/hx-color-picker/hx-color-picker.ts
@@ -1,5 +1,6 @@
-import { LitElement, html, nothing, type PropertyValues } from 'lit';
+import { html, nothing, type PropertyValues } from 'lit';
 import '../../utilities/document-token-adoption.js';
+import { HelixElement } from '../../base/index.js';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { helixColorPickerStyles } from './hx-color-picker.styles.js';
@@ -73,25 +74,17 @@ export type { ColorFormat };
  * ```
  */
 @customElement('hx-color-picker')
-export class HelixColorPicker extends LitElement {
+export class HelixColorPicker extends HelixElement {
   static override styles = [helixColorPickerStyles];
 
   /**
    * Declares this element as form-associated so it participates in native form submission.
    * @internal
    */
-  static formAssociated = true;
-
-  /**
-   * ElementInternals instance used for form participation and constraint validation.
-   * @internal
-   */
-  private _internals: ElementInternals;
+  static override formAssociated = true;
 
   constructor() {
     super();
-    /** @internal */
-    this._internals = this.attachInternals();
     // P1-1: Store bound references so connectedCallback/disconnectedCallback use the same object
     /** @internal */
     this._boundPointerMove = this._handlePointerMove.bind(this);
@@ -313,18 +306,18 @@ export class HelixColorPicker extends LitElement {
   }
 
   /** @internal */
-  formDisabledCallback(disabled: boolean): void {
+  protected override _onFormDisabled(disabled: boolean): void {
     this.disabled = disabled;
   }
 
   /** @internal */
-  formResetCallback(): void {
+  protected override _onFormReset(): void {
     this.value = '#000000';
     this._internals.setFormValue(null);
   }
 
   /** @internal */
-  formStateRestoreCallback(
+  protected override _onFormStateRestore(
     state: string | File | FormData | null,
     _mode: 'restore' | 'autocomplete',
   ): void {
@@ -334,12 +327,12 @@ export class HelixColorPicker extends LitElement {
   }
 
   /** Returns the ValidityState object. */
-  get validity(): ValidityState {
+  override get validity(): ValidityState {
     return this._internals.validity;
   }
 
   /** Returns the current validation message. */
-  get validationMessage(): string {
+  override get validationMessage(): string {
     return this._internals.validationMessage;
   }
 

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -10,21 +10,27 @@ describe('hx-counter', () => {
 
   describe('Rendering', () => {
     it('renders with shadow DOM', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       expect(el.shadowRoot).toBeTruthy();
     });
 
     it('renders a span with the counter part', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
       expect(counter).toBeTruthy();
       expect(counter?.tagName.toLowerCase()).toBe('span');
     });
 
     it('applies default size=md class', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--md')).toBe(true);
+    });
+
+    it('sets role="status" on the counter element', async () => {
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="42"></hx-counter>');
+      const counter = shadowQuery(el, '[part~="counter"]');
+      expect(counter?.getAttribute('role')).toBe('status');
     });
   });
 
@@ -46,32 +52,38 @@ describe('hx-counter', () => {
 
   describe('Property: size', () => {
     it('applies sm class via hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter hx-size="sm" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" hx-size="sm" value="5"></hx-counter>',
+      );
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--sm')).toBe(true);
     });
 
     it('applies md class via hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter hx-size="md" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" hx-size="md" value="5"></hx-counter>',
+      );
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--md')).toBe(true);
     });
 
     it('applies lg class via hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter hx-size="lg" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" hx-size="lg" value="5"></hx-counter>',
+      );
       const counter = shadowQuery(el, '.counter');
       expect(counter?.classList.contains('counter--lg')).toBe(true);
     });
 
     it('backward compat: legacy size attribute maps to hx-size', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter size="sm" value="5"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" size="sm" value="5"></hx-counter>');
       await el.updateComplete;
       expect(el.size).toBe('sm');
     });
 
     it('hx-size takes precedence over legacy size attribute', async () => {
       const el = await fixture<HelixCounter>(
-        '<hx-counter size="sm" hx-size="lg" value="5"></hx-counter>',
+        '<hx-counter label="Count" size="sm" hx-size="lg" value="5"></hx-counter>',
       );
       await el.updateComplete;
       expect(el.size).toBe('lg');
@@ -137,7 +149,7 @@ describe('hx-counter', () => {
     it('accepts all easing values', async () => {
       for (const easing of ['linear', 'ease-in', 'ease-out', 'ease-in-out']) {
         const el = await fixture<HelixCounter>(
-          `<hx-counter easing="${easing}" value="10"></hx-counter>`,
+          `<hx-counter label="Count" easing="${easing}" value="10"></hx-counter>`,
         );
         expect(el.easing).toBe(easing);
         el.remove();
@@ -167,7 +179,7 @@ describe('hx-counter', () => {
         return originalMatchMedia(query);
       });
 
-      const el = await fixture<HelixCounter>('<hx-counter value="500"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="500"></hx-counter>');
       await el.updateComplete;
 
       const counter = shadowQuery(el, '[part~="counter"]');
@@ -280,7 +292,7 @@ describe('hx-counter', () => {
 
   describe('CSS Parts', () => {
     it('exposes "counter" part', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="10"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="10"></hx-counter>');
       expect(shadowQuery(el, '[part~="counter"]')).toBeTruthy();
     });
   });
@@ -292,7 +304,7 @@ describe('hx-counter', () => {
       // WCAG 4.1.2: role="status" implies aria-live="polite", but the visible counter span
       // carries aria-live="off" to suppress per-frame announcements during animation.
       // A separate off-screen live region announces the final value once at animation end.
-      const el = await fixture<HelixCounter>('<hx-counter value="42"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="42"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
       // Visible counter carries aria-live="off" to suppress implicit live behavior of role="status"
       expect(counter?.getAttribute('aria-live')).toBe('off');
@@ -303,7 +315,7 @@ describe('hx-counter', () => {
 
     it('has aria-atomic="true" on the off-screen live region (not on the visible counter)', async () => {
       // WCAG 4.1.2 fix: aria-atomic moved from the visible counter span to a hidden live region
-      const el = await fixture<HelixCounter>('<hx-counter value="42"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="42"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
       // Visible counter must NOT carry aria-atomic
       expect(counter?.getAttribute('aria-atomic')).toBeNull();
@@ -312,8 +324,17 @@ describe('hx-counter', () => {
       expect(liveRegion?.getAttribute('aria-atomic')).toBe('true');
     });
 
-    it('has no axe violations in default state', async () => {
+    it('warns in dev mode when no label is provided', async () => {
+      // Intentionally mounts without label to cover the devWarn path (WCAG 4.1.2 enforcement)
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      await el.updateComplete;
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it('has no axe violations in default state', async () => {
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
@@ -321,7 +342,7 @@ describe('hx-counter', () => {
     it('has no axe violations across all sizes', async () => {
       for (const size of ['sm', 'md', 'lg']) {
         const el = await fixture<HelixCounter>(
-          `<hx-counter hx-size="${size}" value="42"></hx-counter>`,
+          `<hx-counter label="Count" hx-size="${size}" value="42"></hx-counter>`,
         );
         const { violations } = await checkA11y(el);
         expect(violations, `hx-size="${size}" should have no violations`).toEqual([]);
@@ -335,7 +356,7 @@ describe('hx-counter', () => {
   describe('Lifecycle', () => {
     it('cancels animation on disconnect', async () => {
       const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
-      const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="100"></hx-counter>');
       el.remove();
       // cancelAnimationFrame should have been called during disconnectedCallback
       expect(cancelSpy).toHaveBeenCalled();

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -288,14 +288,15 @@ describe('hx-counter', () => {
   // ─── Accessibility (3) ───
 
   describe('Accessibility', () => {
-    it('has aria-live="polite" on the off-screen live region (not on the visible counter)', async () => {
-      // WCAG 4.1.2 fix: aria-live moved from the visible counter span to a hidden live region
-      // so screen readers only announce once at animation end, not on every frame.
+    it('has aria-live="polite" on the off-screen live region; counter span has aria-live="off"', async () => {
+      // WCAG 4.1.2: role="status" implies aria-live="polite", but the visible counter span
+      // carries aria-live="off" to suppress per-frame announcements during animation.
+      // A separate off-screen live region announces the final value once at animation end.
       const el = await fixture<HelixCounter>('<hx-counter value="42"></hx-counter>');
       const counter = shadowQuery(el, '[part~="counter"]');
-      // Visible counter must NOT carry aria-live (prevents per-frame announcements)
-      expect(counter?.getAttribute('aria-live')).toBeNull();
-      // The off-screen .sr-only span carries aria-live instead
+      // Visible counter carries aria-live="off" to suppress implicit live behavior of role="status"
+      expect(counter?.getAttribute('aria-live')).toBe('off');
+      // The off-screen .sr-only span carries aria-live="polite" for end-of-animation announcements
       const liveRegion = el.shadowRoot?.querySelector<HTMLElement>('.sr-only');
       expect(liveRegion?.getAttribute('aria-live')).toBe('polite');
     });

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -136,6 +136,43 @@ describe('hx-counter', () => {
       const el = await fixture<HelixCounter>('<hx-counter duration="2000"></hx-counter>');
       expect(el.duration).toBe(2000);
     });
+
+    it('clamps duration <= 0 and still completes animation', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const originalMatchMedia = window.matchMedia;
+      vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+        if (query === '(prefers-reduced-motion: reduce)') {
+          return {
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          } as MediaQueryList;
+        }
+        return originalMatchMedia(query);
+      });
+
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" duration="0" value="42"></hx-counter>',
+      );
+
+      // Wait for rAF-based animation to complete (clamped to 1ms, finishes in 1-2 frames)
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      await el.updateComplete;
+
+      const counter = shadowQuery(el, '[part~="counter"]');
+      expect(counter?.textContent?.trim()).toBe('42');
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] duration must be > 0 (received 0). Clamping to 1ms.',
+      );
+
+      vi.restoreAllMocks();
+    });
   });
 
   // ─── Property: easing (2) ───
@@ -154,6 +191,37 @@ describe('hx-counter', () => {
         expect(el.easing).toBe(easing);
         el.remove();
       }
+    });
+
+    it('falls back to linear for invalid easing and emits devWarn', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const originalMatchMedia = window.matchMedia;
+      vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+        if (query === '(prefers-reduced-motion: reduce)') {
+          return {
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          } as MediaQueryList;
+        }
+        return originalMatchMedia(query);
+      });
+
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Count" easing="bogus" value="50"></hx-counter>',
+      );
+      await el.updateComplete;
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] Unrecognized easing value "bogus". Falling back to "linear". Valid values: ease-in, ease-out, ease-in-out, linear.',
+      );
+
+      vi.restoreAllMocks();
     });
   });
 
@@ -329,8 +397,49 @@ describe('hx-counter', () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const el = await fixture<HelixCounter>('<hx-counter value="100"></hx-counter>');
       await el.updateComplete;
-      expect(warnSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
+      );
       warnSpy.mockRestore();
+    });
+
+    it('treats whitespace-only label as empty and warns', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const el = await fixture<HelixCounter>('<hx-counter label="   " value="100"></hx-counter>');
+      await el.updateComplete;
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[hx-counter] hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('includes label in sr-only announcement when label is set', async () => {
+      const originalMatchMedia = window.matchMedia;
+      vi.spyOn(window, 'matchMedia').mockImplementation((query: string) => {
+        if (query === '(prefers-reduced-motion: reduce)') {
+          return {
+            matches: true,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+          } as MediaQueryList;
+        }
+        return originalMatchMedia(query);
+      });
+
+      const el = await fixture<HelixCounter>(
+        '<hx-counter label="Total patients" value="1284"></hx-counter>',
+      );
+      await el.updateComplete;
+
+      const liveRegion = el.shadowRoot?.querySelector<HTMLElement>('.sr-only');
+      expect(liveRegion?.textContent).toBe('Total patients: 1,284');
+
+      vi.restoreAllMocks();
     });
 
     it('has no axe violations in default state', async () => {

--- a/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.test.ts
@@ -38,12 +38,12 @@ describe('hx-counter', () => {
 
   describe('Property: value', () => {
     it('defaults to 0', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.value).toBe(0);
     });
 
     it('accepts numeric value attribute', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter value="500"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" value="500"></hx-counter>');
       expect(el.value).toBe(500);
     });
   });
@@ -94,13 +94,13 @@ describe('hx-counter', () => {
 
   describe('Property: format', () => {
     it('defaults to integer format', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.format).toBe('integer');
     });
 
     it('accepts decimal format', async () => {
       const el = await fixture<HelixCounter>(
-        '<hx-counter format="decimal" value="0"></hx-counter>',
+        '<hx-counter label="Count" format="decimal" value="0"></hx-counter>',
       );
       expect(el.format).toBe('decimal');
     });
@@ -110,14 +110,14 @@ describe('hx-counter', () => {
 
   describe('Property: prefix and suffix', () => {
     it('defaults prefix and suffix to empty string', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.prefix).toBe('');
       expect(el.suffix).toBe('');
     });
 
     it('accepts prefix and suffix attributes', async () => {
       const el = await fixture<HelixCounter>(
-        '<hx-counter prefix="$" suffix="%" value="50"></hx-counter>',
+        '<hx-counter label="Price" prefix="$" suffix="%" value="50"></hx-counter>',
       );
       expect(el.prefix).toBe('$');
       expect(el.suffix).toBe('%');
@@ -128,12 +128,12 @@ describe('hx-counter', () => {
 
   describe('Property: duration', () => {
     it('defaults to 1000ms', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.duration).toBe(1000);
     });
 
     it('accepts custom duration', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter duration="2000"></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count" duration="2000"></hx-counter>');
       expect(el.duration).toBe(2000);
     });
 
@@ -179,7 +179,7 @@ describe('hx-counter', () => {
 
   describe('Property: easing', () => {
     it('defaults to ease-out', async () => {
-      const el = await fixture<HelixCounter>('<hx-counter></hx-counter>');
+      const el = await fixture<HelixCounter>('<hx-counter label="Count"></hx-counter>');
       expect(el.easing).toBe('ease-out');
     });
 
@@ -281,7 +281,7 @@ describe('hx-counter', () => {
       });
 
       const el = await fixture<HelixCounter>(
-        '<hx-counter format="integer" value="1000"></hx-counter>',
+        '<hx-counter label="Count" format="integer" value="1000"></hx-counter>',
       );
       await el.updateComplete;
 
@@ -312,7 +312,7 @@ describe('hx-counter', () => {
       });
 
       const el = await fixture<HelixCounter>(
-        '<hx-counter prefix="$" suffix="+" value="99"></hx-counter>',
+        '<hx-counter label="Price" prefix="$" suffix="+" value="99"></hx-counter>',
       );
       await el.updateComplete;
 
@@ -342,7 +342,7 @@ describe('hx-counter', () => {
       });
 
       const el = await fixture<HelixCounter>(
-        '<hx-counter format="decimal" value="42"></hx-counter>',
+        '<hx-counter label="Score" format="decimal" value="42"></hx-counter>',
       );
       await el.updateComplete;
 

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -111,12 +111,20 @@ export class HelixCounter extends LitElement {
   private _prefersReducedMotion = false;
   /** @internal */
   private _motionMql: MediaQueryList | null = null;
+  /**
+   * Normalized easing value after validation. Set once per animation start
+   * to avoid repeated devWarn calls on every requestAnimationFrame tick.
+   * @internal
+   */
+  private _resolvedEasing: 'linear' | 'ease-in' | 'ease-out' | 'ease-in-out' = 'ease-out';
   /** @internal */
   private readonly _handleMotionChange = (e: MediaQueryListEvent): void => {
     this._prefersReducedMotion = e.matches;
     if (this._prefersReducedMotion) {
       this._cancelAnimation();
       this._displayValue = this.value;
+      this._announcedValue = this._buildAnnouncement();
+      this.requestUpdate();
     }
   };
 
@@ -190,9 +198,33 @@ export class HelixCounter extends LitElement {
     }
   }
 
+  /**
+   * Validates `this.easing` once per animation start and stores the result in
+   * `_resolvedEasing`. This prevents devWarn from firing on every rAF tick for
+   * an invalid easing value — the warning is emitted at most once per call.
+   * @internal
+   */
+  private _normalizeEasing(): void {
+    const validEasings: Array<'linear' | 'ease-in' | 'ease-out' | 'ease-in-out'> = [
+      'linear',
+      'ease-in',
+      'ease-out',
+      'ease-in-out',
+    ];
+    if (validEasings.includes(this.easing)) {
+      this._resolvedEasing = this.easing;
+    } else {
+      devWarn(
+        'hx-counter',
+        `Unrecognized easing value "${this.easing as string}". Falling back to "ease-out". Valid values: ease-in, ease-out, ease-in-out, linear.`,
+      );
+      this._resolvedEasing = 'ease-out';
+    }
+  }
+
   /** @internal */
   private _applyEasing(t: number): number {
-    switch (this.easing) {
+    switch (this._resolvedEasing) {
       case 'linear':
         return t;
       case 'ease-in':
@@ -201,18 +233,13 @@ export class HelixCounter extends LitElement {
         return t * (2 - t);
       case 'ease-in-out':
         return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
-      default:
-        devWarn(
-          'hx-counter',
-          `Unrecognized easing value "${this.easing as string}". Falling back to linear. Valid values: ease-in, ease-out, ease-in-out, linear.`,
-        );
-        return t;
     }
   }
 
   /** @internal */
   private _startAnimation(): void {
     this._cancelAnimation();
+    this._normalizeEasing();
 
     const effectiveDuration =
       this.duration <= 0

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -141,7 +141,8 @@ export class HelixCounter extends LitElement {
     }
 
     // WCAG 4.1.2: a numeric value without context is meaningless to screen readers.
-    if (!this.label) {
+    // Normalize: whitespace-only labels are treated as empty.
+    if (!(this.label || '').trim()) {
       devWarn(
         'hx-counter',
         'hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
@@ -216,9 +217,9 @@ export class HelixCounter extends LitElement {
     } else {
       devWarn(
         'hx-counter',
-        `Unrecognized easing value "${this.easing as string}". Falling back to "ease-out". Valid values: ease-in, ease-out, ease-in-out, linear.`,
+        `Unrecognized easing value "${this.easing as string}". Falling back to "linear". Valid values: ease-in, ease-out, ease-in-out, linear.`,
       );
-      this._resolvedEasing = 'ease-out';
+      this._resolvedEasing = 'linear';
     }
   }
 
@@ -295,8 +296,14 @@ export class HelixCounter extends LitElement {
    * @internal
    */
   private _buildAnnouncement(): string {
+    const normalizedLabel = (this.label || '').trim();
+    if (!normalizedLabel) {
+      // No label means the number lacks context — return empty to prevent
+      // announcing a context-free number to screen readers.
+      return '';
+    }
     const formatted = this._formatValue();
-    return this.label ? `${this.label}: ${formatted}` : formatted;
+    return `${normalizedLabel}: ${formatted}`;
   }
 
   // ─── Render ───
@@ -313,7 +320,9 @@ export class HelixCounter extends LitElement {
         role="status"
         aria-live="off"
         class=${classMap(classes)}
-        aria-label=${this.label ? `${this.label}: ${this._formatValue()}` : nothing}
+        aria-label=${(this.label || '').trim()
+          ? `${(this.label || '').trim()}: ${this._formatValue()}`
+          : nothing}
       >
         ${this._formatValue()}
       </span>

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -132,6 +132,14 @@ export class HelixCounter extends LitElement {
       this.size = legacySize as CounterSize;
     }
 
+    // WCAG 4.1.2: a numeric value without context is meaningless to screen readers.
+    if (!this.label) {
+      devWarn(
+        'hx-counter',
+        'hx-counter requires a label for screen reader accessibility (WCAG 4.1.2). Provide the `label` attribute.',
+      );
+    }
+
     // Guard for SSR — window.matchMedia and requestAnimationFrame are unavailable server-side
     if (typeof window === 'undefined') {
       this._displayValue = this.value;
@@ -145,7 +153,7 @@ export class HelixCounter extends LitElement {
 
     if (this._prefersReducedMotion) {
       this._displayValue = this.value;
-      this._announcedValue = this._formatValue();
+      this._announcedValue = this._buildAnnouncement();
     } else {
       this._startAnimation();
     }
@@ -163,7 +171,7 @@ export class HelixCounter extends LitElement {
     if (changedProps.has('value') && changedProps.get('value') !== undefined) {
       if (this._prefersReducedMotion) {
         this._displayValue = this.value;
-        this._announcedValue = this._formatValue();
+        this._announcedValue = this._buildAnnouncement();
       } else {
         this._startValue = this._displayValue;
         this._startTime = null;
@@ -193,6 +201,12 @@ export class HelixCounter extends LitElement {
         return t * (2 - t);
       case 'ease-in-out':
         return t < 0.5 ? 2 * t * t : -1 + (4 - 2 * t) * t;
+      default:
+        devWarn(
+          'hx-counter',
+          `Unrecognized easing value "${this.easing as string}". Falling back to linear. Valid values: ease-in, ease-out, ease-in-out, linear.`,
+        );
+        return t;
     }
   }
 
@@ -200,13 +214,22 @@ export class HelixCounter extends LitElement {
   private _startAnimation(): void {
     this._cancelAnimation();
 
+    const effectiveDuration =
+      this.duration <= 0
+        ? (devWarn(
+            'hx-counter',
+            `duration must be > 0 (received ${this.duration}). Clamping to 1ms.`,
+          ),
+          1)
+        : this.duration;
+
     const step = (timestamp: number): void => {
       if (this._startTime === null) {
         this._startTime = timestamp;
       }
 
       const elapsed = timestamp - this._startTime;
-      const rawProgress = Math.min(elapsed / this.duration, 1);
+      const rawProgress = Math.min(elapsed / effectiveDuration, 1);
       const easedProgress = this._applyEasing(rawProgress);
 
       this._displayValue = this._startValue + (this.value - this._startValue) * easedProgress;
@@ -219,7 +242,7 @@ export class HelixCounter extends LitElement {
         // WCAG 4.1.2: announce the final value only once, at animation end.
         // _announcedValue feeds the off-screen live region so screen readers
         // hear a single announcement rather than one per animation frame.
-        this._announcedValue = this._formatValue();
+        this._announcedValue = this._buildAnnouncement();
       }
     };
 
@@ -238,6 +261,17 @@ export class HelixCounter extends LitElement {
     return `${this.prefix}${num.toLocaleString()}${this.suffix}`;
   }
 
+  /**
+   * Builds the string announced to screen readers at animation end.
+   * Includes label context when present so users hear "Total patients: 1,284"
+   * rather than a bare number with no semantic context.
+   * @internal
+   */
+  private _buildAnnouncement(): string {
+    const formatted = this._formatValue();
+    return this.label ? `${this.label}: ${formatted}` : formatted;
+  }
+
   // ─── Render ───
 
   override render() {
@@ -249,6 +283,8 @@ export class HelixCounter extends LitElement {
     return html`
       <span
         part="counter"
+        role="status"
+        aria-live="off"
         class=${classMap(classes)}
         aria-label=${this.label ? `${this.label}: ${this._formatValue()}` : nothing}
       >

--- a/packages/hx-library/src/components/hx-counter/hx-counter.ts
+++ b/packages/hx-library/src/components/hx-counter/hx-counter.ts
@@ -242,14 +242,13 @@ export class HelixCounter extends LitElement {
     this._cancelAnimation();
     this._normalizeEasing();
 
-    const effectiveDuration =
-      this.duration <= 0
-        ? (devWarn(
-            'hx-counter',
-            `duration must be > 0 (received ${this.duration}). Clamping to 1ms.`,
-          ),
-          1)
-        : this.duration;
+    let effectiveDuration: number;
+    if (this.duration <= 0) {
+      devWarn('hx-counter', `duration must be > 0 (received ${this.duration}). Clamping to 1ms.`);
+      effectiveDuration = 1;
+    } else {
+      effectiveDuration = this.duration;
+    }
 
     const step = (timestamp: number): void => {
       if (this._startTime === null) {
@@ -314,15 +313,15 @@ export class HelixCounter extends LitElement {
       [`counter--${this.size}`]: true,
     };
 
+    const trimmedLabel = (this.label || '').trim();
+
     return html`
       <span
         part="counter"
         role="status"
         aria-live="off"
         class=${classMap(classes)}
-        aria-label=${(this.label || '').trim()
-          ? `${(this.label || '').trim()}: ${this._formatValue()}`
-          : nothing}
+        aria-label=${trimmedLabel ? `${trimmedLabel}: ${this._formatValue()}` : nothing}
       >
         ${this._formatValue()}
       </span>

--- a/packages/hx-library/src/components/hx-file-upload/hx-file-upload.styles.ts
+++ b/packages/hx-library/src/components/hx-file-upload/hx-file-upload.styles.ts
@@ -162,6 +162,8 @@ export const helixFileUploadStyles = css`
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
     padding: var(--hx-space-1, 0.25rem);
     border: none;
     border-radius: var(--hx-border-radius-sm, 0.25rem);
@@ -240,5 +242,51 @@ export const helixFileUploadStyles = css`
     font-size: var(--hx-font-size-xs, 0.75rem);
     color: var(--hx-file-upload-error-color, var(--hx-color-error-text, #b91c1c));
     line-height: var(--hx-line-height-normal, 1.5);
+  }
+
+  /* ─── Forced colors (Windows High Contrast / Forced Colors Mode) ─── */
+
+  @media (forced-colors: active) {
+    .dropzone {
+      border: 2px dashed ButtonText;
+      background-color: Canvas;
+      color: ButtonText;
+    }
+
+    .dropzone--drag-over {
+      border: 2px solid Highlight;
+      outline: none;
+      background-color: Canvas;
+    }
+
+    .dropzone--error {
+      border: 2px solid LinkText;
+    }
+
+    .dropzone:focus-visible {
+      outline: 2px solid Highlight;
+      outline-offset: 2px;
+    }
+
+    .progress-bar {
+      background: Highlight;
+      forced-color-adjust: none;
+    }
+
+    .file-item__remove:hover {
+      outline: 2px solid Highlight;
+      background-color: transparent;
+      color: ButtonText;
+    }
+
+    .file-item__remove:focus-visible {
+      outline: 2px solid Highlight;
+    }
+
+    :host([disabled]) .dropzone {
+      border-color: GrayText;
+      color: GrayText;
+      opacity: 1;
+    }
   }
 `;

--- a/packages/hx-library/src/components/hx-file-upload/hx-file-upload.ts
+++ b/packages/hx-library/src/components/hx-file-upload/hx-file-upload.ts
@@ -4,6 +4,7 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
+import { mixinDelegatesAria } from '../../mixins/index.js';
 import { helixFileUploadStyles } from './hx-file-upload.styles.js';
 
 // Module-level counter for stable, SSR-safe IDs (avoids Math.random() hydration mismatch)
@@ -44,7 +45,7 @@ interface FileEntry {
  * @cssprop [--hx-file-upload-error-color=var(--hx-color-error-500)] - Error state and remove-button hover color.
  */
 @customElement('hx-file-upload')
-export class HelixFileUpload extends LitElement {
+export class HelixFileUpload extends mixinDelegatesAria(LitElement) {
   static override styles = [helixFileUploadStyles];
 
   // ─── Form Association ───
@@ -501,6 +502,31 @@ export class HelixFileUpload extends LitElement {
         detail: { file: removedFile, index },
       }),
     );
+
+    // Restore focus after removal so keyboard users are not stranded.
+    this.updateComplete
+      .then(() => {
+        if (this._files.length === 0) {
+          // List is now empty — return focus to the dropzone.
+          const dropzone = this.shadowRoot?.querySelector<HTMLElement>('[part="dropzone"]');
+          dropzone?.focus();
+        } else {
+          // Focus the remove button at the same position, or the previous one if
+          // the removed item was the last in the list.
+          const removeButtons =
+            this.shadowRoot?.querySelectorAll<HTMLButtonElement>('.file-item__remove');
+          if (removeButtons && removeButtons.length > 0) {
+            const targetIndex = index < this._files.length ? index : this._files.length - 1;
+            const targetButton = removeButtons[targetIndex];
+            if (targetButton) {
+              targetButton.focus();
+            }
+          }
+        }
+      })
+      .catch(() => {
+        // Focus restoration is best-effort; ignore errors.
+      });
   }
 
   // ─── Formatters ───
@@ -603,9 +629,10 @@ export class HelixFileUpload extends LitElement {
           id=${this._dropzoneId}
           role="button"
           tabindex=${this.disabled ? '-1' : '0'}
-          aria-label=${ifDefined(!this.label ? dropzoneLabel : undefined)}
+          aria-label=${ifDefined(!this.label ? (this.ariaLabel ?? dropzoneLabel) : undefined)}
           aria-labelledby=${ifDefined(this.label ? this._labelId : undefined)}
           aria-disabled=${this.disabled ? 'true' : nothing}
+          aria-invalid=${hasError ? 'true' : nothing}
           aria-describedby=${ifDefined(hasError ? this._errorId : undefined)}
           @click=${this._handleDropzoneClick}
           @keydown=${this._handleDropzoneKeyDown}

--- a/packages/hx-library/src/components/hx-form/hx-form.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.ts
@@ -425,13 +425,7 @@ export class HelixForm extends LitElement {
     const errorSummary =
       this._validationErrors.length > 0
         ? html`
-            <div
-              class="hx-form-error-summary"
-              role="alert"
-              aria-live="assertive"
-              aria-atomic="true"
-              tabindex="-1"
-            >
+            <div class="hx-form-error-summary" role="alert" aria-atomic="true" tabindex="-1">
               <ul>
                 ${this._validationErrors.map(
                   (error) => html`<li>${error.message || error.name}</li>`,

--- a/packages/hx-library/src/components/hx-list/hx-list-item.styles.ts
+++ b/packages/hx-library/src/components/hx-list/hx-list-item.styles.ts
@@ -108,4 +108,36 @@ export const helixListItemStyles = css`
       transition: none;
     }
   }
+
+  /* ─── Forced colors (Windows High Contrast / forced-colors mode) ─── */
+
+  @media (forced-colors: active) {
+    /* Selected state: replace background-color with a visible border using system Highlight color */
+    :host([interactive]) .list-item--selected {
+      background-color: transparent;
+      border: 2px solid Highlight;
+      color: HighlightText;
+      forced-color-adjust: none;
+    }
+
+    /* Hover state: use an outline instead of background-color */
+    :host([interactive]) .list-item:hover:not(.list-item--disabled) {
+      background-color: transparent;
+      outline: 1px solid Highlight;
+      outline-offset: -1px;
+    }
+
+    /* Disabled state: use system GrayText color */
+    :host([interactive][disabled]) .list-item,
+    :host([interactive]) .list-item--disabled {
+      color: GrayText;
+    }
+
+    /* Focus ring: ensure visibility in forced-colors mode */
+    :host([interactive]):focus-visible .list-item {
+      outline: 2px solid Highlight;
+      outline-offset: 2px;
+      forced-color-adjust: none;
+    }
+  }
 `;

--- a/packages/hx-library/src/components/hx-list/hx-list.ts
+++ b/packages/hx-library/src/components/hx-list/hx-list.ts
@@ -182,7 +182,7 @@ export class HelixList extends LitElement {
         part="base"
         class="list list--${this.variant}"
         role=${isInteractive ? 'listbox' : 'list'}
-        aria-label=${ifDefined(this.label)}
+        aria-label=${isInteractive ? this.label || 'List' : ifDefined(this.label)}
         aria-multiselectable=${isInteractive ? 'false' : nothing}
         @hx-list-item-click=${this._handleItemClick}
       >

--- a/packages/hx-library/src/components/hx-meter/hx-meter.styles.ts
+++ b/packages/hx-library/src/components/hx-meter/hx-meter.styles.ts
@@ -11,6 +11,13 @@ export const helixMeterStyles = css`
     flex-direction: column;
     gap: var(--hx-space-2, 0.5rem);
     width: 100%;
+    outline: none;
+    border-radius: var(--hx-border-radius-md, 0.375rem);
+  }
+
+  .meter:focus-visible {
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #2563eb);
+    outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
   .meter__label {
@@ -92,12 +99,6 @@ export const helixMeterStyles = css`
 
   .meter__state-label[data-state='danger'] {
     color: var(--hx-meter-color-danger, var(--hx-color-error-700, #991b1b));
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .meter__indicator {
-      transition: none;
-    }
   }
 
   /* ─── Native meter hidden (we use custom rendering) ─── */

--- a/packages/hx-library/src/components/hx-phi-field/hx-phi-field.styles.ts
+++ b/packages/hx-library/src/components/hx-phi-field/hx-phi-field.styles.ts
@@ -97,4 +97,18 @@ export const helixPhiFieldStyles = css`
       transition: none;
     }
   }
+
+  /* ─── Forced Colors (Windows High Contrast Mode) ─── */
+
+  @media (forced-colors: active) {
+    .phi-field__toggle {
+      border: 1px solid ButtonText;
+      forced-color-adjust: none;
+    }
+
+    .phi-field__toggle:focus-visible {
+      outline: 2px solid Highlight;
+      outline-offset: 2px;
+    }
+  }
 `;

--- a/packages/hx-library/src/components/hx-phi-field/hx-phi-field.test.ts
+++ b/packages/hx-library/src/components/hx-phi-field/hx-phi-field.test.ts
@@ -11,53 +11,53 @@ describe('hx-phi-field', () => {
 
   describe('Rendering', () => {
     it('renders with shadow DOM', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(el.shadowRoot).toBeTruthy();
     });
 
     it('defaults to masked state', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       expect(value?.classList.contains('phi-field__value--masked')).toBe(true);
     });
 
     it('exposes "container" CSS part', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(shadowQuery(el, '[part~="container"]')).toBeTruthy();
     });
 
     it('exposes "value" CSS part', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(shadowQuery(el, '[part~="value"]')).toBeTruthy();
     });
 
     it('exposes "toggle" CSS part', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(shadowQuery(el, '[part~="toggle"]')).toBeTruthy();
     });
 
     it('does not expose unmasked data in DOM when masked', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       // The full SSN should not appear anywhere in the shadow DOM when masked
       expect(el.shadowRoot?.innerHTML).not.toContain('123-45-6789');
     });
 
     it('renders toggle button', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]');
       expect(toggle).toBeInstanceOf(HTMLButtonElement);
     });
@@ -72,39 +72,47 @@ describe('hx-phi-field', () => {
     });
 
     it('returns empty masked value when data is empty', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
       const value = shadowQuery(el, '.phi-field__value');
       expect(value?.textContent?.trim()).toBe('');
     });
 
-    it('accepts SSN format', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+    it('accepts SSN format via property', async () => {
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(el.data).toBe('123-45-6789');
     });
 
-    it('accepts MRN format', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="MRN-00123456" field-type="mrn"></hx-phi-field>',
-      );
+    it('accepts MRN format via property', async () => {
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="mrn"></hx-phi-field>');
+      el.data = 'MRN-00123456';
+      await el.updateComplete;
       expect(el.data).toBe('MRN-00123456');
     });
 
-    it('accepts DOB format', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="12/25/1990" field-type="dob"></hx-phi-field>',
-      );
+    it('accepts DOB format via property', async () => {
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="dob"></hx-phi-field>');
+      el.data = '12/25/1990';
+      await el.updateComplete;
       expect(el.data).toBe('12/25/1990');
     });
 
-    it('accepts insurance ID format', async () => {
+    it('accepts insurance ID format via property', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="1234-5678-9012-3456" field-type="insurance"></hx-phi-field>',
+        '<hx-phi-field field-type="insurance"></hx-phi-field>',
       );
+      el.data = '1234-5678-9012-3456';
+      await el.updateComplete;
       expect(el.data).toBe('1234-5678-9012-3456');
+    });
+
+    it('does not reflect data to HTML attribute', async () => {
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
+      // PHI must not appear in the DOM as an attribute
+      expect(el.getAttribute('data')).toBeNull();
     });
   });
 
@@ -112,35 +120,37 @@ describe('hx-phi-field', () => {
 
   describe('Property: fieldType', () => {
     it('defaults to "ssn"', async () => {
-      const el = await fixture<HelixPhiField>('<hx-phi-field data="123-45-6789"></hx-phi-field>');
+      const el = await fixture<HelixPhiField>('<hx-phi-field></hx-phi-field>');
       expect(el.fieldType).toBe('ssn');
     });
 
     it('reflects field-type attribute to host', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="12/25/1990" field-type="dob"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="dob"></hx-phi-field>');
+      el.data = '12/25/1990';
+      await el.updateComplete;
       expect(el.getAttribute('field-type')).toBe('dob');
     });
 
     it('accepts "mrn" field type', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="MRN12345" field-type="mrn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="mrn"></hx-phi-field>');
+      el.data = 'MRN12345';
+      await el.updateComplete;
       expect(el.fieldType).toBe('mrn');
     });
 
     it('accepts "dob" field type', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="01/01/1980" field-type="dob"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="dob"></hx-phi-field>');
+      el.data = '01/01/1980';
+      await el.updateComplete;
       expect(el.fieldType).toBe('dob');
     });
 
     it('accepts "insurance" field type', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="1234-5678-9012-3456" field-type="insurance"></hx-phi-field>',
+        '<hx-phi-field field-type="insurance"></hx-phi-field>',
       );
+      el.data = '1234-5678-9012-3456';
+      await el.updateComplete;
       expect(el.fieldType).toBe('insurance');
     });
   });
@@ -149,34 +159,34 @@ describe('hx-phi-field', () => {
 
   describe('Masking Patterns', () => {
     it('masks SSN to show only last 4 digits', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       expect(value?.textContent?.trim()).toBe('***-**-6789');
     });
 
     it('masks SSN without separators', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123456789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123456789';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       // Fallback: mask all but last 4
       expect(value?.textContent?.trim()).toBe('*****6789');
     });
 
     it('masks MRN to show only last 4 alphanumeric chars', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="MRN12345678" field-type="mrn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="mrn"></hx-phi-field>');
+      el.data = 'MRN12345678';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       expect(value?.textContent?.trim()).toBe('*******5678');
     });
 
     it('masks MRN with separators, preserving them', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="MRN-00123456" field-type="mrn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="mrn"></hx-phi-field>');
+      el.data = 'MRN-00123456';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       // MRN-00123456: alphanumeric = M,R,N,0,0,1,2,3,4,5,6 (11 chars), show last 4 = 3456
       // mask first 7 alphanumeric (M,R,N,0,0,1,2), preserve separator (-), reveal 3456
@@ -184,25 +194,29 @@ describe('hx-phi-field', () => {
     });
 
     it('masks DOB replacing all digits', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="12/25/1990" field-type="dob"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="dob"></hx-phi-field>');
+      el.data = '12/25/1990';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       expect(value?.textContent?.trim()).toBe('**/**/****');
     });
 
     it('masks insurance ID to show only last 4 digits', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="1234-5678-9012-3456" field-type="insurance"></hx-phi-field>',
+        '<hx-phi-field field-type="insurance"></hx-phi-field>',
       );
+      el.data = '1234-5678-9012-3456';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       expect(value?.textContent?.trim()).toBe('****-****-****-3456');
     });
 
     it('masks insurance ID without separators', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="1234567890123456" field-type="insurance"></hx-phi-field>',
+        '<hx-phi-field field-type="insurance"></hx-phi-field>',
       );
+      el.data = '1234567890123456';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       // Fallback: mask all but last 4
       expect(value?.textContent?.trim()).toBe('************3456');
@@ -213,9 +227,9 @@ describe('hx-phi-field', () => {
 
   describe('Reveal / Hide Toggle', () => {
     it('clicking toggle reveals the PHI value', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -225,9 +239,9 @@ describe('hx-phi-field', () => {
     });
 
     it('clicking toggle again hides the PHI value', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -238,9 +252,9 @@ describe('hx-phi-field', () => {
     });
 
     it('unmasked PHI is not in shadow DOM when masked', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       // Reveal then hide
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
@@ -251,9 +265,9 @@ describe('hx-phi-field', () => {
     });
 
     it('unmasked PHI is present in shadow DOM when revealed', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -266,8 +280,10 @@ describe('hx-phi-field', () => {
   describe('Events', () => {
     it('fires hx-phi-access with action="reveal" on reveal', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" field-id="ssn-field"></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" field-id="ssn-field"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-phi-access');
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
@@ -277,8 +293,10 @@ describe('hx-phi-field', () => {
 
     it('fires hx-phi-access with correct fieldId on reveal', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" field-id="ssn-field"></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" field-id="ssn-field"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-phi-access');
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
@@ -288,8 +306,10 @@ describe('hx-phi-field', () => {
 
     it('fires hx-phi-access with correct fieldType on reveal', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" field-id="ssn-field"></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" field-id="ssn-field"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-phi-access');
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
@@ -299,8 +319,10 @@ describe('hx-phi-field', () => {
 
     it('fires hx-phi-access with ISO timestamp on reveal', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" field-id="ssn-field"></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" field-id="ssn-field"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-phi-access');
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
@@ -310,8 +332,10 @@ describe('hx-phi-field', () => {
 
     it('hx-phi-access bubbles and is composed', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" field-id="ssn-field"></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" field-id="ssn-field"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-phi-access');
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
@@ -321,9 +345,9 @@ describe('hx-phi-field', () => {
     });
 
     it('fires hx-phi-access with action="hide" on manual hide', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       // First reveal
       toggle.click();
@@ -337,8 +361,10 @@ describe('hx-phi-field', () => {
 
     it('falls back to element id when fieldId is not set', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field id="my-ssn" data="123-45-6789" field-type="ssn"></hx-phi-field>',
+        '<hx-phi-field id="my-ssn" field-type="ssn"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-phi-access');
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
@@ -351,9 +377,9 @@ describe('hx-phi-field', () => {
 
   describe('Clipboard Protection', () => {
     it('prevents copy when masked', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const container = shadowQuery(el, '.phi-field')!;
       let defaultPrevented = false;
       const copyEvent = new ClipboardEvent('copy', { bubbles: true, cancelable: true });
@@ -367,9 +393,9 @@ describe('hx-phi-field', () => {
     });
 
     it('prevents paste when masked', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const container = shadowQuery(el, '.phi-field')!;
       let defaultPrevented = false;
       const pasteEvent = new ClipboardEvent('paste', { bubbles: true, cancelable: true });
@@ -383,9 +409,9 @@ describe('hx-phi-field', () => {
     });
 
     it('does not prevent copy when revealed', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -406,18 +432,18 @@ describe('hx-phi-field', () => {
 
   describe('Accessibility', () => {
     it('has no axe violations in masked state', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       await page.screenshot();
       const { violations } = await checkA11y(el);
       expect(violations).toEqual([]);
     });
 
     it('has no axe violations in revealed state', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -427,41 +453,41 @@ describe('hx-phi-field', () => {
     });
 
     it('has role="status" live region', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const status = shadowQuery(el, '[role="status"]');
       expect(status).toBeTruthy();
     });
 
     it('has aria-live="polite" on status region', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const status = shadowQuery(el, '[role="status"]');
       expect(status?.getAttribute('aria-live')).toBe('polite');
     });
 
     it('has aria-atomic="true" on status region', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const status = shadowQuery(el, '[role="status"]');
       expect(status?.getAttribute('aria-atomic')).toBe('true');
     });
 
     it('toggle has aria-label when masked', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery(el, '[part="toggle"]')!;
       expect(toggle.getAttribute('aria-label')).toBe('Reveal protected health information');
     });
 
     it('toggle has aria-label when revealed', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -469,17 +495,17 @@ describe('hx-phi-field', () => {
     });
 
     it('toggle aria-pressed is "false" when masked', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery(el, '[part="toggle"]')!;
       expect(toggle.getAttribute('aria-pressed')).toBe('false');
     });
 
     it('toggle aria-pressed is "true" when revealed', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -487,17 +513,17 @@ describe('hx-phi-field', () => {
     });
 
     it('status region announces masked state', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const status = shadowQuery(el, '[role="status"]');
       expect(status?.textContent?.trim()).toBe('Protected health information is masked');
     });
 
     it('status region announces revealed state', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -507,34 +533,46 @@ describe('hx-phi-field', () => {
 
     it('toggle has aria-label using custom label property', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" label="Social Security Number"></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" label="Social Security Number"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery(el, '[part="toggle"]')!;
       expect(toggle.getAttribute('aria-label')).toBe('Reveal social security number');
     });
 
     it('status region uses custom label in announcement', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" label="SSN"></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" label="SSN"></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const status = shadowQuery(el, '[role="status"]');
       expect(status?.textContent?.trim()).toBe('SSN is masked');
     });
 
     it('toggle is a native button element', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery(el, '[part="toggle"]');
       expect(toggle).toBeInstanceOf(HTMLButtonElement);
     });
 
     it('toggle type is "button"', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       expect(toggle.getAttribute('type')).toBe('button');
+    });
+
+    it('masked value span has aria-hidden="true"', async () => {
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
+      const value = shadowQuery(el, '.phi-field__value--masked');
+      expect(value?.getAttribute('aria-hidden')).toBe('true');
     });
   });
 
@@ -551,46 +589,48 @@ describe('hx-phi-field', () => {
     it('all four field types render without errors', async () => {
       for (const fieldType of ['ssn', 'mrn', 'dob', 'insurance'] as const) {
         const el = await fixture<HelixPhiField>(
-          `<hx-phi-field data="test" field-type="${fieldType}"></hx-phi-field>`,
+          `<hx-phi-field field-type="${fieldType}"></hx-phi-field>`,
         );
+        el.data = 'test';
+        await el.updateComplete;
         expect(el.shadowRoot).toBeTruthy();
         el.remove();
       }
     });
 
     it('clipboardTimeout defaults to 30000', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(el.clipboardTimeout).toBe(30000);
     });
 
     it('fieldId defaults to empty string', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(el.fieldId).toBe('');
     });
 
     it('renders all masking types for DOB', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="01/01/1985" field-type="dob"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="dob"></hx-phi-field>');
+      el.data = '01/01/1985';
+      await el.updateComplete;
       const value = shadowQuery(el, '.phi-field__value');
       expect(value?.textContent?.trim()).toBe('**/**/****');
     });
 
     it('label defaults to empty string', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(el.label).toBe('');
     });
 
     it('disabled defaults to false', async () => {
-      const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn"></hx-phi-field>',
-      );
+      const el = await fixture<HelixPhiField>('<hx-phi-field field-type="ssn"></hx-phi-field>');
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(el.disabled).toBe(false);
     });
   });
@@ -600,16 +640,20 @@ describe('hx-phi-field', () => {
   describe('Disabled State', () => {
     it('toggle button is disabled when disabled attribute is set', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" disabled></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" disabled></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       expect(toggle.disabled).toBe(true);
     });
 
     it('does not reveal when disabled', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" disabled></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" disabled></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       const toggle = shadowQuery<HTMLButtonElement>(el, '[part="toggle"]')!;
       toggle.click();
       await el.updateComplete;
@@ -619,8 +663,10 @@ describe('hx-phi-field', () => {
 
     it('reflects disabled attribute on host', async () => {
       const el = await fixture<HelixPhiField>(
-        '<hx-phi-field data="123-45-6789" field-type="ssn" disabled></hx-phi-field>',
+        '<hx-phi-field field-type="ssn" disabled></hx-phi-field>',
       );
+      el.data = '123-45-6789';
+      await el.updateComplete;
       expect(el.hasAttribute('disabled')).toBe(true);
     });
   });

--- a/packages/hx-library/src/components/hx-phi-field/hx-phi-field.ts
+++ b/packages/hx-library/src/components/hx-phi-field/hx-phi-field.ts
@@ -2,6 +2,7 @@ import { LitElement, html, type TemplateResult } from 'lit';
 import '../../utilities/document-token-adoption.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { helixPhiFieldStyles } from './hx-phi-field.styles.js';
+import { devWarn } from '../../utils/dev-warn.js';
 
 /**
  * HIPAA-compliant field component for rendering masked Protected Health Information (PHI).
@@ -33,9 +34,10 @@ export class HelixPhiField extends LitElement {
 
   /**
    * The Protected Health Information value to display or mask.
-   * @attr data
+   * Must be set via the JavaScript property (`element.data = "..."`) — not as an HTML attribute.
+   * Setting PHI as an HTML attribute exposes it in the DOM and browser caches (HIPAA violation).
    */
-  @property({ type: String })
+  @property({ attribute: false })
   data: string = '';
 
   /**
@@ -90,6 +92,13 @@ export class HelixPhiField extends LitElement {
     super.connectedCallback();
     // Enforce HIPAA compliance: prevent browser autofill on the host element
     this.setAttribute('autocomplete', 'off');
+    // Warn if a developer mistakenly sets PHI via the HTML attribute
+    if (this.hasAttribute('data')) {
+      devWarn(
+        'hx-phi-field',
+        'Setting PHI via the `data` HTML attribute is not supported and may expose sensitive data in the DOM. Use the `data` property (element.data = "...") instead.',
+      );
+    }
   }
 
   override disconnectedCallback(): void {
@@ -295,7 +304,10 @@ export class HelixPhiField extends LitElement {
         @paste=${this._handlePaste}
       >
         ${this._masked
-          ? html`<span part="value" class="phi-field__value phi-field__value--masked"
+          ? html`<span
+              part="value"
+              class="phi-field__value phi-field__value--masked"
+              aria-hidden="true"
               >${this._getMaskedValue()}</span
             >`
           : html`<span part="value" class="phi-field__value phi-field__value--revealed"

--- a/packages/hx-library/src/components/hx-popover/hx-popover.ts
+++ b/packages/hx-library/src/components/hx-popover/hx-popover.ts
@@ -543,7 +543,7 @@ export class HelixPopover extends LitElement {
         @mouseleave=${this._handleBodyMouseLeave}
       >
         <slot></slot>
-        ${this.arrow ? html`<div part="arrow"></div>` : ''}
+        ${this.arrow ? html`<div part="arrow"></div>` : nothing}
       </div>
     `;
   }

--- a/packages/hx-library/src/components/hx-popup/hx-popup.ts
+++ b/packages/hx-library/src/components/hx-popup/hx-popup.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, type PropertyValues } from 'lit';
+import { LitElement, html, nothing, type PropertyValues } from 'lit';
 import '../../utilities/document-token-adoption.js';
 import { customElement, property } from 'lit/decorators.js';
 import {
@@ -521,7 +521,7 @@ export class HelixPopup extends LitElement {
       <slot name="anchor" @slotchange=${this._handleAnchorSlotChange}></slot>
       <div part="popup" ?inert=${!this.active}>
         <slot></slot>
-        ${this.arrow ? html`<div part="arrow"></div>` : ''}
+        ${this.arrow ? html`<div part="arrow"></div>` : nothing}
       </div>
     `;
   }

--- a/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
@@ -121,7 +121,7 @@ export const helixStatStyles = css`
   /* ─── Forced Colors (Windows High Contrast Mode) ─── */
 
   @media (forced-colors: active) {
-    :host {
+    .stat__trend {
       forced-color-adjust: none;
     }
 

--- a/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.styles.ts
@@ -106,4 +106,51 @@ export const helixStatStyles = css`
   [hidden] {
     display: none !important;
   }
+
+  /* ─── Visually-hidden live region ─── */
+
+  .stat__live-region {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+  }
+
+  /* ─── Forced Colors (Windows High Contrast Mode) ─── */
+
+  @media (forced-colors: active) {
+    :host {
+      forced-color-adjust: none;
+    }
+
+    .stat__value {
+      color: CanvasText;
+    }
+
+    .stat__label {
+      color: CanvasText;
+    }
+
+    .stat__icon {
+      color: CanvasText;
+    }
+
+    .stat__trend--up {
+      background: Highlight;
+      color: HighlightText;
+      border: 1px solid Highlight;
+    }
+
+    .stat__trend--down {
+      background: ButtonText;
+      color: ButtonFace;
+      border: 1px solid ButtonText;
+    }
+
+    .stat__trend-arrow {
+      color: currentColor;
+    }
+  }
 `;

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -183,12 +183,23 @@ describe('hx-stat', () => {
       expect(shadowQuery(el, '[part~="trend"]')).toBeTruthy();
     });
 
-    it('renders trend element with correct class for forced-colors targeting', async () => {
+    it('stylesheet includes forced-colors media query with distinct trend styles', async () => {
       const el = await fixture<HelixStat>('<hx-stat value="42" trend="up"></hx-stat>');
       await el.updateComplete;
+
+      // Verify the trend element renders with the correct class
       const trend = shadowQuery(el, '.stat__trend');
       expect(trend).toBeTruthy();
-      expect(trend!.classList.contains('stat__trend--up')).toBe(true);
+      expect(trend?.classList.contains('stat__trend--up')).toBe(true);
+
+      // Verify the component's adopted stylesheets contain forced-colors rules
+      const sheets = el.shadowRoot?.adoptedStyleSheets ?? [];
+      const cssText = sheets.map((s) => [...s.cssRules].map((r) => r.cssText).join('\n')).join('\n');
+      expect(cssText).toContain('forced-colors: active');
+
+      // Verify up and down trends map to different border styles in the stylesheet
+      expect(cssText).toContain('.stat__trend--up');
+      expect(cssText).toContain('.stat__trend--down');
     });
   });
 

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -182,6 +182,14 @@ describe('hx-stat', () => {
       const el = await fixture<HelixStat>('<hx-stat value="42" trend="up"></hx-stat>');
       expect(shadowQuery(el, '[part~="trend"]')).toBeTruthy();
     });
+
+    it('renders trend element with correct class for forced-colors targeting', async () => {
+      const el = await fixture<HelixStat>('<hx-stat value="42" trend="up"></hx-stat>');
+      await el.updateComplete;
+      const trend = shadowQuery(el, '.stat__trend');
+      expect(trend).toBeTruthy();
+      expect(trend!.classList.contains('stat__trend--up')).toBe(true);
+    });
   });
 
   // ─── Slots (2) ───

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import { fixture, shadowQuery, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixStat } from './hx-stat.js';
 import './index.js';
@@ -249,6 +249,68 @@ describe('hx-stat', () => {
         expect(violations, `hx-size="${size}" should have no violations`).toEqual([]);
         el.remove();
       }
+    });
+  });
+
+  // ─── aria-live region (4) ───
+
+  describe('aria-live region', () => {
+    it('renders a visually-hidden live region element', async () => {
+      const el = await fixture<HelixStat>('<hx-stat label="Users" value="42"></hx-stat>');
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live).toBeTruthy();
+      expect(live?.getAttribute('aria-live')).toBe('polite');
+      expect(live?.getAttribute('aria-atomic')).toBe('true');
+    });
+
+    it('live region contains value and label text', async () => {
+      const el = await fixture<HelixStat>('<hx-stat label="Patients" value="1,234"></hx-stat>');
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live?.textContent).toContain('1,234');
+      expect(live?.textContent).toContain('Patients');
+    });
+
+    it('live region updates when value changes', async () => {
+      const el = await fixture<HelixStat>('<hx-stat label="Users" value="10"></hx-stat>');
+      el.value = '999';
+      await el.updateComplete;
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live?.textContent).toContain('999');
+    });
+
+    it('live region includes trend direction when set', async () => {
+      const el = await fixture<HelixStat>(
+        '<hx-stat label="Revenue" value="$5,000" trend="up"></hx-stat>',
+      );
+      const live = el.shadowRoot?.querySelector('.stat__live-region');
+      expect(live?.textContent).toContain('up');
+    });
+  });
+
+  // ─── devWarn for empty state (2) ───
+
+  describe('devWarn for empty state', () => {
+    beforeEach(() => {
+      vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('warns when both value and label are empty', async () => {
+      await fixture<HelixStat>('<hx-stat></hx-stat>');
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('unnamed hx-stat'),
+      );
+    });
+
+    it('does not warn about unnamed stat when value is provided', async () => {
+      await fixture<HelixStat>('<hx-stat value="42"></hx-stat>');
+      const unnamedCalls = (console.warn as ReturnType<typeof vi.spyOn>).mock.calls.filter(
+        (args) => String(args[0]).includes('unnamed hx-stat'),
+      );
+      expect(unnamedCalls).toHaveLength(0);
     });
   });
 });

--- a/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.test.ts
@@ -324,6 +324,15 @@ describe('hx-stat', () => {
       );
     });
 
+    it('warns only once across multiple updates (_hasWarnedUnnamed guard)', async () => {
+      const el = await fixture<HelixStat>('<hx-stat></hx-stat>');
+      expect(console.warn).toHaveBeenCalledTimes(1);
+
+      el.requestUpdate();
+      await el.updateComplete;
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
     it('does not warn about unnamed stat when value is provided', async () => {
       await fixture<HelixStat>('<hx-stat value="42"></hx-stat>');
       const unnamedCalls = (console.warn as ReturnType<typeof vi.spyOn>).mock.calls.filter(

--- a/packages/hx-library/src/components/hx-stat/hx-stat.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.ts
@@ -100,14 +100,16 @@ export class HelixStat extends LitElement {
   override updated(changedProperties: Map<PropertyKey, unknown>): void {
     super.updated(changedProperties);
     const identityChanged = changedProperties.has('value') || changedProperties.has('label');
-    if (identityChanged && !this.value && !this.label && !this._hasWarnedUnnamed) {
+    const hasValue = this.value.trim().length > 0;
+    const hasLabel = this.label.trim().length > 0;
+    if (identityChanged && !hasValue && !hasLabel && !this._hasWarnedUnnamed) {
       this._hasWarnedUnnamed = true;
       devWarn(
         'hx-stat',
         'Rendering an unnamed hx-stat; provide at least value or label for screen reader accessibility.',
       );
     }
-    if (this.value || this.label) {
+    if (hasValue || hasLabel) {
       this._hasWarnedUnnamed = false;
     }
   }
@@ -186,9 +188,7 @@ export class HelixStat extends LitElement {
     // readers when any of those properties change programmatically.
     const liveParts: string[] = [];
     const primary =
-      this.label && this.value
-        ? `${this.label}: ${this.value}`
-        : this.value || this.label || '';
+      this.label && this.value ? `${this.label}: ${this.value}` : this.value || this.label || '';
     if (primary) liveParts.push(primary);
     if (hasTrend) liveParts.push(`${this.labelTrend}: ${this.trend}`);
     const liveText = liveParts.join(', ');

--- a/packages/hx-library/src/components/hx-stat/hx-stat.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.ts
@@ -94,6 +94,16 @@ export class HelixStat extends LitElement {
     }
   }
 
+  override updated(changedProperties: Map<PropertyKey, unknown>): void {
+    super.updated(changedProperties);
+    if (!this.value && !this.label) {
+      devWarn(
+        'hx-stat',
+        'Rendering an unnamed hx-stat; provide at least value or label for screen reader accessibility.',
+      );
+    }
+  }
+
   // ─── Slot Detection ───
 
   /** @internal */
@@ -164,6 +174,15 @@ export class HelixStat extends LitElement {
         ? `${this.value}: ${this.label}`
         : this.value || this.label || nothing;
 
+    // Live region text: announces value, label, and trend direction to screen
+    // readers when any of those properties change programmatically.
+    const liveText = [
+      this.label && this.value ? `${this.label}: ${this.value}` : this.value || this.label,
+      hasTrend ? `, ${this.labelTrend}: ${this.trend}` : '',
+    ]
+      .filter(Boolean)
+      .join('');
+
     return html`
       <div
         part="container"
@@ -171,6 +190,7 @@ export class HelixStat extends LitElement {
         role="group"
         aria-label=${groupLabel}
       >
+        <span class="stat__live-region" aria-live="polite" aria-atomic="true">${liveText}</span>
         <div part="header" class="stat__header">
           <span part="icon" class="stat__icon" ?hidden=${!this._hasIcon}>
             <slot name="icon" @slotchange=${this._onIconSlotChange}></slot>

--- a/packages/hx-library/src/components/hx-stat/hx-stat.ts
+++ b/packages/hx-library/src/components/hx-stat/hx-stat.ts
@@ -81,6 +81,9 @@ export class HelixStat extends LitElement {
    */
   @property({ attribute: 'label-trend' }) labelTrend = 'Trend';
 
+  /** @internal tracks whether the "unnamed" devWarn has already fired this lifecycle */
+  private _hasWarnedUnnamed = false;
+
   // ─── Lifecycle ───
 
   override connectedCallback(): void {
@@ -96,11 +99,16 @@ export class HelixStat extends LitElement {
 
   override updated(changedProperties: Map<PropertyKey, unknown>): void {
     super.updated(changedProperties);
-    if (!this.value && !this.label) {
+    const identityChanged = changedProperties.has('value') || changedProperties.has('label');
+    if (identityChanged && !this.value && !this.label && !this._hasWarnedUnnamed) {
+      this._hasWarnedUnnamed = true;
       devWarn(
         'hx-stat',
         'Rendering an unnamed hx-stat; provide at least value or label for screen reader accessibility.',
       );
+    }
+    if (this.value || this.label) {
+      this._hasWarnedUnnamed = false;
     }
   }
 
@@ -176,12 +184,14 @@ export class HelixStat extends LitElement {
 
     // Live region text: announces value, label, and trend direction to screen
     // readers when any of those properties change programmatically.
-    const liveText = [
-      this.label && this.value ? `${this.label}: ${this.value}` : this.value || this.label,
-      hasTrend ? `, ${this.labelTrend}: ${this.trend}` : '',
-    ]
-      .filter(Boolean)
-      .join('');
+    const liveParts: string[] = [];
+    const primary =
+      this.label && this.value
+        ? `${this.label}: ${this.value}`
+        : this.value || this.label || '';
+    if (primary) liveParts.push(primary);
+    if (hasTrend) liveParts.push(`${this.labelTrend}: ${this.trend}`);
+    const liveText = liveParts.join(', ');
 
     return html`
       <div


### PR DESCRIPTION
## Summary

Promotes dev to staging with all P0 audit fixes and P2 cleanups.

### P0 fixes (5)
- #1443 hx-stat: aria-live region, forced-colors styles, devWarn
- #1444 hx-file-upload: aria-invalid, focus restoration, touch targets, mixinDelegatesAria
- #1445 hx-phi-field: hide masked value from screen readers, forced-colors
- #1446 hx-list: accessible name enforcement, forced-colors
- #1447 hx-counter: semantic role, accessible name, live region, input guards

### P2 fixes (4)
- #1428 hx-popover/hx-popup: Lit nothing sentinel for conditional rendering
- #1431 hx-meter: focus-visible ring, remove duplicate reduced-motion
- #1434 hx-card: correct devWarn attribute reference
- #1437 hx-form: remove redundant aria-live on error summary

### Infrastructure
- CI: move security audit to soft-fail gate (npm retired v1 endpoint)