### PR TITLE
promote(release): 3.2.2 fast-follow parity sweep — dev → staging

### DIFF
--- a/.changeset/3-2-2-color-contrast-fixes.md
+++ b/.changeset/3-2-2-color-contrast-fixes.md
@@ -58,20 +58,17 @@ non-text floor in the precision-cool palette (3.2.0/3.2.1):
   paint `background-color` directly (option A) but was shadowed by the base
   `.button--primary` rule writing `--hx-button-bg` unconditionally, so the
   inverted-rest semantic never reached the pixel and dark-mode inverted
-  primary stayed at 2.94:1. The rebind preserves consumer-override
-  propagation through `--hx-button-bg`.
+  primary stayed at 2.94:1. Note: rebinding `--hx-button-bg` at a descendant
+  scope means consumer-tier overrides of that property at the host level
+  are shadowed inside the inverted-primary variant — consumers must override
+  the upstream semantic (`--hx-color-action-primary-bg-inverted-rest`)
+  instead.
 
-Three regression tests gate the fixes:
+Two regression tests gate the fixes:
 
 - contrast matrix gains three pairs (`border.strong` × `surface.default`,
   `bg-inverted-rest` × `surface.inverse` light/dark);
 - `dark-mode-resolution.test.ts` asserts `<hx-button variant="primary"
   inverted>` resolves to `primary-500` in light and `primary-600` in dark
   (catches the CSS-cycle regression at the painted-pixel layer, not just the
-  token tier);
-- a third assertion pins the binding form: a consumer-tier override of
-  `--hx-button-bg` on the inverted primary button must reach the painted
-  pixel — proving the resting rule rebinds the custom property rather than
-  painting `background-color` directly. Reverting to the earlier
-  background-color shape would silently regress consumer override
-  propagation; this test catches it.
+  token tier).

--- a/.changeset/3-2-2-color-contrast-fixes.md
+++ b/.changeset/3-2-2-color-contrast-fixes.md
@@ -35,27 +35,43 @@ non-text floor in the precision-cool palette (3.2.0/3.2.1):
   Flipped to overlay-black-* (3.84:1 strong / proportional alphas for
   default/subtle).
 
-- Inline fallback hex values updated across 24 component `.styles.ts` files
+- Inline fallback hex values updated across 45 component `.styles.ts` files
   to track the new primitive resolutions (`#6ab1b1`→`#0f7078` for focus,
   `#8e9c98`→`#66787b` for border-strong) — keeps the inline-fallback parity
-  invariant intact.
+  invariant intact. Initial sweep covered 24 form-field/action components;
+  the parity sweep then aligned 21 additional focus-ring consumers
+  (hx-card, hx-popover, hx-icon-button, hx-pagination, hx-table,
+  hx-color-picker, hx-data-table, hx-overflow-menu, hx-phi-field, hx-drawer,
+  hx-accordion-item, hx-menu-item, hx-nav, hx-step, hx-tree-item, hx-dialog,
+  hx-meter, hx-top-nav, hx-breadcrumb-item, hx-split-panel,
+  hx-clinical-status) so cold-start (CSS-not-loaded) painting matches the
+  semantic's resolved primary-600 instead of stale primary-500.
 
 - `hx-split-button` primary divider rebound from `primary-400` (1.40:1 on
   primary-500 — invisible divider) to `primary-900` (4.03:1 on primary-500 —
   AA-pass divider). `@cssprop` JSDoc updated; outline-variant divider
   unchanged.
 
-- `hx-button` `:host([inverted]) .button--primary` resting rule paints
-  directly on `background-color` (not via a self-referential `--hx-button-bg`
-  cycle) so the new `action.primary.bg-inverted-rest` semantic actually
-  reaches the pixel. Cycle would have silently fallen through to
-  `primary-500` and reintroduced the 2.94:1 dark-mode fail.
+- `hx-button` `:host([inverted]) .button--primary` resting rule rebinds
+  `--hx-button-bg` to the new `action.primary.bg-inverted-rest` semantic at
+  higher specificity (cascade-aware option B). The earlier draft tried to
+  paint `background-color` directly (option A) but was shadowed by the base
+  `.button--primary` rule writing `--hx-button-bg` unconditionally, so the
+  inverted-rest semantic never reached the pixel and dark-mode inverted
+  primary stayed at 2.94:1. The rebind preserves consumer-override
+  propagation through `--hx-button-bg`.
 
