### PR TITLE
chore(coderabbit): switch profile from assertive to chill

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 # https://docs.coderabbit.ai/getting-started/configure-coderabbit
 
 reviews:
-  profile: 'assertive'
+  profile: 'chill'
   path_filters:
     - '!**/AUDIT.md'
   request_changes_workflow: true


### PR DESCRIPTION
## Summary
- Change CodeRabbit profile from `assertive` to `chill` to reduce nitpick noise while preserving major/critical finding signal.
- `path_instructions` (CSS `var()` fallback allowlist for `*.styles.ts` and `*.stories.ts`), `request_changes_workflow: true`, and `auto_review` scoping are preserved.
- HELiX is open-source, CodeRabbit is free. This tunes signal-to-noise; it does not weaken the security review gate. Branch protection on `dev`/`main` still requires CodeRabbit + Quality Gates.

## Why
Codex adversarial + internal 3-tier review + CodeRabbit was producing 9-10 reviews per PR with CodeRabbit's "assertive" profile contributing the bulk of low-value nitpicks. The `chill` profile still surfaces injection, auth bypass, secrets-in-diff, and genuine correctness issues — only style / minor style-preference noise is suppressed.

## Review status
- Codex adversarial: pass (0 findings) — `.rea/transcripts/codex-review-d4af0be6-1776871956.log`
- code-reviewer: pass
- security-engineer: pass — chill profile does not weaken security review

## Test plan
- [x] Confirm `chill` is a valid CodeRabbit enum value
- [x] Confirm `path_instructions` preserved at lines 32-44
- [x] Confirm `request_changes_workflow` unchanged
- [x] Confirm `auto_review.base_branches: [dev]` unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->