### PR TITLE
promote(release): 3.2.2 codex round-5 remediation — dev → staging

### DIFF
--- a/.changeset/3-2-2-codex-round-5-remediation.md
+++ b/.changeset/3-2-2-codex-round-5-remediation.md
@@ -1,0 +1,11 @@
+---
+'@helixui/library': patch
+---
+
+3.2.2 codex round-5 remediation — residual focus-ring fallback drift + override-path test
+
+Cleanup of three concerns surfaced by codex deep review on the staging→main candidate. Rolls into the same 3.2.2 patch — no new tokens, no API change.
+
+- `hx-combobox` — 2 focus-ring fallback chains (clear button + focused option) still resolved to `primary-500` on cold-start. Aligned to canonical `var(--hx-focus-ring-color, #0f7078)`.
+- `hx-file-upload` — 3 focus-ring fallback chains (dropzone outline + dropzone border-color + file-item__remove outline) had the same drift. Same fix.
+- `dark-mode-resolution.test.ts` — added a positive assertion that consumer-tier override of `--hx-color-action-primary-bg-inverted-rest` reaches the painted pixel in dark mode, proving the documented override contract end-to-end.

--- a/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
+++ b/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
@@ -175,4 +175,17 @@ describe('dark-mode token resolution', () => {
     expect(dark.backgroundColor).not.toBe(light.backgroundColor);
   });
 
+  /**
+   * Pins the documented consumer-override path: the inverted-primary resting
+   * rule reads from --hx-color-action-primary-bg-inverted-rest, so consumers
+   * override THAT semantic (not --hx-button-bg, which is shadowed at the
+   * .button--primary descendant scope). If a future change relocated the
+   * inverted-rest paint off this semantic, this assertion would fail.
+   */
+  it('inverted primary honors semantic override on --hx-color-action-primary-bg-inverted-rest', async () => {
+    const markup =
+      '<hx-button variant="primary" inverted style="--hx-color-action-primary-bg-inverted-rest: rgb(1, 2, 3)">Action</hx-button>';
+    const dark = await resolveStyles('dark', markup, 'hx-button', '.button');
+    expect(dark.backgroundColor).toBe('rgb(1, 2, 3)');
+  });
 });

--- a/packages/hx-library/src/components/hx-combobox/hx-combobox.styles.ts
+++ b/packages/hx-library/src/components/hx-combobox/hx-combobox.styles.ts
@@ -130,7 +130,7 @@ export const helixComboboxStyles = css`
   }
   .field__clear-button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
   .field__loading-indicator {
@@ -204,7 +204,7 @@ export const helixComboboxStyles = css`
   .field__option--focused {
     background-color: var(--hx-combobox-option-hover-bg, var(--hx-color-primary-50, #ebf8f8));
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-combobox-option-focus-ring-offset, -2px);
   }
   .field__option--focused.field__option--selected {
@@ -388,7 +388,7 @@ export const helixComboboxStyles = css`
   }
   .field__chip-remove:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     opacity: 1;
   }

--- a/packages/hx-library/src/components/hx-file-upload/hx-file-upload.styles.ts
+++ b/packages/hx-library/src/components/hx-file-upload/hx-file-upload.styles.ts
@@ -60,15 +60,9 @@ export const helixFileUploadStyles = css`
 
   .dropzone:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-file-upload-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500))
-      );
+      var(--hx-file-upload-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
-    border-color: var(
-      --hx-file-upload-focus-ring-color,
-      var(--hx-focus-ring-color, var(--hx-color-primary-500))
-    );
+    border-color: var(--hx-file-upload-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
   }
 
   .dropzone--drag-over {
@@ -183,10 +177,7 @@ export const helixFileUploadStyles = css`
 
   .file-item__remove:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-file-upload-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-500))
-      );
+      var(--hx-file-upload-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 


### PR DESCRIPTION
## Summary

Promotes PR #1582 (codex round-5) from dev to staging.

### Commits in this promotion

- `ed71b084c` fix(library): remediate codex round-5 findings on 3.2.2 — residual fallback drift + override-path test
- `f2e6253c0` chore: changeset for 3.2.2 codex round-5 remediation

### Scope

- 2 stale focus-ring fallback chains in hx-combobox aligned to `#0f7078`
- 3 stale focus-ring fallback chains in hx-file-upload aligned to `#0f7078`
- 1 new positive assertion in dark-mode-resolution.test.ts proving consumer-tier override of `--hx-color-action-primary-bg-inverted-rest` reaches the painted pixel in dark mode

## Test plan

- [x] PR #1582 merged green to dev
- [ ] Quality Gates pass on staging-targeted run