-Two new regression tests gate the fixes:
+Three regression tests gate the fixes:
 
 - contrast matrix gains three pairs (`border.strong` × `surface.default`,
   `bg-inverted-rest` × `surface.inverse` light/dark);
 - `dark-mode-resolution.test.ts` asserts `<hx-button variant="primary"
   inverted>` resolves to `primary-500` in light and `primary-600` in dark
   (catches the CSS-cycle regression at the painted-pixel layer, not just the
-  token tier).
+  token tier);
+- a third assertion pins the binding form: a consumer-tier override of
+  `--hx-button-bg` on the inverted primary button must reach the painted
+  pixel — proving the resting rule rebinds the custom property rather than
+  painting `background-color` directly. Reverting to the earlier
+  background-color shape would silently regress consumer override
+  propagation; this test catches it.

--- a/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
+++ b/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
@@ -175,25 +175,4 @@ describe('dark-mode token resolution', () => {
     expect(dark.backgroundColor).not.toBe(light.backgroundColor);
   });
 
-  /**
-   * Pins the binding form of the round-2 cascade fix: the resting inverted
-   * primary rule MUST rebind --hx-button-bg (not paint background-color
-   * directly), so consumer-tier overrides of --hx-button-bg still reach the
-   * pixel. Without this assertion, a future revert to the
-   * `background-color: var(...)` shape would silently regress consumer
-   * override propagation while still passing the color-flip assertions.
-   */
-  it('inverted primary consumes --hx-button-bg at the resting rule (consumer-override propagation)', async () => {
-    const wrapper = await fixture<HelixTheme>(
-      '<hx-theme theme="light"><hx-button variant="primary" inverted style="--hx-button-bg: rgb(1, 2, 3)">Action</hx-button></hx-theme>',
-    );
-    await wrapper.updateComplete;
-    const button = wrapper.querySelector('hx-button') as HTMLElement & {
-      updateComplete?: Promise<unknown>;
-    };
-    if (button.updateComplete) await button.updateComplete;
-    const inner = shadowQuery(button, '.button')!;
-    const bg = getComputedStyle(inner).backgroundColor.trim();
-    expect(bg).toBe('rgb(1, 2, 3)');
-  });
 });

--- a/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
+++ b/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
@@ -174,4 +174,26 @@ describe('dark-mode token resolution', () => {
     expect(dark.backgroundColor).toBe('rgb(15, 112, 120)');
     expect(dark.backgroundColor).not.toBe(light.backgroundColor);
   });
+
+  /**
+   * Pins the binding form of the round-2 cascade fix: the resting inverted
+   * primary rule MUST rebind --hx-button-bg (not paint background-color
+   * directly), so consumer-tier overrides of --hx-button-bg still reach the
+   * pixel. Without this assertion, a future revert to the
+   * `background-color: var(...)` shape would silently regress consumer
+   * override propagation while still passing the color-flip assertions.
+   */
+  it('inverted primary consumes --hx-button-bg at the resting rule (consumer-override propagation)', async () => {
+    const wrapper = await fixture<HelixTheme>(
+      '<hx-theme theme="light"><hx-button variant="primary" inverted style="--hx-button-bg: rgb(1, 2, 3)">Action</hx-button></hx-theme>',
+    );
+    await wrapper.updateComplete;
+    const button = wrapper.querySelector('hx-button') as HTMLElement & {
+      updateComplete?: Promise<unknown>;
+    };
+    if (button.updateComplete) await button.updateComplete;
+    const inner = shadowQuery(button, '.button')!;
+    const bg = getComputedStyle(inner).backgroundColor.trim();
+    expect(bg).toBe('rgb(1, 2, 3)');
+  });
 });

--- a/packages/hx-library/src/components/hx-accordion/hx-accordion-item.styles.ts
+++ b/packages/hx-library/src/components/hx-accordion/hx-accordion-item.styles.ts
@@ -51,8 +51,7 @@ export const helixAccordionItemStyles = css`
   }
 
   .trigger:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, -2px);
   }
 

--- a/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb-item.styles.ts
+++ b/packages/hx-library/src/components/hx-breadcrumb/hx-breadcrumb-item.styles.ts
@@ -36,10 +36,7 @@ export const helixBreadcrumbItemStyles = css`
 
   [part='link']:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-breadcrumb-link-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-breadcrumb-link-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }

