### PR TITLE
fix(storybook): reduce OOM crash in sequential story suite (Audit #6)

### DIFF
--- a/apps/storybook/.storybook/preview.ts
+++ b/apps/storybook/.storybook/preview.ts
@@ -12,6 +12,9 @@ setCustomElementsManifest(customElements);
 
 const preview: Preview = {
   parameters: {
+    beforeEach: async () => {
+      document.body.removeAttribute('style');
+    },
     controls: {
       expanded: true,
       sort: 'requiredFirst',

--- a/apps/storybook/.storybook/vitest.setup.ts
+++ b/apps/storybook/.storybook/vitest.setup.ts
@@ -1,3 +1,4 @@
+import { afterEach } from 'vitest';
 import { setProjectAnnotations } from '@storybook/web-components';
 import * as projectAnnotations from './preview';
 
@@ -5,3 +6,19 @@ import * as projectAnnotations from './preview';
 // Storybook's addon-vitest internal setup can call beforeAll on them correctly.
 // More info: https://storybook.js.org/docs/api/portable-stories/portable-stories-vitest#setprojectannotations
 setProjectAnnotations([projectAnnotations]);
+
+afterEach(() => {
+  // Clear story content without removing the persistent mount container.
+  // Storybook reuses #storybook-root between stories — removing the element
+  // causes rendering failures on subsequent stories.
+  const storybookRoot = document.getElementById('storybook-root');
+  if (storybookRoot) {
+    storybookRoot.replaceChildren();
+  }
+  // Remove orphaned test elements added outside the storybook root.
+  document
+    .querySelectorAll('[data-testid]')
+    .forEach((el) => {
+      if (!el.closest('#storybook-root')) el.remove();
+    });
+});

--- a/apps/storybook/.storybook/vitest.setup.ts
+++ b/apps/storybook/.storybook/vitest.setup.ts
@@ -16,9 +16,7 @@ afterEach(() => {
     storybookRoot.replaceChildren();
   }
   // Remove orphaned test elements added outside the storybook root.
-  document
-    .querySelectorAll('[data-testid]')
-    .forEach((el) => {
-      if (!el.closest('#storybook-root')) el.remove();
-    });
+  document.querySelectorAll('[data-testid]').forEach((el) => {
+    if (!el.closest('#storybook-root')) el.remove();
+  });
 });

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -9,7 +9,7 @@
     "build": "storybook build -o dist",
     "build-storybook": "storybook build -o dist",
     "clean": "rm -rf dist",
-    "test": "vitest run"
+    "test": "NODE_OPTIONS='--max-old-space-size=3072' vitest run"
   },
   "dependencies": {
     "@helixui/library": "workspace:*",


### PR DESCRIPTION
## Summary

Addresses the Storybook test suite OOM crash at file ~70 of 84 (deterministic, not a flake — Audit #6 finding).

- **vitest.setup.ts** — `afterEach` clears `#storybook-root` children via `replaceChildren()` instead of removing the container. Storybook reuses `#storybook-root` as a persistent mount point between story files — previous implementation removed the element entirely causing rendering failures on all subsequent stories.
- **preview.ts** — `parameters.beforeEach` strips `document.body` inline styles between stories. Removed `body.className = ''` — the theme decorator (`withThemeByDataAttribute`) targets `<html>`, not `<body>`.
- **package.json** — `NODE_OPTIONS='--max-old-space-size=3072'` raises Node's default heap (~1.5 GB) to 3 GB. Set to 3072 (not 4096) to preserve headroom for Chromium on the 7 GB GitHub Actions runner.

## Codex adversarial review

Run pre-push. Two BLOCKs remediated:
- `[id^="storybook-"]` selector matched and removed `#storybook-root` — fixed with `replaceChildren()`
- `document.body.className = ''` targeted wrong element — removed

Two CONCERNs noted but deferred:
- Root cause not heap-snapshot verified — the fix is the least-invasive approach; full GC tracing can be done if this doesn't resolve the crash
- NODE_OPTIONS single-quote syntax is Linux/macOS only — acceptable since CI is ubuntu-latest only

## Test plan

- [ ] Quality Gates pass (lint, type-check)
- [ ] `skip-changeset` label applied — no public API or package version changes
- [ ] Storybook test suite runs to completion without "Browser connection was closed" on CI