### PR TITLE
fix(publish): replace direct-push release manifest with auto-merge PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -275,10 +275,12 @@ jobs:
         # Runs only on an actual publish — when changesets/action bumps
         # versions without publishing (PR path), no manifest is generated.
 
-      - name: Commit release manifest
+      - name: Open release manifest PR
         if: steps.changesets.outputs.published == 'true'
         env:
           CHANGESET_TOKEN: ${{ secrets.CHANGESET_TOKEN }}
+          GH_TOKEN: ${{ secrets.CHANGESET_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
           HUSKY: '0'
         run: |
           set -euo pipefail
@@ -286,42 +288,50 @@ jobs:
             echo "No release manifest changes to commit."
             exit 0
           fi
+
+          VERSION=$(node -e '
+            try {
+              const a = JSON.parse(process.env.PUBLISHED_PACKAGES || "[]");
+              const p = a.find((x) => x.name === "@helixui/library");
+              console.log(p ? p.version : "");
+            } catch {
+              console.log("");
+            }
+          ')
+          if [ -z "${VERSION}" ]; then
+            VERSION="run-${GITHUB_RUN_ID}"
+          fi
+          BRANCH="release-manifest/${VERSION}"
+
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          # npm publish has already succeeded at this point, so the manifest
-          # MUST land on main. The workflow concurrency group only serialises
-          # runs of this workflow; unrelated merges can still advance main
-          # between actions/checkout and this step. Rebase the manifest on
-          # top of current origin/main to avoid a non-fast-forward rejection
-          # that would leave the npm release without its audit commit.
-          git stash push -u --message 'release-manifest' -- docs/releases/
+
+          # Stage the freshly-generated manifest, then rebuild the branch from
+          # origin/main so the PR contains only the manifest diff.
+          MANIFEST_STAGE=$(mktemp -d)
+          cp -R docs/releases/. "${MANIFEST_STAGE}/"
           git fetch origin main
-          git checkout -B publish-manifest origin/main
-          git stash pop
+          git checkout -B "${BRANCH}" origin/main
+          mkdir -p docs/releases
+          cp -R "${MANIFEST_STAGE}/." docs/releases/
           git add docs/releases/
-          git commit -m 'chore(release): add release manifest [skip ci]'
-
-          # Bounded retry: if another merge lands on main between our fetch
-          # and push, rebase and retry up to 3 times. Any failure after that
-          # is fatal and requires operator intervention — npm publish has
-          # already succeeded, so the manifest commit MUST land.
-          REMOTE="https://x-access-token:${CHANGESET_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          PUSH_OK=0
-          for attempt in 1 2 3; do
-            echo "Manifest push attempt $attempt/3..."
-            git fetch origin main
-            if git rebase origin/main; then
-              if git push "$REMOTE" HEAD:main; then
-                PUSH_OK=1
-                break
-              fi
-            else
-              git rebase --abort || true
-            fi
-            sleep 5
-          done
-
-          if [ "$PUSH_OK" -ne 1 ]; then
-            echo "::error::Failed to push release manifest after 3 attempts. npm publish already succeeded — manifest must be committed manually."
-            exit 1
+          if git diff --cached --quiet; then
+            echo "Manifest already present on main — nothing to commit."
+            exit 0
           fi
+          git commit -m "chore(release): add ${VERSION} release manifest"
+
+          REMOTE="https://x-access-token:${CHANGESET_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push "${REMOTE}" "HEAD:${BRANCH}"
+
+          # CHANGESET_TOKEN must carry `contents: write` + `pull-requests: write`.
+          # The manifest is prettier-ignored (see .prettierignore) and path-only;
+          # required status checks complete quickly on doc-only diffs.
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "${BRANCH}" \
+            --title "chore(release): add ${VERSION} release manifest" \
+            --body "Post-publish manifest for \`${VERSION}\`. Auto-opened by the publish workflow after npm publish succeeded. Documentation only — safe to auto-merge.")
+          echo "Opened: ${PR_URL}"
+          gh pr merge "${PR_URL}" --merge --auto || \
+            echo "::warning::Could not enable auto-merge on ${PR_URL}; manifest PR needs manual merge."


### PR DESCRIPTION
## Summary

The post-publish \"Commit release manifest\" step in \`.github/workflows/publish.yml\` tried to push \`docs/releases/<version>-manifest.json\` directly to protected \`main\` and **failed every release** with GH006 (\"Changes must be made through a pull request\"). npm publish succeeded before the push, so the release itself landed clean, but the manifest commit never did — confirmed in the 3.1.0 release (run \`24863796527\`).

## What changed

Replaces the direct-push retry loop with a PR-based flow:

1. Stage the generated manifest to a tmp dir
2. Branch \`release-manifest/<version>\` from \`origin/main\`
3. Commit and push the branch
4. Open PR with \`gh pr create --base main\`
5. Enable auto-merge with \`gh pr merge --auto\`

Also adds \`docs/releases/*-manifest.json\` to \`.prettierignore\` so the doc-only PR sails through the format gate — manifests are generated artifacts, same treatment as \`custom-elements.json\` and \`figma-inventory.json\`.

## Token requirements

Uses the existing \`CHANGESET_TOKEN\` secret. Requires:
- \`contents: write\` — to push the branch
- \`pull-requests: write\` — to open and auto-merge the PR

(Both scopes are already on the token.)

## Test plan

- [x] Format check passes locally
- [ ] CI Quality Gates pass on dev
- [ ] CodeRabbit review
- [ ] Verify on next release that the manifest PR opens cleanly