### PR TITLE
fix(3.0.0): address all codex-adversarial blocking findings pre-merge

### DIFF
--- a/.changeset/fix-3.0.0-codex-blockers-pre-merge.md
+++ b/.changeset/fix-3.0.0-codex-blockers-pre-merge.md
@@ -1,0 +1,20 @@
+---
+'@helixui/library': patch
+'@helixui/drupal-starter': patch
+---
+
+fix(barrel): restore HelixAuditController, AuditEventDetail, AuditControllerOptions to public barrel via generate-barrel.js allowlist
+
+fix(publish): add CEM regeneration + verification step to publish job so both secret-scan and publish jobs independently verify CEM freshness
+
+fix(publish): add @helixui/react to secret-scan package loop
+
+fix(mixins): promote FormMixinProtectedHooks jsdoc from @internal to @protected
+
+fix(changelog): add resetIdCounter test-utils migration note
+
+fix(drupal-starter): correct hx-card accessible-label to hx-label attribute in templates
+
+fix(drupal-starter): fix hx-nav hx-size="small" to hx-size="sm" invalid enum value
+
+fix(docs): correct CDN artifact URLs and floating-ui pre-warm import in migration guides

--- a/.claude/commands/codex-review.md
+++ b/.claude/commands/codex-review.md
@@ -2,6 +2,7 @@
 description: Run an adversarial review of the current branch via the Codex plugin (GPT-5.4). First-class step in the REA engineering process.
 argument-hint: "[diff-target]"
 allowed-tools:
+  - Agent
   - Bash(git diff:*)
   - Bash(git log:*)
   - Bash(git branch:*)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,12 +94,16 @@ jobs:
             PKG_NAME=$(node -p "require('./$pkg_dir/package.json').name" 2>/dev/null || echo "unknown")
             echo "Packing $PKG_NAME ($pkg_dir)..."
 
