### PR TITLE
promote(3.2.2): dev → staging — codex round-7 remediation

### DIFF
--- a/.changeset/3-2-2-codex-round-7-remediation.md
+++ b/.changeset/3-2-2-codex-round-7-remediation.md
@@ -1,0 +1,16 @@
+---
+'@helixui/library': patch
+---
+
+3.2.2 codex round-7 remediation — repoint inverse-surface borders to border-on-dark-strong
+
+Cleanup of one medium-severity concern surfaced by codex round-7 on the staging→main candidate. Rolls into the same 3.2.2 patch — no token changes, no API change.
+
+Codex flagged that the new `dark.color.border.strong` override (`neutral-500 → neutral-400`) added in 3.2.2 — correct for the dominant case (form-control borders on dark surface.default, which gains 6.27:1 headroom) — regressed two components that bind `border.strong` against `surface.inverse`. In dark mode, `surface.inverse` flips to the light `neutral-100` (#EBEEE9), where `neutral-400` (#8E9C98) lands at 2.44:1, failing WCAG 1.4.11's 3:1 UI floor.
+
+Fix path (a) — architecturally aligned with the new dark-override layer:
+
+- `hx-side-nav` — container, header, and footer divider borders (lines 32, 50, 77) repointed from `--hx-color-border-strong` to `--hx-color-border-on-dark-strong`. The host already binds `surface-inverse` for bg, so this is the correct family. Dark-mode dark-override resolves to overlay-black-50 = 3.84:1 on light surface.inverse (passes).
+- `hx-code-snippet` — copy button border (line 83) and expand button top border (line 128) repointed identically. Both sit on the always-dark block-snippet surface (`surface-inverse`).
+
+Inline cold-start fallback updated to `rgba(255, 255, 255, 0.7)` (overlay-white-70, the light-mode resolved value of `border.on-dark-strong`).

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-04-26T04:57:16.568Z",
+  "generatedAt": "2026-04-26T11:16:10.504Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.2.0",
   "tokensVersion": "3.2.0",
@@ -17606,13 +17606,13 @@
           }
         },
         {
-          "description": "Border color.",
+          "description": "Border color (against the dark surface-inverse host bg).",
           "name": "--hx-side-nav-border-color",
-          "default": "var(--hx-color-border-strong)",
+          "default": "var(--hx-color-border-on-dark-strong)",
           "figmaBinding": {
             "target": "Stroke",
             "layerSelector": "root",
-            "semanticToken": "color/border/strong",
+            "semanticToken": "color/border/on/dark/strong",
             "fallbackPrimitive": null,
             "literalFallback": null
           }
@@ -17676,8 +17676,8 @@
           "figmaBinding": null
         },
         {
-          "description": "Header/footer divider border.",
-          "name": "--hx-color-border-strong",
+          "description": "Container/header/footer divider border (overlay-white-70 light, overlay-black-50 dark — sized for visibility on the mode-flipped surface-inverse).",
+          "name": "--hx-color-border-on-dark-strong",
           "figmaBinding": null
         },
         {

--- a/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.styles.ts
+++ b/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.styles.ts
@@ -80,7 +80,8 @@ export const helixCodeSnippetStyles = css`
     min-width: var(--hx-touch-target-min, 2.75rem);
     min-height: var(--hx-touch-target-min, 2.75rem);
     padding: var(--hx-space-1, 0.25rem) var(--hx-space-2, 0.5rem);
-    border: var(--hx-border-width-thin, 1px) solid var(--hx-color-border-strong, #66787b);
+    border: var(--hx-border-width-thin, 1px) solid
+      var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7));
     border-radius: var(--hx-border-radius-sm, 0.25rem);
     /* Copy button sits on the always-dark block snippet surface; uses inverse family for contrast on the terminal background. */
     background-color: var(--hx-color-surface-inverse, #0d1825);
@@ -125,7 +126,8 @@ export const helixCodeSnippetStyles = css`
     min-height: var(--hx-touch-target-min, 2.75rem);
     padding: var(--hx-space-2, 0.5rem) var(--hx-space-4, 1rem);
     border: none;
-    border-top: var(--hx-border-width-thin, 1px) solid var(--hx-color-border-strong, #66787b);
+    border-top: var(--hx-border-width-thin, 1px) solid
+      var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7));
     /* Expand button is attached to the always-dark block snippet — inverse family maintains the terminal aesthetic. */
     background-color: var(--hx-color-surface-inverse, #0d1825);
     color: var(--hx-color-text-inverse, #ffffff);

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
@@ -29,7 +29,10 @@ export const helixSideNavStyles = css`
     transition: width var(--hx-transition-normal, 300ms) ease;
     overflow: hidden;
     border-inline-end: var(--hx-border-width-thin, 1px) solid
-      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #66787b));
+      var(
+        --hx-side-nav-border-color,
+        var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7))
+      );
   }
 
   /* ─── Collapsed State ─── */
@@ -47,7 +50,10 @@ export const helixSideNavStyles = css`
     flex-shrink: 0;
     min-height: var(--hx-space-14, 3.5rem);
     border-bottom: var(--hx-border-width-thin, 1px) solid
-      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #66787b));
+      var(
+        --hx-side-nav-border-color,
+        var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7))
+      );
     overflow: hidden;
   }
 
