### PR TITLE
fix(codex-campaigns): close 2 adversarial-review concerns before 3.1.0

### DIFF
--- a/.changeset/codex-campaign-tooling-remediation.md
+++ b/.changeset/codex-campaign-tooling-remediation.md
@@ -1,0 +1,19 @@
+---
+'@helixui/library': patch
+---
+
+Close two Codex adversarial-review concerns in the codex-campaigns tooling
+before 3.1.0 ships.
+
+- `scripts/codex-campaigns/lib/run-campaign.sh`: truncate
+  `$REPORT_DIR/transcripts/$slug.last.txt` before each `codex exec`
+  invocation so a retry against a target that has a stale last-message file
+  from a prior crashed run does not re-ingest the previous run's JSONL and
+  misreport the retry as a pass. Additionally, on non-zero Codex exit no
+  longer fall back to scraping the raw transcript — a failed invocation's
+  partial output is not a valid findings source.
+- `scripts/codex-campaigns/lib/consolidate-findings.ts`: seed the scoreboard
+  target map from `campaign-<name>/targets.txt` so targets that produced zero
+  findings (clean passes) still appear with `verdict: "pass"`, making
+  `by_verdict.pass` accurate and letting operators distinguish "passed
+  cleanly" from "never ran."

--- a/scripts/codex-campaigns/lib/consolidate-findings.ts
+++ b/scripts/codex-campaigns/lib/consolidate-findings.ts
@@ -29,10 +29,23 @@ if (!campaign) {
 
 const campaignDir = resolve(`.reports/codex/campaigns/${campaign}`);
 const jsonlPath = resolve(campaignDir, 'findings.jsonl');
+const targetsPath = resolve(`scripts/codex-campaigns/campaign-${campaign}`, 'targets.txt');
 
 if (!existsSync(jsonlPath)) {
   console.error(`findings file not found: ${jsonlPath}`);
   process.exit(2);
+}
+
+// Seed the scoreboard with the full target manifest so targets that produced
+// zero findings (clean passes) still appear with verdict="pass". Without
+// this, the scoreboard only surfaces targets with at least one finding and
+// cannot distinguish "passed cleanly" from "never ran."
+function loadTargetManifest(): string[] {
+  if (!existsSync(targetsPath)) return [];
+  return readFileSync(targetsPath, 'utf8')
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('#'));
 }
 
 const findings: Finding[] = [];
@@ -63,7 +76,7 @@ if (invalid > 0) {
   console.error(`\n${invalid} invalid findings skipped`);
 }
 
-const scoreboard = buildScoreboard(findings);
+const scoreboard = buildScoreboard(findings, loadTargetManifest());
 const markdown = buildMarkdown(campaign, findings, invalid);
 
 writeFileSync(resolve(campaignDir, 'scoreboard.json'), JSON.stringify(scoreboard, null, 2));
@@ -99,9 +112,20 @@ function emptyVerdictMap(): Record<Verdict, number> {
   return { pass: 0, concerns: 0, blocking: 0, error: 0 };
 }
 
