### PR TITLE
feat: 3.2.1 token cascade remediation + cold-start AA fixes

### DIFF
--- a/.changeset/3-2-1-token-cascade-remediation.md
+++ b/.changeset/3-2-1-token-cascade-remediation.md
@@ -1,0 +1,25 @@
+---
+'@helixui/tokens': minor
+'@helixui/library': patch
+'@helixui/react': patch
+---
+
+3.2.1 — token cascade remediation surfaced by Codex Token Cascade campaign pilot.
+
+**Tokens (minor — additive only):**
+- New semantic action layer under `semantic.color.action.{primary,secondary,ghost,danger}.*` for interactive surfaces, with light/dark/HC overrides.
+- New `text.on-primary-strong` and `text.on-error-strong` semantics (neutral-0) for darker hover states where AA contrast demands white.
+- New `border.on-dark-{strong,default,subtle}` semantics for inverted-button outlines, abstracting the overlay-white primitives.
+- New `surface.success-strong` / `warning-strong` / `danger-strong` / `info-strong` semantics for emphasized status surfaces (toast variants).
+- 13 new contrast regression assertions in `contrast.test.ts` covering every new action × text-on-strong pair across light/dark/HC.
+
+**Library (patch — bug fixes):**
+- `hx-button`, `hx-toast`, `hx-side-nav`, `hx-nav-item` variant rules rewritten to consume the new semantic action layer instead of bare primitives. Closes 21 high-severity Token Cascade campaign findings.
+- **Two latent AA cold-start failures fixed in `hx-button`:** the inline hex fallback for `--hx-color-text-on-primary` and `--hx-color-text-on-error` was `#ffffff` while the semantic resolves to `#0D1825`. When the semantic was unset (cold-start, theme switch race) buttons painted white-on-primary-500 (3.43:1) and white-on-error-500 (3.92:1) — both AA failures the semantic was specifically designed to prevent. Inline fallbacks corrected.
+- Stale inline hex fallbacks in `hx-side-nav` corrected to match post-3.2.0 semantic resolutions (text.inverse, border.strong).
+- Forced-colors composition resolved in `hx-button`, `hx-side-nav`, `hx-nav-item`, `hx-text-input` — components no longer double-up on both the `forcedColorsInteractive`/`forcedColorsField` mixin and a bespoke `@media (forced-colors: active)` block.
+- `hx-text-input` `@cssprop` JSDoc defaults aligned with runtime cascade — defaults now reference the semantic tokens used at paint time (`--hx-color-surface-default`, `--hx-color-text-strong`, `--hx-color-border-strong`, `--hx-color-error-text`).
+
+**React (patch — peer bump):** No public API surface delta; wrapper regeneration confirms zero breakage.
+
+No tokens removed, no APIs broken. Pure additive cleanup.

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-04-25T16:30:29.862Z",
+  "generatedAt": "2026-04-25T18:12:29.050Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.2.0",
   "tokensVersion": "3.2.0",
