### PR TITLE
fix(ci): move act-ci.yml test-full gate from job-level to step-level

### DIFF
--- a/.changeset/fix-act-ci-env-job-level-context.md
+++ b/.changeset/fix-act-ci-env-job-level-context.md
@@ -1,0 +1,9 @@
+---
+'@helixui/library': patch
+---
+
+Fix `.github/workflows/act-ci.yml` failing GitHub's workflow validator on every push. The `test-full` job used `env.*` in its job-level `if:`, which is not in the allowed context set (`github`, `inputs`, `needs`, `vars`) per the Actions schema. GitHub rejected the file at preflight validation — creating a "workflow file issue" failure run on every push to every branch since 2026-04-12, visible in Actions UI but not blocking any required check.
+
+Moved the gate to step-level (where `env.*` IS allowed). A new first step (`Check full-test gate`) reads `ACT_MATRIX_TESTS` / `ACT_FULL_TESTS` and writes a `run` output; every subsequent step gates on `steps.gate.outputs.run == 'true'`. Matrix containers still start when the workflow is dispatched but exit cheaply when neither env var is set — identical semantic behavior to the previous job-level gate, just routed through a context GitHub accepts.
+
+`actionlint` now clean on this file. No consumer impact.

--- a/.github/workflows/act-ci.yml
+++ b/.github/workflows/act-ci.yml
@@ -111,18 +111,32 @@ jobs:
           fi
 
   # ── Full suite test with Node version matrix (mirrors ci-matrix.yml) ───
+  # Gated at step level (not job level) — env.* is not an allowed context
+  # in job-level `if:` per GitHub's schema. Every step checks the gate
+  # output from the first step; matrix containers still spin up but
+  # exit cheaply when neither ACT_MATRIX_TESTS nor ACT_FULL_TESTS is set.
   test-full:
     name: Test Full (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: ${{ env.ACT_MATRIX_TESTS == 'true' || env.ACT_FULL_TESTS == 'true' }}
     strategy:
       fail-fast: false
       matrix:
         node-version: [22, 24]
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node ${{ matrix.node-version }} via nvm
+      - name: Check full-test gate
+        id: gate
+        run: |
+          if [ "${ACT_MATRIX_TESTS}" = "true" ] || [ "${ACT_FULL_TESTS}" = "true" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "test-full: skipped (ACT_MATRIX_TESTS/ACT_FULL_TESTS not set)"
+          fi
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v4
+      - if: steps.gate.outputs.run == 'true'
+        name: Setup Node ${{ matrix.node-version }} via nvm
         run: |
           if [ "${{ matrix.node-version }}" != "" ]; then
             export NVM_DIR="$HOME/.nvm"
@@ -134,16 +148,20 @@ jobs:
             nvm use ${{ matrix.node-version }}
             echo "Node version: $(node --version)"
           fi
-      - name: Setup pnpm
+      - if: steps.gate.outputs.run == 'true'
+        name: Setup pnpm
         run: |
           corepack enable
           corepack prepare pnpm@9.15.9 --activate
           pnpm install --frozen-lockfile
-      - name: Install Playwright browsers
+      - if: steps.gate.outputs.run == 'true'
+        name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
-      - name: Build library
+      - if: steps.gate.outputs.run == 'true'
+        name: Build library
         run: pnpm turbo run build --filter='!docs' --filter='!@helixui/admin' --filter='!@helixui/storybook'
-      - name: Run full test suite with hang watchdog
+      - if: steps.gate.outputs.run == 'true'
+        name: Run full test suite with hang watchdog
         run: |
           # Vitest hang watchdog — kills stale processes after 15s of no output
           # Mirrors the pattern from scripts/test-batch.sh


### PR DESCRIPTION
## Summary

- `env.*` is not in the allowed context set for job-level `if:` per GitHub's Actions schema (only `github`, `inputs`, `needs`, `vars`). `actionlint` flags it as an error.
- GitHub has been rejecting `.github/workflows/act-ci.yml` at preflight validation on every push to every branch since 2026-04-12 — surfaced as a "workflow file issue" failure run, noisy but not blocking any required check.
- Moved the gate from the `test-full` job's `if:` to a step-level gate. New first step `Check full-test gate` reads `ACT_MATRIX_TESTS` / `ACT_FULL_TESTS` and writes `run=true|false` to `$GITHUB_OUTPUT`; every subsequent step gates on `steps.gate.outputs.run == 'true'`. Behavior preserved for the only real caller (`scripts/act-ci.sh` always passes both env vars via `act --env` when `--full` or `--matrix` is used).
- `actionlint` now clean on this file.

## Test plan

- [x] `actionlint .github/workflows/act-ci.yml` — passes (locally confirmed)
- [x] Codex adversarial review — **pass** (2 findings, 1 medium cosmetic + 1 low style, neither blocking)
- [x] `code-reviewer` (tier 1) — **approve**
- [x] `security-engineer` — **approve**
- [ ] CI `Quality Gates` green
- [ ] CodeRabbit review completes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Fixed GitHub Actions CI workflow validation issue to ensure the continuous integration pipeline operates correctly. Simplified workflow conditional logic while preserving existing test execution behavior and runtime performance, improving workflow maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->