### PR TITLE
fix(docs): remediate 4 coderabbit findings on pr #1530

### DIFF
--- a/.changeset/fix-coderabbit-pr1530-canonical-wording.md
+++ b/.changeset/fix-coderabbit-pr1530-canonical-wording.md
@@ -1,0 +1,11 @@
+---
+'@helixui/library': patch
+---
+
+fix(docs): clarify `CONTRIBUTING.md` review-process section — Gate 7 (code review) is a manual step, not a CI-automated gate. Previous wording "all 7 quality gates" under "Automated CI checks" conflated the two. Now reads "quality gates 1–6" for automated checks with Gate 7 called out as manual.
+
+fix(docs): standardize Node runtime wording in `docs/typescript-automation-executive-summary.md` from ambiguous "Node.js 22+" to canonical "Node.js 22 LTS or Node.js 24" — matches the `engines` field (`^22.0.0 || ^24.0.0`) and the rest of the documentation.
+
+fix(docs): extend canonical Node runtime wording in `starters/react/README.md` with the Node 20 EOL note (`Node 20 reaches upstream EOL on 2026-04-30`) to match phrasing elsewhere in the repo.
+
+chore(hooks): make `.reports/hook-patches/apply-remove-push-review-gate.py` idempotent — return success if the new block is already present so the one-off applicator is safe to re-run.

--- a/.changeset/fix-coderabbit-pr1530-canonical-wording.md
+++ b/.changeset/fix-coderabbit-pr1530-canonical-wording.md
@@ -2,10 +2,10 @@
 '@helixui/library': patch
 ---
 
-fix(docs): clarify `CONTRIBUTING.md` review-process section — Gate 7 (code review) is a manual step, not a CI-automated gate. Previous wording "all 7 quality gates" under "Automated CI checks" conflated the two. Now reads "quality gates 1–6" for automated checks with Gate 7 called out as manual.
+fix(docs): clarify `CONTRIBUTING.md` review-process section — Gate 7 (code review) is a manual step, not a CI-automated gate. Previous wording "all 7 quality gates" under "Automated CI checks" conflated the two. Now preserves the canonical "all 7 quality gates" phrasing used across the repo and adds a parenthetical clarifying gates 1–6 are CI-enforced while Gate 7 is the manual 3-tier review.
 
 fix(docs): standardize Node runtime wording in `docs/typescript-automation-executive-summary.md` from ambiguous "Node.js 22+" to canonical "Node.js 22 LTS or Node.js 24" — matches the `engines` field (`^22.0.0 || ^24.0.0`) and the rest of the documentation.
 
 fix(docs): extend canonical Node runtime wording in `starters/react/README.md` with the Node 20 EOL note (`Node 20 reaches upstream EOL on 2026-04-30`) to match phrasing elsewhere in the repo.
 
-chore(hooks): make `.reports/hook-patches/apply-remove-push-review-gate.py` idempotent — return success if the new block is already present so the one-off applicator is safe to re-run.
+chore(hooks): make `.reports/hook-patches/apply-remove-push-review-gate.py` idempotent and mixed-state-safe — return success if the new block is already applied, refuse (exit 1) if both old and new blocks are present simultaneously, so the one-off applicator cannot silently succeed while the pre-removal hook invocation is still live.

--- a/.reports/hook-patches/apply-remove-push-review-gate.py
+++ b/.reports/hook-patches/apply-remove-push-review-gate.py
@@ -32,6 +32,10 @@ new_block = '''# ── rea push-review-gate — REMOVED 2026-04-22 ────
 exit 0
 '''
 
+if new_block in content:
+    print('OK (already applied)')
+    sys.exit(0)
+
 if old_block not in content:
     print('OLD BLOCK NOT FOUND', file=sys.stderr)
     sys.exit(1)

--- a/.reports/hook-patches/apply-remove-push-review-gate.py
+++ b/.reports/hook-patches/apply-remove-push-review-gate.py
@@ -32,11 +32,19 @@ new_block = '''# ── rea push-review-gate — REMOVED 2026-04-22 ────
 exit 0
 '''
 
-if new_block in content:
+has_old = old_block in content
+has_new = new_block in content
+
+if has_old and has_new:
+    print('MIXED STATE: both old and new blocks present — refusing to touch', file=sys.stderr)
+    print('  fix .husky/pre-push by hand, then re-run', file=sys.stderr)
+    sys.exit(1)
+
+if has_new:
     print('OK (already applied)')
     sys.exit(0)
 
-if old_block not in content:
+if not has_old:
     print('OLD BLOCK NOT FOUND', file=sys.stderr)
     sys.exit(1)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,8 +299,8 @@ The PR template will guide you through:
 
 All PRs must pass:
 