-function buildScoreboard(items: Finding[]): Scoreboard {
+function buildScoreboard(items: Finding[], manifest: string[]): Scoreboard {
   const targets = new Map<string, TargetScore>();
   const bySeverity = emptySeverityMap();
+
+  // Pre-seed every target from the manifest with a default pass entry so
+  // zero-finding runs register as passes rather than disappearing.
+  for (const target of manifest) {
+    targets.set(target, {
+      target,
+      finding_count: 0,
+      by_severity: emptySeverityMap(),
+      verdict: 'pass',
+    });
+  }
 
   for (const f of items) {
     bySeverity[f.severity] += 1;
@@ -117,6 +141,7 @@ function buildScoreboard(items: Finding[]): Scoreboard {
       };
       targets.set(f.target, entry);
     }
+    if (f.tag && !entry.tag) entry.tag = f.tag;
     entry.finding_count += 1;
     entry.by_severity[f.severity] += 1;
     entry.verdict = escalate(entry.verdict, f.verdict_for_target);

--- a/scripts/codex-campaigns/lib/run-campaign.sh
+++ b/scripts/codex-campaigns/lib/run-campaign.sh
@@ -110,18 +110,30 @@ run_target() {
 
   echo "[$idx/$TOTAL] $tag started=$target_started" | tee -a "$RUN_LOG"
 
+  # Truncate the last-message file before invocation. Without this, a retry
+  # against a target that already has a stale `$slug.last.txt` on disk (from a
+  # prior crashed or non-zero-exit run) would re-ingest the previous run's
+  # findings and misreport the retry as a pass.
+  : > "$last_msg"
+
   # Redirect codex stdin to /dev/null: the outer `while read < "$TARGET_LIST"`
   # loop shares its stdin with every child process by default, and `codex exec`
   # reads stdin to append as an `<stdin>` block — which silently drains the
   # target list file and causes the outer loop to exit after target 1.
+  local codex_rc=0
   if ! codex "${CODEX_ARGS[@]}" -o "$last_msg" "$rendered" </dev/null >"$transcript" 2>&1; then
+    codex_rc=1
     echo "[$idx/$TOTAL] $tag CODEX_EXIT_NONZERO (see $transcript)" | tee -a "$RUN_LOG"
   fi
 
-  # The final agent message is the authoritative JSONL block. Fall back to
-  # transcript-scraping only if --output-last-message produced nothing.
+  # The final agent message is the authoritative JSONL block. On non-zero exit
+  # we do NOT fall back to scraping the raw transcript — a failed invocation's
+  # partial transcript is not a valid findings source, and treating it as one
+  # would turn a crashed Codex run into a silent "clean" verdict.
   local source_file="$last_msg"
-  [[ -s "$source_file" ]] || source_file="$transcript"
+  if [[ $codex_rc -eq 0 ]]; then
+    [[ -s "$source_file" ]] || source_file="$transcript"
+  fi
 
   local parsed=0 rejected=0
   local tmpf; tmpf="$(mktemp)"


### PR DESCRIPTION
## Context

Second Codex adversarial-review pass on the staging→main 3.1.0 diff returned
verdict `concerns` with 2 findings — both in the new codex-campaigns tooling,
neither touching the 3.1.0 product surface. Per
`feedback_codex_deep_review_staging_main.md`, every Codex finding must be
fixed in-PR before the staging→main promotion. This PR closes both.

## Findings closed

### 1. [correctness | medium] `run-campaign.sh:117-124` — stale last-message reuse

A prior run's `$slug.last.txt` persists on disk. If a target is retried after a
crash, lines 123-124 preferred any non-empty `last_msg` over the freshly
captured transcript, so the retry would silently ingest the previous run's
findings and make a failed retry look successful.

**Fix:** Truncate `$last_msg` before each `codex` call. On non-zero Codex
exit, do not fall back to the raw transcript — a failed invocation's partial
output is not a valid findings source.

### 2. [correctness | medium] `consolidate-findings.ts:102-120` — missing passes

`buildScoreboard` only iterated `findings.jsonl`. Targets with zero findings
(clean passes) never registered, so `by_verdict.pass` stayed at 0 and the
per-target table omitted them entirely. Consumers could not distinguish
"passed" from "never ran."

**Fix:** Seed targets from `scripts/codex-campaigns/campaign-<name>/targets.txt`
before the finding loop. Verified on the cem-accuracy campaign — scoreboard now
reports `{pass: 2, concerns: 75, blocking: 4}` across 81 targets (previously
`pass: 0`).

## Release-gate status

- ✅ Semantic token rebinding sweep — Codex clean
- ✅ Shard-aware coverage gate — Codex clean
- ✅ Release-manifest workflow hardening — Codex clean
- ✅ Codex-campaigns tooling — this PR closes the 2 concerns

After this merges, the staging head is ready for the staging→main promotion PR.

## Test plan

- [x] `bash -n scripts/codex-campaigns/lib/run-campaign.sh` — syntax ok
- [x] `pnpm exec tsx scripts/codex-campaigns/lib/consolidate-findings.ts cem-accuracy` — regenerates scoreboard with correct pass counts
- [x] pre-push gates pass locally (lint, format, type-check, tests, shellcheck)