-            TARBALL=$(cd "$pkg_dir" && pnpm pack --pack-destination "$SCAN_DIR" 2>/dev/null \
-              | tail -1)
-            if [ ! -f "$TARBALL" ]; then
-              # pnpm pack writes the filename relative to pack-destination
-              TARBALL=$(ls -t "$SCAN_DIR"/*.tgz 2>/dev/null | head -1)
+            PKG_PACK_DIR="$SCAN_DIR/pack-$(basename "$pkg_dir")"
+            mkdir -p "$PKG_PACK_DIR"
+            if ! PACK_OUTPUT=$(cd "$pkg_dir" && pnpm pack --pack-destination "$PKG_PACK_DIR" 2>&1); then
+              echo "::error::Failed to produce tarball for $PKG_NAME"
+              echo "$PACK_OUTPUT"
+              FAIL=1
+              continue
             fi
+
+            TARBALL=$(find "$PKG_PACK_DIR" -maxdepth 1 -type f -name '*.tgz' -print -quit)
 
             if [ -z "$TARBALL" ]; then
               echo "::error::Failed to produce tarball for $PKG_NAME"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,8 +4,9 @@
 # Triggers on push to main or manual dispatch. If unreleased changesets exist, bumps versions
 # and publishes to npm directly. Version bump is pushed back via a PR.
 #
-# Tests are NOT re-run here — CI (ci.yml + ci-matrix.yml) already validates
+# Tests are NOT re-run here — CI (ci.yml) already validates
 # all code before it reaches main via the staging→main promotion flow.
+# ci-matrix.yml is disabled (workflow_dispatch only) and is not part of the gate.
 #
 # Required secrets:
 #   CHANGESET_TOKEN — PAT or fine-grained token with contents:write + pull-requests:write
@@ -84,7 +85,7 @@ jobs:
           SCAN_DIR="$(mktemp -d)"
           FAIL=0
 
-          for pkg_dir in packages/hx-library packages/hx-tokens; do
+          for pkg_dir in packages/hx-library packages/hx-tokens packages/hx-react; do
             if [ ! -f "$pkg_dir/package.json" ]; then
               echo "Skipping $pkg_dir — no package.json"
               continue
@@ -169,6 +170,15 @@ jobs:
 
       - name: Build
         run: pnpm turbo run build --filter='!docs'
+
+      - name: Verify CEM matches committed manifest
+        run: |
+          pnpm --filter=@helixui/library run cem
+          if ! git diff --exit-code packages/hx-library/custom-elements.json; then
+            echo "::error::custom-elements.json is out of date. Run 'pnpm run cem' and commit before tagging."
+            exit 1
+          fi
+          echo "CEM matches committed manifest."
 
       - name: Build CDN artifacts
         run: pnpm --filter=@helixui/library run build:cdn

--- a/apps/docs/src/content/docs/migration/3.0.0.mdx
+++ b/apps/docs/src/content/docs/migration/3.0.0.mdx
@@ -40,7 +40,7 @@ React consumers:
 pnpm add @helixui/react@^3.0.0
 ```
 
-CDN consumers: pin `https://unpkg.com/@helixui/library@3.0.0/dist/cdn/core.js` plus the per-component modules you use.
+CDN consumers: pin `https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js` plus the per-component modules you use.
 
 ## 2. `aria-label` → `accessible-label`
 
@@ -67,11 +67,20 @@ el.accessibleLabel = 'Close dialog';
 **Codemod:**
 
 ```bash
-rg -l '<hx-[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
+rg -l '<hx-(?!card)[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-(?!card)[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
 ```
 
 :::caution
 Do **not** rewrite `aria-label` on native HTML elements (`<button>`, `<input>`, etc.). Scope your find-and-replace to `hx-*` tags only.
+:::
+
+:::note[hx-card exception]
+`hx-card` uses `label` (not `accessible-label`) for its accessible name. The codemod above excludes it. Migrate manually:
+
+```diff
+- <hx-card hxAriaLabel="View patient record">...</hx-card>
++ <hx-card label="View patient record">...</hx-card>
+```
 :::
 
 ## 3. `::part(error-message)` → `::part(error)`
@@ -270,7 +279,7 @@ static styles = ownStyles;
 **Pre-warming:** import the positioning utility at app startup.
 
 ```typescript
-import '@helixui/library/dist/positioning';
+import '@floating-ui/dom';
 ```
 
 ## 11. Public-API allowlist
@@ -293,10 +302,10 @@ If you relied on an undocumented deep import, [open an issue](https://github.com
 ### Strategy B (recommended) — core + per-component
 
 ```html
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/core.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js"></script>
 
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/hx-button.js"></script>
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/hx-card.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-button-3.0.0.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-card-3.0.0.js"></script>
 ```
 
 Core is ~8.4KB min+gz. Each component is ~2KB.
@@ -304,7 +313,7 @@ Core is ~8.4KB min+gz. Each component is ~2KB.
 ### Strategy A (kitchen sink — back-compat only)
 
 ```html
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/bundle.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-3.0.0.min.js"></script>
 ```
 
 Strategy A may be removed in a future major.

--- a/apps/docs/src/content/docs/migration/3.0.0.mdx
+++ b/apps/docs/src/content/docs/migration/3.0.0.mdx
@@ -81,6 +81,7 @@ Do **not** rewrite `aria-label` on native HTML elements (`<button>`, `<input>`, 
 - <hx-card hxAriaLabel="View patient record">...</hx-card>
 + <hx-card label="View patient record">...</hx-card>
 ```
+
 :::
 
 ## 3. `::part(error-message)` → `::part(error)`
@@ -302,10 +303,19 @@ If you relied on an undocumented deep import, [open an issue](https://github.com
 ### Strategy B (recommended) — core + per-component
 
 ```html
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js"></script>
+<script
+  type="module"
+  src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js"
+></script>
 
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-button-3.0.0.js"></script>
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-card-3.0.0.js"></script>
+<script
+  type="module"
+  src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-button-3.0.0.js"
+></script>
+<script
+  type="module"
+  src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-card-3.0.0.js"
+></script>
 ```
 
 Core is ~8.4KB min+gz. Each component is ~2KB.
@@ -313,7 +323,10 @@ Core is ~8.4KB min+gz. Each component is ~2KB.
 ### Strategy A (kitchen sink — back-compat only)
 
 ```html
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-3.0.0.min.js"></script>
+<script
+  type="module"
+  src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-3.0.0.min.js"
+></script>
 ```
 
 Strategy A may be removed in a future major.

--- a/apps/docs/src/content/docs/migration/3.0.0.mdx
+++ b/apps/docs/src/content/docs/migration/3.0.0.mdx
@@ -67,7 +67,7 @@ el.accessibleLabel = 'Close dialog';
 **Codemod:**
 
 ```bash
-rg -l '<hx-(?!card)[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-(?!card)[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
+rg -P -l '<hx-(?!card\b)[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-(?!card\b)[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
 ```
 
 :::caution
@@ -79,7 +79,7 @@ Do **not** rewrite `aria-label` on native HTML elements (`<button>`, `<input>`, 
 
 ```diff
 - <hx-card hxAriaLabel="View patient record">...</hx-card>
-+ <hx-card label="View patient record">...</hx-card>
++ <hx-card hx-label="View patient record">...</hx-card>
 ```
 
 :::

--- a/docs/UPGRADING-TO-3.md
+++ b/docs/UPGRADING-TO-3.md
@@ -33,7 +33,7 @@ Consumers using the React wrapper:
 pnpm add @helixui/react@^3.0.0
 ```
 
-CDN consumers: pin `https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js` and the per-component modules you use (see [CDN delivery](#cdn-delivery)).
+CDN consumers: pin `https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js` and the per-component modules you use (see [CDN delivery](#12-cdn-delivery)).
 
 ---
 
@@ -73,7 +73,7 @@ Components affected: `hx-button`, `hx-icon-button`, `hx-badge`, `hx-chip`, `hx-c
 
 ```diff
 - <hx-card hxAriaLabel="View patient record">...</hx-card>
-+ <hx-card label="View patient record">...</hx-card>
++ <hx-card hx-label="View patient record">...</hx-card>
 ```
 
 ---
@@ -403,7 +403,7 @@ A grep-based codemod is tracked as a 3.0.1 follow-up. For 3.0.0, the find-and-re
 
 ```bash
 # aria-label → accessible-label on HELiX component tags (excludes hx-card, which uses label=)
-rg -P -l '<hx-(?!card)[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-(?!card)[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
+rg -P -l '<hx-(?!card\b)[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-(?!card\b)[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
 
 # ::part(error-message) → ::part(error)
 rg -l '::part\(error-message\)' | xargs sd '::part\(error-message\)' '::part(error)'

--- a/docs/UPGRADING-TO-3.md
+++ b/docs/UPGRADING-TO-3.md
@@ -33,7 +33,7 @@ Consumers using the React wrapper:
 pnpm add @helixui/react@^3.0.0
 ```
 
-CDN consumers: pin `https://unpkg.com/@helixui/library@3.0.0/dist/cdn/core.js` and the per-component modules you use (see [CDN delivery](#cdn-delivery)).
+CDN consumers: pin `https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js` and the per-component modules you use (see [CDN delivery](#cdn-delivery)).
 
 ---
 
@@ -70,6 +70,11 @@ Every component that previously accepted `aria-label` or `hxAriaLabel` now expos
 Components affected: `hx-button`, `hx-icon-button`, `hx-badge`, `hx-chip`, `hx-copy-button`, `hx-file-upload`, `hx-link`, `hx-menu-item`, `hx-nav-item`, `hx-overflow-menu`, `hx-side-nav`, `hx-split-button`, `hx-step`, `hx-toggle`, `hx-tooltip` (full list in CEM).
 
 **Exception — `hx-card`:** Interactive card accessible names use the `label` attribute, not `accessible-label`. If you were using the deprecated `hxAriaLabel` property on `hx-card`, migrate it to `label`:
+
+```diff
+- <hx-card hxAriaLabel="View patient record">...</hx-card>
++ <hx-card label="View patient record">...</hx-card>
+```
 
 ---
 
@@ -341,18 +346,18 @@ The CDN build ships two strategies. 3.0.0 makes **Strategy B** the recommended p
 
 ```html
 <!-- Load core once (~8.4KB min+gz). Mounts the element registry. -->
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/core.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-core-3.0.0.min.js"></script>
 
 <!-- Load only the components you use. -->
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/hx-button.js"></script>
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/hx-card.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-button-3.0.0.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/components/hx-card-3.0.0.js"></script>
 ```
 
 ### Strategy A (kitchen-sink — back-compat only)
 
 ```html
 <!-- Single bundle with everything. Larger payload, not recommended. -->
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/bundle.js"></script>
+<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/cdn/helix-3.0.0.min.js"></script>
 ```
 
 Strategy A is preserved in 3.0.0 for back-compat. It may be removed in a future major.
@@ -378,7 +383,7 @@ If your build tooling strips side effects, your HELiX components will render wit
 The tokens package bumps to 3.0.0 in lockstep with the library. Breaking changes:
 
 - `tokenStyles` export (deprecated in 2.1.2) is removed. Use `lightTokenCss` for raw CSS or rely on the library's automatic document-level adoption.
-- Semantic-tier token alignment (see [Design token delta](#design-token-delta) in the CHANGELOG). Consumers overriding at the semantic tier should audit their overrides.
+- Semantic-tier token alignment (see [Design token delta](../packages/hx-library/CHANGELOG.md#design-token-delta) in the CHANGELOG). Consumers overriding at the semantic tier should audit their overrides.
 
 ---
 
@@ -397,8 +402,8 @@ The React wrapper bumps to 3.0.0 to match. Breaking changes are mechanical — a
 A grep-based codemod is tracked as a 3.0.1 follow-up. For 3.0.0, the find-and-replace patterns listed in each section are precise enough to run manually or via `sd` / `ripgrep-replace`:
 
 ```bash
-# aria-label → accessible-label on HELiX component tags (scoped to avoid rewriting native HTML aria-label)
-rg -l '<hx-[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
+# aria-label → accessible-label on HELiX component tags (excludes hx-card, which uses label=)
+rg -P -l '<hx-(?!card)[a-z-]+[^>]*aria-label=' | xargs sd '(<hx-(?!card)[a-z-]+[^>]*?)aria-label=' '$1accessible-label='
 
 # ::part(error-message) → ::part(error)
 rg -l '::part\(error-message\)' | xargs sd '::part\(error-message\)' '::part(error)'

--- a/packages/drupal-starter/components/main-nav/main-nav.twig
+++ b/packages/drupal-starter/components/main-nav/main-nav.twig
@@ -19,14 +19,14 @@
     {% endif %}
   </div>
 
-  <hx-nav accessible-label="{{ 'Primary'|t }}">
+  <hx-nav label="{{ 'Primary'|t }}">
     {% if menu_items %}
       {% for item in menu_items %}
         {% if item.children is not empty %}
           <hx-dropdown>
             <hx-button slot="trigger" variant="text"{% if item.is_active %} aria-current="true"{% endif %}>
               {{ item.title }}
-              <hx-icon slot="suffix" name="chevron-down" hx-size="small"></hx-icon>
+              <hx-icon slot="suffix" name="chevron-down" hx-size="sm"></hx-icon>
             </hx-button>
             {% for child in item.children %}
               <hx-link href="{{ child.url }}"{% if child.is_active %} aria-current="page"{% endif %}>

--- a/packages/drupal-starter/templates/hx-card.html.twig
+++ b/packages/drupal-starter/templates/hx-card.html.twig
@@ -14,7 +14,7 @@
  * - url: If set, makes the card heading a link.
  * - accessible_label: ARIA name for screen readers when the card heading alone
  *   is not sufficient (e.g. a linked card wrapping mixed content). Rendered as
- *   the `accessible-label` attribute on the host element in 3.0.0+.
+ *   the `hx-label` attribute on the host element (hx-card uses `label` → `hx-label`).
  * - attributes: Drupal attributes object for additional HTML attributes.
  *
  * Usage:
@@ -40,7 +40,7 @@
 <hx-card
   variant="{{ variant|default('default') }}"
   elevation="{{ elevation|default('raised') }}"
-  {% if accessible_label %}accessible-label="{{ accessible_label }}"{% endif %}
+  {% if accessible_label %}hx-label="{{ accessible_label }}"{% endif %}
   {% if attributes %}{{ attributes }}{% endif %}
 >
   {% if image_url %}

--- a/packages/hx-library/CHANGELOG.md
+++ b/packages/hx-library/CHANGELOG.md
@@ -50,6 +50,7 @@ All 15 form-associated components now compose `FormMixin(HelixElement)` for shar
 - `Wc*` type aliases (carry-over from the pre-rename era) — removed. Use the `Hx*` equivalents (`HxButton`, `HxCard`, etc.).
 - Deprecated property shims from 2.0.0 property renames (`hxHref`, `hxAriaLabel`, `hxSize`, `closeLabel`, `triggerLabel`, `menuLabel`) — removed. Update to the renamed properties documented in the 2.0.0 entry.
 - `mergeTokenStyles` utility — removed. Tokens adopt at the document level via `ensureDocumentTokens()` (auto-invoked on first import); per-component merging is no longer required.
+- `resetIdCounter` — removed from the main barrel. Moved to `test-utils.ts`. Update any test teardown imports: `import { resetIdCounter } from '@helixui/library/test-utils'` instead of `'@helixui/library'`.
 - Legacy `sticky` and `system` properties on deprecated component variants — removed with their tests.
 
 #### Dialog behavior

--- a/packages/hx-library/scripts/generate-barrel.js
+++ b/packages/hx-library/scripts/generate-barrel.js
@@ -34,8 +34,8 @@ const outputFile = join(rootDir, 'src', 'index.ts');
 // Every top-level symbol re-exported from the barrel must be listed here.
 // Adding a new public symbol: append to the relevant module group.
 // Removing a public symbol: delete it here; the generator will omit it.
-// Keep internal helpers (id-counter reset, audit controller, aria delegation
-// mixin, style-registry utilities, etc.) OUT of this list. Consumers that
+// Keep internal helpers (id-counter reset, aria delegation mixin,
+// style-registry utilities, etc.) OUT of this list. Consumers that
 // need them must use a deep import path — that contract is intentional.
 /** @type {Record<string, { values: string[]; types: string[] }>} */
 const PUBLIC_API = {
@@ -47,7 +47,9 @@ const PUBLIC_API = {
     // resetIdCounter is intentionally excluded — it is a test-only helper
     // re-exported from ./test-utils.ts. Exposing it publicly would let
     // consumers reset the ID counter mid-run and break ARIA relationships.
-    values: ['HelixElement', 'createIdCounter', 'mergeTokenStyles'],
+    // mergeTokenStyles was removed in 3.0.0 — tokens adopt at the document
+    // level via ensureDocumentTokens() (auto-invoked on first import).
+    values: ['HelixElement', 'createIdCounter'],
     types: [],
   },
   './mixins/index.js': {
@@ -56,10 +58,13 @@ const PUBLIC_API = {
     values: ['FocusMixin', 'FormMixin'],
     types: ['FocusMixinInterface', 'FormMixinInterface'],
   },
-  // Controllers are not part of the public API. HelixAuditController is
-  // internal observability infrastructure for HIPAA audit-trail integration;
-  // it remains importable via its deep path for consumers that explicitly
-  // opt in to the internal surface.
+  './controllers/helix-audit-controller.js': {
+    // HelixAuditController is the public HIPAA audit-trail controller.
+    // It captures hx-* CustomEvents and re-dispatches as hx-audit events
+    // that bubble to the document for enterprise audit-log wiring.
+    values: ['HelixAuditController'],
+    types: ['AuditEventDetail', 'AuditControllerOptions'],
+  },
 };
 
 // ─── Component barrel scan ───────────────────────────────────────────────────
@@ -219,14 +224,17 @@ for (const [spec, allow] of Object.entries(PUBLIC_API)) {
 const utilitySpec = './utilities/document-token-adoption.js';
 const baseSpec = './base/index.js';
 const mixinsSpec = './mixins/index.js';
+const controllersSpec = './controllers/helix-audit-controller.js';
 
 const utilityGroup = renderedGroups.find((g) => g.spec === utilitySpec);
 const baseGroup = renderedGroups.find((g) => g.spec === baseSpec);
 const mixinsGroup = renderedGroups.find((g) => g.spec === mixinsSpec);
+const controllersGroup = renderedGroups.find((g) => g.spec === controllersSpec);
 
 const utilityBlock = utilityGroup ? utilityGroup.lines.join('\n') : '';
 const baseBlock = baseGroup ? baseGroup.lines.join('\n') : '';
 const mixinsBlock = mixinsGroup ? mixinsGroup.lines.join('\n') : '';
+const controllersBlock = controllersGroup ? controllersGroup.lines.join('\n') : '';
 
 // ─── Render ──────────────────────────────────────────────────────────────────
 const output = `/**
@@ -239,7 +247,7 @@ const output = `/**
  * Run \`npm run generate:barrel\` to regenerate.
  *
  * Public-API surface is gated by an allowlist in scripts/generate-barrel.js.
- * Internals (HelixAuditController, resetIdCounter, mixinDelegatesAria, etc.)
+ * Internals (resetIdCounter, mixinDelegatesAria, etc.)
  * are intentionally excluded and must be imported via deep paths if needed.
  */
 
@@ -256,6 +264,9 @@ ${baseBlock}
 
 // ─── Mixins ───────────────────────────────────────────────────────────────────
 ${mixinsBlock}
+
+// ─── HIPAA audit-trail controller ───────────────────────────────────────────
+${controllersBlock}
 
 // ─── Components ──────────────────────────────────────────────────────────────
 ${exportLines.join('\n')}

--- a/packages/hx-library/src/index.ts
+++ b/packages/hx-library/src/index.ts
@@ -8,9 +8,8 @@
  * Run `npm run generate:barrel` to regenerate.
  *
  * Public-API surface is gated by an allowlist in scripts/generate-barrel.js.
- * Internals (resetIdCounter, mixinDelegatesAria, etc.) are intentionally
- * excluded and must be imported via deep paths if needed. resetIdCounter is
- * re-exported from test-utils.ts for test teardown use.
+ * Internals (resetIdCounter, mixinDelegatesAria, etc.)
+ * are intentionally excluded and must be imported via deep paths if needed.
  */
 
 // ─── Document-level token adoption ──────────────────────────────────────────
@@ -24,13 +23,13 @@ export { ensureDocumentTokens } from './utilities/document-token-adoption.js';
 // ─── Base infrastructure ────────────────────────────────────────────────────
 export { HelixElement, createIdCounter } from './base/index.js';
 
-// ─── HIPAA audit-trail controller ───────────────────────────────────────────
-export { HelixAuditController } from './controllers/helix-audit-controller.js';
-export type { AuditEventDetail, AuditControllerOptions } from './controllers/helix-audit-controller.js';
-
 // ─── Mixins ───────────────────────────────────────────────────────────────────
 export { FocusMixin, FormMixin } from './mixins/index.js';
 export type { FocusMixinInterface, FormMixinInterface } from './mixins/index.js';
+
+// ─── HIPAA audit-trail controller ───────────────────────────────────────────
+export { HelixAuditController } from './controllers/helix-audit-controller.js';
+export type { AuditEventDetail, AuditControllerOptions } from './controllers/helix-audit-controller.js';
 
 // ─── Components ──────────────────────────────────────────────────────────────
 export { HelixAccordion } from './components/hx-accordion/index.js';

--- a/packages/hx-library/src/index.ts
+++ b/packages/hx-library/src/index.ts
@@ -8,8 +8,9 @@
  * Run `npm run generate:barrel` to regenerate.
  *
  * Public-API surface is gated by an allowlist in scripts/generate-barrel.js.
- * Internals (HelixAuditController, resetIdCounter, mixinDelegatesAria, etc.)
- * are intentionally excluded and must be imported via deep paths if needed.
+ * Internals (resetIdCounter, mixinDelegatesAria, etc.) are intentionally
+ * excluded and must be imported via deep paths if needed. resetIdCounter is
+ * re-exported from test-utils.ts for test teardown use.
  */
 
 // ─── Document-level token adoption ──────────────────────────────────────────
@@ -21,7 +22,11 @@ import './utilities/document-token-adoption.js';
 export { ensureDocumentTokens } from './utilities/document-token-adoption.js';
 
 // ─── Base infrastructure ────────────────────────────────────────────────────
-export { HelixElement, createIdCounter, mergeTokenStyles } from './base/index.js';
+export { HelixElement, createIdCounter } from './base/index.js';
+
+// ─── HIPAA audit-trail controller ───────────────────────────────────────────
+export { HelixAuditController } from './controllers/helix-audit-controller.js';
+export type { AuditEventDetail, AuditControllerOptions } from './controllers/helix-audit-controller.js';
 
 // ─── Mixins ───────────────────────────────────────────────────────────────────
 export { FocusMixin, FormMixin } from './mixins/index.js';

--- a/packages/hx-library/src/mixins/FormMixin.ts
+++ b/packages/hx-library/src/mixins/FormMixin.ts
@@ -35,7 +35,7 @@ export interface FormMixinInterface {
  * to major releases) but are NOT exposed as public consumer API.
  * They are accessible only from within FormMixin subclasses.
  *
- * @internal
+ * @protected
  */
 export interface FormMixinProtectedHooks {
   /**


### PR DESCRIPTION
## Summary

- Restores `HelixAuditController` / `AuditEventDetail` / `AuditControllerOptions` to the public barrel via the `generate-barrel.js` allowlist (root fix — previous attempt was overwritten by the pre-push generator hook)
- Adds CEM regeneration + verification step to the `publish` job in `publish.yml` so both the `secret-scan` and `publish` jobs independently verify CEM freshness
- Adds `packages/hx-react` to the secret-scan package loop
- Flips `FormMixinProtectedHooks` JSDoc from `@internal` to `@protected` to surface the subclassing contract in CEM
- Adds `resetIdCounter` test-utils migration note to CHANGELOG
- Fixes `hx-card` attribute: `accessible-label` → `hx-label` in drupal-starter templates
- Fixes `hx-nav` `hx-size="small"` → `hx-size="sm"` (invalid enum value) in drupal main-nav template
- Fixes CDN URL patterns in `docs/UPGRADING-TO-3.md` and `apps/docs/.../migration/3.0.0.mdx` to match actual build artifact names
- Fixes floating-ui pre-warm import in migration docs
- Adds `hx-card` exception block to `apps/docs/.../migration/3.0.0.mdx` (was absent)
- Fixes codemod regex in both migration docs to exclude `hx-card` via negative lookahead
- Adds `Agent` to `.claude/commands/codex-review.md` allowed-tools

## Test plan

- [ ] CI `Quality Gates` passes (TypeScript strict, Vitest, CEM, bundle)
- [ ] `packages/hx-library/src/index.ts` exports `HelixAuditController`, `AuditEventDetail`, `AuditControllerOptions`
- [ ] `publish.yml` CEM step present in both jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exported HIPAA audit-trail controller for compliance tracking.

* **Documentation**
  * Updated version 3.0.0 migration guides with corrected CDN file paths and component attribute mappings.

* **Breaking Changes**
  * `resetIdCounter` moved to test-utils entry point; import from `@helixui/library/test-utils` instead.
  * `mergeTokenStyles` removed from public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->