### PR TITLE
fix(ci): audit batch A — CI infrastructure hardening (4 findings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -833,8 +833,18 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - name: Security audit
-        run: pnpm audit --audit-level=critical 2>&1 || echo "::warning::pnpm audit failed (npm audit endpoint may be unavailable)"
-        continue-on-error: true
+        run: |
+          AUDIT_OUTPUT=$(pnpm audit --audit-level=critical 2>&1)
+          AUDIT_EXIT=$?
+          echo "$AUDIT_OUTPUT"
+          if [ $AUDIT_EXIT -ne 0 ]; then
+            if echo "$AUDIT_OUTPUT" | grep -qE "ECONNRESET|ECONNREFUSED|ETIMEDOUT|ENOTFOUND|network error|code ELIFECYCLE"; then
+              echo "::warning::pnpm audit registry endpoint unavailable — skipping vulnerability check"
+            else
+              echo "::error::Critical vulnerabilities found — see audit output above"
+              exit 1
+            fi
+          fi
 
   # ── Storybook Interaction Tests ─────────────────────────────────────────
   # Runs all 83 component story play functions as Vitest browser mode tests.

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -196,7 +196,7 @@ function main() {
 
   if (components.size === 0) {
     console.warn('No component coverage data found — did tests run with --coverage.enabled?');
-    process.exit(0);
+    process.exit(1);
   }
 
   const passing = [];

--- a/scripts/hooks/dependency-audit.ts
+++ b/scripts/hooks/dependency-audit.ts
@@ -25,7 +25,7 @@
  * - Peer dependency check limited to local workspace packages
  *
  * Performance Optimizations:
- * - npm audit results cached for 5 minutes (per package-lock.json hash)
+ * - npm audit results cached for 5 minutes (per pnpm-lock.yaml hash)
  * - Duplicate detection runs once per hook invocation (not per file)
  * - Bail-fast mode exits on first critical violation
  *
@@ -277,10 +277,10 @@ function parsePackageJson(filePath: string): PackageJson | null {
 }
 
 /**
- * Calculate hash of package-lock.json for cache invalidation
+ * Calculate hash of pnpm-lock.yaml for cache invalidation
  */
 function getPackageLockHash(projectRoot: string): string {
-  const lockFilePath = join(projectRoot, 'package-lock.json');
+  const lockFilePath = join(projectRoot, 'pnpm-lock.yaml');
   if (!existsSync(lockFilePath)) {
     return 'no-lock-file';
   }
@@ -397,7 +397,7 @@ function checkVulnerabilities(
 ): void {
   // Only run if dependencies or lock file changed
   const hasDependencyChanges = stagedFiles.some(
-    (file) => file.endsWith('package.json') || file.endsWith('package-lock.json'),
+    (file) => file.endsWith('package.json') || file.endsWith('pnpm-lock.yaml'),
   );
 
   if (!hasDependencyChanges) {

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,10 @@
       "dependsOn": ["^build"],
       "outputs": ["custom-elements.json"]
     },
+    "prebuild": {
+      "dependsOn": ["^cem"],
+      "outputs": []
+    },
     "generate": {
       "dependsOn": ["^cem"],
       "outputs": ["packages/hx-react/src/components/**"]


### PR DESCRIPTION
## Summary

CI infrastructure fixes from the 3.0.0 systemic audit (Audits #4, #5, #7). No component source changes — infra/tooling only.

- **A4-C1** `scripts/check-coverage.mjs` — `exit(0)` → `exit(1)` when no coverage data found. Silent gate bypass now fails loudly.
- **A5-C1** `.github/workflows/ci.yml` — security audit job: replaces `|| echo warning` + `continue-on-error: true` with a shell block that distinguishes network errors from real CVEs. Critical vulnerabilities now fail CI.
- **A5-M1** `scripts/hooks/dependency-audit.ts` — cache invalidation referenced `package-lock.json` (npm); project uses `pnpm-lock.yaml`. Three references corrected.
- **A7-H1** `turbo.json` — adds `prebuild` task with `dependsOn: ["^cem"]` so `hx-react` prebuild (react-wrapper generator) correctly waits for `hx-library` CEM artifact before running.

## Pre-existing failure

`docs#build` fails on `dev` with `[AstroUserError] The slug "migration/3.0.0" does not exist` — Starlight sidebar references a content file that has not been created yet. Pre-dates this branch; tracked separately.

## Test plan

- [ ] Quality Gates pass (lint, format, type-check — verified locally)
- [ ] `skip-changeset` label applied — infra-only changes, no package version bumps needed
- [ ] Confirm security-audit CI job no longer has `continue-on-error: true`
- [ ] Confirm `turbo.json` prebuild edge visible in `turbo run build --dry`