### PR TITLE
hardening: audit #1 — publish pipeline (10 HIGH fixes, pre-3.0.0)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": [
+    "@helixui/mcp",
     "@helixui/mcp-cem-analyzer",
     "@helixui/mcp-health-scorer",
     "@helixui/mcp-typescript-diagnostics",

--- a/.changeset/fix-3.0.0-codex-blockers-pre-merge.md
+++ b/.changeset/fix-3.0.0-codex-blockers-pre-merge.md
@@ -1,6 +1,5 @@
 ---
 '@helixui/library': patch
-'@helixui/drupal-starter': patch
 ---
 
 fix(barrel): restore HelixAuditController, AuditEventDetail, AuditControllerOptions to public barrel via generate-barrel.js allowlist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,14 @@ jobs:
           echo "CEM matches committed manifest."
 
       - name: Build packages
-        run: pnpm turbo run build --filter='!docs'
+        run: |
+          pnpm turbo run build \
+            --filter=@helixui/library \
+            --filter=@helixui/tokens \
+            --filter=@helixui/react \
+            --filter=@helixui/drupal-behaviors \
+            --filter=@helixui/drupal-starter \
+            --filter=@helixui/mcp
 
       - name: Install gitleaks
         run: |
@@ -187,7 +194,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm turbo run build --filter='!docs'
+        run: |
+          pnpm turbo run build \
+            --filter=@helixui/library \
+            --filter=@helixui/tokens \
+            --filter=@helixui/react \
+            --filter=@helixui/drupal-behaviors \
+            --filter=@helixui/drupal-starter \
+            --filter=@helixui/mcp
 
       - name: Verify CEM matches committed manifest
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -259,4 +259,28 @@ jobs:
           git stash pop
           git add docs/releases/
           git commit -m 'chore(release): add release manifest [skip ci]'
-          git push "https://x-access-token:${CHANGESET_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+
+          # Bounded retry: if another merge lands on main between our fetch
+          # and push, rebase and retry up to 3 times. Any failure after that
+          # is fatal and requires operator intervention — npm publish has
+          # already succeeded, so the manifest commit MUST land.
+          REMOTE="https://x-access-token:${CHANGESET_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          PUSH_OK=0
+          for attempt in 1 2 3; do
+            echo "Manifest push attempt $attempt/3..."
+            git fetch origin main
+            if git rebase origin/main; then
+              if git push "$REMOTE" HEAD:main; then
+                PUSH_OK=1
+                break
+              fi
+            else
+              git rebase --abort || true
+            fi
+            sleep 5
+          done
+
+          if [ "$PUSH_OK" -ne 1 ]; then
+            echo "::error::Failed to push release manifest after 3 attempts. npm publish already succeeded — manifest must be committed manually."
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,21 @@ jobs:
           SCAN_DIR="$(mktemp -d)"
           FAIL=0
 
