### PR TITLE
fix(library): remediate codex round-5 findings on 3.2.2 — residual fallback drift + override-path test

### DIFF
--- a/.changeset/3-2-2-codex-round-5-remediation.md
+++ b/.changeset/3-2-2-codex-round-5-remediation.md
@@ -1,0 +1,11 @@
+---
+'@helixui/library': patch
+---
+
+3.2.2 codex round-5 remediation — residual focus-ring fallback drift + override-path test
+
+Cleanup of three concerns surfaced by codex deep review on the staging→main candidate. Rolls into the same 3.2.2 patch — no new tokens, no API change.
+
+- `hx-combobox` — 2 focus-ring fallback chains (clear button + focused option) still resolved to `primary-500` on cold-start. Aligned to canonical `var(--hx-focus-ring-color, #0f7078)`.
+- `hx-file-upload` — 3 focus-ring fallback chains (dropzone outline + dropzone border-color + file-item__remove outline) had the same drift. Same fix.
+- `dark-mode-resolution.test.ts` — added a positive assertion that consumer-tier override of `--hx-color-action-primary-bg-inverted-rest` reaches the painted pixel in dark mode, proving the documented override contract end-to-end.

--- a/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
+++ b/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
@@ -175,4 +175,17 @@ describe('dark-mode token resolution', () => {
     expect(dark.backgroundColor).not.toBe(light.backgroundColor);
   });
 
+  /**
+   * Pins the documented consumer-override path: the inverted-primary resting
+   * rule reads from --hx-color-action-primary-bg-inverted-rest, so consumers
+   * override THAT semantic (not --hx-button-bg, which is shadowed at the
+   * .button--primary descendant scope). If a future change relocated the
+   * inverted-rest paint off this semantic, this assertion would fail.
+   */
+  it('inverted primary honors semantic override on --hx-color-action-primary-bg-inverted-rest', async () => {
+    const markup =
+      '<hx-button variant="primary" inverted style="--hx-color-action-primary-bg-inverted-rest: rgb(1, 2, 3)">Action</hx-button>';
+    const dark = await resolveStyles('dark', markup, 'hx-button', '.button');
+    expect(dark.backgroundColor).toBe('rgb(1, 2, 3)');
+  });
 });

--- a/packages/hx-library/src/components/hx-combobox/hx-combobox.styles.ts
+++ b/packages/hx-library/src/components/hx-combobox/hx-combobox.styles.ts
@@ -130,7 +130,7 @@ export const helixComboboxStyles = css`
   }
   .field__clear-button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
   .field__loading-indicator {
@@ -204,7 +204,7 @@ export const helixComboboxStyles = css`
   .field__option--focused {
     background-color: var(--hx-combobox-option-hover-bg, var(--hx-color-primary-50, #ebf8f8));
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-combobox-option-focus-ring-offset, -2px);
   }
   .field__option--focused.field__option--selected {
@@ -388,7 +388,7 @@ export const helixComboboxStyles = css`
   }
   .field__chip-remove:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     opacity: 1;
   }

--- a/packages/hx-library/src/components/hx-file-upload/hx-file-upload.styles.ts
+++ b/packages/hx-library/src/components/hx-file-upload/hx-file-upload.styles.ts
@@ -60,15 +60,9 @@ export const helixFileUploadStyles = css`
 
   .dropzone:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-file-upload-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500))
-      );
+      var(--hx-file-upload-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
-    border-color: var(
-      --hx-file-upload-focus-ring-color,
-      var(--hx-focus-ring-color, var(--hx-color-primary-500))
-    );
+    border-color: var(--hx-file-upload-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
   }
 
   .dropzone--drag-over {
@@ -183,10 +177,7 @@ export const helixFileUploadStyles = css`
 
   .file-item__remove:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-file-upload-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500))
-      );
+      var(--hx-file-upload-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 


### PR DESCRIPTION
## Summary

Codex round-5 deep review on the staging→main candidate (PR #1581) surfaced 3 concerns. Per `.rea/policy.yaml` (`review.concerns_blocks: true`), all three block ship. This is the remediation.

### Findings remediated

**1. `hx-combobox` — 2 stale focus-ring fallback chains**

The 3.2.2 sweep updated `border-strong` fallbacks in this file but missed the focus-ring fallbacks immediately adjacent. Aligned to canonical one-level form: `var(--hx-focus-ring-color, #0f7078)`. Sites: `.field__clear-button:focus-visible` (L133), `.field__option--focused` (L207).

**2. `hx-file-upload` — 3 stale focus-ring fallback chains**

Same root cause. Sites: `.dropzone:focus-visible` outline + border-color (L62-65), `.file-item__remove:focus-visible` outline (L179-180).

**3. New positive override-path test**

Codex flagged that the existing inverted-primary bg-flip assertion would still pass if the documented consumer-override path silently broke. Added a third `it()` block that styles `<hx-button variant="primary" inverted style="--hx-color-action-primary-bg-inverted-rest: rgb(1, 2, 3)">` and asserts the painted bg equals that exact value in dark mode — proving the changeset's documented override contract end-to-end.

This is the architecturally-correct shape of the test: consumers override the upstream semantic, not `--hx-button-bg` (which is shadowed at the descendant scope per CSS custom-property cascade).

## Test plan

- [x] Scoped preflight passes (lint, format, type-check, build, CDN+size, smart tests, CEM, changeset)
- [x] Direct vitest run on `dark-mode-resolution.test.ts` — 11/11 passed including new assertion
- [ ] CodeRabbit review
- [ ] CI Quality Gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for dark mode behavior with inverted primary button styling.

* **Style**
  * Updated focus ring styling in combobox and file-upload components for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->