### PR TITLE
fix(codex-3.1.0): close 4 pass-3 adversarial review concerns

### DIFF
--- a/.changeset/codex-3.1.0-pass3-remediation.md
+++ b/.changeset/codex-3.1.0-pass3-remediation.md
@@ -1,0 +1,31 @@
+---
+'@helixui/library': patch
+---
+
+Close four Codex adversarial-review concerns surfaced in pass 3 of the 3.1.0
+staging→main review loop.
+
+- `.github/workflows/ci.yml`: remove the `matrix.shard == '1/4'` gate on the
+  coverage enforcement step. The shard-aware `check-coverage.mjs` intersects
+  `HX_COVERAGE_COMPONENTS` with the components whose tests actually executed
+  on the current shard (read from `.cache/test-results.json`), so each shard
+  enforces its own slice. Restricting to shard 1/4 let any component whose
+  test landed on shards 2-4 regress unchecked.
+- `scripts/codex-campaigns/lib/run-campaign.sh`: emit a synthetic
+  `verdict: "error"` finding when `codex exec` exits non-zero and produces
+  zero parseable findings. Without this, a crashed Codex run left the
+  consolidator's pre-seeded `pass` verdict in place — so a target whose
+  Codex invocation actually crashed would be silently reported as clean.
+- `scripts/codex-campaigns/lib/run-campaign.sh` +
+  `scripts/codex-campaigns/lib/consolidate-findings.ts`: write
+  `${REPORT_DIR}/targets-processed.txt` per run listing only the targets the
+  current invocation processed (honors `--limit` / `--targets` overrides).
+  The consolidator now prefers this file over the full campaign manifest, so
+  partial runs no longer pre-seed un-run targets as `verdict: "pass"` and
+  inflate scoreboard pass counts.
+- `.github/workflows/publish.yml`: include `GITHUB_RUN_ATTEMPT` alongside
+  `GITHUB_RUN_ID` in the release-manifest branch name. `GITHUB_RUN_ID` is
+  stable across reruns of a single workflow run; only `GITHUB_RUN_ATTEMPT`
+  increments. Without it, a rerun of a failed publish would collide with the
+  pre-existing release-manifest branch and cause a non-fast-forward push that
+  orphans the manifest PR.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,12 @@ jobs:
           exit $rc
         working-directory: packages/hx-library
       - name: Enforce coverage thresholds for changed components
-        if: steps.run-tests.outputs.tests_ran == 'true' && matrix.shard == '1/4'
+        # Run on every shard. The shard-aware check-coverage logic intersects
+        # HX_COVERAGE_COMPONENTS with the components whose tests actually ran
+        # on this shard (read from .cache/test-results.json), so each shard
+        # enforces its own slice. Restricting to shard 1/4 would let any
+        # component whose test landed on shards 2-4 regress unchecked.
+        if: steps.run-tests.outputs.tests_ran == 'true'
         env:
           HX_COVERAGE_COMPONENTS: ${{ steps.changed.outputs.components_csv }}
         run: node scripts/check-coverage.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -301,10 +301,13 @@ jobs:
           if [ -z "${VERSION}" ]; then
             VERSION="run-${GITHUB_RUN_ID}"
           fi
-          # Include GITHUB_RUN_ID so reruns of the same published version do
-          # not collide with a pre-existing release-manifest branch (which
-          # would cause a non-fast-forward push and orphan the PR).
-          BRANCH="release-manifest/${VERSION}-${GITHUB_RUN_ID}"
+          # Include both GITHUB_RUN_ID and GITHUB_RUN_ATTEMPT so reruns of the
+          # same published version produce a unique branch name. GITHUB_RUN_ID
+          # is stable across reruns of a single workflow run; only RUN_ATTEMPT
+          # increments. Without RUN_ATTEMPT, a rerun would collide with the
+          # pre-existing release-manifest branch from the failed first attempt
+          # and cause a non-fast-forward push that orphans the PR.
+          BRANCH="release-manifest/${VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
 
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'