-          for pkg_dir in packages/hx-library packages/hx-tokens packages/hx-react; do
+          # Derive the list of publishable packages from the workspace rather
+          # than hardcoding it — any package with "private": true is skipped,
+          # anything else is treated as publishable and scanned.
+          PKG_DIRS=$(node -e "
+            const fs=require('fs'),path=require('path');
+            for (const d of fs.readdirSync('packages')) {
+              const p=path.join('packages',d,'package.json');
+              if (!fs.existsSync(p)) continue;
+              const pkg=JSON.parse(fs.readFileSync(p,'utf8'));
+              if (pkg.private) continue;
+              console.log(path.join('packages',d));
+            }
+          ")
+
+          for pkg_dir in $PKG_DIRS; do
             if [ ! -f "$pkg_dir/package.json" ]; then
               echo "Skipping $pkg_dir — no package.json"
               continue

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,7 +110,7 @@ jobs:
 
             PKG_PACK_DIR="$SCAN_DIR/pack-$(basename "$pkg_dir")"
             mkdir -p "$PKG_PACK_DIR"
-            if ! PACK_OUTPUT=$(cd "$pkg_dir" && pnpm pack --pack-destination "$PKG_PACK_DIR" 2>&1); then
+            if ! PACK_OUTPUT=$(cd "$pkg_dir" && npm pack --pack-destination "$PKG_PACK_DIR" 2>&1); then
               echo "::error::Failed to produce tarball for $PKG_NAME"
               echo "$PACK_OUTPUT"
               FAIL=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
     tags:
       - '@helixui/library@*'
       - '@helixui/tokens@*'
+      - '@helixui/react@*'
+      - '@helixui/drupal-behaviors@*'
+      - '@helixui/drupal-starter@*'
+      - '@helixui/mcp@*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,10 +43,9 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Only run for library releases (primary publishable package)
-    if: startsWith(github.ref_name, '@helixui/library@')
     outputs:
       version: ${{ steps.extract.outputs.version }}
+      pkg_name: ${{ steps.extract.outputs.pkg_name }}
       release_url: ${{ steps.create-release.outputs.html_url }}
       changelog_body: ${{ steps.changelog.outputs.body }}
 
@@ -51,14 +54,35 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from tag
+      # ── Resolve package name, version, and workspace dir from the tag ────
+      # Tag format: @helixui/<name>@<version>. Folder names do not match the
+      # npm name (e.g. @helixui/library lives at packages/hx-library), so a
+      # case statement maps each package to its workspace directory.
+      - name: Extract version and package from tag
         id: extract
         run: |
           TAG="${{ github.ref_name }}"
-          VERSION="${TAG#@helixui/library@}"
+          PKG_NAME="${TAG%@*}"       # e.g. @helixui/library
+          VERSION="${TAG##*@}"       # e.g. 3.0.0
+
+          case "$PKG_NAME" in
+            @helixui/library)          PKG_DIR=packages/hx-library ;;
+            @helixui/tokens)           PKG_DIR=packages/hx-tokens ;;
+            @helixui/react)            PKG_DIR=packages/hx-react ;;
+            @helixui/drupal-behaviors) PKG_DIR=packages/drupal-behaviors ;;
+            @helixui/drupal-starter)   PKG_DIR=packages/drupal-starter ;;
+            @helixui/mcp)              PKG_DIR=packages/helixui-mcp ;;
+            *)
+              echo "::error::Unknown package $PKG_NAME for tag $TAG"
+              exit 1
+              ;;
+          esac
+
+          echo "pkg_name=$PKG_NAME" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Releasing version: $VERSION"
+          echo "pkg_dir=$PKG_DIR" >> "$GITHUB_OUTPUT"
+          echo "Releasing $PKG_NAME version $VERSION from $PKG_DIR"
 
       - uses: pnpm/action-setup@v4
 
@@ -70,14 +94,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # ── Build library + CDN artifacts ────────────────────────────────────
-      - name: Build library
-        run: pnpm turbo run build --filter=@helixui/library
+      # ── Build the package that is being released ─────────────────────────
+      - name: Build package
+        run: pnpm turbo run build --filter=${{ steps.extract.outputs.pkg_name }}
 
+      # ── Build CDN artifacts (library-only) ───────────────────────────────
+      # CDN bundles are specific to @helixui/library; skip cleanly for any
+      # other published package tag.
       - name: Build CDN artifacts
+        if: steps.extract.outputs.pkg_name == '@helixui/library'
         run: pnpm --filter=@helixui/library run build:cdn
 
       - name: Package CDN tarball
+        if: steps.extract.outputs.pkg_name == '@helixui/library'
         run: |
           VERSION="${{ steps.extract.outputs.version }}"
           TARBALL="helix-cdn-${VERSION}.tar.gz"
@@ -91,7 +120,9 @@ jobs:
         id: changelog
         run: |
           VERSION="${{ steps.extract.outputs.version }}"
-          CHANGELOG="packages/hx-library/CHANGELOG.md"
+          PKG_NAME="${{ steps.extract.outputs.pkg_name }}"
+          PKG_DIR="${{ steps.extract.outputs.pkg_dir }}"
+          CHANGELOG="${PKG_DIR}/CHANGELOG.md"
 
           if [ ! -f "$CHANGELOG" ]; then
             echo "body=No changelog found." >> "$GITHUB_OUTPUT"
