### PR TITLE
promote: dev → staging (rea 0.4.0 → 0.6.2 upgrade)

### DIFF
--- a/.changeset/chore-rea-0.6.1-upgrade.md
+++ b/.changeset/chore-rea-0.6.1-upgrade.md
@@ -2,14 +2,13 @@
 '@helixui/library': patch
 ---
 
-chore(rea): bump @bookedsolid/rea devDependency 0.4.0 → 0.6.1
+chore(rea): bump @bookedsolid/rea devDependency 0.4.0 → 0.6.2
 
-0.5.0 shipped the native git pre-push adapter (BUG-008 upstream fix) that consumes `<local-ref> <local-sha> <remote-ref> <remote-sha>` on stdin. Our local `.claude/hooks/push-review-gate.sh` still expects JSON stdin, so the consumer-side jq wrapper in `.husky/pre-push` is load-bearing until a follow-up PR runs `rea upgrade` to replace the hook with the 0.6.x packaged adapter.
+Rolls up the 0.5.0 / 0.6.0 / 0.6.1 / 0.6.2 upgrade chain. Highlights:
 
-0.6.0 added the `__rea__health` meta-tool (gateway self-diagnostic callable during HALT) and `rea doctor` non-git escape hatch via `isGitRepo(baseDir)` supporting directory / gitlink file / symlink shapes.
-
-**Known issue carried forward to 0.6.1:** BUG-011 (`__rea__health` redact/injection middleware bypass — `halt_reason` and downstream `last_error` serialized raw) is **still present** in 0.6.1. Codex adversarial verification confirmed the 0.6.1 `dist/` tree is byte-identical to 0.6.0; the upstream fix did not reach the published tarball. See `Projects/rea/Bug Reports/Rea Bug Reports.md` (bst vault) for the full evidence trail. HELiX does not currently expose `__rea__health` to untrusted callers, so consumer-side impact is limited to operator disclosure via CLI; upgrade proceeds on that basis.
-
-0.6.1 also introduces MEDIUM-severity BUG-012 (cross-repo hook guard trusts `CLAUDE_PROJECT_DIR` as authorization input). Not material to HELiX consumers — rea is a devDependency here, not a commit/push target — but logged for upstream resolution.
+- **0.5.0** shipped the native git pre-push adapter (BUG-008 upstream fix). Our local `.claude/hooks/push-review-gate.sh` still expects Claude-style JSON stdin, so the consumer-side jq wrapper in `.husky/pre-push` remains load-bearing until a follow-up `rea upgrade` run replaces the hook with the 0.6.x packaged adapter.
+- **0.6.0** added the `__rea__health` meta-tool (gateway self-diagnostic callable under HALT) and the `rea doctor` non-git escape hatch via `isGitRepo(baseDir)` for directory / gitlink file / symlink shapes.
+- **0.6.1** introduced a cross-repo hook guard in `commit-review-gate.sh` + `push-review-gate.sh`. Did **not** ship the claimed BUG-011 fix — `dist/` was byte-identical to 0.6.0 (see `Projects/rea/Bug Reports/Rea Bug Reports.md` in bst vault for evidence trail).
+- **0.6.2** actually ships the BUG-011 fix: `sanitizeHealthSnapshot` wired into the `__rea__health` short-circuit path. Default behavior strips `halt_reason` + `last_error` from the MCP response entirely. Explicit opt-in via new `gateway.health.expose_diagnostics: true` policy knob runs the diagnostic strings through redact + injection-scan with a 4096-char truncation cap (bounds adversary-controlled input before pattern matching). UTF-16 surrogate-pair handling prevents silent U+FFFD replacement on truncation. Policy schema is strict-mode (typos like `gateway.heath` fail loudly). Upstream cites their own Codex review trail (C-11.1 through N-3) in the source comments.
 
 Dev dependency only — no component source touched, no public API surface changes, no CEM regeneration needed.

--- a/.changeset/chore-rea-0.6.1-upgrade.md
+++ b/.changeset/chore-rea-0.6.1-upgrade.md
@@ -8,6 +8,8 @@ chore(rea): bump @bookedsolid/rea devDependency 0.4.0 → 0.6.1
 
 0.6.0 added the `__rea__health` meta-tool (gateway self-diagnostic callable during HALT) and `rea doctor` non-git escape hatch via `isGitRepo(baseDir)` supporting directory / gitlink file / symlink shapes.
 