-1. Automated CI checks (all 7 quality gates) — Node 22 (pinned via `.nvmrc`) on Ubuntu
-2. Code review approval
+1. Automated CI checks (quality gates 1–6) — Node 22 (pinned via `.nvmrc`) on Ubuntu
+2. Code review approval (Gate 7 — manual, not enforced by CI)
 3. No merge conflicts with `main`
 
 The optional CI matrix (`ci-matrix.yml`, Node 22/24 on Ubuntu, `workflow_dispatch` only) is a best-effort diagnostic, not a merge gate — auto-triggers are disabled for the 3.0.0 release window and the job has a history of noise unrelated to library code. Run it manually when a PR touches **build tooling, Vite/Turborepo config, or Node runtime APIs**. Node 24 support is declared in `engines` (`^22.0.0 || ^24.0.0`) but is not exercised by any required check; treat a green matrix run as positive signal, not a guarantee, and a red matrix run as a prompt to investigate, not a blanket block.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -299,8 +299,8 @@ The PR template will guide you through:
 
 All PRs must pass:
 
-1. Automated CI checks (quality gates 1–6) — Node 22 (pinned via `.nvmrc`) on Ubuntu
-2. Code review approval (Gate 7 — manual, not enforced by CI)
+1. All 7 quality gates (gates 1–6 are enforced by CI on Node 22, pinned via `.nvmrc`, on Ubuntu; Gate 7 is the manual 3-tier code review below)
+2. Code review approval (Gate 7 — manual)
 3. No merge conflicts with `main`
 
 The optional CI matrix (`ci-matrix.yml`, Node 22/24 on Ubuntu, `workflow_dispatch` only) is a best-effort diagnostic, not a merge gate — auto-triggers are disabled for the 3.0.0 release window and the job has a history of noise unrelated to library code. Run it manually when a PR touches **build tooling, Vite/Turborepo config, or Node runtime APIs**. Node 24 support is declared in `engines` (`^22.0.0 || ^24.0.0`) but is not exercised by any required check; treat a green matrix run as positive signal, not a guarantee, and a red matrix run as a prompt to investigate, not a blanket block.

--- a/docs/typescript-automation-executive-summary.md
+++ b/docs/typescript-automation-executive-summary.md
@@ -161,7 +161,7 @@ This proposal introduces a comprehensive TypeScript automation system for wc-202
 
 ### Technical
 
-- ✅ Node.js 22+ (already installed)
+- ✅ Node.js 22 LTS or Node.js 24 (already installed)
 - ✅ TypeScript 5.7+ (already installed)
 - ⚠️ `ts-morph@^21.0.0` (needs install)
 - ⚠️ `@modelcontextprotocol/sdk` (needs install)

--- a/starters/react/README.md
+++ b/starters/react/README.md
@@ -8,7 +8,7 @@ healthcare web component library.
 
 ## Prerequisites
 
-- Node.js 22 LTS or Node.js 24
+- Node.js 22 LTS or Node.js 24 (Node 20 reaches upstream EOL on 2026-04-30)
 - npm 10+
 
 ---


### PR DESCRIPTION
## Summary

CodeRabbit remediation for PR #1530 (staging→main, 3.0.0 publish unblock). Addresses the 4 actionable findings from the CodeRabbit review of the post-remediation head. Codex round-2 PASS (0 findings) verified.

## Findings addressed

1. **`CONTRIBUTING.md:302-303`** — Preserved canonical "all 7 quality gates" phrasing used across 8+ locations in the repo; added parenthetical clarifying gates 1–6 are CI-enforced while Gate 7 is the manual 3-tier review. Resolves CodeRabbit ambiguity without fragmenting the canonical phrase.

2. **`docs/typescript-automation-executive-summary.md:164`** — "Node.js 22+" → canonical "Node.js 22 LTS or Node.js 24" to match `engines` field and other docs.

3. **`starters/react/README.md:11`** — Added "(Node 20 reaches upstream EOL on 2026-04-30)" to match canonical wording elsewhere.

4. **`.reports/hook-patches/apply-remove-push-review-gate.py`** — Mixed-state-safe idempotency: refuses to touch `.husky/pre-push` when both old and new blocks are present simultaneously (Codex round-1 medium finding); returns success when only the new block is present.

## False positives verified

CodeRabbit also flagged "AI attribution strings" in `.changeset/fix-3.0.0-codex-remediation-gate-removal.md` and `.husky/pre-push`. Both files verified clean — no attribution strings present. Left unchanged per CodeRabbit's own "verify before fixing" guidance.

## Adversarial review

- **Codex round 1** (HEAD `ae1e6e89f`): BLOCKING — 2 findings (mixed-state bug + phrasing divergence)
- **Codex round 2** (HEAD `6dde62f16`): PASS — 0 findings; verified both fixes resolve the round-1 issues without regressions
- Final HEAD `4ccf1f091` only updates changeset release notes to match round-2 wording (no code change)

## Test plan

- [x] Codex round-2 PASS
- [x] Local pre-push gates: format, lint, type-check, test:smart — all passed
- [ ] CI Quality Gates pass
- [ ] CodeRabbit clean re-review
- [ ] Auto-merge → staging → refresh PR #1530 → Jake manual merges staging→main → 3.0.0 publishes