@@ -110,16 +141,19 @@ jobs:
           ' "$CHANGELOG" | sed '/^[[:space:]]*$/d' | head -200)
 
           if [ -z "$BODY" ]; then
-            BODY="See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/packages/hx-library/CHANGELOG.md) for full details."
+            BODY="See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/${PKG_DIR}/CHANGELOG.md) for full details."
           fi
 
           # Write to a file to avoid quoting issues with multiline content
           echo "$BODY" > /tmp/changelog-body.md
           echo "Changelog entry extracted ($(wc -l < /tmp/changelog-body.md) lines)"
 
-      # ── CEM diff between this version and the previous tag ───────────────
+      # ── CEM diff between this version and the previous library tag ───────
+      # CEM diffs are library-specific (only @helixui/library ships a CEM).
+      # Skip cleanly for any other released package.
       - name: Generate CEM diff for release notes
         id: cem-diff
+        if: steps.extract.outputs.pkg_name == '@helixui/library'
         run: |
           VERSION="${{ steps.extract.outputs.version }}"
 
@@ -141,38 +175,57 @@ jobs:
           pnpm --filter=@helixui/library run cem
           cp packages/hx-library/custom-elements.json /tmp/cem-head.json
 
-          # Check out previous tag source and generate base CEM
-          git checkout "$PREV_TAG" -- packages/hx-library/src/ 2>/dev/null || true
-          pnpm --filter=@helixui/library run cem || true
-          cp packages/hx-library/custom-elements.json /tmp/cem-base.json
-
-          # Restore head source
-          git checkout HEAD -- packages/hx-library/src/ 2>/dev/null || true
-
-          # Run diff
-          node scripts/cem-diff.js \
-            --base /tmp/cem-base.json \
-            --head /tmp/cem-head.json \
-            --output /tmp/cem-diff-raw.md || true
-
-          # Wrap in a release notes section
-          if [ -f /tmp/cem-diff-raw.md ]; then
-            echo "" > /tmp/cem-diff-section.md
-            echo "---" >> /tmp/cem-diff-section.md
-            echo "" >> /tmp/cem-diff-section.md
-            cat /tmp/cem-diff-raw.md >> /tmp/cem-diff-section.md
+          # Check out previous tag source and generate base CEM. Each step has
+          # explicit error handling: surface the failure, leave a placeholder
+          # in the release notes, but do not silently swallow the error.
+          if ! git checkout "$PREV_TAG" -- packages/hx-library/src/; then
+            echo "::warning::Unable to check out $PREV_TAG source — CEM diff unavailable"
+            echo "CEM diff unavailable (base checkout failed)." > /tmp/cem-diff-section.md
           else
-            echo "CEM diff unavailable." > /tmp/cem-diff-section.md
+            if ! pnpm --filter=@helixui/library run cem; then
+              echo "::error::CEM regeneration failed on base tag $PREV_TAG"
+              exit 1
+            fi
+            cp packages/hx-library/custom-elements.json /tmp/cem-base.json
+
+            # Restore head source unconditionally and verify the tree is clean.
+            git checkout HEAD -- packages/hx-library/src/
+            if ! git diff --quiet -- packages/hx-library/src/; then
+              echo "::error::Source tree dirty after restore of packages/hx-library/src/"
+              exit 1
+            fi
+
+            if ! node scripts/cem-diff.js \
+              --base /tmp/cem-base.json \
+              --head /tmp/cem-head.json \
+              --output /tmp/cem-diff-raw.md; then
+              echo "::warning::CEM diff script failed"
+              echo "CEM diff unavailable (diff script failed)." > /tmp/cem-diff-section.md
+            else
+              {
+                echo ""
+                echo "---"
+                echo ""
+                cat /tmp/cem-diff-raw.md
+              } > /tmp/cem-diff-section.md
+            fi
           fi
+
+      # ── Non-library releases: no CEM diff section ────────────────────────
+      - name: Skip CEM diff for non-library release
+        if: steps.extract.outputs.pkg_name != '@helixui/library'
+        run: |
+          echo "" > /tmp/cem-diff-section.md
 
       # ── Assemble full release body ────────────────────────────────────────
       - name: Assemble release body
         id: assemble
         run: |
           VERSION="${{ steps.extract.outputs.version }}"
