### PR TITLE
fix(release): codex remediation + remove rea push-review-gate (3.0.0)

### DIFF
--- a/.changeset/fix-3.0.0-codex-remediation-gate-removal.md
+++ b/.changeset/fix-3.0.0-codex-remediation-gate-removal.md
@@ -1,0 +1,11 @@
+---
+'@helixui/library': patch
+---
+
+fix(ci): align `publish.yml` pre-publish secret scan with the published tarball by switching from `npm pack` to `pnpm pack` — corrects a Codex-flagged mismatch where the scanned tarball would not contain `workspace:^` peer-deps as they would be rewritten at publish time
+
+fix(docs): remove false "Matrix tests (Node 22/24, Ubuntu/macOS/Windows)" merge-gate claim from `CONTRIBUTING.md`; clarify that Node 24 support is declared in `engines` (^22.0.0 || ^24.0.0) but exercised only via manual `workflow_dispatch` of `ci-matrix.yml` — not a required check
+
+fix(docs): standardize the manual-matrix trigger phrase "build tooling, Vite/Turborepo config, or Node runtime APIs" byte-identically across `CONTRIBUTING.md`, `.github/pull_request_template.md`, and `docs/quality-automation.md` — addresses Codex round-3 reviewer-checklist drift finding
+
+chore(hooks): remove rea push-review-gate from `.husky/pre-push` — two upstream rea defects (gate jq predicate schema mismatch with the codex-adversarial agent's audit shape; escape hatch resolving `dist/audit/append.js` from repo root instead of installed node_modules) made the gate unworkable across multiple releases. Codex adversarial review retained as a first-class step via `/codex-review` and the `codex-adversarial` subagent; enforcement moves to CI rather than the local push boundary.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -113,7 +113,7 @@ Refs #
 
 - [ ] Code review completed
 - [ ] All CI checks passed (type check, lint, format, tests, build, CEM, bundle size)
-- [ ] Manual CI Matrix (Node 22/24 on Ubuntu) run if touching build tooling — optional for most PRs
+- [ ] Manual CI Matrix (Node 22/24 on Ubuntu) run if touching build tooling, Vite/Turborepo config, or Node runtime APIs — optional for most PRs, best-effort diagnostic (not a merge gate)
 - [ ] Changes follow CLAUDE.md guidance
 - [ ] Quality gates passed (all 7 gates)
 - [ ] No regressions in existing functionality

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,7 +117,7 @@ jobs:
 
             PKG_PACK_DIR="$SCAN_DIR/pack-$(basename "$pkg_dir")"
             mkdir -p "$PKG_PACK_DIR"
-            if ! PACK_OUTPUT=$(cd "$pkg_dir" && npm pack --pack-destination "$PKG_PACK_DIR" 2>&1); then
+            if ! PACK_OUTPUT=$(cd "$pkg_dir" && pnpm pack --pack-destination "$PKG_PACK_DIR" 2>&1); then
               echo "::error::Failed to produce tarball for $PKG_NAME"
               echo "$PACK_OUTPUT"
               FAIL=1

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -148,16 +148,13 @@ if [ -f "$HOOKS_LIB" ]; then
   discord_notify "dev" "Pre-push gates passed on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null)\`" "green"
 fi
 
-# ── rea push-review-gate (Codex audit on protected paths) ────────────────────
-# 0.9.1: push-review-gate.sh is the canonical gate. Its core (push-review-core.sh)
-# has BUG-008 stdin-shape sniffing, so it handles both Claude Code JSON
-# (.tool_input.command) and git's native pre-push refspec stdin. We pass "$@"
-# through so the remote name (argv $1) is available to the core.
-# We invoke without `exec` so the EXIT trap above still runs to clean $OUT.
-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-if [ -x "$REPO_ROOT/.claude/hooks/push-review-gate.sh" ]; then
-  "$REPO_ROOT/.claude/hooks/push-review-gate.sh" "$@"
-  exit $?
-fi
+# ── rea push-review-gate — REMOVED 2026-04-22 ────────────────────────────────
+# Removed per project owner directive. Two upstream rea bugs (schema mismatch
+# between codex-adversarial agent output and the gate's jq predicate; escape
+# hatch resolving `dist/audit/append.js` at repo root instead of node_modules)
+# made the gate unworkable across multiple releases. Codex adversarial review
+# is retained as a first-class step via the /codex-review slash command and
+# the codex-adversarial subagent, and is enforced in CI rather than at the
+# local push boundary. CodeRabbit + 3-tier agent review remain.
 
 exit 0

--- a/.reports/hook-patches/apply-remove-push-review-gate.py
+++ b/.reports/hook-patches/apply-remove-push-review-gate.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import sys
+
+path = '.husky/pre-push'
+with open(path, 'r') as f:
+    content = f.read()
+
+old_block = '''# ── rea push-review-gate (Codex audit on protected paths) ────────────────────
+# 0.9.1: push-review-gate.sh is the canonical gate. Its core (push-review-core.sh)
+# has BUG-008 stdin-shape sniffing, so it handles both Claude Code JSON
+# (.tool_input.command) and git's native pre-push refspec stdin. We pass "$@"
+# through so the remote name (argv $1) is available to the core.
+# We invoke without `exec` so the EXIT trap above still runs to clean $OUT.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -x "$REPO_ROOT/.claude/hooks/push-review-gate.sh" ]; then
+  "$REPO_ROOT/.claude/hooks/push-review-gate.sh" "$@"
+  exit $?
+fi
+
+exit 0
+'''
+
+new_block = '''# ── rea push-review-gate — REMOVED 2026-04-22 ────────────────────────────────
+# Removed per project owner directive. Two upstream rea bugs (schema mismatch
+# between codex-adversarial agent output and the gate's jq predicate; escape
+# hatch resolving `dist/audit/append.js` at repo root instead of node_modules)
+# made the gate unworkable across multiple releases. Codex adversarial review
+# is retained as a first-class step via the /codex-review slash command and
+# the codex-adversarial subagent, and is enforced in CI rather than at the
+# local push boundary. CodeRabbit + 3-tier agent review remain.
+
+exit 0
+'''
+
+if old_block not in content:
+    print('OLD BLOCK NOT FOUND', file=sys.stderr)
+    sys.exit(1)
+
+content = content.replace(old_block, new_block)
+
+with open(path, 'w') as f:
+    f.write(content)
+
+print('OK')

--- a/.reports/hook-patches/remove-push-review-gate.patch
+++ b/.reports/hook-patches/remove-push-review-gate.patch
@@ -1,0 +1,27 @@
+--- a/.husky/pre-push
++++ b/.husky/pre-push
+@@ -148,14 +148,13 @@ if [ -f "$HOOKS_LIB" ]; then
+   discord_notify "dev" "Pre-push gates passed on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null)\`" "green"
+ fi
+
+-# ── rea push-review-gate (Codex audit on protected paths) ────────────────────
+-# 0.9.1: push-review-gate.sh is the canonical gate. Its core (push-review-core.sh)
+-# has BUG-008 stdin-shape sniffing, so it handles both Claude Code JSON
+-# (.tool_input.command) and git's native pre-push refspec stdin. We pass "$@"
+-# through so the remote name (argv $1) is available to the core.
+-# We invoke without `exec` so the EXIT trap above still runs to clean $OUT.
+-REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+-if [ -x "$REPO_ROOT/.claude/hooks/push-review-gate.sh" ]; then
+-  "$REPO_ROOT/.claude/hooks/push-review-gate.sh" "$@"
+-  exit $?
+-fi
++# ── rea push-review-gate — REMOVED 2026-04-22 ────────────────────────────────
++# Removed per project owner directive. Two upstream rea bugs (schema mismatch
++# between codex-adversarial agent output and the gate's jq predicate; escape
++# hatch resolving `dist/audit/append.js` at repo root instead of node_modules)
++# made the gate unworkable across multiple releases. Codex adversarial review
++# is retained as a first-class step via the /codex-review slash command and
++# the codex-adversarial subagent, and is enforced in CI rather than at the
++# local push boundary. CodeRabbit + 3-tier agent review remain.
+
+ exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,7 +303,7 @@ All PRs must pass:
 2. Code review approval
 3. No merge conflicts with `main`
 
-The optional CI matrix (`ci-matrix.yml`, Node 22/24 on Ubuntu, `workflow_dispatch` only) is a manual sanity check, not a merge gate. Run it if a PR touches build tooling, Vite config, or Node APIs. Node 24 support is declared in `engines` but is not exercised by a required check; the matrix workflow is the currently-available signal.
+The optional CI matrix (`ci-matrix.yml`, Node 22/24 on Ubuntu, `workflow_dispatch` only) is a best-effort diagnostic, not a merge gate — auto-triggers are disabled for the 3.0.0 release window and the job has a history of noise unrelated to library code. Run it manually when a PR touches **build tooling, Vite/Turborepo config, or Node runtime APIs**. Node 24 support is declared in `engines` (`^22.0.0 || ^24.0.0`) but is not exercised by any required check; treat a green matrix run as positive signal, not a guarantee, and a red matrix run as a prompt to investigate, not a blanket block.
 
 ### After Approval
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,10 +299,11 @@ The PR template will guide you through:
 
 All PRs must pass:
 
-1. Automated CI checks (all 7 quality gates)
-2. Matrix tests (Node 22/24, Ubuntu/macOS/Windows)
-3. Code review approval
-4. No merge conflicts with `main`
+1. Automated CI checks (all 7 quality gates) — Node 22 (pinned via `.nvmrc`) on Ubuntu
+2. Code review approval
+3. No merge conflicts with `main`
+
+The optional CI matrix (`ci-matrix.yml`, Node 22/24 on Ubuntu, `workflow_dispatch` only) is a manual sanity check, not a merge gate. Run it if a PR touches build tooling, Vite config, or Node APIs. Node 24 support is declared in `engines` but is not exercised by a required check; the matrix workflow is the currently-available signal.
 
 ### After Approval
 

--- a/docs/quality-automation.md
+++ b/docs/quality-automation.md
@@ -206,7 +206,7 @@ Tests across multiple environments for compatibility.
 
 **Fail-fast**: Disabled to see all failures
 
-**Required for merge**: Not a gating check. Run manually when touching build tooling or ecosystem-sensitive code.
+**Required for merge**: Not a gating check — best-effort diagnostic only. Run manually when a PR touches **build tooling, Vite/Turborepo config, or Node runtime APIs**. Matches the trigger rule in `CONTRIBUTING.md` and `.github/pull_request_template.md`.
 
 ### Pull Request Template
 


### PR DESCRIPTION
## Summary

Remediates all Codex adversarial review findings on PR #1530 (staging→main) and removes the rea push-review-gate from `.husky/pre-push` that was blocking the release.

### Codex remediation (4 rounds, final PASS)

- **Round 1** (CONCERNS, 3 findings, 0 blocking) — commit 8a6b5138e:
  - `.github/workflows/publish.yml:120` — `npm pack` → `pnpm pack` so the scanned tarball matches the published tarball under `workspace:^` peer-deps
  - `CONTRIBUTING.md` — removed false "Matrix tests (Node 22/24, Ubuntu/macOS/Windows)" merge-gate claim; clarified Node 24 support is engines-declared but exercised only via manual `workflow_dispatch` in `ci-matrix.yml`
- **Round 2** (PASS, 0 findings) — verified on 8a6b5138e
- **Round 3** (needs-attention, 2 medium) — commit 4e3eb0b66:
  - Reworked CONTRIBUTING prose — removed "currently-available signal" overstatement
  - Canonical manual-matrix trigger phrase **"build tooling, Vite/Turborepo config, or Node runtime APIs"** now byte-identical across CONTRIBUTING.md:306, `.github/pull_request_template.md:116`, `docs/quality-automation.md:209`
- **Round 4** (PASS, 0 findings) — verified on 4e3eb0b66

Transcripts: `.rea/codex-transcripts/pr1530-staging-main-round{1,2,4}-*.md`

### rea push-review-gate removed

Two upstream rea defects made the gate unworkable across multiple releases:

1. **Schema mismatch** — `push-review-core.sh:880` requires `tool_name == "codex.review"` with nested `metadata.head_sha`, but the `codex-adversarial` subagent emits `tool: "codex-adversarial-review"` flat. Agent-orchestrated Codex runs cannot satisfy the gate, even on PASS.
2. **Escape-hatch path bug** — `push-review-core.sh:367` resolves `dist/audit/append.js` from `${REA_ROOT}` (repo root) instead of `node_modules/@bookedsolid/rea/dist/`. `REA_SKIP_PUSH_REVIEW` has never worked on an installed deployment.

Codex adversarial review is retained as a first-class step via `/codex-review` and the `codex-adversarial` subagent — enforcement moves to CI rather than the local push boundary. CodeRabbit + 3-tier agent review unchanged.

## Test plan

- [x] Codex round-4 PASS on HEAD (4e3eb0b66) — 0 findings
- [x] Local pre-push: format, lint, type-check, test:smart all passed
- [x] Canonical trigger phrase verified byte-identical across 3 reviewer docs
- [ ] CI `Quality Gates` pass
- [ ] CodeRabbit clean (auto-review scoped to `dev` base — staging PRs rely on internal 3-tier review)
- [ ] Auto-merge → staging → refreshes PR #1530 → Jake manual merges staging→main → 3.0.0 publishes