@@ -74,7 +80,10 @@ export const helixSideNavStyles = css`
     flex-shrink: 0;
     min-height: var(--hx-space-14, 3.5rem);
     border-top: var(--hx-border-width-thin, 1px) solid
-      var(--hx-side-nav-border-color, var(--hx-color-border-strong, #66787b));
+      var(
+        --hx-side-nav-border-color,
+        var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7))
+      );
     overflow: hidden;
   }
 

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
@@ -29,14 +29,14 @@ import { helixSideNavStyles } from './hx-side-nav.styles.js';
  * @cssprop [--hx-side-nav-collapsed-width=3.5rem] - Collapsed icon-only width.
  * @cssprop [--hx-side-nav-bg=var(--hx-color-surface-inverse)] - Background color.
  * @cssprop [--hx-side-nav-color=var(--hx-color-text-inverse)] - Text color.
- * @cssprop [--hx-side-nav-border-color=var(--hx-color-border-strong)] - Border color.
+ * @cssprop [--hx-side-nav-border-color=var(--hx-color-border-on-dark-strong)] - Border color (against the dark surface-inverse host bg).
  * @cssprop [--hx-side-nav-header-padding=var(--hx-space-4)] - Header padding.
  * @cssprop [--hx-side-nav-footer-padding=var(--hx-space-4)] - Footer padding.
  * @cssprop [--hx-side-nav-toggle-color=var(--hx-color-text-inverse)] - Toggle button icon color (resting).
  * @cssprop [--hx-side-nav-toggle-hover-color=var(--hx-color-text-inverse)] - Toggle button icon color on hover.
  * @cssprop [--hx-color-surface-inverse] - Side-nav surface fill (resolves to neutral-900 light, near-black dark).
  * @cssprop [--hx-color-text-inverse] - Side-nav text color (resolves to neutral-0).
- * @cssprop [--hx-color-border-strong] - Header/footer divider border.
+ * @cssprop [--hx-color-border-on-dark-strong] - Container/header/footer divider border (overlay-white-70 light, overlay-black-50 dark — sized for visibility on the mode-flipped surface-inverse).
  * @cssprop [--hx-color-border-on-dark-subtle] - Toggle button hover surface (overlay-white-10 primitive — semantic layer for inverted affordances).
  */
 @customElement('hx-side-nav')


### PR DESCRIPTION
## Summary
- Promotes `fix/3.2.2-codex-round-7-remediation` (PR #1586) into staging
- Round-7 finding: inverse-surface borders repointed to `var(--hx-color-border-on-dark-strong)`
- JSDoc + CEM regenerated to match the new resolved default

## Test plan
- [ ] Staging CI green (Quality Gates)
- [ ] Codex round-8 review on staging → main (#1581) before merge to main