+          PKG_NAME="${{ steps.extract.outputs.pkg_name }}"
 
           {
-            echo "## @helixui/library v${VERSION}"
+            echo "## ${PKG_NAME} v${VERSION}"
             echo ""
             cat /tmp/changelog-body.md
             echo ""
@@ -183,15 +236,21 @@ jobs:
             echo "**Install**"
             echo ""
             echo '```sh'
-            echo "npm install @helixui/library@${VERSION}"
-            echo '```'
-            echo ""
-            echo "**CDN**"
-            echo ""
-            echo '```html'
-            echo "<script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/@helixui/library@${VERSION}/dist/index.js\"></script>"
+            echo "npm install ${PKG_NAME}@${VERSION}"
             echo '```'
           } > /tmp/release-body.md
+
+          # CDN block is library-specific.
+          if [ "$PKG_NAME" = "@helixui/library" ]; then
+            {
+              echo ""
+              echo "**CDN**"
+              echo ""
+              echo '```html'
+              echo "<script type=\"module\" src=\"https://cdn.jsdelivr.net/npm/@helixui/library@${VERSION}/dist/index.js\"></script>"
+              echo '```'
+            } >> /tmp/release-body.md
+          fi
 
           echo "Release body assembled ($(wc -l < /tmp/release-body.md) lines)"
 
@@ -202,14 +261,23 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           VERSION="${{ steps.extract.outputs.version }}"
+          PKG_NAME="${{ steps.extract.outputs.pkg_name }}"
           TAG="${{ steps.extract.outputs.tag }}"
 
