### PR TITLE
fix(codex-3.1.0): close 5 pass-4 adversarial review findings

### DIFF
--- a/.changeset/codex-3.1.0-pass4-remediation.md
+++ b/.changeset/codex-3.1.0-pass4-remediation.md
@@ -1,0 +1,36 @@
+---
+'@helixui/library': patch
+---
+
+Close five Codex adversarial-review findings surfaced in pass 4 of the 3.1.0
+staging→main review loop. Two of these are regressions introduced by pass 3.
+
+- `scripts/codex-campaigns/lib/run-campaign.sh`: change the synthetic
+  crashed-run finding's `category` from `"infra"` (not in the schema) to
+  `"other"`. Pass 3 added the synthetic finding to surface crashed Codex
+  runs in the scoreboard, but `validate-findings.ts` would have rejected the
+  invalid category and aborted the entire batch via the
+  `validate-after-5-targets` gate — silently hiding the failure the fix was
+  designed to expose.
+- `scripts/check-coverage.mjs`: add a shard-level short-circuit when scoped
+  enforcement is active. The "few test files" branch in `ci.yml` legitimately
+  skips vitest on shards 2-4 when the changed-file set produces fewer test
+  files than shards. Pass 3 removed the `matrix.shard == '1/4'` gate so the
+  coverage step now runs on every shard — without this short-circuit, shards
+  that ran no tests would hit the missing-coverage hard fail and report a
+  misleading "vitest watchdog killed the run" error.
+- `scripts/check-coverage.mjs`: harden `loadShardComponents()` null
+  handling. When `test-results.json` is missing entirely, fail loudly with a
+  named-file error instead of silently bypassing the shard intersection
+  (which would re-introduce the false-failure the shard-aware check exists
+  to fix).
+- `scripts/codex-campaigns/lib/run-campaign.sh`: append the target name to
+  `targets-processed.txt` AFTER `run_target` returns, not before. If the
+  process is killed mid-target (OOM, CI timeout, watchdog), the target stays
+  absent from the processed list so the consolidator does not pre-seed it as
+  `verdict: "pass"` and silently convert a killed run into a clean pass.
+- `scripts/codex-campaigns/lib/run-campaign.sh`: on `--resume`, preserve the
+  existing `targets-processed.txt` (append) instead of truncating. Pass 3
+  always truncated on every invocation, which broke the resume workflow by
+  rewriting the processed-target list with only the resumed subset and
+  losing every previously-completed target from scoreboard pre-seeding.