@@ -23368,36 +23368,36 @@
         {
           "description": "Input background color.",
           "name": "--hx-input-bg",
-          "default": "var(--hx-color-neutral-0)",
+          "default": "var(--hx-color-surface-default)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/0",
+            "semanticToken": "color/surface/default",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
           "description": "Input text color.",
           "name": "--hx-input-color",
-          "default": "var(--hx-color-neutral-800)",
+          "default": "var(--hx-color-text-strong)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/800",
+            "semanticToken": "color/text/strong",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
           "description": "Input border color.",
           "name": "--hx-input-border-color",
-          "default": "var(--hx-color-neutral-300)",
+          "default": "var(--hx-color-border-strong)",
           "figmaBinding": {
             "target": "Stroke",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/300",
+            "semanticToken": "color/border/strong",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
@@ -23440,24 +23440,24 @@
         {
           "description": "Error state color.",
           "name": "--hx-input-error-color",
-          "default": "var(--hx-color-error-500)",
+          "default": "var(--hx-color-error-text)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/error",
-            "fallbackPrimitive": "color/error/500",
+            "semanticToken": "color/error/text",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
           "description": "Label text color.",
           "name": "--hx-input-label-color",
-          "default": "var(--hx-color-neutral-700)",
+          "default": "var(--hx-color-text-strong)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/700",
+            "semanticToken": "color/text/strong",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },

--- a/packages/hx-library/src/components/hx-button/hx-button.styles.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.styles.ts
@@ -48,10 +48,7 @@ export const helixButtonStyles = css`
 
   .button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-button-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-button-focus-ring-color, var(--hx-focus-ring-color, #6ab1b1));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -89,8 +86,11 @@ export const helixButtonStyles = css`
   /* ─── Style Variants ─── */
 
   .button--primary {
-    --hx-button-bg: var(--hx-color-primary-500, #429797);
-    --hx-button-color: var(--hx-color-text-on-primary, #ffffff);
+    --hx-button-bg: var(--hx-color-action-primary-bg, #429797);
+    /* Inline #0d1825 matches text.on-primary's resolved primitive (neutral-900);
+       cold-start without the semantic still paints AA-tuned dark-on-primary
+       rather than white-on-primary (3.43:1 fail). */
+    --hx-button-color: var(--hx-color-text-on-primary, #0d1825);
     --hx-button-border-color: transparent;
   }
 
@@ -98,8 +98,8 @@ export const helixButtonStyles = css`
     --hx-button-bg: transparent;
     /* primary-500 (#429797) text on white surface = 3.43:1 — fails AA.
        primary-600 (#0F7078) on white = 6.06:1 — AA pass. */
-    --hx-button-color: var(--hx-color-primary-600, #0f7078);
-    --hx-button-border-color: var(--hx-color-primary-600, #0f7078);
+    --hx-button-color: var(--hx-color-action-secondary-fg, #0f7078);
+    --hx-button-border-color: var(--hx-color-action-secondary-border, #0f7078);
   }
 
   .button--secondary:hover {
@@ -117,25 +117,29 @@ export const helixButtonStyles = css`
   }
 
   .button--danger {
-    --hx-button-bg: var(--hx-color-error-500, #e5493e);
-    --hx-button-color: var(--hx-color-text-on-error, #ffffff);
+    --hx-button-bg: var(--hx-color-action-danger-bg, #e5493e);
+    /* Inline #0d1825 matches text.on-error's resolved primitive (neutral-900);
+       cold-start without the semantic still paints AA-tuned dark-on-error
+       rather than white-on-error (3.92:1 fail). */
+    --hx-button-color: var(--hx-color-text-on-error, #0d1825);
     --hx-button-border-color: transparent;
   }
 
   /* on-error tokens are tuned for error-500 (neutral-900 on #E5493E ≈ 4.59:1).
-     error-600 (#C92A2A) drops that to 2.25:1 — AA fail. Hold fg at neutral-0
-     directly so darker hover fills stay legible. Mirrors hx-toast precedent
-     (commit 300e21ab0). */
+     error-600 (#C92A2A) drops that to 2.25:1 — AA fail. text.on-error-strong
+     resolves to neutral-0 across modes (no dark flip) so the darker hover fill
+     stays legible. Mirrors hx-toast precedent (commit 300e21ab0); routed
+     through the semantic tier in 3.2.1 token-cascade remediation. */
   .button--danger:hover {
-    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-error-600, #c92a2a));
-    --hx-button-color: var(--hx-color-neutral-0, #ffffff);
+    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-action-danger-bg-hover, #c92a2a));
+    --hx-button-color: var(--hx-color-text-on-error-strong, #ffffff);
   }
 
   .button--ghost {
     --hx-button-bg: transparent;
     /* primary-500 (#429797) text on white surface = 3.43:1 — fails AA.
        primary-600 (#0F7078) on white = 6.06:1 — AA pass. */
-    --hx-button-color: var(--hx-color-primary-600, #0f7078);
+    --hx-button-color: var(--hx-color-action-ghost-fg, #0f7078);
     --hx-button-border-color: transparent;
   }
 
@@ -154,12 +158,13 @@ export const helixButtonStyles = css`
   }
 
   /* on-primary token resolves to neutral-900 (#0D1825) — tuned for primary-500.
-     primary-600 (#0F7078) drops the pair to 3.07:1 — AA fail. Pin fg at
-     neutral-0 for the darker hover fill. Mirrors hx-toast precedent
-     (commit 300e21ab0). */
+     primary-600 (#0F7078) drops the pair to 3.07:1 — AA fail. text.on-primary-strong
+     resolves to neutral-0 across modes (no dark flip) for the darker hover fill.
+     Mirrors hx-toast precedent (commit 300e21ab0); routed through the semantic
+     tier in 3.2.1 token-cascade remediation. */
   .button--primary:hover {
-    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-primary-600, #0f7078));
-    --hx-button-color: var(--hx-color-neutral-0, #ffffff);
+    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-action-primary-bg-hover, #0f7078));
+    --hx-button-color: var(--hx-color-text-on-primary-strong, #ffffff);
   }
 
   /* ─── Disabled ─── */
@@ -205,7 +210,7 @@ export const helixButtonStyles = css`
 
   /* Override text color and filter-based hover/active for all variants */
   :host([inverted]) .button {
-    color: var(--hx-button-inverted-color, var(--hx-color-neutral-0, #ffffff));
+    color: var(--hx-button-inverted-color, var(--hx-color-text-inverse, #ffffff));
     filter: none;
   }
 
@@ -220,35 +225,35 @@ export const helixButtonStyles = css`
   :host([inverted]) .button:focus-visible {
     outline-color: var(
       --hx-button-inverted-focus-ring-color,
-      var(--hx-overlay-white-50, rgba(255, 255, 255, 0.5))
+      var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.5))
     );
   }
 
   /* Primary inverted — slight transparent white overlay on hover */
   :host([inverted]) .button--primary:hover {
-    --hx-button-bg: var(--hx-color-primary-400, #6ab1b1);
+    --hx-button-bg: var(--hx-color-action-primary-bg-inverted-hover, #6ab1b1);
   }
 
-  /* Secondary inverted — white border and text */
+  /* Secondary inverted — white border and translucent hover fill */
   :host([inverted]) .button--secondary {
-    --hx-button-border-color: var(--hx-overlay-white-70, rgba(255, 255, 255, 0.7));
+    --hx-button-border-color: var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7));
   }
 
   :host([inverted]) .button--secondary:hover {
-    --hx-button-bg: var(--hx-overlay-white-15, rgba(255, 255, 255, 0.15));
+    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.15));
   }
 
   /* Tertiary inverted */
   :host([inverted]) .button--tertiary {
-    --hx-button-bg: var(--hx-overlay-white-15, rgba(255, 255, 255, 0.15));
+    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.15));
     --hx-button-border-color: transparent;
   }
 
   :host([inverted]) .button--tertiary:hover {
-    --hx-button-bg: var(--hx-overlay-white-25, rgba(255, 255, 255, 0.25));
+    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.25));
   }
 
-  /* Ghost inverted — transparent base, white hover bg */
+  /* Ghost inverted — transparent base, translucent hover bg */
   :host([inverted]) .button--ghost {
     --hx-button-bg: transparent;
     --hx-button-border-color: transparent;
@@ -257,17 +262,17 @@ export const helixButtonStyles = css`
   :host([inverted]) .button--ghost:hover {
     --hx-button-bg: var(
       --hx-button-inverted-ghost-hover-bg,
-      var(--hx-overlay-white-20, rgba(255, 255, 255, 0.2))
+      var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.2))
     );
   }
 
   /* Outline inverted — white border */
   :host([inverted]) .button--outline {
-    --hx-button-border-color: var(--hx-overlay-white-70, rgba(255, 255, 255, 0.7));
+    --hx-button-border-color: var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7));
   }
 
   :host([inverted]) .button--outline:hover {
-    --hx-button-bg: var(--hx-overlay-white-15, rgba(255, 255, 255, 0.15));
+    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.15));
   }
 
   /* ─── Prefix / Suffix / Label ─── */

--- a/packages/hx-library/src/components/hx-button/hx-button.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.ts
@@ -6,7 +6,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { HelixElement } from '../../base/index.js';
 import { mixinDelegatesAria } from '../../mixins/index.js';
 import { helixButtonStyles } from './hx-button.styles.js';
-import { forcedColorsInteractive } from '../../styles/forced-colors.js';
 import { devWarn } from '../../utils/dev-warn.js';
 
 /** Detail for the hx-click event dispatched by hx-button. */
@@ -93,7 +92,12 @@ export interface HxButtonClickDetail {
  */
 @customElement('hx-button')
 export class HelixButton extends mixinDelegatesAria(HelixElement) {
-  static override styles = [helixButtonStyles, forcedColorsInteractive];
+  // 3.2.1: forced-colors deference is owned by the bespoke @media block in
+  // hx-button.styles.ts (covers loading/disabled/focus, not just the base).
+  // Do NOT also compose forcedColorsInteractive here — the mixin's docstring
+  // forbids dual composition (XOR rule) and the dual approach was flagged in
+  // the token-cascade campaign findings.
+  static override styles = [helixButtonStyles];
 
   // ─── Form Association ───
 

--- a/packages/hx-library/src/components/hx-side-nav/hx-nav-item.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-nav-item.styles.ts
@@ -75,10 +75,7 @@ export const helixNavItemStyles = css`
 
   .nav-item__link:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-nav-item-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-400, #6ab1b1))
-      );
+      var(--hx-nav-item-focus-ring-color, var(--hx-focus-ring-color, #6ab1b1));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -88,14 +85,23 @@ export const helixNavItemStyles = css`
     /* Active state sits on the darker primary-600 (#0F7078) fill. White text
        (#ffffff) on primary-600 = 5.39:1 WCAG AA pass. text-on-primary now
        resolves to neutral-900 (intended for the lighter primary-500 surface)
-       which would fail here, so we hold the active fg at neutral-0. */
-    background-color: var(--hx-nav-item-active-bg, var(--hx-color-primary-600, #0f7078));
-    color: var(--hx-nav-item-active-color, var(--hx-color-neutral-0, #ffffff));
+       which would fail here. text.on-primary-strong holds at neutral-0 across
+       modes (no dark flip) so the active fg stays AA. 3.2.1: routed through
+       the action.* / on-{role}-strong semantic tier per token-cascade
+       remediation (no more bare primary-600 / neutral-0 consumption). */
+    background-color: var(
+      --hx-nav-item-active-bg,
+      var(--hx-color-action-primary-bg-hover, #0f7078)
+    );
+    color: var(--hx-nav-item-active-color, var(--hx-color-text-on-primary-strong, #ffffff));
   }
 
   :host([active]) .nav-item__link:hover {
-    /* text-on-primary (#ffffff) on primary-700 (#0F6363) = WCAG AA ✓ */
-    background-color: var(--hx-nav-item-active-hover-bg, var(--hx-color-primary-700, #0f6363));
+    /* text.on-primary-strong (#ffffff) on primary-700 (#0F6363) = WCAG AA ✓ */
+    background-color: var(
+      --hx-nav-item-active-hover-bg,
+      var(--hx-color-action-primary-bg-active, #0f6363)
+    );
   }
 
   /* ─── Disabled State ─── */
@@ -186,9 +192,10 @@ export const helixNavItemStyles = css`
     top: 50%;
     transform: translateY(-50%);
     /* tooltip is an inverted surface — flips per mode via surface-inverse /
-       text-inverse. */
-    background-color: var(--hx-color-surface-inverse, #0d1825);
-    color: var(--hx-color-text-inverse, #ebeee9);
+       text-inverse. 3.2.1: wrapped with component-tier slots so consumers can
+       theme tooltip surface/text without overriding the global semantics. */
+    background-color: var(--hx-nav-item-tooltip-bg, var(--hx-color-surface-inverse, #0d1825));
+    color: var(--hx-nav-item-tooltip-color, var(--hx-color-text-inverse, #ffffff));
     padding: var(--hx-space-1, 0.25rem) var(--hx-space-2, 0.5rem);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
     font-size: var(--hx-font-size-xs, 0.75rem);

--- a/packages/hx-library/src/components/hx-side-nav/hx-nav-item.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-nav-item.ts
@@ -2,7 +2,6 @@ import { html, nothing } from 'lit';
 import '../../utilities/document-token-adoption.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HelixElement, createIdCounter } from '../../base/index.js';
-import { forcedColorsInteractive } from '../../styles/forced-colors.js';
 import { helixNavItemStyles } from './hx-nav-item.styles.js';
 
 const _nextNavItemId = createIdCounter('hx-nav-item');
@@ -36,7 +35,11 @@ const _nextNavItemId = createIdCounter('hx-nav-item');
  */
 @customElement('hx-nav-item')
 export class HelixNavItem extends HelixElement {
-  static override styles = [helixNavItemStyles, forcedColorsInteractive];
+  // 3.2.1: forced-colors deference is owned by the bespoke @media block in
+  // hx-nav-item.styles.ts (active border, focus outline, tooltip border).
+  // Do NOT also compose forcedColorsInteractive — XOR rule per the mixin
+  // docstring.
+  static override styles = [helixNavItemStyles];
 
   /** @internal — per-instance tooltip ID */
   private _tooltipId = `${_nextNavItemId()}-tooltip`;

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
@@ -10,7 +10,7 @@ export const helixSideNavStyles = css`
        and evaluates their text against the page white background, producing
        false-positive color-contrast violations (WCAG 2.1 AA). */
     background-color: var(--hx-side-nav-bg, var(--hx-color-surface-inverse, #0d1825));
-    color: var(--hx-side-nav-color, var(--hx-color-text-inverse, #ebeee9));
+    color: var(--hx-side-nav-color, var(--hx-color-text-inverse, #ffffff));
   }
 
   * {
@@ -25,11 +25,11 @@ export const helixSideNavStyles = css`
     height: 100%;
     width: var(--hx-side-nav-width, 16rem);
     background-color: var(--hx-side-nav-bg, var(--hx-color-surface-inverse, #0d1825));
-    color: var(--hx-side-nav-color, var(--hx-color-text-inverse, #ebeee9));
+    color: var(--hx-side-nav-color, var(--hx-color-text-inverse, #ffffff));
     transition: width var(--hx-transition-normal, 300ms) ease;
     overflow: hidden;
     border-inline-end: var(--hx-border-width-thin, 1px) solid
-      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #313e4b));
+      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #8e9c98));
   }
 
   /* ─── Collapsed State ─── */
@@ -47,7 +47,7 @@ export const helixSideNavStyles = css`
     flex-shrink: 0;
     min-height: var(--hx-space-14, 3.5rem);
     border-bottom: var(--hx-border-width-thin, 1px) solid
-      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #313e4b));
+      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #8e9c98));
     overflow: hidden;
   }
 
@@ -74,7 +74,7 @@ export const helixSideNavStyles = css`
     flex-shrink: 0;
     min-height: var(--hx-space-14, 3.5rem);
     border-top: var(--hx-border-width-thin, 1px) solid
-      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #313e4b));
+      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #8e9c98));
     overflow: hidden;
   }
 
@@ -97,7 +97,7 @@ export const helixSideNavStyles = css`
     border: none;
     border-radius: var(--hx-border-radius-sm, 0.25rem);
     background: transparent;
-    color: var(--hx-side-nav-toggle-color, var(--hx-color-text-inverse, #b6bfb9));
+    color: var(--hx-side-nav-toggle-color, var(--hx-color-text-inverse, #ffffff));
     cursor: pointer;
     transition:
       background-color var(--hx-transition-fast, 150ms) ease,
@@ -106,10 +106,10 @@ export const helixSideNavStyles = css`
 
   .side-nav__toggle:hover {
     background-color: var(
-      --hx-overlay-white-10,
+      --hx-color-border-on-dark-subtle,
       rgba(255, 255, 255, 0.1)
     ); /* fallback for browsers without color-mix() */
-    color: var(--hx-color-text-inverse, #ebeee9);
+    color: var(--hx-side-nav-toggle-hover-color, var(--hx-color-text-inverse, #ffffff));
   }
 
   @supports (color: color-mix(in srgb, red 50%, blue)) {
@@ -120,10 +120,7 @@ export const helixSideNavStyles = css`
 
   .side-nav__toggle:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-side-nav-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-400, #6ab1b1))
-      );
+      var(--hx-side-nav-focus-ring-color, var(--hx-focus-ring-color, #6ab1b1));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
@@ -2,7 +2,6 @@ import { html, type PropertyValues } from 'lit';
 import '../../utilities/document-token-adoption.js';
 import { customElement, property } from 'lit/decorators.js';
 import { HelixElement } from '../../base/index.js';
-import { forcedColorsInteractive } from '../../styles/forced-colors.js';
 import { helixSideNavStyles } from './hx-side-nav.styles.js';
 
 /**
@@ -56,7 +55,10 @@ import { helixSideNavStyles } from './hx-side-nav.styles.js';
  */
 @customElement('hx-side-nav')
 export class HelixSideNav extends HelixElement {
-  static override styles = [helixSideNavStyles, forcedColorsInteractive];
+  // 3.2.1: forced-colors deference is owned by the bespoke @media block in
+  // hx-side-nav.styles.ts (toggle button, header/footer borders). Do NOT also
+  // compose forcedColorsInteractive — XOR rule per the mixin docstring.
+  static override styles = [helixSideNavStyles];
 
   // ─── Properties ───
 

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.ts
@@ -45,14 +45,14 @@ export interface HxTextInputDetail {
  * @csspart help-text - The help text container.
  * @csspart error - The error message container.
  *
- * @cssprop [--hx-input-bg=var(--hx-color-neutral-0)] - Input background color.
- * @cssprop [--hx-input-color=var(--hx-color-neutral-800)] - Input text color.
- * @cssprop [--hx-input-border-color=var(--hx-color-neutral-300)] - Input border color.
+ * @cssprop [--hx-input-bg=var(--hx-color-surface-default)] - Input background color.
+ * @cssprop [--hx-input-color=var(--hx-color-text-strong)] - Input text color.
+ * @cssprop [--hx-input-border-color=var(--hx-color-border-strong)] - Input border color.
  * @cssprop [--hx-input-border-radius=var(--hx-border-radius-md)] - Input border radius.
  * @cssprop [--hx-input-font-family=var(--hx-font-family-sans)] - Input font family.
  * @cssprop [--hx-input-focus-ring-color=var(--hx-focus-ring-color)] - Focus ring color.
- * @cssprop [--hx-input-error-color=var(--hx-color-error-500)] - Error state color.
- * @cssprop [--hx-input-label-color=var(--hx-color-neutral-700)] - Label text color.
+ * @cssprop [--hx-input-error-color=var(--hx-color-error-text)] - Error state color.
+ * @cssprop [--hx-input-label-color=var(--hx-color-text-strong)] - Label text color.
  * @cssprop [--hx-input-sm-font-size=0.875rem] - Font size for the sm size variant.
  * @cssprop [--hx-input-lg-font-size=1.125rem] - Font size for the lg size variant.
  * @cssprop [--hx-opacity-disabled] - Opacity.

--- a/packages/hx-library/src/components/hx-toast/hx-toast.styles.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.styles.ts
@@ -61,33 +61,38 @@ export const helixToastStyles = css`
    * error-600) because the lighter -500 fills can't pass AA against white
    * text in the precision-cool palette. The neutral-900 on-{role} tokens
    * are tuned for the lighter -500 surfaces and would fail here (e.g.
-   * neutral-900 on primary-600 = 3.07:1), so we hold fg at neutral-0
-   * directly for primary/success/danger.
-   * - neutral-0 on primary-600 (#0F7078) = 5.39:1 — AA pass
-   * - neutral-0 on success-700 (#146831) = 6.88:1 — AA pass
+   * neutral-900 on primary-600 = 3.07:1), so the on-{role}-strong tokens
+   * (neutral-0, no dark-mode flip) keep fg legible on the darker fills.
+   * - text.on-primary-strong on info.bg-strong (primary-600, #0F7078) = 5.39:1
+   * - text.on-success-strong on success.bg-strong (success-700, #146831) = 6.88:1
    *   (success-600 #0E8A4A on white = 4.41:1 — drifts under AA at 14px)
-   * - neutral-0 on error-600   (#C92A2A) = 5.92:1 — AA pass
-   * - neutral-900 on warning-500 (#C2711C) = 4.83:1 — AA pass
+   * - text.on-error-strong   on danger.bg-strong  (error-600, #C92A2A) = 5.92:1
+   * - text.on-warning        on warning.bg-strong (warning-500, #C2711C) = 4.83:1
    *   (warning stays on the lighter -500 surface so on-warning works)
+   *
+   * 3.2.1 token-cascade: bg variants now route through surface.{role}-strong
+   * semantics; fg variants route through text.on-{role}-strong (or on-warning
+   * for the warning variant). Component-tier tokens are NOT bypassed — the
+   * --hx-toast-bg / --hx-toast-color slots remain the single override point.
    */
   .toast--success {
-    --hx-toast-bg: var(--hx-color-success-700, #146831);
-    --hx-toast-color: var(--hx-color-neutral-0, #ffffff);
+    --hx-toast-bg: var(--hx-color-surface-success-strong, #146831);
+    --hx-toast-color: var(--hx-color-text-on-success-strong, #ffffff);
   }
 
   .toast--warning {
-    --hx-toast-bg: var(--hx-color-warning-500, #c2711c);
+    --hx-toast-bg: var(--hx-color-surface-warning-strong, #c2711c);
     --hx-toast-color: var(--hx-color-text-on-warning, #0d1825);
   }
 
   .toast--danger {
-    --hx-toast-bg: var(--hx-color-error-600, #c92a2a);
-    --hx-toast-color: var(--hx-color-neutral-0, #ffffff);
+    --hx-toast-bg: var(--hx-color-surface-danger-strong, #c92a2a);
+    --hx-toast-color: var(--hx-color-text-on-error-strong, #ffffff);
   }
 
   .toast--info {
-    --hx-toast-bg: var(--hx-color-primary-600, #0f7078);
-    --hx-toast-color: var(--hx-color-neutral-0, #ffffff);
+    --hx-toast-bg: var(--hx-color-surface-info-strong, #0f7078);
+    --hx-toast-color: var(--hx-color-text-on-primary-strong, #ffffff);
   }
 
   /* ─── Severity Label (WCAG 1.4.1) ─── */

--- a/packages/hx-tokens/src/__tests__/contrast.test.ts
+++ b/packages/hx-tokens/src/__tests__/contrast.test.ts
@@ -468,6 +468,102 @@ const PAIRS: PairSpec[] = [
     label: 'text.on-info on info-600 (HC bright fill)',
     modes: ['high-contrast'],
   },
+  // 3.2.1 token-cascade remediation: text.on-{role}-strong tokens (the
+  // semantic-tier siblings of text.on-{role} that pin to neutral-0 for
+  // surfaces darker than the AA-tuned -500 stop). These exist specifically to
+  // route the "white on -600/-700" pattern through the semantic tier instead
+  // of letting components reach to neutral-0 directly. We assert against the
+  // action.* surfaces consumers actually pair them with so any future palette
+  // tweak that drops one of these pairings below AA fails here. HC mode flips
+  // the on-{role}-strong tokens to #000 (the -600 ramp stops are bright
+  // fills); the HC pairs cover that contract.
+  {
+    text: '--hx-color-text-on-primary-strong',
+    surface: '--hx-color-action-primary-bg-hover',
+    threshold: 4.5,
+    label: 'text.on-primary-strong on action.primary.bg-hover',
+    modes: ['light', 'dark'],
+  },
+  {
+    text: '--hx-color-text-on-primary-strong',
+    surface: '--hx-color-action-primary-bg-active',
+    threshold: 4.5,
+    label: 'text.on-primary-strong on action.primary.bg-active',
+    modes: ['light', 'dark'],
+  },
+  {
+    text: '--hx-color-text-on-primary-strong',
+    surface: '--hx-color-action-primary-bg-hover',
+    threshold: 4.5,
+    label: 'text.on-primary-strong on action.primary.bg-hover (HC bright fill)',
+    modes: ['high-contrast'],
+  },
+  {
+    text: '--hx-color-text-on-primary-strong',
+    surface: '--hx-color-action-primary-bg-active',
+    threshold: 4.5,
+    label: 'text.on-primary-strong on action.primary.bg-active (HC bright fill)',
+    modes: ['high-contrast'],
+  },
+  {
+    text: '--hx-color-text-on-error-strong',
+    surface: '--hx-color-action-danger-bg-hover',
+    threshold: 4.5,
+    label: 'text.on-error-strong on action.danger.bg-hover',
+    modes: ['light', 'dark'],
+  },
+  {
+    text: '--hx-color-text-on-error-strong',
+    surface: '--hx-color-action-danger-bg-active',
+    threshold: 4.5,
+    label: 'text.on-error-strong on action.danger.bg-active',
+    modes: ['light', 'dark'],
+  },
+  {
+    text: '--hx-color-text-on-error-strong',
+    surface: '--hx-color-action-danger-bg-hover',
+    threshold: 4.5,
+    label: 'text.on-error-strong on action.danger.bg-hover (HC bright fill)',
+    modes: ['high-contrast'],
+  },
+  // Resting action surfaces pair with their AA-tuned on-{role} (neutral-900
+  // in light/dark, #000 in HC) — same as the bare brand-500 pairs above, but
+  // routed through the semantic action.* tier. Asserted to lock in the
+  // semantic-tier contract.
+  {
+    text: '--hx-color-text-on-primary',
+    surface: '--hx-color-action-primary-bg',
+    threshold: 4.5,
+    label: 'text.on-primary on action.primary.bg',
+  },
+  {
+    text: '--hx-color-text-on-error',
+    surface: '--hx-color-action-danger-bg',
+    threshold: 4.5,
+    label: 'text.on-error on action.danger.bg',
+  },
+  // Secondary/ghost outline treatments paint primary-600 fg on the body
+  // surface (resting) and on action.{role}.bg-hover (hovered). Both must be
+  // body-text AA.
+  {
+    text: '--hx-color-action-secondary-fg',
+    surface: '--hx-color-surface-default',
+    threshold: 4.5,
+    label: 'action.secondary.fg on surface.default',
+  },
+  {
+    text: '--hx-color-action-secondary-fg',
+    surface: '--hx-color-action-secondary-bg-hover',
+    threshold: 4.5,
+    label: 'action.secondary.fg on action.secondary.bg-hover',
+    modes: ['light', 'dark'],
+  },
+  {
+    text: '--hx-color-action-ghost-fg',
+    surface: '--hx-color-surface-default',
+    threshold: 4.5,
+    label: 'action.ghost.fg on surface.default',
+  },
   // Link text on body surface
   {
     text: '--hx-color-text-link',

--- a/packages/hx-tokens/src/__tests__/contrast.test.ts
+++ b/packages/hx-tokens/src/__tests__/contrast.test.ts
@@ -564,6 +564,39 @@ const PAIRS: PairSpec[] = [
     threshold: 4.5,
     label: 'action.ghost.fg on surface.default',
   },
+  // 3.2.1 token-cascade remediation: surface.{role}-strong tokens (the
+  // emphasis-prominence sibling of surface.{role}, used by hx-toast variant
+  // fills and any other "loud" status surface). Each pairs with the
+  // on-{role}-strong text semantic the consuming component actually paints —
+  // these on-strong text tokens hold at neutral-0 across modes (no dark
+  // override) precisely so emphasis fills paint white-on-dark in both light
+  // and dark mode rather than flipping with text.inverse. Warning is the
+  // exception (warming-500 is light enough that neutral-900 reads better),
+  // matching the existing on-warning contract.
+  {
+    text: '--hx-color-text-on-success-strong',
+    surface: '--hx-color-surface-success-strong',
+    threshold: 4.5,
+    label: 'text.on-success-strong on surface.success-strong',
+  },
+  {
+    text: '--hx-color-text-on-warning',
+    surface: '--hx-color-surface-warning-strong',
+    threshold: 4.5,
+    label: 'text.on-warning on surface.warning-strong',
+  },
+  {
+    text: '--hx-color-text-on-error-strong',
+    surface: '--hx-color-surface-danger-strong',
+    threshold: 4.5,
+    label: 'text.on-error-strong on surface.danger-strong',
+  },
+  {
+    text: '--hx-color-text-on-primary-strong',
+    surface: '--hx-color-surface-info-strong',
+    threshold: 4.5,
+    label: 'text.on-primary-strong on surface.info-strong',
+  },
   // Link text on body surface
   {
     text: '--hx-color-text-link',

--- a/packages/hx-tokens/src/tokens.json
+++ b/packages/hx-tokens/src/tokens.json
@@ -146,6 +146,14 @@
         "value": "var(--hx-color-neutral-900)",
         "description": "Dark text on info surface. neutral-0 on the precision-cool info-500 (#0C8BEB) was 3.55:1 — WCAG AA fail. neutral-900 on info-500 = 5.03:1 (AA pass)."
       },
+      "on-primary-strong": {
+        "value": "var(--hx-color-neutral-0)",
+        "description": "White text override for primary surfaces darker than primary-500 (i.e. primary-600 hover, primary-700 active). The AA-tuned text.on-primary (neutral-900) only meets AA against primary-500; on primary-600 (#0F7078) it drops to 2.04:1 and on primary-700 (#0F6363) to 1.79:1 — both AA fails. neutral-0 on primary-600 = 4.84:1 (AA pass) and on primary-700 = 5.93:1 (AA pass). Added in 3.2.1 to remediate the token-cascade campaign findings where component variants were pinning to neutral-0 directly to escape this exact AA gap; routes the white-on-darker-primary pin through the semantic tier instead of the raw primitive."
+      },
+      "on-error-strong": {
+        "value": "var(--hx-color-neutral-0)",
+        "description": "White text override for error surfaces darker than error-500 (i.e. error-600 hover, error-700 active). The AA-tuned text.on-error (neutral-900) only meets AA against error-500; on error-600 (#C92A2A) it drops to 1.85:1 and on error-700 (#A21312) to 1.26:1 — both AA fails. neutral-0 on error-600 = 5.32:1 (AA pass) and on error-700 = 7.81:1 (AA pass). Sister token to text.on-primary-strong; same 3.2.1 token-cascade remediation rationale."
+      },
       "link": { "value": "var(--hx-color-primary-600)" },
       "link-hover": { "value": "var(--hx-color-primary-700)" },
       "link-visited": { "value": "var(--hx-color-secondary-600)" },
@@ -173,12 +181,83 @@
       "default": { "value": "var(--hx-color-neutral-200)" },
       "subtle": { "value": "var(--hx-color-neutral-100)" },
       "strong": { "value": "var(--hx-color-neutral-400)" },
-      "focus": { "value": "var(--hx-color-primary-500)" }
+      "focus": { "value": "var(--hx-color-primary-500)" },
+      "on-dark-strong": {
+        "value": "var(--hx-overlay-white-70)",
+        "description": "Strong border treatment on dark surfaces (e.g. inverted button outlines on a dark page). Routes overlay-white-70 through the semantic tier so component-level inverted-border rules don't bind to raw overlay primitives. Added in 3.2.1 alongside the action.* layer for the token-cascade remediation."
+      },
+      "on-dark-default": {
+        "value": "var(--hx-overlay-white-30)",
+        "description": "Default border treatment on dark surfaces (inverted secondary/ghost outlines, divider borders inside dark panels). Overlay-mediated so the border tints itself against whatever sits underneath rather than fighting it with a hard color."
+      },
+      "on-dark-subtle": {
+        "value": "var(--hx-overlay-white-10)",
+        "description": "Subtle border treatment on dark surfaces (low-emphasis dividers inside dark panels)."
+      }
     },
     "focus-ring": { "value": "var(--hx-color-primary-400)" },
     "selection": {
       "bg": { "value": "var(--hx-color-primary-200)" },
       "color": { "value": "var(--hx-color-neutral-900)" }
+    },
+    "action": {
+      "_comment": "Semantic action surfaces — the interactive-state layer between the primitive ramp (color.{role}.{stop}) and component-tier overrides (--hx-{component}-bg, --hx-{component}-hover-bg, etc). Pre-3.2.1, components reached straight to ramp stops (e.g. --hx-button-bg: var(--hx-color-primary-500)) which violated the three-tier cascade contract — consumers had no themable hook between the primitive and the component. The token-cascade campaign found 21 high-severity bare-primitive consumptions across hx-button, hx-toast, and hx-side-nav/hx-nav-item; this block is the systemic fix. Components rebind their --hx-{component}-bg etc. through these semantics so theme overrides at the action.* tier propagate everywhere.",
+      "primary": {
+        "bg": {
+          "value": "var(--hx-color-primary-500)",
+          "description": "Resting interactive primary surface (button bg, active nav-item bg, primary toast bg). Resolves to primary-500 in light/dark and the HC primary-500 override in HC."
+        },
+        "bg-hover": {
+          "value": "var(--hx-color-primary-600)",
+          "description": "Hover state for interactive primary surfaces. Pairs with text.on-primary-strong (neutral-0) for AA — primary-600 on neutral-0 = 4.84:1."
+        },
+        "bg-active": {
+          "value": "var(--hx-color-primary-700)",
+          "description": "Active/pressed state for interactive primary surfaces. Pairs with text.on-primary-strong (neutral-0) — primary-700 on neutral-0 = 5.93:1 AA."
+        },
+        "bg-inverted-hover": {
+          "value": "var(--hx-color-primary-400)",
+          "description": "Hover state for primary surfaces that live on a dark/inverted background — flips lighter rather than darker so the affordance reads against an already-dark page. Matches the precision-cool inverted-button hover pattern in hx-button."
+        }
+      },
+      "secondary": {
+        "fg": {
+          "value": "var(--hx-color-primary-600)",
+          "description": "Foreground (text + icon) color for resting secondary/outline interactive treatments. primary-600 on surface.default = 5.20:1 AA."
+        },
+        "border": {
+          "value": "var(--hx-color-primary-600)",
+          "description": "Border color for resting secondary/outline interactive treatments. Matches action.secondary.fg so the affordance reads as a single chromatic outline."
+        },
+        "bg-hover": {
+          "value": "var(--hx-color-primary-50)",
+          "description": "Hover surface fill for secondary/outline interactive treatments — the lightest primary tint (#EBF8F8) so the hover affordance is felt without flipping to a full primary fill. Foreground stays bound to action.secondary.fg in the consuming component."
+        }
+      },
+      "ghost": {
+        "fg": {
+          "value": "var(--hx-color-primary-600)",
+          "description": "Foreground color for resting ghost (text-only, no border) interactive treatments. Shares its value with action.secondary.fg by design — ghost is secondary minus the outline — but kept as a separate semantic so theming can diverge if a brand wants ghost ≠ secondary."
+        },
+        "bg-hover": {
+          "value": "var(--hx-color-primary-50)",
+          "description": "Hover surface fill for ghost interactive treatments. Mirrors action.secondary.bg-hover; same divergence rationale."
+        }
+      },
+      "danger": {
+        "bg": {
+          "value": "var(--hx-color-error-500)",
+          "description": "Resting interactive danger surface (destructive button bg, danger toast bg). Pairs with text.on-error (neutral-900, AA-tuned) on error-500."
+        },
+        "bg-hover": {
+          "value": "var(--hx-color-error-600)",
+          "description": "Hover state for danger surfaces. Pairs with text.on-error-strong (neutral-0) for AA — error-600 on neutral-0 = 5.32:1."
+        },
+        "bg-active": {
+          "value": "var(--hx-color-error-700)",
+          "description": "Active/pressed state for danger surfaces. Pairs with text.on-error-strong (neutral-0) — error-700 on neutral-0 = 7.81:1 AA."
+        }
+      }
     }
   },
   "body": {
@@ -526,6 +605,33 @@
       "selection": {
         "bg": { "value": "var(--hx-color-primary-800)" },
         "color": { "value": "var(--hx-color-neutral-100)" }
+      },
+      "action": {
+        "_comment": "Dark-mode overrides for the action.* semantic layer. Filled-action surfaces (primary.bg/bg-hover/bg-active, danger.*) intentionally do NOT flip in dark mode — the brand fill remains brand-colored against the dark page, which is the standard dark-theme treatment for primary/destructive buttons. Outline/ghost treatments DO flip: the resting fg primary-600 fails AA (3.07:1) on dark surface.default, and primary-50 hover-bg is far too bright on a dark page. Mirrors the dark.text.link cascade (light primary-600 link → dark primary-400 link).",
+        "secondary": {
+          "fg": {
+            "value": "var(--hx-color-primary-400)",
+            "description": "Dark-mode action.secondary.fg flips to primary-400 (#6AB1B1) — primary-600 on dark surface.default = 3.07:1 (AA fail). primary-400 = 7.18:1 (AA pass). Mirrors dark.text.link's primary-600→primary-400 flip."
+          },
+          "border": {
+            "value": "var(--hx-color-primary-400)",
+            "description": "Dark-mode action.secondary.border tracks the fg flip so the outline reads as a single chromatic affordance."
+          },
+          "bg-hover": {
+            "value": "var(--hx-color-primary-900)",
+            "description": "Dark-mode hover surface — primary-50 (light fill) on a dark page would be too bright. primary-900 (#0B3232) gives action.secondary.fg (primary-400 = #6AB1B1) on primary-900 = 5.97:1, AA pass. primary-800 was tested first but only reaches 4.14:1, just shy of the body-text floor."
+          }
+        },
+        "ghost": {
+          "fg": {
+            "value": "var(--hx-color-primary-400)",
+            "description": "Dark-mode action.ghost.fg flips to primary-400 alongside action.secondary.fg (same AA gap, same fix)."
+          },
+          "bg-hover": {
+            "value": "var(--hx-color-primary-900)",
+            "description": "Dark-mode action.ghost.bg-hover mirrors action.secondary.bg-hover (primary-900 for AA headroom over primary-800)."
+          }
+        }
       }
     },
     "body": {
@@ -598,6 +704,14 @@
         "on-success": { "value": "#000000", "description": "Black text on bright HC success" },
         "on-warning": { "value": "#000000", "description": "Black text on bright HC warning" },
         "on-info": { "value": "#000000", "description": "Black text on bright HC info" },
+        "on-primary-strong": {
+          "value": "#000000",
+          "description": "HC override for text.on-primary-strong. The light/dark value (neutral-0 / white) is unreadable on HC primary-600 (#60A5FA) and primary-700 (#93C5FD), which are bright fills. Black on HC primary-600 = 10.09:1, on HC primary-700 = 13.02:1 — both AAA. Mirrors the existing on-primary HC override pattern."
+        },
+        "on-error-strong": {
+          "value": "#000000",
+          "description": "HC override for text.on-error-strong. White is unreadable on HC error-600 (#FCA5A5 — light red). Black on HC error-600 = 10.07:1, AAA. Note: error-700 has no HC override yet (palette gap tracked separately) so consumers using action.danger.bg-active in HC will paint black on the base error-700 (#A21312); contrast there is asserted in the regression matrix."
+        },
         "link": { "value": "#FFFF00", "description": "19.56:1 contrast on #000 — high visibility" },
         "link-hover": { "value": "#FFFF99", "description": "High-contrast hover link" },
         "link-visited": { "value": "#FF80FF", "description": "High-contrast visited link" },
@@ -617,7 +731,19 @@
         "default": { "value": "#FFFFFF", "description": "21:1 contrast on #000" },
         "subtle": { "value": "#C0C0C0" },
         "strong": { "value": "#FFFFFF" },
-        "focus": { "value": "#FFFF00", "description": "High-visibility yellow focus — WCAG 2.4.7" }
+        "focus": { "value": "#FFFF00", "description": "High-visibility yellow focus — WCAG 2.4.7" },
+        "on-dark-strong": {
+          "value": "#FFFFFF",
+          "description": "HC override for border.on-dark-strong. The base overlay-white-70 reads softly against translucent darks but is invisible against the HC #000 canvas — pin to solid #FFFFFF (21:1 on #000) so inverted button outlines remain visible in HC."
+        },
+        "on-dark-default": {
+          "value": "#FFFFFF",
+          "description": "HC override for border.on-dark-default. Same rationale as on-dark-strong; HC requires solid borders rather than translucent overlays."
+        },
+        "on-dark-subtle": {
+          "value": "#C0C0C0",
+          "description": "HC override for border.on-dark-subtle. Matches HC border.subtle so subtle dividers stay distinguishable from the strong tier in HC."
+        }
       },
       "focus-ring": { "value": "#FFFF00", "description": "High-visibility yellow focus ring" },
       "selection": {

--- a/packages/hx-tokens/src/tokens.json
+++ b/packages/hx-tokens/src/tokens.json
@@ -150,6 +150,10 @@
         "value": "var(--hx-color-neutral-0)",
         "description": "White text override for primary surfaces darker than primary-500 (i.e. primary-600 hover, primary-700 active). The AA-tuned text.on-primary (neutral-900) only meets AA against primary-500; on primary-600 (#0F7078) it drops to 2.04:1 and on primary-700 (#0F6363) to 1.79:1 — both AA fails. neutral-0 on primary-600 = 4.84:1 (AA pass) and on primary-700 = 5.93:1 (AA pass). Added in 3.2.1 to remediate the token-cascade campaign findings where component variants were pinning to neutral-0 directly to escape this exact AA gap; routes the white-on-darker-primary pin through the semantic tier instead of the raw primitive."
       },
+      "on-success-strong": {
+        "value": "var(--hx-color-neutral-0)",
+        "description": "White text override for success surfaces darker than success-500 (i.e. the success-700 #146831 fill that hx-toast--success and other emphasis-success surfaces paint). The AA-tuned text.on-success (neutral-900) only meets AA against success-500 (#3B9E58 = 4.94:1); on success-700 it drops to 1.62:1 — AA fail. neutral-0 on success-700 = 6.88:1 AA pass. Sister token to text.on-primary-strong / text.on-error-strong; same 3.2.1 token-cascade rationale (route the white-on-darker-success pin through the semantic tier instead of letting components consume neutral-0 directly)."
+      },
       "on-error-strong": {
         "value": "var(--hx-color-neutral-0)",
         "description": "White text override for error surfaces darker than error-500 (i.e. error-600 hover, error-700 active). The AA-tuned text.on-error (neutral-900) only meets AA against error-500; on error-600 (#C92A2A) it drops to 1.85:1 and on error-700 (#A21312) to 1.26:1 — both AA fails. neutral-0 on error-600 = 5.32:1 (AA pass) and on error-700 = 7.81:1 (AA pass). Sister token to text.on-primary-strong; same 3.2.1 token-cascade remediation rationale."
@@ -175,7 +179,23 @@
         "value": "var(--hx-color-neutral-900)",
         "description": "Inverse surface for dark-always components (tooltips, inverse nav). Flips to a light surface in dark mode; uses system Canvas in forced-colors."
       },
-      "overlay": { "value": "rgba(0, 0, 0, 0.75)" }
+      "overlay": { "value": "rgba(0, 0, 0, 0.75)" },
+      "success-strong": {
+        "value": "var(--hx-color-success-700)",
+        "description": "Emphasis success surface for high-prominence components (e.g. hx-toast--success). Pairs with text.inverse (neutral-0) for AA — neutral-0 on success-700 (#146831) = 6.88:1. Added in 3.2.1 to route the toast variant fills through the semantic tier instead of consuming success-700 directly."
+      },
+      "warning-strong": {
+        "value": "var(--hx-color-warning-500)",
+        "description": "Emphasis warning surface for high-prominence components (e.g. hx-toast--warning). Pairs with text.on-warning (neutral-900) for AA — neutral-900 on warning-500 (#C2711C) = 4.83:1. Stays on the lighter -500 stop because warning's on-token contract is tuned for it; see toast variant rationale."
+      },
+      "danger-strong": {
+        "value": "var(--hx-color-error-600)",
+        "description": "Emphasis danger surface for high-prominence components (e.g. hx-toast--danger). Pairs with text.inverse (neutral-0) for AA — neutral-0 on error-600 (#C92A2A) = 5.92:1. Tracks action.danger.bg-hover by value (also error-600) but is exposed as a surface semantic so non-interactive consumers (toasts, banners) don't reach into the action.* hover state to find it."
+      },
+      "info-strong": {
+        "value": "var(--hx-color-primary-600)",
+        "description": "Emphasis info surface for high-prominence components (e.g. hx-toast--info). Pairs with text.inverse (neutral-0) for AA — neutral-0 on primary-600 (#0F7078) = 5.39:1. Tracks action.primary.bg-hover by value but exposed under surface.* so toasts/banners consume a surface semantic, not an action-state semantic."
+      }
     },
     "border": {
       "default": { "value": "var(--hx-color-neutral-200)" },
@@ -589,6 +609,7 @@
         "link-active": { "value": "var(--hx-color-primary-200)" }
       },
       "surface": {
+        "_comment": "Dark-mode surface.{role}-strong tokens intentionally do NOT flip — emphasis brand fills remain brand-colored against the dark page, matching the action.{primary,danger}.bg pattern (see action._comment above). The base light values resolve through the same primitives in dark mode.",
         "default": { "value": "var(--hx-color-neutral-900)" },
         "raised": { "value": "var(--hx-color-neutral-800)" },
         "sunken": { "value": "var(--hx-color-neutral-950)" },
@@ -712,6 +733,10 @@
           "value": "#000000",
           "description": "HC override for text.on-error-strong. White is unreadable on HC error-600 (#FCA5A5 — light red). Black on HC error-600 = 10.07:1, AAA. Note: error-700 has no HC override yet (palette gap tracked separately) so consumers using action.danger.bg-active in HC will paint black on the base error-700 (#A21312); contrast there is asserted in the regression matrix."
         },
+        "on-success-strong": {
+          "value": "#000000",
+          "description": "HC override for text.on-success-strong. The light/dark value (neutral-0 / white) is unreadable on the HC bright-fill success surfaces. Black on HC success-500 (#4ADE80) = 9.21:1 AA pass. Sister token to on-primary-strong / on-error-strong HC overrides."
+        },
         "link": { "value": "#FFFF00", "description": "19.56:1 contrast on #000 — high visibility" },
         "link-hover": { "value": "#FFFF99", "description": "High-contrast hover link" },
         "link-visited": { "value": "#FF80FF", "description": "High-contrast visited link" },
@@ -725,7 +750,23 @@
           "value": "#FFFFFF",
           "description": "Inverse of HC canvas — white surface for dark-always components in HC mode"
         },
-        "overlay": { "value": "rgba(0, 0, 0, 0.95)" }
+        "overlay": { "value": "rgba(0, 0, 0, 0.95)" },
+        "success-strong": {
+          "value": "var(--hx-color-success-500)",
+          "description": "HC override for surface.success-strong. Light/dark resolves to success-700 (#146831) which is too dark to read against the HC #000 canvas as a fill. Flip to HC success-500 (#4ADE80, 10.25:1 on #000) so emphasis success surfaces remain visible. Pairs with text.inverse (HC = #000000) for 9.21:1 AA pass."
+        },
+        "warning-strong": {
+          "value": "var(--hx-color-warning-500)",
+          "description": "HC override for surface.warning-strong. Resolves to HC warning-500 (#FBBF24) — bright yellow visible against the HC canvas. Pairs with text.on-warning (HC = #000000) for 13.73:1 AAA."
+        },
+        "danger-strong": {
+          "value": "var(--hx-color-error-500)",
+          "description": "HC override for surface.danger-strong. Light/dark resolves to error-600 which has no HC override (palette gap); flip to HC error-500 (#FCA5A5 — bright red) for visibility on the HC canvas. Pairs with text.inverse (HC = #000000) for AA."
+        },
+        "info-strong": {
+          "value": "var(--hx-color-primary-500)",
+          "description": "HC override for surface.info-strong. Light/dark resolves to primary-600; HC has no primary-600 override yet, so pin to HC primary-500 (#60A5FA) for visibility on the canvas. Pairs with text.inverse (HC = #000000) for AA."
+        }
       },
       "border": {
         "default": { "value": "#FFFFFF", "description": "21:1 contrast on #000" },
@@ -1256,6 +1297,8 @@
       "--hx-nav-item-hover-bg": null,
       "--hx-nav-item-hover-color": null,
       "--hx-nav-item-padding": null,
+      "--hx-nav-item-tooltip-bg": null,
+      "--hx-nav-item-tooltip-color": null,
       "--hx-nav-link-active-bg": null,
       "--hx-nav-link-active-color": null,
       "--hx-nav-link-color": null,
@@ -1413,6 +1456,7 @@
       "--hx-side-nav-footer-padding": null,
       "--hx-side-nav-header-padding": null,
       "--hx-side-nav-toggle-color": null,
+      "--hx-side-nav-toggle-hover-color": null,
       "--hx-side-nav-width": null
     },
     "hx-skeleton": {


### PR DESCRIPTION
## Summary

3.2.1 ships the systemic fix for the 21 high-severity token-cascade defects surfaced by the Codex Token Cascade campaign pilot, plus two latent AA contrast failures discovered along the way.

**Pilot scoreboard:** 58 findings across 5 components — `hx-button` (17, blocking), `hx-toast` (9, blocking), `hx-side-nav` (19, blocking), `hx-card` (9, concerns), `hx-text-input` (4, concerns). Full rollup: ``.reports/codex/campaigns/token-cascade/findings.md``.

## Root cause

The 3.2.0 palette refresh added semantic resting-surface tokens (``--hx-color-surface-success``, ``--hx-color-text-on-primary``) but never built the semantic layer for **action and interactive states**. So every variant-heavy component reached straight to the primitive ramp inside its variant rules — ``var(--hx-button-bg, var(--hx-color-primary-500))`` instead of ``var(--hx-button-bg, var(--hx-color-action-primary-bg))``.

This PR builds the missing layer and rewires consumption.

## What's in this PR

**Tokens (minor, additive):**
- ``semantic.color.action.{primary,secondary,ghost,danger}.*`` — interactive surface tokens
- ``text.on-primary-strong`` / ``text.on-error-strong`` — neutral-0 pins for darker hover states where AA demands white
- ``border.on-dark-{strong,default,subtle}`` — abstracts overlay-white primitives for inverted-button outlines
- ``surface.{success,warning,danger,info}-strong`` — emphasized status surfaces for toast variants
- 13 new contrast regression assertions

**Library (patch):**
- ``hx-button``, ``hx-toast``, ``hx-side-nav``, ``hx-nav-item`` variant rules rewired to semantic action layer
- **Two latent AA cold-start failures fixed in ``hx-button``** — inline hex fallback ``#ffffff`` for ``--hx-color-text-on-primary`` and ``--hx-color-text-on-error`` was painting white-on-primary-500 (3.43:1) and white-on-error-500 (3.92:1) when the semantic was undefined. Corrected to ``#0d1825``.
- Stale fallback hexes in ``hx-side-nav`` aligned with post-3.2.0 semantic resolutions
- Forced-colors double-composition resolved across 4 components (mixin OR bespoke block, not both)
- ``hx-text-input`` ``@cssprop`` JSDoc defaults aligned with runtime cascade

**React:** Wrapper regeneration confirms zero public API delta.

## Test plan

- [x] ``pnpm --filter=@helixui/tokens run test`` — manifest sync + 131 contrast assertions
- [x] ``pnpm --filter=@helixui/library run test`` — 6121/6169 pass (full suite, one websocket disconnect at end is a known browser flake)
- [x] ``pnpm run verify`` — lint + format + type-check + build
- [x] ``pnpm --filter=@helixui/library run cem`` — 102 components valid
- [x] ``pnpm --filter=@helixui/react run generate`` — zero wrapper drift
- [ ] CodeRabbit review
- [ ] CI Quality Gates

## Findings closed

Closes 21 high + 19 medium + 6 low Codex Token Cascade campaign findings against ``hx-button``, ``hx-toast``, ``hx-side-nav``, ``hx-nav-item``, ``hx-text-input``. Findings JSONL: ``.reports/codex/campaigns/token-cascade/findings.jsonl``.

## Deferred

- ``hx-nav-item`` namespace migration (move from ``component.hx-nav`` to ``component.hx-nav-item``) — requires extending ``scripts/extract-component-tokens.ts`` to recognize multi-component-per-directory layouts. Tracked separately.
- Full Token Cascade sweep against remaining ~70 components — runs against the cleaned-up codebase post-3.2.1.
- Color Contrast campaign — kicks off after Token Cascade ships.