### PR TITLE
promote(3.2.2): dev → staging — round-6 remediation fast-follow

### DIFF
--- a/.changeset/3-2-2-codex-round-6-remediation.md
+++ b/.changeset/3-2-2-codex-round-6-remediation.md
@@ -1,0 +1,12 @@
+---
+'@helixui/library': patch
+---
+
+3.2.2 codex round-6 remediation — residual focus-ring drift + override-path light sister + on-dark inline-fallback contract
+
+Cleanup of four low-severity concerns surfaced by codex deep review on the staging→main candidate after round-5 landed. Rolls into the same 3.2.2 patch — no new tokens, no API change.
+
+- `hx-carousel` — 3 focus-ring fallback chains (nav-btn, play-pause-btn, pagination-item outlines) still resolved to `primary-500` on cold-start. Aligned to canonical `var(--hx-focus-ring-color, #0f7078)`.
+- `hx-select` — focused-option outline carried a dead `var(--_focus-ring-color, var(--hx-color-primary-500))` tail. `--_focus-ring-color` is unconditionally defined on `:host` (line 24) so the tail is unreachable; dropped to `var(--_focus-ring-color)`.
+- `dark-mode-resolution.test.ts` — added a light-mode sister assertion to the bg-inverted-rest override-path test, proving the `--hx-color-action-primary-bg-inverted-rest` consumer override is mode-agnostic (not just a dark-mode contract).
+- `hx-button` — added an inline-fallback contract comment at the head of the inverted-mode block documenting that the literal `rgba(255, 255, 255, 0.X)` arms on `--hx-color-border-on-dark-*` are a light-mode-only last resort. At runtime, `<hx-theme>` injects `dark.color.border.on-dark-*` as overlay-black-* so dark-mode inverted buttons stay visible on the now-light surface.inverse. Future relocation outside an `<hx-theme>` host should switch to mode-aware tokens.

--- a/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
+++ b/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
@@ -188,4 +188,11 @@ describe('dark-mode token resolution', () => {
     const dark = await resolveStyles('dark', markup, 'hx-button', '.button');
     expect(dark.backgroundColor).toBe('rgb(1, 2, 3)');
   });
+
+  it('inverted primary honors semantic override in light mode too (override path is mode-agnostic)', async () => {
+    const markup =
+      '<hx-button variant="primary" inverted style="--hx-color-action-primary-bg-inverted-rest: rgb(4, 5, 6)">Action</hx-button>';
+    const light = await resolveStyles('light', markup, 'hx-button', '.button');
+    expect(light.backgroundColor).toBe('rgb(4, 5, 6)');
+  });
 });

--- a/packages/hx-library/src/components/hx-button/hx-button.styles.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.styles.ts
@@ -231,6 +231,16 @@ export const helixButtonStyles = css`
 
   /* ─── Inverted Mode ─── */
 
+  /* Inline-fallback contract for --hx-color-border-on-dark-* in this section:
+     the literal rgba(255, 255, 255, 0.X) arms are a LIGHT-MODE-only last
+     resort (cold-start, CSS-not-loaded). At runtime, hx-theme injects
+     dark.color.border.on-dark-* as overlay-black-* so dark-mode inverted
+     buttons stay visible on the now-light surface.inverse (#EBEEE9). The
+     inline white overlays would render invisible (≈1.1:1) on a light surface,
+     but they never paint when the theme is mounted. If a future change moves
+     these into a context where hx-theme is not guaranteed, replace with
+     mode-aware tokens. */
+
   /* Override text color and filter-based hover/active for all variants */
   :host([inverted]) .button {
     color: var(--hx-button-inverted-color, var(--hx-color-text-inverse, #ffffff));

--- a/packages/hx-library/src/components/hx-carousel/hx-carousel.styles.ts
+++ b/packages/hx-library/src/components/hx-carousel/hx-carousel.styles.ts
@@ -64,7 +64,7 @@ export const helixCarouselStyles = css`
 
   .nav-btn:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-carousel-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-carousel-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -106,7 +106,7 @@ export const helixCarouselStyles = css`
 
   .play-pause-btn:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-carousel-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-carousel-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -178,7 +178,7 @@ export const helixCarouselStyles = css`
 
   .pagination-item:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-carousel-focus-ring-color, var(--hx-focus-ring-color, var(--hx-color-primary-500)));
+      var(--hx-carousel-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-full, 9999px);
   }

--- a/packages/hx-library/src/components/hx-select/hx-select.styles.ts
+++ b/packages/hx-library/src/components/hx-select/hx-select.styles.ts
@@ -236,8 +236,7 @@ export const helixSelectStyles = css`
 
   .field__option--focused {
     background-color: var(--_option-hover-bg);
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--_focus-ring-color, var(--hx-color-primary-500));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--_focus-ring-color);
     outline-offset: var(--hx-select-option-focus-ring-offset, -2px);
   }
 


### PR DESCRIPTION
## Summary

Promotes #1584 (3.2.2 codex round-6 remediation) from dev → staging so PR #1581 (staging → main) picks it up before the next codex pass.

## Changes carried

- 1 commit: `fix(library): remediate codex round-6 findings on 3.2.2`
- Touches: hx-carousel.styles.ts, hx-select.styles.ts, hx-button.styles.ts (comment only), dark-mode-resolution.test.ts (+1 test), `.changeset/3-2-2-codex-round-6-remediation.md`

## Test plan

- [x] verify + tests already green on #1584 dev merge
- [ ] staging CI green
- [ ] codex round-7 on #1581 (staging → main) returns `pass`