### PR TITLE
promote: dev → staging (codex-final remediation round 1 + 2)

### DIFF
--- a/.changeset/fix-3.0.0-codex-final-remediation.md
+++ b/.changeset/fix-3.0.0-codex-final-remediation.md
@@ -1,0 +1,19 @@
+---
+'@helixui/library': patch
+---
+
+fix(docs): rewrite `hx-phi-field` §6 migration to use `data` property (attribute: false) — prior text described `value` attribute/property, which does not exist on the component
+
+fix(docs): correct subclassing example to import `FormMixin` from `@helixui/library` root barrel — the `/mixins` subpath export is intentionally absent from `package.json` exports map
+
+fix(docs): correct public-API allowlist prose to reflect that `FocusMixin`, `FormMixin`, and `HelixAuditController` are re-exported from the root barrel (no `/mixins` subpath)
+
+fix(docs): correct `::part(error)` component list — 13 components actually expose the part (hx-checkbox, hx-checkbox-group, hx-combobox, hx-date-picker, hx-field, hx-file-upload, hx-number-input, hx-radio-group, hx-select, hx-switch, hx-text-input, hx-textarea, hx-time-picker); removed invalid entries (hx-radio, hx-slider, hx-color-picker, hx-phi-field)
+
+fix(docs): disambiguate `hx-card` accessible-name migration — HTML attribute is `hx-label`, JS property is `label`
+
+fix(docs): replace `@helixui/library/mixins` import prescription in components-guide ARIA docs with `ElementInternals.ariaLabel` + explicit template binding — the internal `mixinDelegatesAria` helper is not a public export
+
+fix(ci): reorder `publish.yml` so release-manifest generation runs after `changesets/action` and is gated on `outputs.published == 'true'`; commit the manifest back to main via dedicated step
+
+fix(shipping): replace stale `@wc-2026/library` specifier with `@helixui/library` in shipped CSS import, Drupal JS dynamic import, and Twig library registration comments (prose.css, hx-toast.drupal.js, hx-spinner.twig, hx-code-snippet.twig)

--- a/.github/workflows/act-ci.yml
+++ b/.github/workflows/act-ci.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node ${{ matrix.node-version }} via nvm

--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20, 22, 24]
+        node-version: [22, 24]
         os: [ubuntu-latest]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,32 @@ jobs:
           LOGFILE=$(mktemp /tmp/helix-ci-shard.XXXXXX)
           PATHS="${{ steps.changed.outputs.paths }}"
           echo "Running shard ${VITEST_SHARD} over: $PATHS"
+          # Vitest 3.x refuses to run when the shard total is >= the number
+          # of test files ("--shard <count> must be a smaller than count of
+          # test files"). When the smart-changed filter resolves fewer test
+          # files than the matrix has shards, collapse: shard 1 runs every
+          # file unsharded, and the other shards exit cleanly with nothing
+          # to do. Without this, a PR that touches 1–3 components fails all
+          # 4 shards with a cryptic startup error.
+          # shellcheck disable=SC2086
+          TEST_FILE_COUNT=$(find $PATHS -type f -name '*.test.ts' 2>/dev/null | wc -l | tr -d ' ')
+          TEST_FILE_COUNT=${TEST_FILE_COUNT:-0}
+          SHARD_INDEX="${VITEST_SHARD%/*}"
+          SHARD_TOTAL="${VITEST_SHARD#*/}"
+          SHARD_ARGS=(--shard="$VITEST_SHARD")
+          if [[ "$TEST_FILE_COUNT" -le "$SHARD_TOTAL" ]]; then
+            if [[ "$SHARD_INDEX" -ne 1 ]]; then
+              echo "[ci-shard-${VITEST_SHARD}] only $TEST_FILE_COUNT test files — skipping (shard ${SHARD_INDEX}/${SHARD_TOTAL} has nothing to run)"
+              echo "tests_ran=true" >> "$GITHUB_OUTPUT"
+              # Write an empty JSON report so the upload-artifact step has
+              # something to find and does not warn.
+              mkdir -p .cache
+              echo '{"testResults":[],"numTotalTests":0,"numPassedTests":0,"numFailedTests":0}' > .cache/test-results.json
+              exit 0
+            fi
+            echo "[ci-shard-${VITEST_SHARD}] only $TEST_FILE_COUNT test files — running all on shard 1 without --shard"
+            SHARD_ARGS=()
+          fi
           # Use verbose reporter so the watchdog can count ✓/× markers when
           # vitest is force-killed before its summary line is flushed.
           # Keep json so .cache/test-results.json is still written (vitest
@@ -301,7 +327,7 @@ jobs:
           # shellcheck disable=SC2086
           run_vitest_with_watchdog "ci-shard-${VITEST_SHARD}" "$LOGFILE" \
             pnpm exec vitest run $PATHS \
-              --shard="$VITEST_SHARD" \
+              "${SHARD_ARGS[@]}" \
               --coverage.enabled \
               --reporter=verbose \
               --reporter=json || rc=$?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,6 +303,13 @@ jobs:
           SHARD_TOTAL="${VITEST_SHARD#*/}"
           SHARD_ARGS=(--shard="$VITEST_SHARD")
           if [[ "$TEST_FILE_COUNT" -le "$SHARD_TOTAL" ]]; then
+            if [[ "$TEST_FILE_COUNT" -eq 0 ]]; then
+              echo "[ci-shard-${VITEST_SHARD}] no test files resolved from: $PATHS — skipping"
+              echo "tests_ran=true" >> "$GITHUB_OUTPUT"
+              mkdir -p .cache
+              echo '{"testResults":[],"numTotalTests":0,"numPassedTests":0,"numFailedTests":0}' > .cache/test-results.json
+              exit 0
+            fi
             if [[ "$SHARD_INDEX" -ne 1 ]]; then
               echo "[ci-shard-${VITEST_SHARD}] only $TEST_FILE_COUNT test files — skipping (shard ${SHARD_INDEX}/${SHARD_TOTAL} has nothing to run)"
               echo "tests_ran=true" >> "$GITHUB_OUTPUT"
@@ -337,9 +344,14 @@ jobs:
             echo "FAILED TESTS:"
             grep "^[[:space:]]*×" "$LOGFILE" 2>/dev/null | head -60 || true
             echo ""
-            echo "--- vitest error output (everything before Coverage report) ---"
-            awk '/Coverage report from/{exit} {print}' "$LOGFILE" || true
-            echo ""
+            # Only print the pre-coverage slice when the marker is actually
+            # present — otherwise awk falls through and duplicates the whole
+            # log against the tail -50 below.
+            if grep -q "Coverage report from" "$LOGFILE" 2>/dev/null; then
+              echo "--- vitest error output (everything before Coverage report) ---"
+              awk '/Coverage report from/{exit} {print}' "$LOGFILE" || true
+              echo ""
+            fi
             echo "--- last 50 lines of full log ---"
             tail -50 "$LOGFILE" || true
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,8 +311,11 @@ jobs:
             echo "FAILED TESTS:"
             grep "^[[:space:]]*×" "$LOGFILE" 2>/dev/null | head -60 || true
             echo ""
-            echo "--- last 200 lines of vitest log ---"
-            tail -200 "$LOGFILE" || true
+            echo "--- vitest error output (everything before Coverage report) ---"
+            awk '/Coverage report from/{exit} {print}' "$LOGFILE" || true
+            echo ""
+            echo "--- last 50 lines of full log ---"
+            tail -50 "$LOGFILE" || true
           fi
           echo "tests_ran=true" >> "$GITHUB_OUTPUT"
           exit $rc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,14 +293,18 @@ jobs:
           # vitest is force-killed before its summary line is flushed.
           # Keep json so .cache/test-results.json is still written (vitest
           # replaces config reporters when --reporter is passed).
