### PR TITLE
fix(ci): resolve vitest 3.x browser.instances merge in cross-browser workflow

### DIFF
--- a/.changeset/fix-cross-browser-vitest-instances.md
+++ b/.changeset/fix-cross-browser-vitest-instances.md
@@ -1,0 +1,11 @@
+---
+'@helixui/library': patch
+---
+
+fix(ci): resolve vitest 3.x browser.instances merge bug in cross-browser workflow
+
+The cross-browser CI matrix was failing with "The 4th item in browser.instances doesn't have it" because Vitest 3.x appends CLI `--browser.instances` onto the config's 3-engine array instead of replacing it. Switched to env-var-driven config (`BROWSER=<engine>`) and removed the CLI flag.
+
+fix(ci): build @helixui/library before type-check in CI workflow
+
+Turbo's `^build` dependency on the `type-check` task was not reliably honored on fresh CI runners, causing `@helixui/react`'s deep-path imports (`@helixui/library/components/*`, which resolve through the `exports` map to `dist/`) to fail with TS2306. Added an explicit `pnpm turbo run build --filter=@helixui/library` step before type-check.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,11 @@ jobs:
           node-version: 20
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
+      # Build @helixui/library first — @helixui/react's type-check resolves
+      # deep-path imports (`@helixui/library/components/*`) through the
+      # `exports` map which points at `dist/`. Turbo's `^build` dependency is
+      # not reliably honored on fresh CI runners, so build explicitly.
+      - run: pnpm turbo run build --filter=@helixui/library
       - run: pnpm turbo run type-check --filter='!docs'
 
   # ── Tests (need Playwright browsers) ────────────────────────────────────

--- a/.github/workflows/cross-browser.yml
+++ b/.github/workflows/cross-browser.yml
@@ -82,13 +82,11 @@ jobs:
             echo "Running tests for specific components: $PATHS"
             BROWSER=${{ matrix.browser }} pnpm exec vitest run \
               --config vitest.config.cross-browser.ts \
-              --browser.instances "[{\"browser\":\"${{ matrix.browser }}\"}]" \
               $PATHS
           else
             echo "Running full test suite on ${{ matrix.browser }}"
             BROWSER=${{ matrix.browser }} pnpm exec vitest run \
-              --config vitest.config.cross-browser.ts \
-              --browser.instances "[{\"browser\":\"${{ matrix.browser }}\"}]"
+              --config vitest.config.cross-browser.ts
           fi
         working-directory: packages/hx-library
 

--- a/packages/hx-library/vitest.config.cross-browser.ts
+++ b/packages/hx-library/vitest.config.cross-browser.ts
@@ -4,6 +4,22 @@ import { fileURLToPath } from 'url';
 
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
+const SUPPORTED_BROWSERS = ['chromium', 'firefox', 'webkit'] as const;
+type SupportedBrowser = (typeof SUPPORTED_BROWSERS)[number];
+
+function resolveBrowserInstances(): { browser: SupportedBrowser }[] {
+  const envBrowser = process.env.BROWSER;
+  if (!envBrowser) {
+    return SUPPORTED_BROWSERS.map((browser) => ({ browser }));
+  }
+  if (!(SUPPORTED_BROWSERS as readonly string[]).includes(envBrowser)) {
+    throw new Error(
+      `Invalid BROWSER env var: "${envBrowser}". Expected one of: ${SUPPORTED_BROWSERS.join(', ')}.`,
+    );
+  }
+  return [{ browser: envBrowser as SupportedBrowser }];
+}
+
 /**
  * Cross-browser test configuration for Vitest browser mode.
  *
@@ -31,9 +47,8 @@ export default defineConfig({
       viewport: { width: 1280, height: 720 },
       // In CI each matrix job sets BROWSER=<engine> so only that engine runs.
       // Locally (no BROWSER env var) all three engines run in sequence.
-      instances: process.env.BROWSER
-        ? [{ browser: process.env.BROWSER as 'chromium' | 'firefox' | 'webkit' }]
-        : [{ browser: 'chromium' }, { browser: 'firefox' }, { browser: 'webkit' }],
+      // Validated at config load — fails fast on typos (e.g. BROWSER=chrome).
+      instances: resolveBrowserInstances(),
     },
     include: [
       'src/components/**/*.test.ts',

--- a/packages/hx-library/vitest.config.cross-browser.ts
+++ b/packages/hx-library/vitest.config.cross-browser.ts
@@ -29,8 +29,11 @@ export default defineConfig({
       provider: 'playwright',
       headless: true,
       viewport: { width: 1280, height: 720 },
-      // Run all three browser engines for cross-browser validation.
-      instances: [{ browser: 'chromium' }, { browser: 'firefox' }, { browser: 'webkit' }],
+      // In CI each matrix job sets BROWSER=<engine> so only that engine runs.
+      // Locally (no BROWSER env var) all three engines run in sequence.
+      instances: process.env.BROWSER
+        ? [{ browser: process.env.BROWSER as 'chromium' | 'firefox' | 'webkit' }]
+        : [{ browser: 'chromium' }, { browser: 'firefox' }, { browser: 'webkit' }],
     },
     include: [
       'src/components/**/*.test.ts',


### PR DESCRIPTION
## Summary

- Vitest 3.2.4 **appends** CLI `--browser.instances` to the config's existing array instead of replacing it, producing 4 items where the merged entry lacks a `browser` property
- Fix: read `process.env.BROWSER` in `vitest.config.cross-browser.ts` to select a single instance; fall back to all three when unset (local runs)
- Remove redundant `--browser.instances` CLI flag from `cross-browser.yml` — the `BROWSER` env var already set in each matrix step drives instance selection

## Test plan

- [ ] Cross-Browser (chromium) passes
- [ ] Cross-Browser (firefox) passes  
- [ ] Cross-Browser (webkit) passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved cross-browser testing configuration to enable more efficient CI/CD pipeline execution through targeted browser testing while maintaining comprehensive browser coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->