### PR TITLE
fix(3.2.1): codex round-2 remediation — 7 findings

### DIFF
--- a/.changeset/3-2-1-token-cascade-remediation.md
+++ b/.changeset/3-2-1-token-cascade-remediation.md
@@ -13,6 +13,7 @@
 - New `surface.success-strong` / `warning-strong` / `danger-strong` / `info-strong` semantics for emphasized status surfaces (toast variants).
 - New HC override for `action.danger.bg-active` flips to HC error-500 — closes a palette gap where base error-700 paired with text.on-error-strong (HC = #000000) at 2.56:1, an AA failure flagged by adversarial review.
 - 14 new contrast regression assertions in `contrast.test.ts` covering every new action × text-on-strong pair across light/dark/HC, including the action.danger.bg-active HC pair the gap fix now satisfies.
+- Token description contrast ratios recomputed and corrected (round 2): `text.on-primary-strong`, `text.on-error-strong`, `text.on-success`, `surface.danger-strong`, `surface.info-strong`, and the `action.{primary,danger}.bg-{hover,active}` claims now match values produced by the WCAG 2.1 luminance formula. Conclusions unchanged — the AA pass/fail verdicts hold; only the cited numbers were stale.
 
 **Library (patch — bug fixes):**
 - `hx-button`, `hx-toast`, `hx-side-nav`, `hx-nav-item` variant rules rewritten to consume the new semantic action layer instead of bare primitives. Closes 21 high-severity Token Cascade campaign findings.
@@ -22,6 +23,13 @@
 - Stale inline hex fallbacks in `hx-side-nav` corrected to match post-3.2.0 semantic resolutions (text.inverse, border.strong).
 - Forced-colors composition resolved in `hx-button`, `hx-side-nav`, `hx-nav-item`, `hx-text-input` — components no longer double-up on both the `forcedColorsInteractive`/`forcedColorsField` mixin and a bespoke `@media (forced-colors: active)` block. `hx-text-input` now drops the `forcedColorsField` mixin entirely; the bespoke block (which already covered wrapper/input/placeholder/focus/disabled/error/label/help-text — strictly more than the mixin) is the sole HC owner.
 - `hx-text-input` `@cssprop` JSDoc defaults aligned with runtime cascade — defaults now reference the semantic tokens used at paint time (`--hx-color-surface-default`, `--hx-color-text-strong`, `--hx-color-border-strong`, `--hx-color-error-text`).
+- **Round-2 fixes (Codex re-review on PR #1568):**
+  - `hx-button` secondary/ghost hover rebound from `surface.raised` to `action.{secondary,ghost}.bg-hover` so the new semantic action layer is actually consumed (the dark-mode hover overrides for these variants were previously dead code).
+  - All four inverted-button hover fallbacks for `--hx-color-border-on-dark-default` normalized to `rgba(255, 255, 255, 0.3)` to match the resolved semantic value, eliminating cold-start opacity inconsistency across secondary/ghost/outline/tertiary inverted hover states.
+  - `hx-nav-item` bespoke forced-colors block now mirrors the full `forcedColorsInteractive` mixin contract (resting `ButtonFace`/`ButtonText`/`ButtonText`, `:hover` flips to `Highlight`/`HighlightText`, disabled `GrayText` + opacity reset). The previous bespoke block only covered active-border + focus-outline + tooltip-border, leaving normal/hover/disabled HC affordances regressed when the mixin was dropped.
+  - `hx-side-nav` bespoke forced-colors block adds the missing `.side-nav__toggle:hover` rule (`Highlight`/`HighlightText`/`Highlight`) — the toggle button lost its HC hover affordance when the mixin was dropped.
+  - `hx-side-nav` and `hx-nav-item` `@cssprop` JSDoc defaults aligned with runtime cascade (drop stale `neutral-900`/`neutral-100`/`neutral-700`/`primary-600` claims; reference the actual `surface.inverse`/`text.inverse`/`border.strong`/`action.primary.bg-hover`/`text.on-primary-strong` semantics that resolve at paint time). New `--hx-side-nav-toggle-hover-color`, `--hx-nav-item-tooltip-bg`, `--hx-nav-item-tooltip-color` hooks documented.
+  - New library-level regression test pins `hx-button` secondary/ghost hover backgrounds to the resolved primary-50 (#EBF8F8) value, catching any future drift back to a surface-raised binding.
 
 **React (patch — peer bump):** No public API surface delta; wrapper regeneration confirms zero breakage.
 

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-04-25T18:12:29.050Z",
+  "generatedAt": "2026-04-25T20:02:01.523Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.2.0",
   "tokensVersion": "3.2.0",
@@ -13658,12 +13658,12 @@
         {
           "description": "Item text color.",
           "name": "--hx-nav-item-color",
-          "default": "var(--hx-color-neutral-300)",
+          "default": "var(--hx-color-text-inverse)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/300",
+            "semanticToken": "color/text/inverse",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
@@ -13675,36 +13675,36 @@
         {
           "description": "Item hover text color.",
           "name": "--hx-nav-item-hover-color",
-          "default": "var(--hx-color-neutral-100)",
+          "default": "var(--hx-color-text-inverse)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/100",
+            "semanticToken": "color/text/inverse",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
           "description": "Active item background.",
           "name": "--hx-nav-item-active-bg",
-          "default": "var(--hx-color-primary-600)",
+          "default": "var(--hx-color-action-primary-bg-hover)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/primary",
-            "fallbackPrimitive": "color/primary/600",
+            "semanticToken": "color/action/primary/bg/hover",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
           "description": "Active item text color.",
           "name": "--hx-nav-item-active-color",
-          "default": "var(--hx-color-neutral-50)",
+          "default": "var(--hx-color-text-on-primary-strong)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/50",
+            "semanticToken": "color/text/on/primary/strong",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
@@ -13716,12 +13716,36 @@
         {
           "description": "Component host background color.",
           "name": "--hx-nav-item-host-bg",
-          "default": "var(--hx-color-neutral-900)",
+          "default": "var(--hx-color-surface-inverse)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/900",
+            "semanticToken": "color/surface/inverse",
+            "fallbackPrimitive": null,
+            "literalFallback": null
+          }
+        },
+        {
+          "description": "Tooltip background color (collapsed-rail tooltip).",
+          "name": "--hx-nav-item-tooltip-bg",
+          "default": "var(--hx-color-surface-inverse)",
+          "figmaBinding": {
+            "target": "Fill",
+            "layerSelector": "root",
+            "semanticToken": "color/surface/inverse",
+            "fallbackPrimitive": null,
+            "literalFallback": null
+          }
+        },
+        {
+          "description": "Tooltip text color (collapsed-rail tooltip).",
+          "name": "--hx-nav-item-tooltip-color",
+          "default": "var(--hx-color-text-inverse)",
+          "figmaBinding": {
+            "target": "Fill",
+            "layerSelector": "root",
+            "semanticToken": "color/text/inverse",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         }
@@ -17626,36 +17650,36 @@
         {
           "description": "Background color.",
           "name": "--hx-side-nav-bg",
-          "default": "var(--hx-color-neutral-900)",
+          "default": "var(--hx-color-surface-inverse)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/900",
+            "semanticToken": "color/surface/inverse",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
           "description": "Text color.",
           "name": "--hx-side-nav-color",
-          "default": "var(--hx-color-neutral-100)",
+          "default": "var(--hx-color-text-inverse)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/100",
+            "semanticToken": "color/text/inverse",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
           "description": "Border color.",
           "name": "--hx-side-nav-border-color",
-          "default": "var(--hx-color-neutral-700)",
+          "default": "var(--hx-color-border-strong)",
           "figmaBinding": {
             "target": "Stroke",
             "layerSelector": "root",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/700",
+            "semanticToken": "color/border/strong",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
@@ -17684,14 +17708,26 @@
           }
         },
         {
-          "description": "Toggle button icon color.",
+          "description": "Toggle button icon color (resting).",
           "name": "--hx-side-nav-toggle-color",
-          "default": "var(--hx-color-neutral-400)",
+          "default": "var(--hx-color-text-inverse)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "::part(toggle)",
-            "semanticToken": "color/neutral",
-            "fallbackPrimitive": "color/neutral/400",
+            "semanticToken": "color/text/inverse",
+            "fallbackPrimitive": null,
+            "literalFallback": null
+          }
+        },
+        {
+          "description": "Toggle button icon color on hover.",
+          "name": "--hx-side-nav-toggle-hover-color",
+          "default": "var(--hx-color-text-inverse)",
+          "figmaBinding": {
+            "target": "Fill",
+            "layerSelector": "root",
+            "semanticToken": "color/text/inverse",
+            "fallbackPrimitive": null,
             "literalFallback": null
           }
         },

--- a/packages/hx-library/src/components/hx-button/hx-button.styles.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.styles.ts
@@ -103,7 +103,7 @@ export const helixButtonStyles = css`
   }
 
   .button--secondary:hover {
-    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-surface-raised, #f5f8f3));
+    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-action-secondary-bg-hover, #ebf8f8));
   }
 
   .button--tertiary {
@@ -144,7 +144,7 @@ export const helixButtonStyles = css`
   }
 
   .button--ghost:hover {
-    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-surface-raised, #f5f8f3));
+    --hx-button-bg: var(--hx-button-hover-bg, var(--hx-color-action-ghost-bg-hover, #ebf8f8));
   }
 
   .button--outline {
@@ -243,7 +243,7 @@ export const helixButtonStyles = css`
   }
 
   :host([inverted]) .button--secondary:hover {
-    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.15));
+    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.3));
   }
 
   /* Tertiary inverted — resting at subtle (10%) lifts to default (30%) on hover
@@ -267,7 +267,7 @@ export const helixButtonStyles = css`
   :host([inverted]) .button--ghost:hover {
     --hx-button-bg: var(
       --hx-button-inverted-ghost-hover-bg,
-      var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.2))
+      var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.3))
     );
   }
 
@@ -277,7 +277,7 @@ export const helixButtonStyles = css`
   }
 
   :host([inverted]) .button--outline:hover {
-    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.15));
+    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.3));
   }
 
   /* ─── Prefix / Suffix / Label ─── */

--- a/packages/hx-library/src/components/hx-button/hx-button.test.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.test.ts
@@ -925,6 +925,69 @@ describe('hx-button', () => {
     });
   });
 
+  // ─── Variant hover token binding (3.2.1 round-2 regression net) ───
+  //
+  // Codex round-2 caught that secondary/ghost hover rules still bound to
+  // --hx-color-surface-raised instead of the new action.* layer, leaving the
+  // dark-mode action.{secondary,ghost}.bg-hover overrides as dead code. These
+  // assertions pin the binding two ways:
+  //   1. The shadow-root CSS source contains the correct semantic in the
+  //      :hover rule (catches a regression in the styles.ts file).
+  //   2. The cited semantic actually resolves to primary-50 (#EBF8F8) in the
+  //      page context (catches a regression in tokens.json).
+  // Together they prove the cascade is wired end-to-end without depending on
+  // browser :hover simulation, which is unreliable in headless test runners.
+
+  describe('Variant hover token binding (3.2.1 regression net)', () => {
+    const cssSource = (el: HelixButton): string => {
+      const styles = (el.constructor as typeof HelixButton).styles;
+      const list = Array.isArray(styles) ? styles : [styles];
+      return list.map((s) => (s ? String((s as { cssText?: string }).cssText ?? s) : '')).join('\n');
+    };
+
+    const resolveSemantic = async (token: string): Promise<string> => {
+      const probe = document.createElement('div');
+      probe.style.backgroundColor = `var(${token})`;
+      document.body.appendChild(probe);
+      try {
+        return getComputedStyle(probe).backgroundColor;
+      } finally {
+        probe.remove();
+      }
+    };
+
+    it('secondary :hover rule references --hx-color-action-secondary-bg-hover', async () => {
+      const el = await fixture<HelixButton>('<hx-button variant="secondary">Click</hx-button>');
+      const css = cssSource(el);
+      expect(css).toMatch(
+        /\.button--secondary:hover\s*\{[^}]*--hx-color-action-secondary-bg-hover/,
+      );
+      expect(css).not.toMatch(
+        /\.button--secondary:hover\s*\{[^}]*--hx-color-surface-raised/,
+      );
+    });
+
+    it('ghost :hover rule references --hx-color-action-ghost-bg-hover', async () => {
+      const el = await fixture<HelixButton>('<hx-button variant="ghost">Click</hx-button>');
+      const css = cssSource(el);
+      expect(css).toMatch(/\.button--ghost:hover\s*\{[^}]*--hx-color-action-ghost-bg-hover/);
+      expect(css).not.toMatch(/\.button--ghost:hover\s*\{[^}]*--hx-color-surface-raised/);
+    });
+
+    it('action.secondary.bg-hover resolves to primary-50 (#EBF8F8)', async () => {
+      // primary-50 = #EBF8F8 → rgb(235, 248, 248)
+      expect(await resolveSemantic('--hx-color-action-secondary-bg-hover')).toBe(
+        'rgb(235, 248, 248)',
+      );
+    });
+
+    it('action.ghost.bg-hover resolves to primary-50 (#EBF8F8)', async () => {
+      expect(await resolveSemantic('--hx-color-action-ghost-bg-hover')).toBe(
+        'rgb(235, 248, 248)',
+      );
+    });
+  });
+
   // ─── Property: type — form integration ───
 
   describe('Property: type — form integration', () => {

--- a/packages/hx-library/src/components/hx-side-nav/hx-nav-item.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-nav-item.styles.ts
@@ -258,8 +258,38 @@ export const helixNavItemStyles = css`
   /* ─── Forced Colors (Windows High Contrast) ─── */
 
   @media (forced-colors: active) {
+    /*
+     * Bespoke block — sole owner of forced-colors deference for hx-nav-item
+     * (the forcedColorsInteractive mixin is intentionally NOT composed; XOR
+     * rule in styles/forced-colors.ts). Mirrors the mixin's interactive
+     * contract (ButtonFace / ButtonText / Highlight on hover, GrayText on
+     * disabled) for the .nav-item__link interactive surface, then layers the
+     * component-specific active-state border and tooltip border on top.
+     */
+    .nav-item__link {
+      forced-color-adjust: none;
+      background-color: ButtonFace;
+      color: ButtonText;
+      border: 1px solid ButtonText;
+    }
+
+    .nav-item__link:hover {
+      background-color: Highlight;
+      color: HighlightText;
+      border-color: Highlight;
+    }
+
+    :host([disabled]) {
+      opacity: 1;
+    }
+
+    :host([disabled]) .nav-item__link {
+      color: GrayText;
+      border-color: GrayText;
+    }
+
     :host([active]) .nav-item__link {
-      border: 1px solid Highlight;
+      border-color: Highlight;
     }
 
     .nav-item__link:focus-visible {

--- a/packages/hx-library/src/components/hx-side-nav/hx-nav-item.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-nav-item.ts
@@ -25,13 +25,15 @@ const _nextNavItemId = createIdCounter('hx-nav-item');
  * @csspart badge - The badge container.
  * @csspart children - The children container.
  *
- * @cssprop [--hx-nav-item-color=var(--hx-color-neutral-300)] - Item text color.
+ * @cssprop [--hx-nav-item-color=var(--hx-color-text-inverse)] - Item text color.
  * @cssprop [--hx-nav-item-hover-bg] - Item hover background.
- * @cssprop [--hx-nav-item-hover-color=var(--hx-color-neutral-100)] - Item hover text color.
- * @cssprop [--hx-nav-item-active-bg=var(--hx-color-primary-600)] - Active item background.
- * @cssprop [--hx-nav-item-active-color=var(--hx-color-neutral-50)] - Active item text color.
+ * @cssprop [--hx-nav-item-hover-color=var(--hx-color-text-inverse)] - Item hover text color.
+ * @cssprop [--hx-nav-item-active-bg=var(--hx-color-action-primary-bg-hover)] - Active item background.
+ * @cssprop [--hx-nav-item-active-color=var(--hx-color-text-on-primary-strong)] - Active item text color.
  * @cssprop [--hx-nav-item-padding] - Item padding.
- * @cssprop [--hx-nav-item-host-bg=var(--hx-color-neutral-900)] - Component host background color.
+ * @cssprop [--hx-nav-item-host-bg=var(--hx-color-surface-inverse)] - Component host background color.
+ * @cssprop [--hx-nav-item-tooltip-bg=var(--hx-color-surface-inverse)] - Tooltip background color (collapsed-rail tooltip).
+ * @cssprop [--hx-nav-item-tooltip-color=var(--hx-color-text-inverse)] - Tooltip text color (collapsed-rail tooltip).
  */
 @customElement('hx-nav-item')
 export class HelixNavItem extends HelixElement {

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
@@ -166,8 +166,16 @@ export const helixSideNavStyles = css`
     }
 
     .side-nav__toggle {
+      forced-color-adjust: none;
+      background-color: ButtonFace;
       color: ButtonText;
       border: 1px solid ButtonText;
+    }
+
+    .side-nav__toggle:hover {
+      background-color: Highlight;
+      color: HighlightText;
+      border-color: Highlight;
     }
 
     .side-nav__toggle:focus-visible {

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
@@ -27,12 +27,13 @@ import { helixSideNavStyles } from './hx-side-nav.styles.js';
  *
  * @cssprop [--hx-side-nav-width=16rem] - Full expanded width.
  * @cssprop [--hx-side-nav-collapsed-width=3.5rem] - Collapsed icon-only width.
- * @cssprop [--hx-side-nav-bg=var(--hx-color-neutral-900)] - Background color.
- * @cssprop [--hx-side-nav-color=var(--hx-color-neutral-100)] - Text color.
- * @cssprop [--hx-side-nav-border-color=var(--hx-color-neutral-700)] - Border color.
+ * @cssprop [--hx-side-nav-bg=var(--hx-color-surface-inverse)] - Background color.
+ * @cssprop [--hx-side-nav-color=var(--hx-color-text-inverse)] - Text color.
+ * @cssprop [--hx-side-nav-border-color=var(--hx-color-border-strong)] - Border color.
  * @cssprop [--hx-side-nav-header-padding=var(--hx-space-4)] - Header padding.
  * @cssprop [--hx-side-nav-footer-padding=var(--hx-space-4)] - Footer padding.
- * @cssprop [--hx-side-nav-toggle-color=var(--hx-color-neutral-400)] - Toggle button icon color.
+ * @cssprop [--hx-side-nav-toggle-color=var(--hx-color-text-inverse)] - Toggle button icon color (resting).
+ * @cssprop [--hx-side-nav-toggle-hover-color=var(--hx-color-text-inverse)] - Toggle button icon color on hover.
  * @cssprop [--hx-color-neutral-900] - Color.
  * @cssprop [--hx-color-neutral-100] - Color.
  * @cssprop [--hx-transition-normal] - Transition timing.

--- a/packages/hx-tokens/src/tokens.json
+++ b/packages/hx-tokens/src/tokens.json
@@ -139,7 +139,7 @@
       },
       "on-success": {
         "value": "var(--hx-color-neutral-900)",
-        "description": "Dark text on success surface. neutral-0 (white) on success-500 (#16A34A) was 2.8:1 — WCAG AA fail. neutral-900 on success-500 = 11.2:1 (AAA). Matches the on-warning pattern."
+        "description": "Dark text on success surface. neutral-0 (white) on success-500 (#16A34A) was 3.30:1 — WCAG AA fail for body text. neutral-900 on success-500 = 5.43:1 (AA pass). Matches the on-warning pattern."
       },
       "on-warning": { "value": "var(--hx-color-neutral-900)" },
       "on-info": {
@@ -148,7 +148,7 @@
       },
       "on-primary-strong": {
         "value": "var(--hx-color-neutral-0)",
-        "description": "White text override for primary surfaces darker than primary-500 (i.e. primary-600 hover, primary-700 active). The AA-tuned text.on-primary (neutral-900) only meets AA against primary-500; on primary-600 (#0F7078) it drops to 2.04:1 and on primary-700 (#0F6363) to 1.79:1 — both AA fails. neutral-0 on primary-600 = 4.84:1 (AA pass) and on primary-700 = 5.93:1 (AA pass). Added in 3.2.1 to remediate the token-cascade campaign findings where component variants were pinning to neutral-0 directly to escape this exact AA gap; routes the white-on-darker-primary pin through the semantic tier instead of the raw primitive."
+        "description": "White text override for primary surfaces darker than primary-500 (i.e. primary-600 hover, primary-700 active). The AA-tuned text.on-primary (neutral-900) only meets AA against primary-500; on primary-600 (#0F7078) it drops to 3.07:1 and on primary-700 (#0F6363) to 2.54:1 — both AA fails. neutral-0 on primary-600 = 5.82:1 (AA pass) and on primary-700 = 7.03:1 (AA pass). Added in 3.2.1 to remediate the token-cascade campaign findings where component variants were pinning to neutral-0 directly to escape this exact AA gap; routes the white-on-darker-primary pin through the semantic tier instead of the raw primitive."
       },
       "on-success-strong": {
         "value": "var(--hx-color-neutral-0)",
@@ -156,7 +156,7 @@
       },
       "on-error-strong": {
         "value": "var(--hx-color-neutral-0)",
-        "description": "White text override for error surfaces darker than error-500 (i.e. error-600 hover, error-700 active). The AA-tuned text.on-error (neutral-900) only meets AA against error-500; on error-600 (#C92A2A) it drops to 1.85:1 and on error-700 (#A21312) to 1.26:1 — both AA fails. neutral-0 on error-600 = 5.32:1 (AA pass) and on error-700 = 7.81:1 (AA pass). Sister token to text.on-primary-strong; same 3.2.1 token-cascade remediation rationale."
+        "description": "White text override for error surfaces darker than error-500 (i.e. error-600 hover, error-700 active). The AA-tuned text.on-error (neutral-900) only meets AA against error-500; on error-600 (#C92A2A) it drops to 3.28:1 and on error-700 (#A21312) to 2.25:1 — both AA fails. neutral-0 on error-600 = 5.46:1 (AA pass) and on error-700 = 7.96:1 (AA pass). Sister token to text.on-primary-strong; same 3.2.1 token-cascade remediation rationale."
       },
       "link": { "value": "var(--hx-color-primary-600)" },
       "link-hover": { "value": "var(--hx-color-primary-700)" },
@@ -190,11 +190,11 @@
       },
       "danger-strong": {
         "value": "var(--hx-color-error-600)",
-        "description": "Emphasis danger surface for high-prominence components (e.g. hx-toast--danger). Pairs with text.inverse (neutral-0) for AA — neutral-0 on error-600 (#C92A2A) = 5.92:1. Tracks action.danger.bg-hover by value (also error-600) but is exposed as a surface semantic so non-interactive consumers (toasts, banners) don't reach into the action.* hover state to find it."
+        "description": "Emphasis danger surface for high-prominence components (e.g. hx-toast--danger). Pairs with text.inverse (neutral-0) for AA — neutral-0 on error-600 (#C92A2A) = 5.46:1. Tracks action.danger.bg-hover by value (also error-600) but is exposed as a surface semantic so non-interactive consumers (toasts, banners) don't reach into the action.* hover state to find it."
       },
       "info-strong": {
         "value": "var(--hx-color-primary-600)",
-        "description": "Emphasis info surface for high-prominence components (e.g. hx-toast--info). Pairs with text.inverse (neutral-0) for AA — neutral-0 on primary-600 (#0F7078) = 5.39:1. Tracks action.primary.bg-hover by value but exposed under surface.* so toasts/banners consume a surface semantic, not an action-state semantic."
+        "description": "Emphasis info surface for high-prominence components (e.g. hx-toast--info). Pairs with text.inverse (neutral-0) for AA — neutral-0 on primary-600 (#0F7078) = 5.82:1. Tracks action.primary.bg-hover by value but exposed under surface.* so toasts/banners consume a surface semantic, not an action-state semantic."
       }
     },
     "border": {
@@ -229,11 +229,11 @@
         },
         "bg-hover": {
           "value": "var(--hx-color-primary-600)",
-          "description": "Hover state for interactive primary surfaces. Pairs with text.on-primary-strong (neutral-0) for AA — primary-600 on neutral-0 = 4.84:1."
+          "description": "Hover state for interactive primary surfaces. Pairs with text.on-primary-strong (neutral-0) for AA — primary-600 on neutral-0 = 5.82:1."
         },
         "bg-active": {
           "value": "var(--hx-color-primary-700)",
-          "description": "Active/pressed state for interactive primary surfaces. Pairs with text.on-primary-strong (neutral-0) — primary-700 on neutral-0 = 5.93:1 AA."
+          "description": "Active/pressed state for interactive primary surfaces. Pairs with text.on-primary-strong (neutral-0) — primary-700 on neutral-0 = 7.03:1 AA."
         },
         "bg-inverted-hover": {
           "value": "var(--hx-color-primary-400)",
@@ -271,11 +271,11 @@
         },
         "bg-hover": {
           "value": "var(--hx-color-error-600)",
-          "description": "Hover state for danger surfaces. Pairs with text.on-error-strong (neutral-0) for AA — error-600 on neutral-0 = 5.32:1."
+          "description": "Hover state for danger surfaces. Pairs with text.on-error-strong (neutral-0) for AA — error-600 on neutral-0 = 5.46:1."
         },
         "bg-active": {
           "value": "var(--hx-color-error-700)",
-          "description": "Active/pressed state for danger surfaces. Pairs with text.on-error-strong (neutral-0) — error-700 on neutral-0 = 7.81:1 AA."
+          "description": "Active/pressed state for danger surfaces. Pairs with text.on-error-strong (neutral-0) — error-700 on neutral-0 = 7.96:1 AA."
         }
       }
     }


### PR DESCRIPTION
## Summary

Round-2 remediation for the 7 findings raised by `/codex-review` on PR #1568 (the 3.2.1 staging→main candidate). Codex was BLOCKING; this PR addresses #1–#6 in code and #7 (description-only contrast ratios) inline. Lands on `staging` so PR #1568 picks it up automatically.

## Findings remediated

1. **`hx-button` secondary/ghost hover binding** — rebound `:hover` rules from `--hx-color-surface-raised` to the new `--hx-color-action-{secondary,ghost}-bg-hover` semantics. The dark-mode overrides for these variants were previously dead code. New regression test pins the binding via cssText introspection + semantic resolution so a future drift fails CI.
2. **`hx-button` inverted hover fallback drift** — normalized all four `--hx-color-border-on-dark-default` hover fallbacks to `rgba(255, 255, 255, 0.3)` to match the resolved semantic. Eliminates cold-start opacity inconsistency across secondary/ghost/outline/tertiary inverted hover states.
3. **`hx-nav-item` HC interactive contract regression** — bespoke `@media (forced-colors: active)` block expanded from active-border-only to full mixin contract: resting `ButtonFace`/`ButtonText`, `:hover` `Highlight`/`HighlightText`, disabled `GrayText` + opacity reset. Mirrors the `forcedColorsInteractive` contract that the bespoke block replaced.
4. **`hx-side-nav` HC toggle hover regression** — added `.side-nav__toggle:hover` rule (`Highlight`/`HighlightText`/`Highlight`) and `forced-color-adjust: none` on the toggle button. Toggle lost its HC hover affordance when the mixin was dropped.
5. **`hx-button` regression test net** — new "Variant hover token binding (3.2.1 regression net)" describe block with 4 deterministic tests (cssText introspection + semantic probe) that catches any future drift back to a surface-raised binding for secondary/ghost.
6. **`hx-side-nav` + `hx-nav-item` `@cssprop` JSDoc drift** — defaults aligned with runtime cascade. Drop stale `neutral-900` / `neutral-100` / `neutral-700` / `primary-600` claims; reference the actual `surface.inverse` / `text.inverse` / `border.strong` / `action.primary.bg-hover` / `text.on-primary-strong` semantics that resolve at paint time. New hooks documented: `--hx-side-nav-toggle-hover-color`, `--hx-nav-item-tooltip-bg`, `--hx-nav-item-tooltip-color`.
7. **`tokens.json` contrast description drift (round 2)** — 8 token description ratios recomputed via WCAG 2.1 luminance: `text.on-primary-strong`, `text.on-error-strong`, `text.on-success`, `surface.danger-strong`, `surface.info-strong`, `action.{primary,danger}.bg-{hover,active}`. Conclusions unchanged (AA pass/fail verdicts hold); only the cited numbers were stale.

## Verification

- `pnpm run lint` — pass
- `pnpm run format:check` — pass
- `pnpm run type-check` — pass (0 errors across 17 packages)
- `hx-button.test.ts` — 106/106 pass (incl. 4 new regression tests)
- `hx-side-nav.test.ts` + `hx-nav-item.test.ts` — 81/81 pass
- `tokens/contrast.test.ts` — 144/144 pass
- CEM + figma-inventory regenerated
- React wrappers regenerated (no public API delta)

## Test plan

- [x] Lint, format, type-check
- [x] hx-button regression net (4 new tests)
- [x] hx-side-nav + hx-nav-item full suites
- [x] tokens contrast matrix (144 assertions)
- [ ] Quality Gates CI on staging
- [ ] Re-run `/codex-review` on PR #1568 post-merge