### PR TITLE
fix(3.2.1): codex round-4 remediation — pr #1568 staging→main

### DIFF
--- a/.changeset/3-2-1-token-cascade-remediation.md
+++ b/.changeset/3-2-1-token-cascade-remediation.md
@@ -36,6 +36,11 @@
   - `hx-toast.styles.ts` inline contrast comments corrected (`5.39:1` → `5.82:1` for primary-600, `5.92:1` → `5.46:1` for error-600).
   - `hx-toast.ts` `@cssprop` JSDoc defaults aligned with runtime cascade (drop stale `--hx-color-neutral-900`/`--hx-color-neutral-0` claims; reference the actual `--hx-color-surface-inverse`/`--hx-color-text-inverse` semantics that resolve at paint time).
   - `contrast.test.ts` adds `action.ghost.fg × action.ghost.bg-hover` regression assertion (light/dark) — mirrors the existing secondary pair so a future theme split between secondary and ghost cannot silently regress ghost-hover contrast.
+- **Round-4 fixes (Codex re-review on PR #1568, third pass):**
+  - `tokens.json` description contrast ratios recomputed and corrected (round 4) for entries the round-3 sweep missed: `text.secondary` (neutral-700 on surface.default `10.84:1`/raised `10.10:1`/sunken `9.01:1` → `10.93:1`/`10.20:1`/`9.34:1`); `text.muted` (neutral-600 on surface.raised `7.36:1`/default `7.88:1`/sunken `6.55:1` → `7.25:1`/`7.76:1`/`6.63:1`); `action.secondary.fg` (primary-600 on surface.default `5.20:1` → `5.82:1`); dark `action.secondary.fg` (primary-400 `7.18:1` → `7.27:1`); dark `action.secondary.bg-hover` (primary-400 on primary-900 `5.97:1` → `5.63:1`).
+  - `hx-nav-item.styles.ts` inline active-state contrast comment corrected (`5.39:1` → `5.82:1` for white on primary-600) — sibling occurrence missed in round 3's `hx-toast.styles.ts` sweep.
+  - `hx-toast.ts` `@cssprop` block fully aligned with runtime cascade — replaced the stale primitive entries (`--hx-color-neutral-900`, `--hx-color-neutral-0`, `--hx-color-success-600`, `--hx-color-warning-500`, `--hx-color-error-600`, `--hx-color-primary-600`) with the semantic tokens the variant rules actually consume (`surface.{success,warning,danger,info}-strong`, `text.on-{success,warning,error-strong,primary-strong}`).
+  - `contrast.test.ts` adds two `action.secondary.border` × `surface.default` and `action.secondary.border` × `action.secondary.bg-hover` assertions (light/dark, threshold 3:1) — covers the outline button border affordance at WCAG 1.4.11 floor.
 
 **React (patch — peer bump):** No public API surface delta; wrapper regeneration confirms zero breakage.
 

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-04-25T20:44:50.116Z",
+  "generatedAt": "2026-04-25T21:18:39.950Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.2.0",
   "tokensVersion": "3.2.0",
@@ -25085,13 +25085,13 @@
           "figmaBinding": null
         },
         {
-          "description": "Color.",
-          "name": "--hx-color-neutral-900",
+          "description": "Default-variant background semantic (neutral-900 anchor; flipped per mode).",
+          "name": "--hx-color-surface-inverse",
           "figmaBinding": null
         },
         {
-          "description": "Color.",
-          "name": "--hx-color-neutral-0",
+          "description": "Default-variant foreground semantic (neutral-0 anchor; flipped per mode).",
+          "name": "--hx-color-text-inverse",
           "figmaBinding": null
         },
         {
@@ -25149,23 +25149,43 @@
           "figmaBinding": null
         },
         {
-          "description": "Color.",
-          "name": "--hx-color-success-600",
+          "description": "Success-variant background semantic (3.2.1 cascade).",
+          "name": "--hx-color-surface-success-strong",
           "figmaBinding": null
         },
         {
-          "description": "Color.",
-          "name": "--hx-color-warning-500",
+          "description": "Warning-variant background semantic (3.2.1 cascade).",
+          "name": "--hx-color-surface-warning-strong",
           "figmaBinding": null
         },
         {
-          "description": "Color.",
-          "name": "--hx-color-error-600",
+          "description": "Danger-variant background semantic (3.2.1 cascade).",
+          "name": "--hx-color-surface-danger-strong",
           "figmaBinding": null
         },
         {
-          "description": "Color.",
-          "name": "--hx-color-primary-600",
+          "description": "Info-variant background semantic (3.2.1 cascade).",
+          "name": "--hx-color-surface-info-strong",
+          "figmaBinding": null
+        },
+        {
+          "description": "Success-variant foreground semantic (neutral-0 across modes).",
+          "name": "--hx-color-text-on-success-strong",
+          "figmaBinding": null
+        },
+        {
+          "description": "Warning-variant foreground semantic (neutral-900; warning sits on lighter -500 fill).",
+          "name": "--hx-color-text-on-warning",
+          "figmaBinding": null
+        },
+        {
+          "description": "Danger-variant foreground semantic (neutral-0 across modes).",
+          "name": "--hx-color-text-on-error-strong",
+          "figmaBinding": null
+        },
+        {
+          "description": "Info-variant foreground semantic (neutral-0 across modes).",
+          "name": "--hx-color-text-on-primary-strong",
           "figmaBinding": null
         },
         {

--- a/packages/hx-library/src/components/hx-side-nav/hx-nav-item.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-nav-item.styles.ts
@@ -83,7 +83,7 @@ export const helixNavItemStyles = css`
 
   :host([active]) .nav-item__link {
     /* Active state sits on the darker primary-600 (#0F7078) fill. White text
-       (#ffffff) on primary-600 = 5.39:1 WCAG AA pass. text-on-primary now
+       (#ffffff) on primary-600 = 5.82:1 WCAG AA pass. text-on-primary now
        resolves to neutral-900 (intended for the lighter primary-500 surface)
        which would fail here. text.on-primary-strong holds at neutral-0 across
        modes (no dark flip) so the active fg stays AA. 3.2.1: routed through

--- a/packages/hx-library/src/components/hx-toast/hx-toast.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.ts
@@ -39,8 +39,8 @@ export type ToastVariant = 'default' | 'success' | 'warning' | 'danger' | 'info'
  * @cssprop [--hx-space-3] - Spacing token.
  * @cssprop [--hx-space-4] - Spacing token.
  * @cssprop [--hx-border-radius-md] - CSS custom property.
- * @cssprop [--hx-color-neutral-900] - Color.
- * @cssprop [--hx-color-neutral-0] - Color.
+ * @cssprop [--hx-color-surface-inverse] - Default-variant background semantic (neutral-900 anchor; flipped per mode).
+ * @cssprop [--hx-color-text-inverse] - Default-variant foreground semantic (neutral-0 anchor; flipped per mode).
  * @cssprop [--hx-toast-font-family=var(--hx-font-family-sans)] - CSS custom property.
  * @cssprop [--hx-font-family-sans] - Font family.
  * @cssprop [--hx-font-size-sm] - Font size.
@@ -49,10 +49,14 @@ export type ToastVariant = 'default' | 'success' | 'warning' | 'danger' | 'info'
  * @cssprop [--hx-toast-enter-translate=var(--hx-space-2)] - CSS custom property.
  * @cssprop [--hx-space-2] - Spacing token.
  * @cssprop [--hx-transition-normal] - Transition timing.
- * @cssprop [--hx-color-success-600] - Color.
- * @cssprop [--hx-color-warning-500] - Color.
- * @cssprop [--hx-color-error-600] - Color.
- * @cssprop [--hx-color-primary-600] - Color.
+ * @cssprop [--hx-color-surface-success-strong] - Success-variant background semantic (3.2.1 cascade).
+ * @cssprop [--hx-color-surface-warning-strong] - Warning-variant background semantic (3.2.1 cascade).
+ * @cssprop [--hx-color-surface-danger-strong] - Danger-variant background semantic (3.2.1 cascade).
+ * @cssprop [--hx-color-surface-info-strong] - Info-variant background semantic (3.2.1 cascade).
+ * @cssprop [--hx-color-text-on-success-strong] - Success-variant foreground semantic (neutral-0 across modes).
+ * @cssprop [--hx-color-text-on-warning] - Warning-variant foreground semantic (neutral-900; warning sits on lighter -500 fill).
+ * @cssprop [--hx-color-text-on-error-strong] - Danger-variant foreground semantic (neutral-0 across modes).
+ * @cssprop [--hx-color-text-on-primary-strong] - Info-variant foreground semantic (neutral-0 across modes).
  * @cssprop [--hx-touch-target-min] - Minimum touch target size.
  * @cssprop [--hx-space-1] - Spacing token.
  * @cssprop [--hx-border-radius-sm] - CSS custom property.

--- a/packages/hx-tokens/src/__tests__/contrast.test.ts
+++ b/packages/hx-tokens/src/__tests__/contrast.test.ts
@@ -578,6 +578,24 @@ const PAIRS: PairSpec[] = [
     label: 'action.ghost.fg on action.ghost.bg-hover',
     modes: ['light', 'dark'],
   },
+  // 3.2.1 round-4: action.secondary.border defines the resting outline of
+  // outline-style buttons. WCAG 1.4.11 requires 3:1 against the adjacent
+  // surface (resting body fill AND the hover fill) so the affordance does not
+  // visually disappear when the user hovers.
+  {
+    text: '--hx-color-action-secondary-border',
+    surface: '--hx-color-surface-default',
+    threshold: 3,
+    label: 'action.secondary.border on surface.default',
+    modes: ['light', 'dark'],
+  },
+  {
+    text: '--hx-color-action-secondary-border',
+    surface: '--hx-color-action-secondary-bg-hover',
+    threshold: 3,
+    label: 'action.secondary.border on action.secondary.bg-hover',
+    modes: ['light', 'dark'],
+  },
   // 3.2.1 token-cascade remediation: surface.{role}-strong tokens (the
   // emphasis-prominence sibling of surface.{role}, used by hx-toast variant
   // fills and any other "loud" status surface). Each pairs with the

--- a/packages/hx-tokens/src/tokens.json
+++ b/packages/hx-tokens/src/tokens.json
@@ -113,11 +113,11 @@
       },
       "secondary": {
         "value": "var(--hx-color-neutral-700)",
-        "description": "Secondary body text. Bumped from neutral-600 to neutral-700 in 3.2.0 alongside text.muted moving from neutral-500 to neutral-600 — preserves the primary > strong > secondary > muted hierarchy now that muted occupies the slot secondary used to live in. neutral-700 (#313E4B) on surface.default (#FFFFFF) = 10.84:1, on surface.raised (#F5F8F3) = 10.10:1, on surface.sunken (#EBEEE9) = 9.01:1 — all AAA."
+        "description": "Secondary body text. Bumped from neutral-600 to neutral-700 in 3.2.0 alongside text.muted moving from neutral-500 to neutral-600 — preserves the primary > strong > secondary > muted hierarchy now that muted occupies the slot secondary used to live in. neutral-700 (#313E4B) on surface.default (#FFFFFF) = 10.93:1, on surface.raised (#F5F8F3) = 10.20:1, on surface.sunken (#EBEEE9) = 9.34:1 — all AAA."
       },
       "muted": {
         "value": "var(--hx-color-neutral-600)",
-        "description": "Muted body text. Bumped from neutral-500 to neutral-600 in 3.2.0. The new precision-cool neutral-500 (#66787B) on surface.raised (#F5F8F3) = 4.32:1 — fails the 4.5:1 body-text floor. neutral-600 (#4A5362) on surface.raised = 7.36:1, on surface.default = 7.88:1, on surface.sunken = 6.55:1 — AA pass everywhere. Pre-existing palette bug from commit 2 caught by the new contrast regression matrix."
+        "description": "Muted body text. Bumped from neutral-500 to neutral-600 in 3.2.0. The new precision-cool neutral-500 (#66787B) on surface.raised (#F5F8F3) = 4.32:1 — fails the 4.5:1 body-text floor. neutral-600 (#4A5362) on surface.raised = 7.25:1, on surface.default = 7.76:1, on surface.sunken = 6.63:1 — AA pass everywhere. Pre-existing palette bug from commit 2 caught by the new contrast regression matrix."
       },
       "placeholder": {
         "value": "var(--hx-color-neutral-500)",
@@ -243,7 +243,7 @@
       "secondary": {
         "fg": {
           "value": "var(--hx-color-primary-600)",
-          "description": "Foreground (text + icon) color for resting secondary/outline interactive treatments. primary-600 on surface.default = 5.20:1 AA."
+          "description": "Foreground (text + icon) color for resting secondary/outline interactive treatments. primary-600 on surface.default = 5.82:1 AA."
         },
         "border": {
           "value": "var(--hx-color-primary-600)",
@@ -632,7 +632,7 @@
         "secondary": {
           "fg": {
             "value": "var(--hx-color-primary-400)",
-            "description": "Dark-mode action.secondary.fg flips to primary-400 (#6AB1B1) — primary-600 on dark surface.default = 3.07:1 (AA fail). primary-400 = 7.18:1 (AA pass). Mirrors dark.text.link's primary-600→primary-400 flip."
+            "description": "Dark-mode action.secondary.fg flips to primary-400 (#6AB1B1) — primary-600 on dark surface.default = 3.07:1 (AA fail). primary-400 = 7.27:1 (AA pass). Mirrors dark.text.link's primary-600→primary-400 flip."
           },
           "border": {
             "value": "var(--hx-color-primary-400)",
@@ -640,7 +640,7 @@
           },
           "bg-hover": {
             "value": "var(--hx-color-primary-900)",
-            "description": "Dark-mode hover surface — primary-50 (light fill) on a dark page would be too bright. primary-900 (#0B3232) gives action.secondary.fg (primary-400 = #6AB1B1) on primary-900 = 5.97:1, AA pass. primary-800 was tested first but only reaches 4.14:1, just shy of the body-text floor."
+            "description": "Dark-mode hover surface — primary-50 (light fill) on a dark page would be too bright. primary-900 (#0B3232) gives action.secondary.fg (primary-400 = #6AB1B1) on primary-900 = 5.63:1, AA pass. primary-800 was tested first but only reaches 4.14:1, just shy of the body-text floor."
           }
         },
         "ghost": {


### PR DESCRIPTION
## Summary
Codex round-4 review on PR #1568 returned BLOCKING with 5 findings. All fixed in this PR.

| ID | Severity | Location | Fix |
|---|---|---|---|
| R3-1 | high | `tokens.json:116,120` | text.secondary `10.84/10.10/9.01` → `10.93/10.20/9.34`; text.muted `7.36/7.88/6.55` → `7.25/7.76/6.63` |
| R3-2 | high | `tokens.json:246,635,643` | action.secondary.fg light `5.20→5.82`, dark fg `7.18→7.27`, dark bg-hover `5.97→5.63` |
| R3-3 | medium | `hx-toast.ts:42+` | replaced 6 stale primitive `@cssprop` entries with the semantic tokens variant rules actually consume |
| R3-4 | medium | `contrast.test.ts:556` | added action.secondary.border × surface.default and × bg-hover assertions (light/dark, 3:1 WCAG 1.4.11) |
| R3-5 | low | `hx-nav-item.styles.ts:86` | active-state comment `5.39:1` → `5.82:1` (sibling occurrence missed in round-3 toast sweep) |

All contrast ratios independently recomputed via WCAG 2.1 sRGB luminance formula before edit.

## Test plan
- [x] tokens contrast suite: **150/150** passing (was 146 — added 4 border assertions)
- [x] tokenstype-check clean
- [x] librarytype-check clean
- [x] pre-push smart test suite passed
- [ ] CI completes green
- [ ] PR auto-merges to staging
- [ ] Round-5 codex pass on PR #1568 (verify clean)