--- a/scripts/codex-campaigns/lib/consolidate-findings.ts
+++ b/scripts/codex-campaigns/lib/consolidate-findings.ts
@@ -29,7 +29,12 @@ if (!campaign) {
 
 const campaignDir = resolve(`.reports/codex/campaigns/${campaign}`);
 const jsonlPath = resolve(campaignDir, 'findings.jsonl');
-const targetsPath = resolve(`scripts/codex-campaigns/campaign-${campaign}`, 'targets.txt');
+const fullManifestPath = resolve(`scripts/codex-campaigns/campaign-${campaign}`, 'targets.txt');
+// Per-run manifest written by run-campaign.sh — lists only the targets the
+// most recent invocation actually processed (honors --limit / --targets).
+// Prefer this over the full manifest so partial runs don't pre-seed un-run
+// targets as `verdict: "pass"`.
+const processedManifestPath = resolve(campaignDir, 'targets-processed.txt');
 
 if (!existsSync(jsonlPath)) {
   console.error(`findings file not found: ${jsonlPath}`);
@@ -41,8 +46,9 @@ if (!existsSync(jsonlPath)) {
 // this, the scoreboard only surfaces targets with at least one finding and
 // cannot distinguish "passed cleanly" from "never ran."
 function loadTargetManifest(): string[] {
-  if (!existsSync(targetsPath)) return [];
-  return readFileSync(targetsPath, 'utf8')
+  const path = existsSync(processedManifestPath) ? processedManifestPath : fullManifestPath;
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf8')
     .split('\n')
     .map((l) => l.trim())
     .filter((l) => l.length > 0 && !l.startsWith('#'));

--- a/scripts/codex-campaigns/lib/run-campaign.sh
+++ b/scripts/codex-campaigns/lib/run-campaign.sh
@@ -86,6 +86,14 @@ TOTAL="$(wc -l < "$TARGET_LIST" | tr -d ' ')"
 [[ -f "$FINDINGS" ]] || : > "$FINDINGS"
 START_COUNT="$(wc -l < "$FINDINGS" | tr -d ' ')"
 
+# Track the targets actually processed in this run. Without this, a partial
+# run (--limit / --targets override) would consolidate against the full
+# campaign manifest and pre-seed every un-run target as `verdict: "pass"`,
+# inflating scoreboard pass counts and hiding gaps. The consolidator prefers
+# this file when present.
+TARGETS_PROCESSED="$REPORT_DIR/targets-processed.txt"
+: > "$TARGETS_PROCESSED"
+
 echo "campaign=$CAMPAIGN targets=$TOTAL head=$HEAD_SHA" | tee -a "$RUN_LOG"
 
 # ─── Per-target execution ─────────────────────────────────────────────────
@@ -149,6 +157,38 @@ run_target() {
     fi
   done < "$source_file"
 
+  # Crashed Codex runs must register as `error` verdicts, not silent passes.
+  # Without this, a non-zero exit produces an empty $last_msg → zero parsed
+  # findings → the consolidator's pre-seeded `pass` verdict for the target
+  # stands. Emit a synthetic finding so scoreboard.json + audit logs surface
+  # the failure.
+  if (( codex_rc != 0 )) && (( parsed == 0 )); then
+    local now; now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    jq -nc \
+      --arg campaign "$CAMPAIGN" \
+      --arg target "$target" \
+      --arg tag "$tag" \
+      --arg ts "$now" \
+      --arg sha "$HEAD_SHA" \
+      --arg transcript "$transcript" \
+      '{
+        campaign: $campaign,
+        target: $target,
+        tag: $tag,
+        ts: $ts,
+        codex_run: $sha,
+        severity: "high",
+        category: "infra",
+        file: $transcript,
+        line: 1,
+        issue: "codex exec exited non-zero — no findings parsed",
+        evidence: "see transcript",
+        fix: "rerun the target or inspect the transcript for the underlying failure",
+        verdict_for_target: "error"
+      }' >> "$tmpf"
+    parsed=1
+  fi
+
   # Sequential loop — no concurrent appenders, so no locking needed.
   # If we ever add `xargs -P`, reintroduce flock here.
   if (( parsed > 0 )); then
@@ -156,12 +196,13 @@ run_target() {
   fi
   rm -f "$tmpf"
 
-  echo "[$idx/$TOTAL] $tag parsed=$parsed rejected=$rejected" | tee -a "$RUN_LOG"
+  echo "[$idx/$TOTAL] $tag parsed=$parsed rejected=$rejected codex_rc=$codex_rc" | tee -a "$RUN_LOG"
 }
 
 IDX=0
 while IFS= read -r target; do
   IDX=$((IDX + 1))
+  echo "$target" >> "$TARGETS_PROCESSED"
   run_target "$target" "$IDX"
 
   if (( IDX % 5 == 0 )); then


### PR DESCRIPTION
## Summary

Codex adversarial review pass 3 against staging head `f0e9ab3e6` returned `concerns` with 4 findings (2 HIGH, 2 MEDIUM). All four are fixed here.

| # | Severity | File | Issue |
|---|---|---|---|
| 1 | HIGH | `.github/workflows/ci.yml` | Coverage gate restricted to `matrix.shard == '1/4'` — components whose tests landed on shards 2-4 could regress unchecked. |
| 2 | HIGH | `scripts/codex-campaigns/lib/run-campaign.sh` | Crashed `codex exec` (non-zero exit, empty `last_msg`) silently inherited the consolidator's pre-seeded `pass` verdict. |
| 3 | MEDIUM | `scripts/codex-campaigns/lib/run-campaign.sh` + `consolidate-findings.ts` | Partial runs (`--limit` / `--targets`) consolidated against the full manifest, pre-seeding un-run targets as `pass` and inflating scoreboard counts. |
| 4 | MEDIUM | `.github/workflows/publish.yml` | `GITHUB_RUN_ID` is stable across reruns; release-manifest branch name collided on rerun, causing non-fast-forward push that orphaned the manifest PR. |

## Fixes

1. **ci.yml** — drop the shard==1/4 gate. `check-coverage.mjs` already intersects `HX_COVERAGE_COMPONENTS` with components whose tests actually executed on the current shard (read from `.cache/test-results.json`), so each shard enforces its own slice.
2. **run-campaign.sh** — when `codex_rc != 0 && parsed == 0`, emit a synthetic `verdict: "error"` JSONL finding via `jq -nc` so the scoreboard surfaces the failure as `error`, not `pass`.
3. **run-campaign.sh + consolidate-findings.ts** — write `${REPORT_DIR}/targets-processed.txt` per run; consolidator's `loadTargetManifest()` prefers it over the full `campaign-<name>/targets.txt` when present.
4. **publish.yml** — change branch name to `release-manifest/${VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`. `GITHUB_RUN_ATTEMPT` is auto-injected by the runner and increments per rerun.

## Test plan

- [x] Lint clean
- [x] Format clean
- [x] Type-check clean
- [x] Pre-push test:smart passed
- [ ] CI Quality Gates pass on this PR
- [ ] CodeRabbit review

## Codex audit

Pass-3 findings will be re-validated after merge via fresh `/codex-review main` against the updated staging head. Per `feedback_codex_deep_review_staging_main.md`, this is the iteration loop — expect another pass if Codex surfaces new concerns.