### PR TITLE
promote: dev → staging (codex sanitizeCss fix)

### DIFF
--- a/.changeset/fix-sanitize-css-url-bypass.md
+++ b/.changeset/fix-sanitize-css-url-bypass.md
@@ -1,0 +1,5 @@
+---
+'@helixui/library': patch
+---
+
+Harden `sanitizeCss` against protocol-relative URL bypass and quoted-string brace-count false-positives (codex-adversarial final-pass finding).

--- a/packages/hx-library/src/utilities/__tests__/sanitizeCss.test.ts
+++ b/packages/hx-library/src/utilities/__tests__/sanitizeCss.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeCss } from '../sanitizeCss.js';
+
+const COMPONENT = 'test-sanitize';
+
+describe('sanitizeCss — url() scheme enforcement', () => {
+  it('accepts relative paths', () => {
+    expect(sanitizeCss('.a { background: url(./img.png); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts data: URIs', () => {
+    expect(sanitizeCss('.a { background: url(data:image/png;base64,aGk=); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts blob: URIs', () => {
+    expect(sanitizeCss('.a { background: url(blob:https://host/abc); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts fragment references (#symbol)', () => {
+    expect(sanitizeCss('.a { clip-path: url(#my-clip); }', COMPONENT)).not.toBeNull();
+  });
+
+  it('rejects explicit http:// URLs', () => {
+    expect(sanitizeCss('.a { background: url(http://evil.example/x.png); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects explicit https:// URLs', () => {
+    expect(sanitizeCss('.a { background: url(https://evil.example/x.png); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs (//host/path)', () => {
+    expect(sanitizeCss('.a { background: url(//evil.example/x.png); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs with surrounding whitespace', () => {
+    expect(sanitizeCss('.a { background: url("  //evil.example/x  "); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs with leading tab', () => {
+    expect(sanitizeCss(".a { background: url('\t//evil.example/x'); }", COMPONENT)).toBeNull();
+  });
+
+  it('rejects ftp:// URLs', () => {
+    expect(sanitizeCss('.a { background: url(ftp://evil.example/x); }', COMPONENT)).toBeNull();
+  });
+});
+
+describe('sanitizeCss — brace balance with strings and comments', () => {
+  it('accepts double-quoted content with closing brace', () => {
+    expect(sanitizeCss('.a::before { content: "}"; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts double-quoted content with opening brace', () => {
+    expect(sanitizeCss('.a::before { content: "{"; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts single-quoted content with both braces', () => {
+    expect(sanitizeCss(".a::before { content: '{}{}'; }", COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts SVG data URI with braces inside string', () => {
+    const svg =
+      '.a { background: url("data:image/svg+xml,<svg xmlns=\\"http://www.w3.org/2000/svg\\"><style>g{fill:red}</style></svg>"); }';
+    expect(sanitizeCss(svg, COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts escaped quotes within a quoted string', () => {
+    expect(sanitizeCss('.a::before { content: "\\"}\\""; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('accepts block comments that contain braces', () => {
+    expect(sanitizeCss('/* { brace in comment } */ .a { color: red; }', COMPONENT)).not.toBeNull();
+  });
+
+  it('still rejects an unbalanced closing brace outside strings', () => {
+    expect(sanitizeCss('.a { color: red; } }', COMPONENT)).toBeNull();
+  });
+
+  it('still rejects a stray opening brace outside strings', () => {
+    expect(sanitizeCss('.a { color: red;', COMPONENT)).toBeNull();
+  });
+
+  it('still rejects unbalanced close appearing before an open outside strings', () => {
+    expect(sanitizeCss('} .a { color: red; }', COMPONENT)).toBeNull();
+  });
+});
+
+describe('sanitizeCss — blocked patterns still enforced', () => {
+  it('rejects expression(', () => {
+    expect(sanitizeCss('.a { width: expression(alert(1)); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects @import', () => {
+    expect(sanitizeCss('@import url("x.css"); .a { color: red; }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects -moz-binding', () => {
+    expect(sanitizeCss('.a { -moz-binding: url(x.xml); }', COMPONENT)).toBeNull();
+  });
+
+  it('rejects behavior:', () => {
+    expect(sanitizeCss('.a { behavior: url(x.htc); }', COMPONENT)).toBeNull();
+  });
+});

--- a/packages/hx-library/src/utilities/sanitizeCss.ts
+++ b/packages/hx-library/src/utilities/sanitizeCss.ts
@@ -48,6 +48,11 @@ function isUrlSafe(urlValue: string): boolean {
   // Empty url() is harmless
   if (trimmed === '') return true;
 
+  // Protocol-relative URLs (//host/path) resolve against the page's current
+  // protocol and load from an external host — same risk as explicit http://.
+  // Must reject before the allow-prefix / scheme checks, since they have no colon.
+  if (trimmed.startsWith('//')) return false;
+
   // Allow explicitly safe prefixes
   for (const prefix of ALLOWED_URL_PREFIXES) {
     if (trimmed.startsWith(prefix)) return true;
@@ -65,12 +70,50 @@ function isUrlSafe(urlValue: string): boolean {
 /**
  * Checks whether braces in the CSS string are balanced.
  * Unbalanced braces can be used to escape scoped selectors and inject global
- * styles into the document.
+ * styles into the document. Braces inside strings (`"..."`, `'...'`) and block
+ * comments are ignored so legitimate content like `content: "}"` or SVG data
+ * URIs (`url("data:image/svg+xml,<svg>{...}</svg>")`) does not trigger a false
+ * rejection.
  */
 function areBracesBalanced(css: string): boolean {
   let depth = 0;
+  let quote: '"' | "'" | null = null;
+  let inComment = false;
+
   for (let i = 0; i < css.length; i++) {
     const ch = css[i];
+
+    if (inComment) {
+      if (ch === '*' && css[i + 1] === '/') {
+        inComment = false;
+        i++;
+      }
+      continue;
+    }
+
+    if (quote !== null) {
+      if (ch === '\\') {
+        // Skip the escaped character (including an escaped quote).
+        i++;
+        continue;
+      }
+      if (ch === quote) {
+        quote = null;
+      }
+      continue;
+    }
+
+    if (ch === '/' && css[i + 1] === '*') {
+      inComment = true;
+      i++;
+      continue;
+    }
+
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+
     if (ch === '{') {
       depth++;
     } else if (ch === '}') {


### PR DESCRIPTION
## Summary

Promotes codex-adversarial final-pass remediation from dev to staging, refreshing PR #1481 for the final codex re-run.

## Included

- #1488 — `sanitizeCss.ts` protocol-relative URL bypass + brace-scanner string/comment state (+ 23 regression tests, all passing)

## Gates

- CodeRabbit passed on #1488
- All CI required checks green on #1488 at merge time
- Auto-merge used for dev merge

## Next

1. Auto-merge this PR on green
2. PR #1481 (staging → main) refreshes
3. Re-run codex-adversarial on refreshed diff — expected PASS
4. Publish FINAL-codex-adversarial.md
5. Jake clicks merge on #1481