-0.6.1 patches the HIGH-severity `__rea__health` redact/injection middleware bypass identified by Codex adversarial review on the 0.6.0 PR (logged as BUG-011).
+**Known issue carried forward to 0.6.1:** BUG-011 (`__rea__health` redact/injection middleware bypass — `halt_reason` and downstream `last_error` serialized raw) is **still present** in 0.6.1. Codex adversarial verification confirmed the 0.6.1 `dist/` tree is byte-identical to 0.6.0; the upstream fix did not reach the published tarball. See `Projects/rea/Bug Reports/Rea Bug Reports.md` (bst vault) for the full evidence trail. HELiX does not currently expose `__rea__health` to untrusted callers, so consumer-side impact is limited to operator disclosure via CLI; upgrade proceeds on that basis.
+
+0.6.1 also introduces MEDIUM-severity BUG-012 (cross-repo hook guard trusts `CLAUDE_PROJECT_DIR` as authorization input). Not material to HELiX consumers — rea is a devDependency here, not a commit/push target — but logged for upstream resolution.
 
 Dev dependency only — no component source touched, no public API surface changes, no CEM regeneration needed.

--- a/.changeset/chore-rea-0.6.1-upgrade.md
+++ b/.changeset/chore-rea-0.6.1-upgrade.md
@@ -1,0 +1,13 @@
+---
+'@helixui/library': patch
+---
+
+chore(rea): bump @bookedsolid/rea devDependency 0.4.0 → 0.6.1
+
+0.5.0 shipped the native git pre-push adapter (BUG-008 upstream fix) that consumes `<local-ref> <local-sha> <remote-ref> <remote-sha>` on stdin. Our local `.claude/hooks/push-review-gate.sh` still expects JSON stdin, so the consumer-side jq wrapper in `.husky/pre-push` is load-bearing until a follow-up PR runs `rea upgrade` to replace the hook with the 0.6.x packaged adapter.
+
+0.6.0 added the `__rea__health` meta-tool (gateway self-diagnostic callable during HALT) and `rea doctor` non-git escape hatch via `isGitRepo(baseDir)` supporting directory / gitlink file / symlink shapes.
+
+0.6.1 patches the HIGH-severity `__rea__health` redact/injection middleware bypass identified by Codex adversarial review on the 0.6.0 PR (logged as BUG-011).
+
+Dev dependency only — no component source touched, no public API surface changes, no CEM regeneration needed.

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.4.0",
+    "@bookedsolid/rea": "^0.6.0",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.6.0",
+    "@bookedsolid/rea": "^0.6.1",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.6.1",
+    "@bookedsolid/rea": "^0.6.2",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.6.2
+        version: 0.6.2
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -671,8 +671,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.6.1':
-    resolution: {integrity: sha512-sX/bUbCcKbmUJPpY+JBqAmtoq0vIdWdUOKURnd9dJX5luFBY9JZMDWdA2M8U9S213YliHzEkdpOtI5NPouwS0g==}
+  '@bookedsolid/rea@0.6.2':
+    resolution: {integrity: sha512-MVgSAfcez9Lw03e/FPyFvwOOA/h0EG4PJRiAF7fdLkRI4teY9JPaCrir9oINUPtFQOaAVRM/tIwLLIGkCiAUVw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7057,7 +7057,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.6.1':
+  '@bookedsolid/rea@0.6.2':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -671,8 +671,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.4.0':
-    resolution: {integrity: sha512-9aeQ5FVEP8B2ga08mwz6BtbfBRsfZBmlus5SBrY4pIfFiJtB57e8Tk7CyIdHE0i4TJZdrofDqGgAI7+U+GkVxA==}
+  '@bookedsolid/rea@0.6.0':
+    resolution: {integrity: sha512-ut+LwaxEI+6R/VUMYOlb8P07Q6VdOBucQ6cn9bviZsEYpUI7iC8ncFP2gduz7/YJH7WEzCy2GeqWW3JGqjkcKA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7057,7 +7057,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.4.0':
+  '@bookedsolid/rea@0.6.0':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.6.0
-        version: 0.6.0
+        specifier: ^0.6.1
+        version: 0.6.1
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -671,8 +671,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.6.0':
-    resolution: {integrity: sha512-ut+LwaxEI+6R/VUMYOlb8P07Q6VdOBucQ6cn9bviZsEYpUI7iC8ncFP2gduz7/YJH7WEzCy2GeqWW3JGqjkcKA==}
+  '@bookedsolid/rea@0.6.1':
+    resolution: {integrity: sha512-sX/bUbCcKbmUJPpY+JBqAmtoq0vIdWdUOKURnd9dJX5luFBY9JZMDWdA2M8U9S213YliHzEkdpOtI5NPouwS0g==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7057,7 +7057,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.6.0':
+  '@bookedsolid/rea@0.6.1':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0


### PR DESCRIPTION
## Summary

Promotes `dev` → `staging` after landing the `@bookedsolid/rea` 0.4.0 → 0.6.2 upgrade chain (PR #1492, merged to dev at 2026-04-20T17:33:25Z).

Six commits from dev:
- `eea50e03` chore(rea): upgrade to @bookedsolid/rea 0.6.0
- `cc53a51d` chore(rea): bump @bookedsolid/rea 0.6.0 → 0.6.1
- `cf347da2` chore(changeset): add changeset for rea 0.6.1 devDep bump
- `c0fd78b2` fix(changeset): correct rea 0.6.1 fix claim — BUG-011 still open upstream
- `2b5f1214` chore(rea): bump @bookedsolid/rea 0.6.1 → 0.6.2 (actual BUG-011 fix)
- `4f060433` Merge pull request #1492

## What ships

- **0.5.0** — native git pre-push adapter (BUG-008 upstream fix). Consumer-side jq wrapper in `.husky/pre-push` remains load-bearing until a follow-up `rea upgrade` run replaces the local Claude-style hook.
- **0.6.0** — `__rea__health` meta-tool + `rea doctor` non-git escape hatch via `isGitRepo(baseDir)`.
- **0.6.1** — cross-repo hook guard in `commit-review-gate.sh` / `push-review-gate.sh`. Did **not** ship the claimed BUG-011 fix (dist/ byte-identical to 0.6.0 — evidence trail in bst vault `Projects/rea/Bug Reports/Rea Bug Reports.md`).
- **0.6.2** — actual BUG-011 fix: `sanitizeHealthSnapshot()` wired into the `__rea__health` short-circuit. Default strips `halt_reason` + `last_error` from the MCP response. Explicit opt-in via new `gateway.health.expose_diagnostics: true` policy knob runs diagnostic strings through redact + injection-scan with a 4096-char truncation cap (bounds adversary-controlled input before pattern matching). UTF-16 surrogate-pair handling prevents silent U+FFFD replacement on truncation. Strict-mode policy schema.

## Verification

- Independent byte-level diff: fresh `npm pack @bookedsolid/rea@0.6.2` + `diff -qr dist/` confirms BUG-011 fix in shipped artifact
- Registry integrity: `sha512-MVgSAfcez9Lw03e/FPyFvwOOA/h0EG4PJRiAF7fdLkRI4teY9JPaCrir9oINUPtFQOaAVRM/tIwLLIGkCiAUVw==`
- Codex adversarial review on PR #1492: **PASS** (1 LOW finding F-LOW-1 filed as BUG-014 for future upstream hardening; no HIGH/MEDIUM)
- All 5 pre-push gates green on each commit (Prettier, ESLint, tsc, test:smart, shellcheck)
- Quality Gates + CodeRabbit both SUCCESS on PR #1492

Dev dependency only — no component source touched, no public API surface changes, no CEM regeneration.

## Test plan

- [x] `pnpm install --frozen-lockfile` resolves (686 packages)
- [x] `pnpm run lint` — all tasks green
- [x] `pnpm run type-check` — all tasks green
- [x] `pnpm run test:smart` — no component changes, no tests impacted
- [x] Quality Gates CI passed on dev PR
- [x] CodeRabbit re-review acknowledged false-positive about package registry; stale CHANGES_REQUESTED dismissed post-verification