+          # Do not let `set -e` abort the step when the watchdog returns
+          # non-zero — we need the diagnostic block below to surface vitest's
+          # actual error instead of GitHub Actions killing the step with no
+          # output on the way.
+          rc=0
           # shellcheck disable=SC2086
           run_vitest_with_watchdog "ci-shard-${VITEST_SHARD}" "$LOGFILE" \
             pnpm exec vitest run $PATHS \
               --shard="$VITEST_SHARD" \
               --coverage.enabled \
               --reporter=verbose \
-              --reporter=json
-          rc=$?
+              --reporter=json || rc=$?
           # On failure, surface only failed test lines + tail of log.
           # On success, suppress the log entirely — passing ticks are noise.
           if [[ $rc -ne 0 ]]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -187,21 +187,8 @@ jobs:
       - name: Build CDN artifacts
         run: pnpm --filter=@helixui/library run build:cdn
 
-      - name: Generate release manifest
-        id: manifest
-        run: node scripts/generate-release-manifest.mjs
-        env:
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_SHA: ${{ github.sha }}
-          GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_REF: ${{ github.ref }}
-        # Emits docs/releases/<tag>-manifest.json with SHA, CI run ID,
-        # changeset list, bundle size snapshot, CEM SHA, and publish actor.
-        # Committed as part of the version-bump PR that changesets/action
-        # creates below.
-
       - name: Version and Publish
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm run changeset:publish
@@ -216,3 +203,34 @@ jobs:
           # version bump commits). The hook is designed for developer workflows,
           # not for internal CI git operations.
           HUSKY: '0'