-          gh release create "$TAG" \
-            --repo "${{ github.repository }}" \
-            --title "@helixui/library v${VERSION}" \
-            --notes-file /tmp/release-body.md \
-            --latest \
-            "${{ env.tarball }}#${{ env.tarball_name }}"
+          # CDN tarball asset is library-only.
+          if [ "$PKG_NAME" = "@helixui/library" ] && [ -n "${tarball:-}" ]; then
+            gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --title "${PKG_NAME} v${VERSION}" \
+              --notes-file /tmp/release-body.md \
+              --latest \
+              "${tarball}#${tarball_name}"
+          else
+            gh release create "$TAG" \
+              --repo "${{ github.repository }}" \
+              --title "${PKG_NAME} v${VERSION}" \
+              --notes-file /tmp/release-body.md
+          fi
 
           RELEASE_URL=$(gh release view "$TAG" \
             --repo "${{ github.repository }}" \
@@ -232,11 +300,12 @@ jobs:
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
           RELEASE_CHANNEL_ID: '1478227528412958810'
+          PKG_NAME: ${{ needs.github-release.outputs.pkg_name }}
           VERSION: ${{ needs.github-release.outputs.version }}
           RELEASE_URL: ${{ needs.github-release.outputs.release_url }}
         run: |
-          MESSAGE="**@helixui/library v${VERSION} released**\n\n"
-          MESSAGE+="Install: \`npm install @helixui/library@${VERSION}\`\n"
+          MESSAGE="**${PKG_NAME} v${VERSION} released**\n\n"
+          MESSAGE+="Install: \`npm install ${PKG_NAME}@${VERSION}\`\n"
           MESSAGE+="Release notes: ${RELEASE_URL}"
 
           curl -s -X POST \

--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -96,6 +96,9 @@
     "directory": "packages/hx-library"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://helix.bookedsolid.tech",
   "bugs": "https://github.com/bookedsolidtech/helix/issues",
   "keywords": [

--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -37,7 +37,21 @@
     "./dist/css/index.css": "./dist/css/index.css"
   },
   "files": [
-    "dist",
+    "dist/index.js",
+    "dist/index.js.map",
+    "dist/index.d.ts",
+    "dist/index.d.ts.map",
+    "dist/form-test-utils.d.ts",
+    "dist/form-test-utils.d.ts.map",
+    "dist/base/**",
+    "dist/components/**",
+    "dist/controllers/**",
+    "dist/css/**",
+    "dist/mixins/**",
+    "dist/shared/**",
+    "dist/styles/**",
+    "dist/utilities/**",
+    "dist/utils/**",
     "custom-elements.json",
     "fouc.css"
   ],

--- a/packages/hx-tokens/package.json
+++ b/packages/hx-tokens/package.json
@@ -49,6 +49,9 @@
     "directory": "packages/hx-tokens"
   },
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://helix.bookedsolid.tech",
   "bugs": "https://github.com/bookedsolidtech/helix/issues",
   "keywords": [


### PR DESCRIPTION
## Summary

Remediation for **Audit #1 — Publish Pipeline** (Codex adversarial review, verdict BLOCK, 10 HIGH findings).

This PR is part of the pre-3.0.0 systemic audit cycle. Each audit → adversarial review → fix → merge → next audit. Sequential, no overlap.

## Findings fixed (9 commits)

| Finding | Description | Commit |
|---|---|---|
| H-1 | Remove stray `@helixui/drupal-starter: patch` from `fix-3.0.0-codex-blockers-pre-merge` changeset (silent out-of-narrative bump) | `dfd347ade` |
| H-8 | Add `@helixui/mcp` to `.changeset/config.json` `ignore` list | `6701fc070` |
| H-4 | Narrow `packages/hx-library` `files` field to exclude `dist/tools/` internal CEM tooling (1058 → 1038 files in tarball) | `43c0fd689` |
| H-9 | Add `publishConfig: {access: public}` to `@helixui/library` and `@helixui/tokens` for consistency | `93d17245c` |
| H-3, H-5 | `release.yml` now triggers on all publishable tags (react, drupal-*, mcp) with parameterized `PKG_NAME` / `PKG_DIR`; CEM-diff step replaces 3× `\|\| true` silent-failure guards with explicit error branches | `e0976211d` |
| H-2 | `secret-scan` derives package list from runtime `private:false` detection (was hard-coded to 3 packages; now covers drupal-behaviors, drupal-starter, mcp) | `8f025fd5d` |
| H-6 | `secret-scan` uses `npm pack` (matches what `changesets/action` → `npm publish` produces) | `1ec4905f6` |
| H-7 | Release-manifest push wrapped in 3-attempt rebase-and-retry loop with explicit error on exhaustion | `a59a24c2a` |
| H-10 | Narrow `turbo run build` filter in publish workflow to the 6 publishable packages (was `--filter='!docs'` which built admin + storybook) | `5f936d555` |

## Deliberately not touched

- **M-9** (`packages/hx-react` `prebuild`/`generate`) — pending Jake's decision (generator is flagged as file-corrupting in CLAUDE.md; fix path requires choosing between fixing the generator vs committing generated sources)
- **H-4 sourcemap emission** — tarball size reduction via `build.sourcemap: hidden` needs library engineer coordination; scoped for follow-up
- **H-8 `helixui-mcp` postinstall script removal** — supply-chain anti-pattern flagged; out of scope for pipeline hardening PR

## Verification

- `pnpm run lint` — pass
- `pnpm run format:check` — pass
- `pnpm run type-check` — pass
- `pnpm run build --filter=<6 publishable packages>` — pass
- `pnpm exec -C packages/hx-library npm pack --dry-run` — 1038 files, no `dist/tools/` paths
- YAML syntax of both workflows validated via `js-yaml.load()`

**`pnpm run verify` fails ONLY on the pre-existing `docs#build` slug regression** (tracked separately as pending work; NOT introduced by this PR — reproduces on pre-change tree).

## Audit follow-ups (next in queue)

- Audit #2 — Changeset aggregation (verify 3.0.0 queue is semver-coherent)
- Audit #3 — Breaking-change manifest + migration guide completeness
- Audit #4 — Coverage gate gap
- Audit #5 — `dependency-audit-gate.sh` parser bug
- Audit #6 — Storybook Tests flake tolerance
- Audit #7 — `pnpm install` hx-react corruption

## Test plan

- [x] Quality Gates CI (lint/format/type-check/build/tests)
- [x] CodeRabbit review
- [ ] Merge to `dev`, then promote `dev → staging` before cutting 3.0.0