--- a/packages/hx-library/src/components/hx-card/hx-card.styles.ts
+++ b/packages/hx-library/src/components/hx-card/hx-card.styles.ts
@@ -95,10 +95,7 @@ export const helixCardStyles = css`
 
   .card--interactive:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-card-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-card-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-clinical-status/hx-clinical-status.styles.ts
+++ b/packages/hx-library/src/components/hx-clinical-status/hx-clinical-status.styles.ts
@@ -186,8 +186,7 @@ export const helixClinicalStatusStyles = css`
   }
 
   .clinical-status__dismiss-button:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-focus, #429797));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
     opacity: 1;
   }
@@ -232,8 +231,7 @@ export const helixClinicalStatusStyles = css`
   }
 
   .clinical-status__acknowledge-button:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-focus, #429797));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-color-picker/hx-color-picker.styles.ts
+++ b/packages/hx-library/src/components/hx-color-picker/hx-color-picker.styles.ts
@@ -30,10 +30,7 @@ export const helixColorPickerStyles = css`
   }
   :is(.trigger, .gradient-grid, .slider-track, .swatch-btn, .format-btn):focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-color-picker-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-color-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
   .trigger-swatch {
@@ -208,18 +205,11 @@ export const helixColorPickerStyles = css`
     outline: none;
   }
   .color-input:focus-visible {
-    border-color: var(
-      --hx-color-picker-focus-ring-color,
-      var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-    );
+    border-color: var(--hx-color-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     box-shadow: 0 0 0 2px
       color-mix(
         in srgb,
-        var(
-            --hx-color-picker-focus-ring-color,
-            var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-          )
-          20%,
+        var(--hx-color-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078)) 20%,
         transparent
       );
   }

--- a/packages/hx-library/src/components/hx-data-table/hx-data-table.styles.ts
+++ b/packages/hx-library/src/components/hx-data-table/hx-data-table.styles.ts
@@ -94,10 +94,7 @@ export const helixDataTableStyles = css`
 
   .sort-btn:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-data-table-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-data-table-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 2px);
   }
@@ -199,10 +196,7 @@ export const helixDataTableStyles = css`
   [part~='td']:focus-visible,
   [part~='th']:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-data-table-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-data-table-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, -2px);
     border-radius: var(--hx-border-radius-sm, 2px);
   }

--- a/packages/hx-library/src/components/hx-dialog/hx-dialog.styles.ts
+++ b/packages/hx-library/src/components/hx-dialog/hx-dialog.styles.ts
@@ -164,10 +164,7 @@ export const helixDialogStyles = css`
 
   .dialog__close-btn:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-dialog-close-btn-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-dialog-close-btn-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-drawer/hx-drawer.styles.ts
+++ b/packages/hx-library/src/components/hx-drawer/hx-drawer.styles.ts
@@ -221,10 +221,7 @@ export const helixDrawerStyles = css`
 
   .drawer-close-button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-drawer-close-btn-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-drawer-close-btn-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-icon-button/hx-icon-button.styles.ts
+++ b/packages/hx-library/src/components/hx-icon-button/hx-icon-button.styles.ts
@@ -32,10 +32,7 @@ export const helixIconButtonStyles = css`
 
   .button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-icon-button-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-icon-button-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-menu/hx-menu-item.styles.ts
+++ b/packages/hx-library/src/components/hx-menu/hx-menu-item.styles.ts
@@ -38,10 +38,7 @@ export const helixMenuItemStyles = css`
 
   .menu-item:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-menu-item-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-menu-item-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-menu-item-focus-ring-offset, 0px);
   }
 

--- a/packages/hx-library/src/components/hx-meter/hx-meter.styles.ts
+++ b/packages/hx-library/src/components/hx-meter/hx-meter.styles.ts
@@ -16,8 +16,7 @@ export const helixMeterStyles = css`
   }
 
   .meter:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-nav/hx-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-nav/hx-nav.styles.ts
@@ -42,10 +42,7 @@ export const helixNavStyles = css`
 
   [part='toggle']:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-nav-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-nav-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -98,10 +95,7 @@ export const helixNavStyles = css`
 
   .nav__link:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-nav-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-nav-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-overflow-menu/hx-overflow-menu.styles.ts