--- a/scripts/check-coverage.mjs
+++ b/scripts/check-coverage.mjs
@@ -66,7 +66,13 @@ const HX_COVERAGE_COMPONENTS = process.env.HX_COVERAGE_COMPONENTS
 // component list with "components whose test file was in this run" so the
 // coverage gate only enforces on components the shard actually exercised.
 function loadShardComponents() {
-  if (!existsSync(TEST_RESULTS_PATH)) return null;
+  if (!existsSync(TEST_RESULTS_PATH)) {
+    // Treated as a hard error by the caller when scoped enforcement is on —
+    // we cannot intersect against a list that does not exist, and silently
+    // enforcing every scoped component on every shard would re-introduce
+    // the false-failure that the shard-aware check exists to fix.
+    return null;
+  }
   try {
     const results = JSON.parse(readFileSync(TEST_RESULTS_PATH, 'utf8'));
     const names = (results.testResults || [])
@@ -75,7 +81,8 @@ function loadShardComponents() {
       .map(extractComponent)
       .filter(Boolean);
     return new Set(names);
-  } catch {
+  } catch (err) {
+    console.error(`Failed to parse ${TEST_RESULTS_PATH}: ${err.message}`);
     return null;
   }
 }
@@ -233,6 +240,35 @@ function main() {
     statements: config.threshold?.statements ?? THRESHOLD,
   };
   const exemptions = config.exemptions ?? {};
+
+  // Shard-level short-circuit. The "few test files" branch in ci.yml writes
+  // an empty test-results.json and skips vitest entirely on shards 2-4 when
+  // the changed-file set produces fewer test files than shards. With no
+  // vitest run there is no coverage data — but the shard still has nothing
+  // to enforce. Exit 0 before loadCoverageData() trips the missing-data
+  // hard fail. Only applies when scoped enforcement is active; full runs
+  // continue to require coverage data.
+  if (HX_COVERAGE_COMPONENTS) {
+    const shardComponentsEarly = loadShardComponents();
+    if (shardComponentsEarly === null) {
+      console.error(
+        `Coverage gate: ${TEST_RESULTS_PATH} is missing or unreadable. ` +
+          `Cannot determine which scoped components ran on this shard. ` +
+          `Ensure the test step writes test-results.json before invoking check-coverage.`,
+      );
+      if (process.env.GITHUB_ACTIONS === 'true') {
+        console.log(`::error title=Coverage gate failed::missing test-results.json`);
+      }
+      process.exit(1);
+    }
+    if (shardComponentsEarly.size === 0) {
+      console.log(
+        `Shard had no test files to run — nothing to enforce. ` +
+          `Scoped components [${[...HX_COVERAGE_COMPONENTS].join(', ')}] are checked on the shards that ran their tests.`,
+      );
+      process.exit(0);
+    }
+  }
 
   const coverageData = loadCoverageData();
   const components = aggregateByComponent(coverageData);

--- a/scripts/codex-campaigns/lib/run-campaign.sh
+++ b/scripts/codex-campaigns/lib/run-campaign.sh
@@ -91,8 +91,16 @@ START_COUNT="$(wc -l < "$FINDINGS" | tr -d ' ')"
 # campaign manifest and pre-seed every un-run target as `verdict: "pass"`,
 # inflating scoreboard pass counts and hiding gaps. The consolidator prefers
 # this file when present.
+#
+# Resume semantics: on `--resume` we APPEND so a resumed run preserves the
+# prior invocations' processed-target list. On a fresh run we truncate. A
+# target is only appended AFTER `run_target` returns, so a killed-mid-target
+# invocation does not falsely register the target as a clean pass when the
+# consolidator pre-seeds the manifest (see consolidate-findings.ts).
 TARGETS_PROCESSED="$REPORT_DIR/targets-processed.txt"
-: > "$TARGETS_PROCESSED"
+if (( RESUME == 0 )); then
+  : > "$TARGETS_PROCESSED"
+fi
 
 echo "campaign=$CAMPAIGN targets=$TOTAL head=$HEAD_SHA" | tee -a "$RUN_LOG"
 
@@ -178,7 +186,7 @@ run_target() {
         ts: $ts,
         codex_run: $sha,
         severity: "high",
-        category: "infra",
+        category: "other",
         file: $transcript,
         line: 1,
         issue: "codex exec exited non-zero — no findings parsed",
@@ -202,8 +210,11 @@ run_target() {
 IDX=0
 while IFS= read -r target; do
   IDX=$((IDX + 1))
-  echo "$target" >> "$TARGETS_PROCESSED"
   run_target "$target" "$IDX"
+  # Append AFTER run_target completes — if the process is killed mid-target
+  # (OOM, CI timeout, watchdog), the target stays absent from the processed
+  # list, so the consolidator does not pre-seed it as `verdict: "pass"`.
+  echo "$target" >> "$TARGETS_PROCESSED"
 
   if (( IDX % 5 == 0 )); then
     echo "validating after batch of 5…" | tee -a "$RUN_LOG"


### PR DESCRIPTION
## Summary

Codex adversarial review pass 4 against staging head `89e81183a` returned **BLOCKING** with 5 findings (1 CRITICAL, 2 HIGH, 2 MEDIUM). Two are regressions introduced by pass 3. All five fixed here.

| # | Severity | File | Issue |
|---|---|---|---|
| 1 | CRITICAL | `run-campaign.sh` | Synthetic crashed-run finding used `category: "infra"` — not in schema. `validate-findings.ts` would reject it and abort the entire batch, silently hiding the failure the fix was designed to surface. |
| 2 | HIGH | `ci.yml` × `check-coverage.mjs` | Pass 3 dropped the shard==1/4 gate; on shards with no test files (small PRs), missing coverage data hits the hard-fail path with a misleading "vitest watchdog killed" message. |
| 3 | MEDIUM | `check-coverage.mjs` | `loadShardComponents()` returned `null` when test-results.json was missing, then the skip condition silently bypassed the shard intersection — re-introducing the false-failure the shard-aware check exists to fix. |
| 4 | HIGH | `run-campaign.sh` | `targets-processed.txt` was written BEFORE `run_target`. A killed-mid-target invocation left the target in the processed list with no findings, so the consolidator pre-seeded it as `verdict: "pass"`. |
| 5 | MEDIUM | `run-campaign.sh` | `--resume` truncated `targets-processed.txt` on every invocation, losing all prior-run progress and breaking the resume workflow's scoreboard pre-seeding. |

## Fixes

1. **F1** — Change synthetic finding `category: "infra"` → `"other"` (1 line).
2. **F2** — Add early short-circuit in `check-coverage.mjs` `main()`: when `HX_COVERAGE_COMPONENTS` is set AND the shard's test-results.json contains an empty test array, exit 0 with "shard had no tests to run" before reaching `loadCoverageData()`.
3. **F3** — When test-results.json is missing entirely, fail loudly with the named file path instead of returning null.
4. **F4** — Move `echo "$target" >> "$TARGETS_PROCESSED"` to AFTER `run_target` returns.
5. **F5** — On `--resume`, append to `targets-processed.txt` instead of truncating.

## Codex audit

- Pass 4 audit entry: `.rea/audit.jsonl:161` (verdict: `blocking`, 5 findings)
- Pass 5 will run after this merges, against the new staging head. Per `feedback_codex_deep_review_staging_main.md`, iterating until verdict is `pass` (or only info-level findings remain).

## Test plan

- [x] Lint, format, type-check (clean before push)
- [x] Pre-push test:smart passed
- [ ] CI Quality Gates pass
- [ ] CodeRabbit review