### PR TITLE
fix(release): roll back drupal packages from 4.0.0 to 3.0.1

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,5 +16,8 @@
     "@helixui/admin",
     "@helixui/storybook",
     "docs"
-  ]
+  ],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/packages/drupal-behaviors/CHANGELOG.md
+++ b/packages/drupal-behaviors/CHANGELOG.md
@@ -1,11 +1,13 @@
 # @helixui/drupal-behaviors
 
-## 4.0.0
+## 3.0.1
 
 ### Patch Changes
 
 - Updated dependencies [36d5bde]
   - @helixui/library@3.1.0
+
+  Note: the 3.1.0 release cycle initially published this package as `4.0.0` because changesets' default policy treats any peer-dependency update as a major bump. The bump was cosmetic — the peer range `^3.0.0` still satisfies `@helixui/library@3.1.0` and no API changed. `4.0.0` was unpublished from npm and this patch release (`3.0.1`) is the correct version. `.changeset/config.json` now sets `onlyUpdatePeerDependentsWhenOutOfRange: true` to prevent recurrence.
 
 ## 3.0.0
 

--- a/packages/drupal-behaviors/package.json
+++ b/packages/drupal-behaviors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helixui/drupal-behaviors",
-  "version": "4.0.0",
+  "version": "3.0.1",
   "description": "Drupal behaviors for all interactive HELiX web components using the once() pattern",
   "license": "MIT",
   "author": "BookedSolid Technologies",

--- a/packages/drupal-starter/CHANGELOG.md
+++ b/packages/drupal-starter/CHANGELOG.md
@@ -1,11 +1,13 @@
 # @helixui/drupal-starter
 
-## 4.0.0
+## 3.0.1
 
 ### Patch Changes
 
 - Updated dependencies [36d5bde]
   - @helixui/library@3.1.0
+
+  Note: the 3.1.0 release cycle initially published this package as `4.0.0` because changesets' default policy treats any peer-dependency update as a major bump. The bump was cosmetic — the peer range `^3.0.0` still satisfies `@helixui/library@3.1.0` and no API changed. `4.0.0` was unpublished from npm and this patch release (`3.0.1`) is the correct version. `.changeset/config.json` now sets `onlyUpdatePeerDependentsWhenOutOfRange: true` to prevent recurrence.
 
 ## 3.0.0
 

--- a/packages/drupal-starter/package.json
+++ b/packages/drupal-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helixui/drupal-starter",
-  "version": "4.0.0",
+  "version": "3.0.1",
   "description": "Pre-built composition SDCs for Drupal using HELiX web components",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary

The 3.1.0 release cycle published `@helixui/drupal-behaviors` and `@helixui/drupal-starter` as **4.0.0**. Nothing breaking actually shipped — changesets' default policy treats any peer-dependency update as a major bump on the dependent, even when the existing range (`^3.0.0`) still satisfies the new library version (3.1.0). The changelog entry for 4.0.0 was literally just "Updated dependencies → @helixui/library@3.1.0" under a 4.0.0 header.

## What's in this PR

- `packages/drupal-behaviors/package.json`: `4.0.0` → `3.0.1`
- `packages/drupal-starter/package.json`: `4.0.0` → `3.0.1`
- CHANGELOGs for both packages: rewrite the bogus `## 4.0.0` header as `## 3.0.1` with a note explaining the rollback
- `.changeset/config.json`: enable `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true` so future in-range peer updates trigger a patch (not a major) on dependents

## npm state

`@helixui/drupal-behaviors@4.0.0` and `@helixui/drupal-starter@4.0.0` have already been **unpublished from npm** (inside the 72-hour window). Current latest on npm for both: **3.0.0**.

Republish as **3.0.1** will happen manually after this lands on main — no publish workflow changeset needed.

## Test plan

- [x] Local `pnpm run format:check`, `pnpm run lint`, `pnpm run type-check` pass
- [x] No source code changes; diff is scoped to version strings, CHANGELOG headers, and changeset config
- [ ] CI green
- [ ] After merge: `npm publish --workspace=packages/drupal-behaviors` and `--workspace=packages/drupal-starter` at 3.0.1