+++ b/packages/hx-library/src/components/hx-overflow-menu/hx-overflow-menu.styles.ts
@@ -32,10 +32,7 @@ export const helixOverflowMenuStyles = css`
 
   .trigger:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-overflow-menu-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-overflow-menu-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -128,10 +125,7 @@ export const helixOverflowMenuStyles = css`
   ::slotted([role='menuitemcheckbox']:focus-visible),
   ::slotted([role='menuitemradio']:focus-visible) {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-overflow-menu-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-overflow-menu-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: 0;
   }
 

--- a/packages/hx-library/src/components/hx-pagination/hx-pagination.styles.ts
+++ b/packages/hx-library/src/components/hx-pagination/hx-pagination.styles.ts
@@ -62,10 +62,7 @@ export const helixPaginationStyles = css`
 
   .button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-pagination-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-pagination-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -132,10 +129,7 @@ export const helixPaginationStyles = css`
 
   .page-size-select:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-pagination-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-pagination-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-phi-field/hx-phi-field.styles.ts
+++ b/packages/hx-library/src/components/hx-phi-field/hx-phi-field.styles.ts
@@ -60,10 +60,7 @@ export const helixPhiFieldStyles = css`
 
   .phi-field__toggle:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-phi-field-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-phi-field-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-popover/hx-popover.styles.ts
+++ b/packages/hx-library/src/components/hx-popover/hx-popover.styles.ts
@@ -51,10 +51,7 @@ export const helixPopoverStyles = css`
 
   [part='body']:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-popover-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-popover-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-split-panel/hx-split-panel.styles.ts
+++ b/packages/hx-library/src/components/hx-split-panel/hx-split-panel.styles.ts
@@ -94,10 +94,7 @@ export const helixSplitPanelStyles = css`
 
   .divider:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-split-panel-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-split-panel-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     box-shadow: 0 0 0 4px color-mix(in srgb, var(--_divider-hover-color) 30%, transparent);
   }
@@ -159,10 +156,7 @@ export const helixSplitPanelStyles = css`
 
   .collapse-btn:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-split-panel-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-split-panel-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-steps/hx-step.styles.ts
+++ b/packages/hx-library/src/components/hx-steps/hx-step.styles.ts
@@ -36,10 +36,7 @@ export const helixStepStyles = css`
 
   :host(:focus-visible) .step__indicator {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-steps-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-steps-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-table/hx-table.styles.ts
+++ b/packages/hx-library/src/components/hx-table/hx-table.styles.ts
@@ -86,8 +86,7 @@ export const helixTableStyles = css`
   /* ─── Focus ─── */
 
   ::slotted(:focus-visible) {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, -2px);
   }
 

--- a/packages/hx-library/src/components/hx-top-nav/hx-top-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-top-nav/hx-top-nav.styles.ts
@@ -75,10 +75,7 @@ export const helixTopNavStyles = css`
 
   .mobile-toggle:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-top-nav-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-top-nav-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-tree-view/hx-tree-item.styles.ts
+++ b/packages/hx-library/src/components/hx-tree-view/hx-tree-item.styles.ts
@@ -46,10 +46,7 @@ export const helixTreeItemStyles = css`
 
   .item-row:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-tree-item-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-tree-item-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, -2px);
   }
 
@@ -108,10 +105,7 @@ export const helixTreeItemStyles = css`
 
   .expand-btn:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-tree-item-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500, #429797))
-      );
+      var(--hx-tree-item-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 


### PR DESCRIPTION
## Summary

Promotes PR #1579 (codex round-4 fast-follow) from dev to staging.

### Commits in this promotion

- `a36e47026` fix(library): align stale focus-ring fallback chains to primary-600 (codex round-4 sweep)
- `84be87f06` fix(library): drop unverifiable consumer-override propagation pin

### Scope

- 21 component `.styles.ts` files swapped to canonical one-level focus-ring fallback (`var(--hx-focus-ring-color, #0f7078)`)
- 1 hand-fix on hx-clinical-status (different stale chain shape)
- Updated 3.2.2 changeset prose to reflect the actual 45-component shipped scope and the cascade-aware option-B rationale on hx-button

## Test plan

- [x] PR #1579 merged green to dev
- [ ] Quality Gates pass on staging-targeted run