### PR TITLE
fix(security): unanchor figma-inventory.json gitleaks allowlist for tarball scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -42,8 +42,11 @@ paths = [
     # Next.js build cache — auto-generated preview mode keys, not real secrets
     '''\.next/''',
     # Figma inventory — generated design token catalog, contains token names like
-    # "duration/slow" that trip generic-api-key rules; no secrets live here
-    '''^packages/hx-library/figma-inventory\.json$''',
+    # "duration/slow" that trip generic-api-key rules; no secrets live here.
+    # Pattern is unanchored so it matches both the in-repo path
+    # (packages/hx-library/figma-inventory.json) and the publish-time tarball
+    # extract path (/tmp/.../extract-helixui-library-X/package/figma-inventory.json).
+    '''figma-inventory\.json$''',
 ]
 
 regexes = [


### PR DESCRIPTION
## Why

The 3.2.0 publish job (run [24934824168](https://github.com/bookedsolidtech/helix/actions/runs/24934824168)) failed on the pre-publish secret scan with a generic-api-key false positive against \`figma-inventory.json\`:

\`\`\`
File: /tmp/tmp.7lL0KnQwNS/extract-helixui-library-3.1.0/package/figma-inventory.json
Line: 1656
Match: "semanticToken": "duration/slow"
\`\`\`

\`duration/slow\` is a CSS animation duration token name; the entropy is high enough to trigger gitleaks' default \`generic-api-key\` rule. The file is already in the gitleaks allowlist — but the path pattern was anchored to the repo-relative form (\`^packages/hx-library/figma-inventory.json$\`), which only matches in-repo scans. The publish workflow runs gitleaks against the **extracted tarball** at \`/tmp/.../extract-helixui-library-X/package/figma-inventory.json\`, where the anchor doesn't match.

## What

Drop the path-anchor so the pattern matches both forms:
- \`packages/hx-library/figma-inventory.json\` (in-repo scans)
- \`/tmp/.../extract-helixui-library-X/package/figma-inventory.json\` (publish-time tarball scan)

\`\`\`diff
-    '''^packages/hx-library/figma-inventory\.json$''',
+    '''figma-inventory\.json$''',
\`\`\`

## Impact

Unblocks the 3.2.0 npm publish + GitHub release. Once this lands on main, publish.yml retriggers and the secret scan will pass.

## Risk

Minimal. The unanchored pattern still requires the basename \`figma-inventory.json\`. The trailing \`$\` anchor prevents accidental matches against any file whose name happens to end with that string mid-path.

## Verification

- [x] Local repo scan still excludes the file (pre-commit gitleaks passed on this branch)
- Pending: publish workflow re-runs cleanly after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated secret scanning configuration to improve detection across deployment artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->