+
+      - name: Generate release manifest
+        if: steps.changesets.outputs.published == 'true'
+        id: manifest
+        run: node scripts/generate-release-manifest.mjs
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_REF: ${{ github.ref }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        # Emits docs/releases/<tag>-manifest.json with SHA, CI run ID,
+        # changeset list, bundle size snapshot, CEM SHA, and publish actor.
+        # Runs only on an actual publish — when changesets/action bumps
+        # versions without publishing (PR path), no manifest is generated.
+
+      - name: Commit release manifest
+        if: steps.changesets.outputs.published == 'true'
+        env:
+          CHANGESET_TOKEN: ${{ secrets.CHANGESET_TOKEN }}
+        run: |
+          if ! git status --porcelain docs/releases/ | grep -q .; then
+            echo "No release manifest changes to commit."
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add docs/releases/
+          git commit -m 'chore(release): add release manifest [skip ci]'
+          git push "https://x-access-token:${CHANGESET_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -224,6 +224,7 @@ jobs:
         if: steps.changesets.outputs.published == 'true'
         env:
           CHANGESET_TOKEN: ${{ secrets.CHANGESET_TOKEN }}
+          HUSKY: '0'
         run: |
           if ! git status --porcelain docs/releases/ | grep -q .; then
             echo "No release manifest changes to commit."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -226,12 +226,23 @@ jobs:
           CHANGESET_TOKEN: ${{ secrets.CHANGESET_TOKEN }}
           HUSKY: '0'
         run: |
+          set -euo pipefail
           if ! git status --porcelain docs/releases/ | grep -q .; then
             echo "No release manifest changes to commit."
             exit 0
           fi
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          # npm publish has already succeeded at this point, so the manifest
+          # MUST land on main. The workflow concurrency group only serialises
+          # runs of this workflow; unrelated merges can still advance main
+          # between actions/checkout and this step. Rebase the manifest on
+          # top of current origin/main to avoid a non-fast-forward rejection
+          # that would leave the npm release without its audit commit.
+          git stash push -u --message 'release-manifest' -- docs/releases/
+          git fetch origin main
+          git checkout -B publish-manifest origin/main
+          git stash pop
           git add docs/releases/
           git commit -m 'chore(release): add release manifest [skip ci]'
           git push "https://x-access-token:${CHANGESET_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main

--- a/apps/docs/src/content/docs/components-guide/events/delegation.md
+++ b/apps/docs/src/content/docs/components-guide/events/delegation.md
@@ -101,40 +101,19 @@ private _handleShadowClick = (e: Event) => {
 
 Arrow function property syntax (`private _handleShadowClick = ...`) preserves `this` binding when the function is used as a callback directly. When using Lit template bindings (`@click=${...}`), Lit handles binding automatically.
 
-## ARIA Delegation with `mixinDelegatesAria`
+## ARIA Delegation in HELiX Components
 
-A common challenge in shadow DOM is connecting ARIA attributes on the host element to the interactive element inside the shadow root. For example, `aria-label` on `<hx-button>` should reach the `<button>` inside. HELiX provides `mixinDelegatesAria` for this:
+A common challenge in shadow DOM is connecting ARIA attributes on the host element to the interactive element inside the shadow root. For example, `aria-label` on `<hx-button>` should reach the `<button>` inside, not remain on the custom-element host that assistive technologies would otherwise read as a generic element.
 
-```typescript
-import { LitElement, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
-import { mixinDelegatesAria } from '@helixui/library/mixins';
-
-const Base = mixinDelegatesAria(LitElement);
-
-@customElement('hx-button')
-export class HelixButton extends Base {
-  override render() {
-    return html`
-      <!--
-        The mixin forwards aria-label, aria-expanded, aria-controls, etc.
-        from the host to this button element automatically.
-      -->
-      <button>
-        <slot></slot>
-      </button>
-    `;
-  }
-}
-```
-
-With `mixinDelegatesAria`, a consumer can write:
+Built-in HELiX components solve this with `accessible-label` — a public host attribute that components forward to the inner target via `ElementInternals.ariaLabel` or template binding. Consumers write:
 
 ```html
 <hx-button accessible-label="Close dialog">X</hx-button>
 ```
 
-And the `aria-label` correctly targets the inner `<button>` — not the `<hx-button>` host element that assistive technologies would otherwise see as a generic `div`.
+And the accessible name correctly reaches the interactive inner element.
+
+If you are building your own custom elements (not extending HELiX components), implement forwarding with `ElementInternals` ARIA properties — see [Form Accessibility](/components-guide/forms/accessibility/#elementinternalsarialabel-vs-attribute). The internal helper HELiX components use for attribute-level forwarding is not part of the public API; consumers should prefer `ElementInternals.ariaLabel` and explicit template bindings to the inner element.
 
 ## `delegatesFocus`
 

--- a/apps/docs/src/content/docs/components-guide/events/delegation.md
+++ b/apps/docs/src/content/docs/components-guide/events/delegation.md
@@ -107,19 +107,21 @@ A common challenge in shadow DOM is connecting ARIA attributes on the host eleme
 
 HELiX components solve this in one of two ways, depending on the component:
 
-1. **Native `aria-label` / `aria-labelledby`.** Most components (including `hx-button`) inherit from an internal mixin that reads `this.ariaLabel` / `this.ariaLabelledBy` and forwards the accessible name to the inner interactive element. For these, use the standard HTML attribute:
+1. **Components that document native `aria-label` / `aria-labelledby`.** Some HELiX components (including `hx-button`) read `this.ariaLabel` / `this.ariaLabelledBy` from standard HTML attributes and forward them to the inner interactive element. For these documented components, use the standard HTML attribute:
 
    ```html
    <hx-button aria-label="Close dialog">X</hx-button>
    ```
 
-2. **Explicit `accessible-label` attribute.** A small set of form controls and composite widgets — `hx-text-input`, `hx-textarea`, `hx-select`, `hx-combobox`, `hx-split-button`, `hx-steps`, `hx-action-bar` — expose a public `accessible-label` attribute (and matching `accessibleLabel` JS property):
+2. **Components that document `accessible-label`.** A small set of form controls and composite widgets — `hx-text-input`, `hx-textarea`, `hx-select`, `hx-combobox`, `hx-split-button`, `hx-steps`, `hx-action-bar` — expose a public `accessible-label` attribute (and matching `accessibleLabel` JS property):
 
    ```html
    <hx-text-input accessible-label="Search patients" placeholder="Last name"></hx-text-input>
    ```
 
    Use `accessible-label` only on components that document it; every component page lists its public attributes.
+
+Do not apply either pattern universally. Components that own their accessible-name lifecycle expose component-specific APIs instead — for example, `hx-status-indicator` derives its accessible name from the `label` property and overwrites any host `aria-label` you set, so you must use `<hx-status-indicator label="Patient online">` rather than `aria-label="…"`. Consult each component's documented API before applying an accessible-name attribute.
 
 If you are building your own custom elements (not extending HELiX components), implement forwarding with `ElementInternals` ARIA properties — see [Form Accessibility](/components-guide/forms/accessibility/#elementinternalsarialabel-vs-attribute). The internal helpers HELiX components use are not part of the public API; build your own forwarding with `ElementInternals.ariaLabel` and explicit template bindings to the inner element.
 

--- a/apps/docs/src/content/docs/components-guide/events/delegation.md
+++ b/apps/docs/src/content/docs/components-guide/events/delegation.md
@@ -105,15 +105,23 @@ Arrow function property syntax (`private _handleShadowClick = ...`) preserves `t
 
 A common challenge in shadow DOM is connecting ARIA attributes on the host element to the interactive element inside the shadow root. For example, `aria-label` on `<hx-button>` should reach the `<button>` inside, not remain on the custom-element host that assistive technologies would otherwise read as a generic element.
 
-Built-in HELiX components solve this with `accessible-label` — a public host attribute that components forward to the inner target via `ElementInternals.ariaLabel` or template binding. Consumers write:
+HELiX components solve this in one of two ways, depending on the component:
 
-```html
-<hx-button accessible-label="Close dialog">X</hx-button>
-```
+1. **Native `aria-label` / `aria-labelledby`.** Most components (including `hx-button`) inherit from an internal mixin that reads `this.ariaLabel` / `this.ariaLabelledBy` and forwards the accessible name to the inner interactive element. For these, use the standard HTML attribute:
 
-And the accessible name correctly reaches the interactive inner element.
+   ```html
+   <hx-button aria-label="Close dialog">X</hx-button>
+   ```
 
-If you are building your own custom elements (not extending HELiX components), implement forwarding with `ElementInternals` ARIA properties — see [Form Accessibility](/components-guide/forms/accessibility/#elementinternalsarialabel-vs-attribute). The internal helper HELiX components use for attribute-level forwarding is not part of the public API; consumers should prefer `ElementInternals.ariaLabel` and explicit template bindings to the inner element.
+2. **Explicit `accessible-label` attribute.** A small set of form controls and composite widgets — `hx-text-input`, `hx-textarea`, `hx-select`, `hx-combobox`, `hx-split-button`, `hx-steps`, `hx-action-bar` — expose a public `accessible-label` attribute (and matching `accessibleLabel` JS property):
+
+   ```html
+   <hx-text-input accessible-label="Search patients" placeholder="Last name"></hx-text-input>
+   ```
+
+   Use `accessible-label` only on components that document it; every component page lists its public attributes.
+
+If you are building your own custom elements (not extending HELiX components), implement forwarding with `ElementInternals` ARIA properties — see [Form Accessibility](/components-guide/forms/accessibility/#elementinternalsarialabel-vs-attribute). The internal helpers HELiX components use are not part of the public API; build your own forwarding with `ElementInternals.ariaLabel` and explicit template bindings to the inner element.
 
 ## `delegatesFocus`
 

--- a/apps/docs/src/content/docs/components-guide/forms/accessibility.md
+++ b/apps/docs/src/content/docs/components-guide/forms/accessibility.md
@@ -147,11 +147,13 @@ The standard challenge: a consumer writes `<hx-text-input accessible-label="Pati
 HELiX handles this in one of two ways, depending on the component:
 
 1. **Components that document `accessible-label`.** Form controls and composite widgets — `hx-text-input`, `hx-textarea`, `hx-select`, `hx-combobox`, `hx-split-button`, `hx-steps`, `hx-action-bar` — expose a public `accessible-label` attribute (property: `accessibleLabel`) and forward it to the inner interactive element via `ElementInternals.ariaLabel` or a template binding. Every component page lists its public attributes; use `accessible-label` only on components that document it.
-2. **Components that accept native `aria-label`.** Most other HELiX components (including `hx-button`) read `this.ariaLabel` / `this.ariaLabelledBy` from the standard HTML attributes and forward those to the inner element. For these, use the native attribute:
+2. **Components that document native `aria-label` / `aria-labelledby`.** Some HELiX components (including `hx-button`) read `this.ariaLabel` / `this.ariaLabelledBy` from standard HTML attributes and forward them to the inner element. For these documented components, use the native attribute:
 
    ```html
    <hx-button aria-label="Close dialog">X</hx-button>
    ```
+
+Do not apply either pattern universally. Components that own their accessible-name lifecycle expose component-specific APIs instead — for example, `hx-status-indicator` derives its accessible name from the `label` property and overwrites any host `aria-label` you set, so you must use `<hx-status-indicator label="Patient online">` rather than `aria-label="…"`. Consult each component's documented API before applying an accessible-name attribute.
 
 The following LitElement pattern illustrates the `accessible-label` forwarding approach used in category (1):
 

--- a/apps/docs/src/content/docs/components-guide/forms/accessibility.md
+++ b/apps/docs/src/content/docs/components-guide/forms/accessibility.md
@@ -142,25 +142,32 @@ Using `ElementInternals` ARIA properties is preferable to adding ARIA attributes
 
 ## Forwarding Host ARIA to Shadow Elements
 
-The standard challenge: a consumer writes `<hx-button accessible-label="Close">` but an `aria-label` placed on the host `<hx-button>` does not automatically reach the `<button>` inside the shadow root — assistive technology would see it on the wrong element.
+The standard challenge: a consumer writes `<hx-text-input accessible-label="Patient last name">`, but an attribute placed on the host custom element does not automatically reach the `<input>` inside the shadow root — assistive technology would see it on the wrong element.
 
-Built-in HELiX components expose a public `accessible-label` attribute (property: `accessibleLabel`) and forward it to the inner interactive element, either via `ElementInternals.ariaLabel` on the host or via a template binding on the shadow-DOM target:
+HELiX handles this in one of two ways, depending on the component:
+
+1. **Components that document `accessible-label`.** Form controls and composite widgets — `hx-text-input`, `hx-textarea`, `hx-select`, `hx-combobox`, `hx-split-button`, `hx-steps`, `hx-action-bar` — expose a public `accessible-label` attribute (property: `accessibleLabel`) and forward it to the inner interactive element via `ElementInternals.ariaLabel` or a template binding. Every component page lists its public attributes; use `accessible-label` only on components that document it.
+2. **Components that accept native `aria-label`.** Most other HELiX components (including `hx-button`) read `this.ariaLabel` / `this.ariaLabelledBy` from the standard HTML attributes and forward those to the inner element. For these, use the native attribute:
+
+   ```html
+   <hx-button aria-label="Close dialog">X</hx-button>
+   ```
+
+The following LitElement pattern illustrates the `accessible-label` forwarding approach used in category (1):
 
 ```typescript
 import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-@customElement('hx-button')
-export class HelixButton extends LitElement {
+@customElement('my-custom-input')
+export class MyCustomInput extends LitElement {
   static override styles = css`:host { display: inline-flex; }`;
 
   @property({ attribute: 'accessible-label' }) accessibleLabel = '';
 
   override render() {
     return html`
-      <button aria-label=${this.accessibleLabel || nothing}>
-        <slot></slot>
-      </button>
+      <input aria-label=${this.accessibleLabel || nothing} />
     `;
   }
 }
@@ -169,8 +176,8 @@ export class HelixButton extends LitElement {
 Consumer usage:
 
 ```html
-<!-- accessible-label is a public host attribute; components forward it to the inner element. -->
-<hx-button accessible-label="Close dialog">X</hx-button>
+<!-- accessible-label is a public host attribute on components that document it. -->
+<hx-text-input accessible-label="Patient last name" placeholder="Last name"></hx-text-input>
 ```
 
 For built-in HELiX components that accept additional ARIA state (`aria-expanded`, `aria-controls`), the component documents the specific attributes it forwards. When building your own custom elements, prefer `ElementInternals.ariaExpanded` / `ariaControls` or explicit template bindings — the internal attribute-level forwarding helper used by HELiX components is not part of the public API.

--- a/apps/docs/src/content/docs/components-guide/forms/accessibility.md
+++ b/apps/docs/src/content/docs/components-guide/forms/accessibility.md
@@ -1,6 +1,6 @@
 ---
 title: Form Accessibility
-description: Build accessible form controls in HELiX using ARIA roles, ElementInternals ARIA reflection, and the mixinDelegatesAria pattern.
+description: Build accessible form controls in HELiX using ARIA roles, ElementInternals ARIA reflection, and accessible-label forwarding to shadow-DOM targets.
 ---
 
 Form controls must be accessible to users of assistive technologies. Shadow DOM creates unique challenges: ARIA relationships that reference element IDs (like `aria-labelledby`) and focus management both need special handling when elements live in different shadow roots.
@@ -77,7 +77,7 @@ These attributes connect controls to their accessible names and descriptions.
 <hx-text-input accessible-label="Search products"></hx-text-input>
 ```
 
-**`aria-labelledby`** — points to the ID of a visible label element. Works for elements in the same DOM scope; cross-shadow-DOM references require `mixinDelegatesAria` (see below):
+**`aria-labelledby`** — points to the ID of a visible label element. Works for elements in the same DOM scope; cross-shadow-DOM references need either `aria-labelledby` on an element that shares a DOM scope with the label, or forwarding via `ElementInternals.ariaLabelledByElements` on the custom element (see [Forwarding Host ARIA](#forwarding-host-aria-to-shadow-elements) below):
 ```html
 <label id="city-label">City</label>
 <hx-text-input aria-labelledby="city-label"></hx-text-input>
@@ -140,32 +140,28 @@ override connectedCallback() {
 
 Using `ElementInternals` ARIA properties is preferable to adding ARIA attributes to the shadow root's container element because it attaches semantics at the correct level of the accessibility tree.
 
-## `mixinDelegatesAria` — Forwarding Host Attributes to Shadow Elements
+## Forwarding Host ARIA to Shadow Elements
 
-The standard challenge: a consumer writes `<hx-button accessible-label="Close">` but the `aria-label` on the host `<hx-button>` does not automatically reach the `<button>` inside the shadow root — the assistive technology sees it on the wrong element.
+The standard challenge: a consumer writes `<hx-button accessible-label="Close">` but an `aria-label` placed on the host `<hx-button>` does not automatically reach the `<button>` inside the shadow root — assistive technology would see it on the wrong element.
 
-HELiX's `mixinDelegatesAria` solves this by observing ARIA attributes on the host and mirroring them to the designated inner element:
+Built-in HELiX components expose a public `accessible-label` attribute (property: `accessibleLabel`) and forward it to the inner interactive element, either via `ElementInternals.ariaLabel` on the host or via a template binding on the shadow-DOM target:
 
 ```typescript
-import { LitElement, html, css } from 'lit';
-import { customElement, query } from 'lit/decorators.js';
-import { mixinDelegatesAria } from '@helixui/library/mixins';
-
-const Base = mixinDelegatesAria(LitElement);
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
 
 @customElement('hx-button')
-export class HelixButton extends Base {
+export class HelixButton extends LitElement {
   static override styles = css`:host { display: inline-flex; }`;
 
-  @query('button') private _button!: HTMLButtonElement;
-
-  // mixinDelegatesAria reads _ariaTarget to know where to forward attributes
-  protected get _ariaTarget() {
-    return this._button;
-  }
+  @property({ attribute: 'accessible-label' }) accessibleLabel = '';
 
   override render() {
-    return html`<button><slot></slot></button>`;
+    return html`
+      <button aria-label=${this.accessibleLabel || nothing}>
+        <slot></slot>
+      </button>
+    `;
   }
 }
 ```
@@ -173,11 +169,11 @@ export class HelixButton extends Base {
 Consumer usage:
 
 ```html
-<!-- accessible-label, aria-expanded, aria-controls automatically forwarded to inner <button> -->
-<hx-button accessible-label="Close dialog" aria-expanded="false" aria-controls="dialog-1">
-  Close
-</hx-button>
+<!-- accessible-label is a public host attribute; components forward it to the inner element. -->
+<hx-button accessible-label="Close dialog">X</hx-button>
 ```
+
+For built-in HELiX components that accept additional ARIA state (`aria-expanded`, `aria-controls`), the component documents the specific attributes it forwards. When building your own custom elements, prefer `ElementInternals.ariaExpanded` / `ariaControls` or explicit template bindings — the internal attribute-level forwarding helper used by HELiX components is not part of the public API.
 
 ## Connecting Visible Labels to Custom Controls
 
@@ -194,4 +190,4 @@ The browser connects the label to the custom element via the `for` / `id` associ
 
 - [Element Internals and Form Association](/components-guide/forms/element-internals/) — `attachInternals()` and `setFormValue()`
 - [Form Validation](/components-guide/forms/validation/) — `setValidity()` and constraint validation
-- [Event Delegation](/components-guide/events/delegation/) — `delegatesFocus` and `mixinDelegatesAria`
+- [Event Delegation](/components-guide/events/delegation/) — `delegatesFocus` and ARIA forwarding patterns

--- a/apps/docs/src/content/docs/migration/3.0.0.mdx
+++ b/apps/docs/src/content/docs/migration/3.0.0.mdx
@@ -161,7 +161,9 @@ Audit each hit. Confirmation dialogs, clinical alerts, and blocking workflows sh
 **Positive security change — HIPAA hardening.** Consumers that already set PHI via the `data` JS property benefit silently.
 :::
 
-`hx-phi-field` holds Protected Health Information via the `data` JS property. The property is declared with `@property({ attribute: false })` so Lit does not observe a `data` HTML attribute. If raw HTML markup sets `<hx-phi-field data="...">`, the component's `connectedCallback` rescues the value into the `data` property, emits a `console.warn`, and removes the attribute from the DOM so PHI is not retained in `outerHTML`, DevTools, or SSR snapshots.
+`hx-phi-field` holds Protected Health Information via the `data` JS property. The property is declared with `@property({ attribute: false })` so Lit does not observe a `data` HTML attribute. If raw HTML markup sets `<hx-phi-field data="...">`, the component's `connectedCallback` reassigns the value onto the `data` property and removes the attribute from the live DOM so the PHI is not retained in `outerHTML` or DevTools after upgrade. In development builds the rescue also emits a `console.warn`; production builds strip the warn at build time.
+
+This runtime rescue is a **mitigation, not a cleanup**. Any value shipped as an HTML attribute is already present in the SSR / server-rendered source, the HTTP response body, `View Source`, browser caches, and any access logs that recorded the response, all of which the client cannot reach. Never place PHI in HTML markup — always assign it to the `data` JS property on a live element reference.
 
 The supported pattern — set `data` via JS:
 
@@ -177,8 +179,10 @@ el.data = '123-45-6789';
 The unsupported pattern — setting via HTML attribute:
 
 ```html
-<!-- Do not do this. The component warns and strips the attribute at runtime,
-     but the raw value is briefly present in the HTML source (SSR, view-source). -->
+<!-- Do not do this. The client-side rescue removes the attribute from the live
+     DOM after upgrade, but the raw value has already been sent to the browser
+     in the SSR source and remains in view-source, HTTP response bodies, access
+     logs, and caches. Never ship PHI in HTML markup. -->
 <hx-phi-field data="123-45-6789"></hx-phi-field>
 ```
 
@@ -302,7 +306,9 @@ import '@floating-ui/dom';
 
 ## 11. Public-API allowlist
 
-3.0.0 blocks undocumented deep imports. The public surface is the root barrel (`@helixui/library`) and per-component entry points (`@helixui/library/components/<hx-name>`). There is no `@helixui/library/mixins` subpath export — `FocusMixin`, `FormMixin`, `HelixElement`, and `HelixAuditController` are all re-exported from the root barrel. Consumers importing from anything else will see a build-time error.
+3.0.0 blocks undocumented JavaScript/TypeScript deep imports. For JS/TS symbols, the public surface is the root barrel (`@helixui/library`) and per-component entry points (`@helixui/library/components/<hx-name>`). There is no `@helixui/library/mixins` subpath export — `FocusMixin`, `FormMixin`, `HelixElement`, and `HelixAuditController` are all re-exported from the root barrel. Consumers importing other JS/TS subpaths will see a build-time error.
+
+Documented non-JS asset subpaths (public CSS bundles under `@helixui/library/dist/css/*.css`, `@helixui/library/fouc.css`, and `@helixui/library/custom-elements.json`) remain part of the public surface via their package export paths and are unaffected by this rule.
 
 ```typescript
 // Before — blocked in 3.0.0

--- a/apps/docs/src/content/docs/migration/3.0.0.mdx
+++ b/apps/docs/src/content/docs/migration/3.0.0.mdx
@@ -75,11 +75,16 @@ Do **not** rewrite `aria-label` on native HTML elements (`<button>`, `<input>`, 
 :::
 
 :::note[hx-card exception]
-`hx-card` uses `label` (not `accessible-label`) for its accessible name. The codemod above excludes it. Migrate manually:
+`hx-card` uses `hx-label` (HTML attribute) / `label` (JS property) for its accessible name — not `accessible-label`. The codemod above excludes it. Migrate manually:
 
 ```diff
 - <hx-card hxAriaLabel="View patient record">...</hx-card>
 + <hx-card hx-label="View patient record">...</hx-card>
+```
+
+```diff
+- el.hxAriaLabel = 'View patient record';
++ el.label = 'View patient record';
 ```
 
 :::
@@ -150,21 +155,34 @@ rg '<hx-dialog\b(?![^>]*\bmodal\b)' -g '*.twig' -g '*.html.twig'
 
 Audit each hit. Confirmation dialogs, clinical alerts, and blocking workflows should add `modal`. Inline drawers and sidebar panels should stay non-modal.
 
-## 6. `hx-phi-field` — PHI attribute stripped post-hydration
+## 6. `hx-phi-field` — PHI set via JS property, never as an HTML attribute
 
 :::note
-**Positive security change.** HIPAA-aligned deployments benefit silently. Only consumers reading `el.getAttribute('value')` need to update.
+**Positive security change — HIPAA hardening.** Consumers that already set PHI via the `data` JS property benefit silently.
 :::
 
-In 2.x, `<hx-phi-field value="...">` left the `value` attribute on the element, exposing PHI via `getAttribute('value')`, `outerHTML`, SSR dumps, and DevTools. In 3.0.0 the attribute is removed after `connectedCallback`; the property retains the value.
+`hx-phi-field` holds Protected Health Information via the `data` JS property. The property is declared with `@property({ attribute: false })` so Lit does not observe a `data` HTML attribute. If raw HTML markup sets `<hx-phi-field data="...">`, the component's `connectedCallback` rescues the value into the `data` property, emits a `console.warn`, and removes the attribute from the DOM so PHI is not retained in `outerHTML`, DevTools, or SSR snapshots.
+
+The supported pattern — set `data` via JS:
+
+```html
+<hx-phi-field id="mrn" field-id="patient-mrn" field-type="mrn"></hx-phi-field>
+```
 
 ```typescript
-// Before — worked, but leaked PHI in DOM serialization
-const phi = el.getAttribute('value');
-
-// After — read the property instead
-const phi = el.value;
+const el = document.querySelector('hx-phi-field#mrn');
+el.data = '123-45-6789';
 ```
+
+The unsupported pattern — setting via HTML attribute:
+
+```html
+<!-- Do not do this. The component warns and strips the attribute at runtime,
+     but the raw value is briefly present in the HTML source (SSR, view-source). -->
+<hx-phi-field data="123-45-6789"></hx-phi-field>
+```
+
+Consumers setting PHI via the `data` property need no change. Consumers setting PHI via an HTML attribute must move the assignment to JavaScript.
 
 This change surfaced during the Figgy (Northwell) integration audit as a HIPAA-relevant exposure vector.
 
@@ -183,8 +201,7 @@ Inherited for free:
 Subclassing example:
 
 ```typescript
-import { HelixElement } from '@helixui/library';
-import { FormMixin } from '@helixui/library/mixins';
+import { HelixElement, FormMixin } from '@helixui/library';
 
 class MyCustomInput extends FormMixin(HelixElement) {
   static override formAssociated = true;
@@ -285,7 +302,7 @@ import '@floating-ui/dom';
 
 ## 11. Public-API allowlist
 
-3.0.0 blocks undocumented deep imports. Consumers importing from anything other than the root barrel, `@helixui/library/mixins`, or documented per-component entry points will see a build-time error.
+3.0.0 blocks undocumented deep imports. The public surface is the root barrel (`@helixui/library`) and per-component entry points (`@helixui/library/components/<hx-name>`). There is no `@helixui/library/mixins` subpath export — `FocusMixin`, `FormMixin`, `HelixElement`, and `HelixAuditController` are all re-exported from the root barrel. Consumers importing from anything else will see a build-time error.
 
 ```typescript
 // Before — blocked in 3.0.0

--- a/docs/UPGRADING-TO-3.md
+++ b/docs/UPGRADING-TO-3.md
@@ -171,7 +171,9 @@ rg -P '<hx-dialog\b(?![^>]*\bmodal\b)' -g '*.twig' -g '*.html.twig'
 
 > **Positive security change — HIPAA hardening.** Most consumers benefit silently.
 
-`hx-phi-field` holds Protected Health Information via the `data` JS property. The property is declared with `@property({ attribute: false })`, so Lit does not observe a `data` HTML attribute. If raw HTML markup sets `<hx-phi-field data="...">`, the component's `connectedCallback` detects the attribute, rescues the value into the `data` property, emits a `console.warn`, and removes the attribute from the DOM so PHI is not retained in `outerHTML`, DevTools, or SSR snapshots.
+`hx-phi-field` holds Protected Health Information via the `data` JS property. The property is declared with `@property({ attribute: false })`, so Lit does not observe a `data` HTML attribute. If raw HTML markup sets `<hx-phi-field data="...">`, the component's `connectedCallback` reassigns the value onto the `data` property and removes the attribute from the live DOM so PHI is not retained in subsequent `outerHTML` or DevTools DOM inspection after hydration. In development builds the rescue also emits a `console.warn`; production builds strip the warn at build time via the dev-only `devWarn` helper.
+
+This runtime rescue is a **mitigation, not a cleanup**. It cannot remove PHI from the original SSR HTML, HTTP response body, `View Source`, browser caches, or any access logs that recorded the response — all of which the client cannot reach. Attribute usage for PHI remains unsupported; PHI must be assigned to the `data` JS property on a live element reference, never shipped as HTML markup.
 
 **The supported pattern — set `data` via JS:**
 
@@ -187,8 +189,10 @@ el.data = '123-45-6789';
 **The unsupported pattern — setting via HTML attribute:**
 
 ```html
-<!-- Do not do this. The component warns and strips the attribute at runtime,
-     but the raw value is briefly present in the HTML source (SSR, view-source). -->
+<!-- Do not do this. The client-side rescue removes the attribute from the live
+     DOM after upgrade, but the raw value has already been sent to the browser
+     in the SSR source and remains in view-source, HTTP response bodies, access
+     logs, and caches. Never ship PHI in HTML markup. -->
 <hx-phi-field data="123-45-6789"></hx-phi-field>
 ```
 
@@ -331,7 +335,7 @@ import '@floating-ui/dom';
 
 ## 11. Public-API allowlist
 
-3.0.0 introduces a public-API allowlist that blocks undocumented deep imports from leaking through `@helixui/library`. The public surface is the root barrel (`@helixui/library`) and the per-component entry points (`@helixui/library/components/<hx-name>`). There is no `@helixui/library/mixins` subpath export — `FocusMixin`, `FormMixin`, `HelixElement`, and `HelixAuditController` are all re-exported from the root barrel. Consumers importing from anything else will see a build-time error.
+3.0.0 introduces a public-API allowlist that blocks undocumented JavaScript/TypeScript deep imports from leaking through `@helixui/library`. For JS/TS symbols, the public surface is the root barrel (`@helixui/library`) and the per-component entry points (`@helixui/library/components/<hx-name>`). There is no `@helixui/library/mixins` subpath export — `FocusMixin`, `FormMixin`, `HelixElement`, and `HelixAuditController` are all re-exported from the root barrel. Consumers importing other JS/TS subpaths will see a build-time error; documented CSS and manifest asset exports (`@helixui/library/dist/css/*.css`, `@helixui/library/fouc.css`, `@helixui/library/custom-elements.json`) remain available via their package export paths.
 
 **Find-and-replace:**
 

--- a/docs/UPGRADING-TO-3.md
+++ b/docs/UPGRADING-TO-3.md
@@ -69,11 +69,16 @@ Every component that previously accepted `aria-label` or `hxAriaLabel` now expos
 
 Components affected: `hx-button`, `hx-icon-button`, `hx-badge`, `hx-chip`, `hx-copy-button`, `hx-file-upload`, `hx-link`, `hx-menu-item`, `hx-nav-item`, `hx-overflow-menu`, `hx-side-nav`, `hx-split-button`, `hx-step`, `hx-toggle`, `hx-tooltip` (full list in CEM).
 
-**Exception — `hx-card`:** Interactive card accessible names use the `label` attribute, not `accessible-label`. If you were using the deprecated `hxAriaLabel` property on `hx-card`, migrate it to `label`:
+**Exception — `hx-card`:** Interactive card accessible names use `hx-label` (HTML attribute) / `label` (JS property), not `accessible-label`. If you were using the deprecated `hxAriaLabel` property on `hx-card`, migrate:
 
 ```diff
 - <hx-card hxAriaLabel="View patient record">...</hx-card>
 + <hx-card hx-label="View patient record">...</hx-card>
+```
+
+```diff
+- el.hxAriaLabel = 'View patient record';
++ el.label = 'View patient record';
 ```
 
 ---
@@ -91,7 +96,7 @@ Every form control renames the validation-message CSS part from `error-message` 
 
 **Regex for codemod:** `/::part\(error-message\)/g` → `::part(error)`.
 
-Components affected: `hx-text-input`, `hx-textarea`, `hx-select`, `hx-combobox`, `hx-checkbox`, `hx-radio`, `hx-date-picker`, `hx-time-picker`, `hx-number-input`, `hx-slider`, `hx-file-upload`, `hx-color-picker`, `hx-field`, `hx-switch`, `hx-phi-field`.
+Components affected: `hx-checkbox`, `hx-checkbox-group`, `hx-combobox`, `hx-date-picker`, `hx-field`, `hx-file-upload`, `hx-number-input`, `hx-radio-group`, `hx-select`, `hx-switch`, `hx-text-input`, `hx-textarea`, `hx-time-picker`.
 
 ---
 
@@ -162,32 +167,34 @@ rg -P '<hx-dialog\b(?![^>]*\bmodal\b)' -g '*.twig' -g '*.html.twig'
 
 ---
 
-## 6. `hx-phi-field` — PHI attribute removed from DOM post-hydration
+## 6. `hx-phi-field` — PHI set via JS property, never as an HTML attribute
 
 > **Positive security change — HIPAA hardening.** Most consumers benefit silently.
 
-In 2.x, `<hx-phi-field value="123-45-6789">` left the `value` attribute on the element after `connectedCallback`, meaning PHI values were readable via:
+`hx-phi-field` holds Protected Health Information via the `data` JS property. The property is declared with `@property({ attribute: false })`, so Lit does not observe a `data` HTML attribute. If raw HTML markup sets `<hx-phi-field data="...">`, the component's `connectedCallback` detects the attribute, rescues the value into the `data` property, emits a `console.warn`, and removes the attribute from the DOM so PHI is not retained in `outerHTML`, DevTools, or SSR snapshots.
 
-- `el.getAttribute('value')`
-- `el.outerHTML`
-- Server-side HTML dumps (SSR, snapshot tests, audit logs)
-- Browser DevTools element inspector
+**The supported pattern — set `data` via JS:**
 
-In 3.0.0 the attribute is stripped from the DOM after hydration. The `value` property still holds the value for reactive updates, form submission, and programmatic access.
-
-**Consumer impact.** Most consumers read PHI via the `value` property — they are unaffected. Only consumers reading the `value` *attribute* need to update:
-
-```typescript
-// Before — worked, but exposed PHI in DOM serialization
-const phi = el.getAttribute('value');
-const html = el.outerHTML; // PHI leaked in the string
-
-// After — use the property accessor
-const phi = el.value;
-const html = el.outerHTML; // PHI no longer present
+```html
+<hx-phi-field id="mrn" field-id="patient-mrn" field-type="mrn"></hx-phi-field>
 ```
 
-**Why this change ships in 3.0.0.** HIPAA-aligned deployments (clinical records, patient portals) must not expose PHI through DOM serialization. The attribute retention in 2.x was a latent exposure vector surfaced during the Figgy (Northwell) integration audit.
+```typescript
+const el = document.querySelector('hx-phi-field#mrn');
+el.data = '123-45-6789';
+```
+
+**The unsupported pattern — setting via HTML attribute:**
+
+```html
+<!-- Do not do this. The component warns and strips the attribute at runtime,
+     but the raw value is briefly present in the HTML source (SSR, view-source). -->
+<hx-phi-field data="123-45-6789"></hx-phi-field>
+```
+
+**Consumer impact.** Consumers that already set PHI via the `data` property are unaffected. Consumers setting PHI via the HTML attribute must move the assignment to JavaScript.
+
+**Why this change ships in 3.0.0.** HIPAA-aligned deployments (clinical records, patient portals) must not expose PHI through DOM serialization. The prior permissive attribute behavior was a latent exposure vector surfaced during the Figgy (Northwell) integration audit.
 
 ---
 
@@ -206,8 +213,7 @@ All 15 form-associated components now compose `FormMixin(HelixElement)`. If you 
 **Subclassing example:**
 
 ```ts
-import { HelixElement } from '@helixui/library';
-import { FormMixin } from '@helixui/library/mixins';
+import { HelixElement, FormMixin } from '@helixui/library';
 
 class MyCustomInput extends FormMixin(HelixElement) {
   static override formAssociated = true;
@@ -325,7 +331,7 @@ import '@floating-ui/dom';
 
 ## 11. Public-API allowlist
 
-3.0.0 introduces a public-API allowlist that blocks undocumented deep imports from leaking through `@helixui/library`. Consumers importing from anything other than the root barrel, `@helixui/library/mixins`, or the documented per-component entry points will see a build-time error.
+3.0.0 introduces a public-API allowlist that blocks undocumented deep imports from leaking through `@helixui/library`. The public surface is the root barrel (`@helixui/library`) and the per-component entry points (`@helixui/library/components/<hx-name>`). There is no `@helixui/library/mixins` subpath export — `FocusMixin`, `FormMixin`, `HelixElement`, and `HelixAuditController` are all re-exported from the root barrel. Consumers importing from anything else will see a build-time error.
 
 **Find-and-replace:**
 

--- a/packages/hx-library/CHANGELOG.md
+++ b/packages/hx-library/CHANGELOG.md
@@ -81,9 +81,9 @@ Drupal / Twig consumers should grep `*.twig` templates for the same pattern.
 
 #### `hx-phi-field` PHI no longer accepted via HTML attributes (security hardening)
 
-`hx-phi-field` exposes PHI exclusively through the `data` JS property. The underlying `@property({ attribute: false })` declaration means Lit does not reflect `data` to or from any HTML attribute — the property is **not** settable via `setAttribute('data', …)` or initial `<hx-phi-field data="…">` markup, and it does not appear in `outerHTML` or server-side DOM dumps.
+`hx-phi-field` exposes PHI exclusively through the `data` JS property (typed `string`). The underlying `@property({ attribute: false })` declaration means Lit does not reflect `data` to or from any HTML attribute. Do not use `setAttribute('data', …)` or initial `<hx-phi-field data="…">` markup for PHI.
 
-As a belt-and-suspenders defense for consumers writing PHI-laden markup anyway, `connectedCallback` scans for stray `data` / `value` attributes on the host, removes them from the DOM, and logs a `console.warn` identifying the element. PHI therefore cannot leak through DOM serialization, HTML templates, or browser DevTools Elements-panel inspection.
+As a belt-and-suspenders defense for consumers writing PHI-laden markup anyway, `connectedCallback` scans for stray `data` / `value` attributes on the host, removes them from the live DOM, and in development builds emits a `console.warn` identifying the element (the warn is stripped from production builds). This cleanup reduces exposure after upgrade, but PHI in HTML is still unsafe because it may already be present in templates, HTTP response bodies, `View Source`, browser caches, access logs, or pre-upgrade DOM — none of which the client can reach.
 
 Consumers must set PHI via the property on a live element reference:
 
@@ -91,10 +91,11 @@ Consumers must set PHI via the property on a live element reference:
 // Correct — property assignment after insertion
 const el = document.createElement('hx-phi-field');
 document.body.append(el);
-el.data = { mrn: '12345', dob: '1990-01-01' };
+el.data = 'MRN: 12345 • DOB: 1990-01-01';
 
-// Do NOT do this — ignored + warned + attribute stripped
-document.body.insertAdjacentHTML('beforeend', '<hx-phi-field data=\'{"mrn":"12345"}\'></hx-phi-field>');
+// Do NOT do this — the raw value is already in the HTML source the browser
+// received. The client-side strip only protects the live DOM after hydration.
+document.body.insertAdjacentHTML('beforeend', '<hx-phi-field data="123-45-6789"></hx-phi-field>');
 ```
 
 Consumers reading PHI continue to use the `data` property (`el.data`). Any existing integration reading the `value` attribute via `getAttribute` or `outerHTML` must migrate to the property accessor.

--- a/packages/hx-library/CHANGELOG.md
+++ b/packages/hx-library/CHANGELOG.md
@@ -27,7 +27,7 @@ Consumers subclassing `HelixElement` or applying `FormMixin` should treat these 
 | Component | Old | New |
 | --- | --- | --- |
 | ARIA-labelable components (except `hx-card`) | `aria-label` / `hxAriaLabel` | `accessible-label` / `accessibleLabel` |
-| `hx-card` | `hxAriaLabel` | `label` |
+| `hx-card` | `hxAriaLabel` (prop) / no attribute | `label` (prop) / `hx-label` (attribute) |
 | `hx-date-picker` | native modal `<dialog>` | non-modal popup dialog |
 | `hx-time-picker` | native modal `<dialog>` | non-modal popup dialog |
 
@@ -39,7 +39,7 @@ The `accessible-label` naming aligns HELiX with the ARIA 1.2 guidance that `aria
 | --- | --- | --- |
 | all form controls | `error-message` | `error` |
 
-Form controls (`hx-text-input`, `hx-textarea`, `hx-select`, `hx-combobox`, `hx-checkbox`, `hx-radio`, `hx-date-picker`, `hx-time-picker`, `hx-number-input`, `hx-slider`, `hx-file-upload`, `hx-color-picker`, `hx-field`, `hx-switch`, `hx-phi-field`) now expose the validation-message slot as `part="error"` for consistency with `help-text`. Consumers targeting `::part(error-message)` must update selectors to `::part(error)`.
+Form controls (`hx-checkbox`, `hx-checkbox-group`, `hx-combobox`, `hx-date-picker`, `hx-field`, `hx-file-upload`, `hx-number-input`, `hx-radio-group`, `hx-select`, `hx-switch`, `hx-text-input`, `hx-textarea`, `hx-time-picker`) now expose the validation-message slot as `part="error"` for consistency with `help-text`. Consumers targeting `::part(error-message)` must update selectors to `::part(error)`.
 
 #### FormMixin consolidation
 
@@ -79,19 +79,25 @@ rg '<hx-dialog\b(?![^>]*\bmodal\b)' --type html --type tsx --type vue
 
 Drupal / Twig consumers should grep `*.twig` templates for the same pattern.
 
-#### `hx-phi-field` PHI attribute no longer retained post-hydration (security hardening)
+#### `hx-phi-field` PHI no longer accepted via HTML attributes (security hardening)
 
-`<hx-phi-field value="...">` previously left the `value` attribute on the DOM after `connectedCallback`, meaning PHI values were readable via `el.getAttribute('value')`, `el.outerHTML`, server-side DOM dumps, and browser DevTools inspection. In 3.0.0 the attribute is stripped from the DOM after hydration; the property still holds the value for reactive updates and form submission.
+`hx-phi-field` exposes PHI exclusively through the `data` JS property. The underlying `@property({ attribute: false })` declaration means Lit does not reflect `data` to or from any HTML attribute — the property is **not** settable via `setAttribute('data', …)` or initial `<hx-phi-field data="…">` markup, and it does not appear in `outerHTML` or server-side DOM dumps.
 
-This is a **positive security change** for HIPAA-aligned integrations — PHI no longer leaks through DOM serialization. Consumers reading PHI via the `value` property (e.g. `el.value`) are unaffected. Consumers reading the `value` *attribute* via `getAttribute` or `outerHTML` must switch to the property accessor.
+As a belt-and-suspenders defense for consumers writing PHI-laden markup anyway, `connectedCallback` scans for stray `data` / `value` attributes on the host, removes them from the DOM, and logs a `console.warn` identifying the element. PHI therefore cannot leak through DOM serialization, HTML templates, or browser DevTools Elements-panel inspection.
+
+Consumers must set PHI via the property on a live element reference:
 
 ```typescript
-// Before — worked, but exposed PHI in DOM serialization
-const phi = el.getAttribute('value');
+// Correct — property assignment after insertion
+const el = document.createElement('hx-phi-field');
+document.body.append(el);
+el.data = { mrn: '12345', dob: '1990-01-01' };
 
-// After — PHI attribute is removed post-hydration; use the property
-const phi = el.value;
+// Do NOT do this — ignored + warned + attribute stripped
+document.body.insertAdjacentHTML('beforeend', '<hx-phi-field data=\'{"mrn":"12345"}\'></hx-phi-field>');
 ```
+
+Consumers reading PHI continue to use the `data` property (`el.data`). Any existing integration reading the `value` attribute via `getAttribute` or `outerHTML` must migrate to the property accessor.
 
 #### Bundle layout / barrel imports
 

--- a/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.twig
+++ b/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.twig
@@ -71,7 +71,7 @@
  *
  *     hx-code-snippet:
  *       js:
- *         path/to/@wc-2026/library/dist/hx-code-snippet.js: { attributes: { type: module } }
+ *         path/to/@helixui/library/dist/hx-code-snippet.js: { attributes: { type: module } }
  *
  *   Attach in your template or preprocess function:
  *     {{ attach_library('mytheme/hx-code-snippet') }}

--- a/packages/hx-library/src/components/hx-spinner/hx-spinner.twig
+++ b/packages/hx-library/src/components/hx-spinner/hx-spinner.twig
@@ -28,7 +28,7 @@
     Load the component script in your theme's .libraries.yml:
       hx-spinner:
         js:
-          path/to/@wc-2026/library/dist/hx-spinner.js: { attributes: { type: module } }
+          path/to/@helixui/library/dist/hx-spinner.js: { attributes: { type: module } }
 
     Attach the library in your template:
       {{ attach_library('mytheme/hx-spinner') }}

--- a/packages/hx-library/src/components/hx-toast/hx-toast.drupal.js
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.drupal.js
@@ -6,7 +6,7 @@
  *
  * Attach trigger elements with a `data-hx-toast` attribute containing a JSON
  * object of toast options. The behavior calls the imperative `toast()` utility
- * from @wc-2026/library when the trigger is clicked.
+ * from @helixui/library when the trigger is clicked.
  *
  * @example Twig template
  *   <button
@@ -51,7 +51,7 @@
             return;
           }
 
-          import('@wc-2026/library/components/hx-toast/index.js')
+          import('@helixui/library/components/hx-toast/index.js')
             .then(function (module) {
               module.toast(rawOptions);
             })

--- a/packages/hx-library/src/components/hx-toast/hx-toast.drupal.js
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.drupal.js
@@ -51,7 +51,7 @@
             return;
           }
 
-          import('@helixui/library/components/hx-toast/index.js')
+          import('@helixui/library/components/hx-toast')
             .then(function (module) {
               module.toast(rawOptions);
             })

--- a/packages/hx-library/src/styles/prose/prose.css
+++ b/packages/hx-library/src/styles/prose/prose.css
@@ -9,7 +9,7 @@
    intentionally need page-wide WYSIWYG reset styles scoped via your own selector.
 
    Usage:
-     @import '@wc-2026/library/styles/prose/prose.css';
+     @import '@helixui/library/styles/prose/prose.css';
 
    Override prose custom properties at :root or on any ancestor:
      :root {

--- a/scripts/generate-release-manifest.mjs
+++ b/scripts/generate-release-manifest.mjs
@@ -58,12 +58,23 @@ const changesetFiles = existsSync(changesetDir)
 const publishedPackages = (() => {
   const raw = process.env.PUBLISHED_PACKAGES;
   if (!raw) return [];
+  let parsed;
   try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `PUBLISHED_PACKAGES is set but not valid JSON — refusing to write an ` +
+        `incomplete release manifest. Raw value (first 200 chars): ` +
+        `${raw.slice(0, 200)} — original error: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `PUBLISHED_PACKAGES parsed but is not an array — expected the output ` +
+        `shape from changesets/action. Got: ${typeof parsed}`,
+    );
+  }
+  return parsed;
 })();
 
 const cdnBudget = readJson(join(REPO_ROOT, '.cdn-budget.json'));

--- a/scripts/generate-release-manifest.mjs
+++ b/scripts/generate-release-manifest.mjs
@@ -55,6 +55,17 @@ const changesetFiles = existsSync(changesetDir)
   ? readdirSync(changesetDir).filter((f) => f.endsWith('.md') && f !== 'README.md')
   : [];
 
+const publishedPackages = (() => {
+  const raw = process.env.PUBLISHED_PACKAGES;
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+})();
+
 const cdnBudget = readJson(join(REPO_ROOT, '.cdn-budget.json'));
 
 const cemPath = join(REPO_ROOT, 'packages/hx-library/custom-elements.json');
@@ -99,14 +110,16 @@ const manifest = {
     '@helixui/react': reactPkg.version ?? null,
   },
   changeset_files: changesetFiles,
+  published_packages: publishedPackages,
   merged_prs_since_last_tag: mergedPrs,
   last_tag: lastTag,
   cem_sha256: cemSha,
   cdn_budget_snapshot: cdnBudget,
   coderabbit_final_review_sha: process.env.CODERABBIT_FINAL_REVIEW_SHA ?? null,
   notes:
-    'Emitted by scripts/generate-release-manifest.mjs during the publish workflow. ' +
-    'Committed to the repo as part of the version-bump PR that changesets/action creates.',
+    'Emitted by scripts/generate-release-manifest.mjs during the publish workflow ' +
+    'after changesets/action publishes to npm. Committed back to main via a ' +
+    'dedicated step in publish.yml — not part of the version-bump PR.',
 };
 
 if (!existsSync(MANIFEST_DIR)) {

--- a/scripts/lib/vitest-watchdog.sh
+++ b/scripts/lib/vitest-watchdog.sh
@@ -46,9 +46,8 @@ run_vitest_with_watchdog() {
   while kill -0 "$vitest_pid" 2>/dev/null; do
     sleep "$poll_interval"
     local current_size
-    current_size=$(stat -f "%z" "$logfile" 2>/dev/null \
-      || stat -c "%s" "$logfile" 2>/dev/null \
-      || echo 0)
+    current_size=$(wc -c < "$logfile" 2>/dev/null | tr -d '[:space:]' || echo 0)
+    current_size=${current_size:-0}
     local elapsed=$(( $(date +%s) - start_time ))
 
     if [[ "$current_size" -eq "$last_size" ]] && [[ "$current_size" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Promotes codex-final remediation (blocking + concerns findings) and CodeRabbit round-1 + round-2 findings from `dev` to `staging`, refreshing staging→main PR #1481 for final codex pass.

## Included PRs

- #1486 — Codex final remediation + CodeRabbit round-1 (10 threads) + round-2 (4 threads)
- #1485 — upstream remediation promoted through dev earlier

## Remediation Highlights

**Codex blocking/concerns addressed on dev:**
- Migration docs: qualified deep-import restriction to JS/TS (CSS/CEM assets are documented public exports)
- PHI hardening: client-side `connectedCallback` attribute stripping clarified as mitigation-not-cleanup (SSR source, HTTP response body, View Source, caches remain unreachable)
- CHANGELOG: `hx-phi-field` `data: string` (not `object`) matches `@property({ attribute: false }) data: string`
- `hx-toast.drupal.js` import path fix
- `generate-release-manifest.mjs`: fail-closed on malformed `PUBLISHED_PACKAGES` JSON

**CodeRabbit round-1 (10):** per-file docs fixes, CEM accuracy notes

**CodeRabbit round-2 (4):**
- `ci.yml`: short-circuit vitest when `TEST_FILE_COUNT=0` (shard collapse path)
- `ci.yml`: guard diagnostic `awk` with `grep -q "Coverage report from"` marker check
- `publish.yml`: harden release-manifest commit with `set -euo pipefail` + stash/fetch/checkout-B from `origin/main`/pop pattern (prevents non-fast-forward after successful npm publish)
- `docs/components-guide/forms/accessibility.md` + `events/delegation.md`: scope native `aria-label` to components that document it; add `hx-status-indicator` `label`-property caveat

## Gate Status

- All 14 CodeRabbit threads resolved via GraphQL
- Required checks (Quality Gates + CodeRabbit) green on #1486 pre-merge
- Storybook Tests known flake (informational-only per 3.0.0 policy, flip to blocking in 3.1)
- dev is 9 commits ahead of staging

## Next Steps

1. Auto-merge this PR once Quality Gates green
2. Staging advances → PR #1481 (staging→main) refreshes
3. Run codex-adversarial on refreshed #1481 diff
4. Remediate until PASS or nits-only
5. Publish `FINAL-codex-adversarial.md` to `Projects/HELiX/Audits/3.0.0-RC/`
6. Jake clicks merge on #1481