### PR TITLE
fix(sanitize-css): reject protocol-relative URLs + track string/comment state in brace scan

### DIFF
--- a/.changeset/fix-sanitize-css-url-bypass.md
+++ b/.changeset/fix-sanitize-css-url-bypass.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+Harden `sanitizeCss` against protocol-relative URL bypass and quoted-string brace-count false-positives (codex-adversarial final-pass finding).

--- a/packages/hx-library/src/utilities/__tests__/sanitizeCss.test.ts
+++ b/packages/hx-library/src/utilities/__tests__/sanitizeCss.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeCss } from '../sanitizeCss.js';
+
+const COMPONENT = 'test-sanitize';
+
+describe('sanitizeCss — url() scheme enforcement', () => {
+  it('accepts relative paths', () => {
+    expect(sanitizeCss('.a { background: url(./img.png); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts data: URIs', () => {
+    expect(sanitizeCss('.a { background: url(data:image/png;base64,aGk=); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts blob: URIs', () => {
+    expect(sanitizeCss('.a { background: url(blob:https://host/abc); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts fragment references (#symbol)', () => {
+    expect(sanitizeCss('.a { clip-path: url(#my-clip); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('rejects explicit http:// URLs', () => {
+    expect(sanitizeCss('.a { background: url(http://evil.example/x.png); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects explicit https:// URLs', () => {
+    expect(sanitizeCss('.a { background: url(https://evil.example/x.png); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs (//host/path)', () => {
+    expect(sanitizeCss('.a { background: url(//evil.example/x.png); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs with surrounding whitespace', () => {
+    expect(sanitizeCss('.a { background: url("  //evil.example/x  "); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs with leading tab', () => {
+    expect(sanitizeCss(".a { background: url('\t//evil.example/x'); }", COMPONENT)).toBeNull();
+  });
+
+  it('rejects ftp:// URLs', () => {
+    expect(sanitizeCss('.a { background: url(ftp://evil.example/x); }', COMPONENT)).toBeNull();
+  });
+});
+
+describe('sanitizeCss — brace balance with strings and comments', () => {
+  it('accepts double-quoted content with closing brace', () => {
+    expect(sanitizeCss('.a::before { content: "}"; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts double-quoted content with opening brace', () => {
+    expect(sanitizeCss('.a::before { content: "{"; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts single-quoted content with both braces', () => {
+    expect(sanitizeCss(".a::before { content: '{}{}'; }", COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts SVG data URI with braces inside string', () => {
+    const svg =
+      '.a { background: url("data:image/svg+xml,<svg xmlns=\\"http://www.w3.org/2000/svg\\"><style>g{fill:red}</style></svg>"); }';
+    expect(sanitizeCss(svg, COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts escaped quotes within a quoted string', () => {
+    expect(sanitizeCss('.a::before { content: "\\"}\\""; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts block comments that contain braces', () => {
+    expect(sanitizeCss('/* { brace in comment } */ .a { color: red; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('still rejects an unbalanced closing brace outside strings', () => {
+    expect(sanitizeCss('.a { color: red; } }', COMPONENT)).toBeNull();
+  });
+
+  it('still rejects a stray opening brace outside strings', () => {
+    expect(sanitizeCss('.a { color: red;', COMPONENT)).toBeNull();
+  });
+
+  it('still rejects unbalanced close appearing before an open outside strings', () => {
+    expect(sanitizeCss('} .a { color: red; }', COMPONENT)).toBeNull();
+  });
+});
+
+describe('sanitizeCss — blocked patterns still enforced', () => {
+  it('rejects expression(', () => {
+    expect(sanitizeCss('.a { width: expression(alert(1)); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects @import', () => {
+    expect(sanitizeCss('@import url("x.css"); .a { color: red; }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects -moz-binding', () => {
+    expect(sanitizeCss('.a { -moz-binding: url(x.xml); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects behavior:', () => {
+    expect(sanitizeCss('.a { behavior: url(x.htc); }', COMPONENT)).toBeNull();
+  });
+});

--- a/packages/hx-library/src/utilities/sanitizeCss.ts
+++ b/packages/hx-library/src/utilities/sanitizeCss.ts
@@ -48,6 +48,11 @@ function isUrlSafe(urlValue: string): boolean {
   // Empty url() is harmless
   if (trimmed === '') return true;
 
+  // Protocol-relative URLs (//host/path) resolve against the page's current
+  // protocol and load from an external host — same risk as explicit http://.
+  // Must reject before the allow-prefix / scheme checks, since they have no colon.
+  if (trimmed.startsWith('//')) return false;
+
   // Allow explicitly safe prefixes
   for (const prefix of ALLOWED_URL_PREFIXES) {
     if (trimmed.startsWith(prefix)) return true;
@@ -65,12 +70,50 @@ function isUrlSafe(urlValue: string): boolean {
 /**
  * Checks whether braces in the CSS string are balanced.
  * Unbalanced braces can be used to escape scoped selectors and inject global
- * styles into the document.
+ * styles into the document. Braces inside strings (`"..."`, `'...'`) and block
+ * comments are ignored so legitimate content like `content: "}"` or SVG data
+ * URIs (`url("data:image/svg+xml,<svg>{...}</svg>")`) does not trigger a false
+ * rejection.
  */
 function areBracesBalanced(css: string): boolean {
   let depth = 0;
+  let quote: '"' | "'" | null = null;
+  let inComment = false;
+
   for (let i = 0; i < css.length; i++) {
     const ch = css[i];
+
+    if (inComment) {
+      if (ch === '*' && css[i + 1] === '/') {
+        inComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (quote !== null) {
+      if (ch === '\\') {
+        // Skip the escaped character (including an escaped quote).
+        i++;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '/' && css[i + 1] === '*') {
+      inComment = true;
+      i++;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+
     if (ch === '{') {
       depth++;
     } else if (ch === '}') {


### PR DESCRIPTION
## Summary

Codex-adversarial final-pass on PR #1481 (staging→main) flagged two blocking defects in the newly-added `sanitizeCss.ts` utility shipping in 3.0.0. This PR fixes both with regression tests.

## Blocking finding #1 — Protocol-relative URL bypass (security, high)

`isUrlSafe()` scheme regex `/^[a-z][a-z0-9+\-.]*:/i` requires a `:`. A value like `url(//attacker.example/x)` has no scheme, so it fell through to the `return true` relative-path branch. Browsers resolve `//host/path` against the page's current protocol and load from an external host — same blast radius as explicit `http://`.

**Fix:** Reject any trimmed value starting with `//` before the allow-prefix/scheme checks.

## Blocking finding #2 — Brace counter ignored strings/comments (correctness, high)

`areBracesBalanced()` walked every character without tracking quote or block-comment state. Legitimate CSS like `content: "}"` or `url("data:image/svg+xml,<svg>...{...}...</svg>")` produced a non-zero depth and caused the entire stylesheet to be silently dropped via `devWarn`. HELiX ships token-based icon slots + SVG data URIs and this sanitizer runs on every consumer-supplied `light-css`, so this would have broken real Drupal / trip-planner / well-helix / Northwell migrations on first use.

**Fix:** Track single/double quote state (with `\\` escape handling) and block comments. Only count braces outside strings and comments.

## Tests

New file `packages/hx-library/src/utilities/__tests__/sanitizeCss.test.ts` — 23 tests, 23 passing in ~4s.

Coverage:
- **url() scheme enforcement (10):** relative, data:, blob:, #fragment, http://, https://, ftp:// + 3 protocol-relative variants (`//host/path`, whitespace-wrapped, leading tab)
- **Brace balance with strings/comments (9):** `content: "}"`, `content: "{"`, `'{}{}'`, SVG data URI with inline `<style>{…}</style>`, escaped quotes, block comments, truly unbalanced cases still rejected
- **Blocked patterns (4):** `expression(`, `@import`, `-moz-binding`, `behavior:` regression

## Context

This is the only remaining codex-blocking finding between PR #1481 and Jake's merge click for 3.0.0. After this lands on dev, dev→staging promotion refreshes PR #1481, codex re-runs, and (expected) PASS unlocks the final merge.