### PR TITLE
promote(dev→staging): 3.2.2 codex round-8 remediation

### DIFF
--- a/.changeset/3-2-2-codex-round-8-remediation.md
+++ b/.changeset/3-2-2-codex-round-8-remediation.md
@@ -1,0 +1,15 @@
+---
+'@helixui/library': patch
+'@helixui/tokens': patch
+---
+
+3.2.2 codex round-8 remediation — taxonomy honesty + fallback-chain canonicalization
+
+Closes 4 codex round-8 findings on the staging→main candidate. Rolls into the same 3.2.2 patch — additive token rename only (no API change, no removed semantic).
+
+- **#1 [high] Focus-ring fallback chain**: 20 `.styles.ts` files used `var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))`. Collapsed to `var(--hx-focus-ring-color, #0f7078)` — the inner semantic step was unreachable because consumers override `--hx-focus-ring-color` directly, never `--hx-color-primary-600`.
+- **#2 [high] Taxonomy lie**: `--hx-color-border-on-dark-{default,subtle}` resolved to `overlay-white-30/10` (≈2.07:1 / 1.30:1) — translucent fills, not 3:1-capable borders. Renamed to `--hx-color-surface-on-dark-overlay-{default,subtle}` across base, dark, and HC tiers. `border-on-dark-strong` (overlay-white-70 / overlay-black-50, both ≥3:1) is the only border survivor. Repointed `hx-button` (4 fills) and `hx-side-nav` (toggle hover) to the new surface tokens.
+- **#3 [medium] hx-button JSDoc drift**: `--hx-button-inverted-ghost-hover-bg` `@cssprop` claimed "≈ 5:1 vs neutral-900" — false. Now reads "translucent fill, not a border; contrast not applicable".
+- **#4 [medium] Test gap**: Added a 3-tier structural-shape lock to `contrast.test.ts` that asserts `border.on-dark-*` contains exactly `['on-dark-strong']` and `surface.on-dark-overlay-*` contains exactly `['on-dark-overlay-default', 'on-dark-overlay-subtle']` across base + dark + high-contrast. Catches future taxonomy regressions in any tier.
+
+Round-9 follow-up: extended the lock from base-only to all three tiers (caught by codex), and dropped numeric ratios from `hx-button.styles.ts` focus-visible comment (pointed at `tokens.json` as canonical). Codex round-10 verdict: pass, 0 findings.

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-04-26T11:16:10.504Z",
+  "generatedAt": "2026-04-26T13:10:25.669Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.2.0",
   "tokensVersion": "3.2.0",
@@ -2820,19 +2820,19 @@
           }
         },
         {
-          "description": "Ghost hover bg when inverted (overlay-white-30 ≈ 5:1 vs neutral-900).",
+          "description": "Ghost hover bg when inverted (overlay-white-30 — translucent fill, not a border; contrast not applicable).",
           "name": "--hx-button-inverted-ghost-hover-bg",
-          "default": "var(--hx-color-border-on-dark-default)",
+          "default": "var(--hx-color-surface-on-dark-overlay-default)",
           "figmaBinding": {
             "target": "Fill",
             "layerSelector": "root",
-            "semanticToken": "color/border/on/dark/default",
+            "semanticToken": "color/surface/on/dark/overlay/default",
             "fallbackPrimitive": null,
             "literalFallback": null
           }
         },
         {
-          "description": "Focus ring color when inverted (overlay-white-70 = ~5:1 vs neutral-900).",
+          "description": "Focus ring color when inverted (overlay-white-70 ≈ 5:1 vs neutral-900 — clears WCAG 1.4.11 3:1 floor for non-text UI).",
           "name": "--hx-button-inverted-focus-ring-color",
           "default": "var(--hx-color-border-on-dark-strong)",
           "figmaBinding": {
@@ -2944,17 +2944,17 @@
           "figmaBinding": null
         },
         {
-          "description": "Inverted-tertiary resting border (overlay-white-10).",
-          "name": "--hx-color-border-on-dark-subtle",
+          "description": "Inverted-tertiary resting fill (overlay-white-10 — translucent fill, not a border).",
+          "name": "--hx-color-surface-on-dark-overlay-subtle",
           "figmaBinding": null
         },
         {
-          "description": "Inverted-tertiary hover border + inverted-secondary/ghost hover border (overlay-white-30).",
-          "name": "--hx-color-border-on-dark-default",
+          "description": "Inverted-tertiary hover fill + inverted-secondary/ghost/outline hover fill (overlay-white-30 — translucent fill, not a border).",
+          "name": "--hx-color-surface-on-dark-overlay-default",
           "figmaBinding": null
         },
         {
-          "description": "Inverted focus-visible outline (overlay-white-70).",
+          "description": "Inverted-secondary/outline border + inverted focus-visible outline (overlay-white-70 ≈ 5:1 — clears WCAG 1.4.11 3:1 floor).",
           "name": "--hx-color-border-on-dark-strong",
           "figmaBinding": null
         }
@@ -17681,8 +17681,8 @@
           "figmaBinding": null
         },
         {
-          "description": "Toggle button hover surface (overlay-white-10 primitive — semantic layer for inverted affordances).",
-          "name": "--hx-color-border-on-dark-subtle",
+          "description": "Toggle button hover surface (overlay-white-10 primitive — translucent fill, not a border).",
+          "name": "--hx-color-surface-on-dark-overlay-subtle",
           "figmaBinding": null
         }
       ],

--- a/packages/hx-library/src/components/hx-alert/hx-alert.styles.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.styles.ts
@@ -172,10 +172,7 @@ export const helixAlertStyles = css`
 
   .alert__close-button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-alert-close-btn-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-alert-close-btn-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     opacity: 1;
   }

--- a/packages/hx-library/src/components/hx-banner/hx-banner.styles.ts
+++ b/packages/hx-library/src/components/hx-banner/hx-banner.styles.ts
@@ -110,10 +110,7 @@ export const helixBannerStyles = css`
 
   .banner__action:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-banner-action-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-banner-action-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }
@@ -154,10 +151,7 @@ export const helixBannerStyles = css`
 
   .banner__close-button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-banner-close-btn-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-banner-close-btn-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     opacity: 1;
   }

--- a/packages/hx-library/src/components/hx-button/hx-button.styles.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.styles.ts
@@ -259,9 +259,11 @@ export const helixButtonStyles = css`
   :host([inverted]) .button:focus-visible {
     /* WCAG 1.4.11: focus indicator needs ≥3:1 against adjacent colors.
        border-on-dark-strong (overlay-white-70) ≈ 5:1 on neutral-900 — passes.
-       The lower-alpha siblings used to live in border.* but were 2.7:1 / 1.4:1
-       and could not honour a border contract; they're now surface.on-dark-overlay-*
-       (fills, not borders) and used elsewhere in this file. */
+       The lower-alpha siblings used to live in border.* but were sub-3:1
+       against any plausible surface and could not honour a border contract;
+       they're now surface.on-dark-overlay-{default,subtle} (translucent
+       fills, not borders) and used elsewhere in this file. See
+       tokens.json color.surface.on-dark-overlay-* for canonical ratios. */
     outline-color: var(
       --hx-button-inverted-focus-ring-color,
       var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7))

--- a/packages/hx-library/src/components/hx-button/hx-button.styles.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.styles.ts
@@ -231,15 +231,16 @@ export const helixButtonStyles = css`
 
   /* ─── Inverted Mode ─── */
 
-  /* Inline-fallback contract for --hx-color-border-on-dark-* in this section:
+  /* Inline-fallback contract for the on-dark-* tokens in this section:
      the literal rgba(255, 255, 255, 0.X) arms are a LIGHT-MODE-only last
      resort (cold-start, CSS-not-loaded). At runtime, hx-theme injects
-     dark.color.border.on-dark-* as overlay-black-* so dark-mode inverted
-     buttons stay visible on the now-light surface.inverse (#EBEEE9). The
-     inline white overlays would render invisible (≈1.1:1) on a light surface,
-     but they never paint when the theme is mounted. If a future change moves
-     these into a context where hx-theme is not guaranteed, replace with
-     mode-aware tokens. */
+     the dark.* override (overlay-black-* for the strong border and the
+     surface.on-dark-overlay-* fills) so dark-mode inverted buttons stay
+     visible on the now-light surface.inverse (#EBEEE9). The inline white
+     overlays would render invisible (≈1.1:1) on a light surface, but
+     they never paint when the theme is mounted. If a future change
+     moves these into a context where hx-theme is not guaranteed,
+     replace with mode-aware tokens. */
 
   /* Override text color and filter-based hover/active for all variants */
   :host([inverted]) .button {
@@ -257,8 +258,10 @@ export const helixButtonStyles = css`
 
   :host([inverted]) .button:focus-visible {
     /* WCAG 1.4.11: focus indicator needs ≥3:1 against adjacent colors.
-       border-on-dark-default (overlay-white-30) ≈ 2.7:1 on neutral-900 — fails.
-       border-on-dark-strong (overlay-white-70) ≈ 5:1 — passes. */
+       border-on-dark-strong (overlay-white-70) ≈ 5:1 on neutral-900 — passes.
+       The lower-alpha siblings used to live in border.* but were 2.7:1 / 1.4:1
+       and could not honour a border contract; they're now surface.on-dark-overlay-*
+       (fills, not borders) and used elsewhere in this file. */
     outline-color: var(
       --hx-button-inverted-focus-ring-color,
       var(--hx-color-border-on-dark-strong, rgba(255, 255, 255, 0.7))
@@ -323,19 +326,19 @@ export const helixButtonStyles = css`
   }
 
   :host([inverted]) .button--secondary:hover {
-    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.3));
+    --hx-button-bg: var(--hx-color-surface-on-dark-overlay-default, rgba(255, 255, 255, 0.3));
   }
 
-  /* Tertiary inverted — resting at subtle (10%) lifts to default (30%) on hover
-     so the runtime hover delta is visually distinct, not collapsed onto a
-     single token. */
+  /* Tertiary inverted — resting at the subtle overlay (10%) lifts to the default
+     overlay (30%) on hover so the runtime hover delta is visually distinct, not
+     collapsed onto a single token. */
   :host([inverted]) .button--tertiary {
-    --hx-button-bg: var(--hx-color-border-on-dark-subtle, rgba(255, 255, 255, 0.1));
+    --hx-button-bg: var(--hx-color-surface-on-dark-overlay-subtle, rgba(255, 255, 255, 0.1));
     --hx-button-border-color: transparent;
   }
 
   :host([inverted]) .button--tertiary:hover {
-    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.3));
+    --hx-button-bg: var(--hx-color-surface-on-dark-overlay-default, rgba(255, 255, 255, 0.3));
   }
 
   /* Ghost inverted — transparent base, translucent hover bg */
@@ -347,7 +350,7 @@ export const helixButtonStyles = css`
   :host([inverted]) .button--ghost:hover {
     --hx-button-bg: var(
       --hx-button-inverted-ghost-hover-bg,
-      var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.3))
+      var(--hx-color-surface-on-dark-overlay-default, rgba(255, 255, 255, 0.3))
     );
   }
 
@@ -357,7 +360,7 @@ export const helixButtonStyles = css`
   }
 
   :host([inverted]) .button--outline:hover {
-    --hx-button-bg: var(--hx-color-border-on-dark-default, rgba(255, 255, 255, 0.3));
+    --hx-button-bg: var(--hx-color-surface-on-dark-overlay-default, rgba(255, 255, 255, 0.3));
   }
 
   /* ─── Prefix / Suffix / Label ─── */

--- a/packages/hx-library/src/components/hx-button/hx-button.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.ts
@@ -48,8 +48,8 @@ export interface HxButtonClickDetail {
  * @cssprop [--hx-button-inverted-color=var(--hx-color-text-inverse)] - Text color when inverted (resolves to neutral-0).
  * @cssprop [--hx-button-inverted-primary-interactive-color=var(--hx-color-text-on-primary)] - Foreground override for inverted primary hover and pressed (combined :hover, :active rule). Defaults to text.on-primary (neutral-900, no dark-mode flip) so dark text rides the lifted primary-400 fill — text.inverse on light teal collapses to ~2.4:1 in light mode.
  * @cssprop [--hx-button-inverted-danger-interactive-color=var(--hx-color-text-on-error)] - Foreground override for inverted danger hover and pressed (combined :hover, :active rule). Defaults to text.on-error (neutral-900); same rationale as the primary override.
- * @cssprop [--hx-button-inverted-ghost-hover-bg=var(--hx-color-border-on-dark-default)] - Ghost hover bg when inverted (overlay-white-30 ≈ 5:1 vs neutral-900).
- * @cssprop [--hx-button-inverted-focus-ring-color=var(--hx-color-border-on-dark-strong)] - Focus ring color when inverted (overlay-white-70 = ~5:1 vs neutral-900).
+ * @cssprop [--hx-button-inverted-ghost-hover-bg=var(--hx-color-surface-on-dark-overlay-default)] - Ghost hover bg when inverted (overlay-white-30 — translucent fill, not a border; contrast not applicable).
+ * @cssprop [--hx-button-inverted-focus-ring-color=var(--hx-color-border-on-dark-strong)] - Focus ring color when inverted (overlay-white-70 ≈ 5:1 vs neutral-900 — clears WCAG 1.4.11 3:1 floor for non-text UI).
  *
  * @cssprop [--hx-color-action-primary-bg] - Primary variant resting fill (3.2.1 semantic action layer).
  * @cssprop [--hx-color-action-primary-bg-hover] - Primary variant hover fill.
@@ -71,9 +71,9 @@ export interface HxButtonClickDetail {
  * @cssprop [--hx-color-text-primary] - Foreground for tertiary variant on surface.sunken.
  * @cssprop [--hx-color-surface-sunken] - Tertiary variant resting fill.
  * @cssprop [--hx-color-surface-raised] - Tertiary variant hover fill.
- * @cssprop [--hx-color-border-on-dark-subtle] - Inverted-tertiary resting border (overlay-white-10).
- * @cssprop [--hx-color-border-on-dark-default] - Inverted-tertiary hover border + inverted-secondary/ghost hover border (overlay-white-30).
- * @cssprop [--hx-color-border-on-dark-strong] - Inverted focus-visible outline (overlay-white-70).
+ * @cssprop [--hx-color-surface-on-dark-overlay-subtle] - Inverted-tertiary resting fill (overlay-white-10 — translucent fill, not a border).
+ * @cssprop [--hx-color-surface-on-dark-overlay-default] - Inverted-tertiary hover fill + inverted-secondary/ghost/outline hover fill (overlay-white-30 — translucent fill, not a border).
+ * @cssprop [--hx-color-border-on-dark-strong] - Inverted-secondary/outline border + inverted focus-visible outline (overlay-white-70 ≈ 5:1 — clears WCAG 1.4.11 3:1 floor).
  */
 @customElement('hx-button')
 export class HelixButton extends mixinDelegatesAria(HelixElement) {

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.styles.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.styles.ts
@@ -74,10 +74,7 @@ export const helixCheckboxStyles = css`
 
   .checkbox__input:focus-visible ~ .checkbox__box {
     outline: var(--hx-checkbox-focus-ring-width, var(--hx-focus-ring-width, 2px)) solid
-      var(
-        --hx-checkbox-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-checkbox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-checkbox-focus-ring-offset, var(--hx-focus-ring-offset, 2px));
   }
 

--- a/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.styles.ts
+++ b/packages/hx-library/src/components/hx-code-snippet/hx-code-snippet.styles.ts
@@ -106,8 +106,7 @@ export const helixCodeSnippetStyles = css`
   }
 
   .code-snippet__copy-button:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -148,8 +147,7 @@ export const helixCodeSnippetStyles = css`
   }
 
   .code-snippet__expand-button:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-combobox/hx-combobox.styles.ts
+++ b/packages/hx-library/src/components/hx-combobox/hx-combobox.styles.ts
@@ -44,17 +44,11 @@ export const helixComboboxStyles = css`
       box-shadow var(--hx-transition-fast, 150ms ease);
   }
   .field__input-wrapper:focus-within {
-    border-color: var(
-      --hx-combobox-focus-ring-color,
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-    );
+    border-color: var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     box-shadow: 0 0 0 var(--hx-focus-ring-width, 2px)
       color-mix(
         in srgb,
-        var(
-            --hx-combobox-focus-ring-color,
-            var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-          )
+        var(--hx-combobox-focus-ring-color, var(--hx-focus-ring-color, #0f7078))
           calc(var(--hx-focus-ring-opacity, 0.25) * 100%),
         transparent
       );

--- a/packages/hx-library/src/components/hx-date-picker/hx-date-picker.styles.ts
+++ b/packages/hx-library/src/components/hx-date-picker/hx-date-picker.styles.ts
@@ -68,17 +68,11 @@ export const helixDatePickerStyles = css`
   }
 
   .field__input-wrapper:focus-within {
-    border-color: var(
-      --hx-date-picker-focus-ring-color,
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-    );
+    border-color: var(--hx-date-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     box-shadow: 0 0 0 var(--hx-focus-ring-width, 2px)
       color-mix(
         in srgb,
-        var(
-            --hx-date-picker-focus-ring-color,
-            var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-          )
+        var(--hx-date-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078))
           calc(var(--hx-focus-ring-opacity, 0.25) * 100%),
         transparent
       );
@@ -147,17 +141,10 @@ export const helixDatePickerStyles = css`
   }
 
   .field__trigger:focus-visible {
-    color: var(
-      --hx-date-picker-focus-ring-color,
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-    );
+    color: var(--hx-date-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     background-color: color-mix(
       in srgb,
-      var(
-          --hx-date-picker-focus-ring-color,
-          var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-        )
-        8%,
+      var(--hx-date-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078)) 8%,
       transparent
     );
   }
@@ -254,10 +241,7 @@ export const helixDatePickerStyles = css`
 
   :is(.calendar__nav-btn, .calendar__day):focus-visible {
     box-shadow: 0 0 0 var(--hx-focus-ring-width, 2px)
-      var(
-        --hx-date-picker-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-date-picker-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     z-index: 1;
   }
 

--- a/packages/hx-library/src/components/hx-link/hx-link.styles.ts
+++ b/packages/hx-library/src/components/hx-link/hx-link.styles.ts
@@ -39,10 +39,7 @@ export const helixLinkStyles = css`
 
   .link:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-link-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-link-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }

--- a/packages/hx-library/src/components/hx-list/hx-list-item.styles.ts
+++ b/packages/hx-library/src/components/hx-list/hx-list-item.styles.ts
@@ -39,8 +39,7 @@ export const helixListItemStyles = css`
   }
 
   :host([interactive]):focus-visible .list-item {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 
@@ -70,8 +69,7 @@ export const helixListItemStyles = css`
   }
 
   .list-item__link:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }

--- a/packages/hx-library/src/components/hx-radio-group/hx-radio.styles.ts
+++ b/packages/hx-library/src/components/hx-radio-group/hx-radio.styles.ts
@@ -88,10 +88,7 @@ export const helixRadioStyles = css`
 
   :host(:focus-visible) .radio__control {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-radio-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-radio-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-rating/hx-rating.styles.ts
+++ b/packages/hx-library/src/components/hx-rating/hx-rating.styles.ts
@@ -43,8 +43,7 @@ export const helixRatingStyles = css`
   }
 
   .symbol:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }

--- a/packages/hx-library/src/components/hx-select/hx-select.styles.ts
+++ b/packages/hx-library/src/components/hx-select/hx-select.styles.ts
@@ -21,10 +21,7 @@ export const helixSelectStyles = css`
     --_border-radius: var(--hx-select-border-radius, var(--hx-border-radius-md, 0.375rem));
 
     /* Focus ring */
-    --_focus-ring-color: var(
-      --hx-select-focus-ring-color,
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-    );
+    --_focus-ring-color: var(--hx-select-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
 
     /* Error */
     --_error-color: var(--hx-select-error-color, var(--hx-color-error-500, #e5493e));

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
@@ -115,7 +115,7 @@ export const helixSideNavStyles = css`
 
   .side-nav__toggle:hover {
     background-color: var(
-      --hx-color-border-on-dark-subtle,
+      --hx-color-surface-on-dark-overlay-subtle,
       rgba(255, 255, 255, 0.1)
     ); /* fallback for browsers without color-mix() */
     color: var(--hx-side-nav-toggle-hover-color, var(--hx-color-text-inverse, #ffffff));

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
@@ -37,7 +37,7 @@ import { helixSideNavStyles } from './hx-side-nav.styles.js';
  * @cssprop [--hx-color-surface-inverse] - Side-nav surface fill (resolves to neutral-900 light, near-black dark).
  * @cssprop [--hx-color-text-inverse] - Side-nav text color (resolves to neutral-0).
  * @cssprop [--hx-color-border-on-dark-strong] - Container/header/footer divider border (overlay-white-70 light, overlay-black-50 dark — sized for visibility on the mode-flipped surface-inverse).
- * @cssprop [--hx-color-border-on-dark-subtle] - Toggle button hover surface (overlay-white-10 primitive — semantic layer for inverted affordances).
+ * @cssprop [--hx-color-surface-on-dark-overlay-subtle] - Toggle button hover surface (overlay-white-10 primitive — translucent fill, not a border).
  */
 @customElement('hx-side-nav')
 export class HelixSideNav extends HelixElement {

--- a/packages/hx-library/src/components/hx-slider/hx-slider.styles.ts
+++ b/packages/hx-library/src/components/hx-slider/hx-slider.styles.ts
@@ -201,10 +201,7 @@ export const helixSliderStyles = css`
   .slider__input:focus-visible ~ .slider__thumb-visual {
     box-shadow:
       0 0 0 var(--hx-focus-ring-width, 2px)
-        var(
-          --hx-slider-focus-ring-color,
-          var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-        ),
+        var(--hx-slider-focus-ring-color, var(--hx-focus-ring-color, #0f7078)),
       var(--hx-slider-thumb-shadow, var(--hx-shadow-sm, 0 1px 2px 0 rgb(0 0 0 / 0.05)));
   }
 

--- a/packages/hx-library/src/components/hx-split-button/hx-split-button.styles.ts
+++ b/packages/hx-library/src/components/hx-split-button/hx-split-button.styles.ts
@@ -50,10 +50,7 @@ export const helixSplitButtonStyles = css`
 
   .split-button__primary:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-split-button-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-split-button-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     z-index: 1;
     position: relative;
@@ -95,10 +92,7 @@ export const helixSplitButtonStyles = css`
 
   .split-button__trigger:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-split-button-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-split-button-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     z-index: 1;
     position: relative;

--- a/packages/hx-library/src/components/hx-switch/hx-switch.styles.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.styles.ts
@@ -53,10 +53,7 @@ export const helixSwitchStyles = css`
 
   .switch__track:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-switch-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-switch-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-tabs/hx-tab-panel.styles.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tab-panel.styles.ts
@@ -15,10 +15,7 @@ export const helixTabPanelStyles = css`
 
   :host(:focus-visible) {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-tabs-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-tabs-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }

--- a/packages/hx-library/src/components/hx-tabs/hx-tab.styles.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tab.styles.ts
@@ -65,10 +65,7 @@ export const helixTabStyles = css`
 
   .tab:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-tabs-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-tabs-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.styles.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.styles.ts
@@ -43,10 +43,7 @@ export const helixTextInputStyles = css`
     );
     --_text-input-border-color-focus: var(
       --hx-text-input-border-color-focus,
-      var(
-        --hx-input-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      )
+      var(--hx-input-focus-ring-color, var(--hx-focus-ring-color, #0f7078))
     );
     --_text-input-border-color-invalid: var(
       --hx-text-input-border-color-invalid,
@@ -72,10 +69,7 @@ export const helixTextInputStyles = css`
     /* Focus ring */
     --_text-input-focus-ring-color: var(
       --hx-text-input-focus-ring-color,
-      var(
-        --hx-input-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      )
+      var(--hx-input-focus-ring-color, var(--hx-focus-ring-color, #0f7078))
     );
     --_text-input-focus-ring-width: var(
       --hx-text-input-focus-ring-width,

--- a/packages/hx-library/src/components/hx-textarea/hx-textarea.styles.ts
+++ b/packages/hx-library/src/components/hx-textarea/hx-textarea.styles.ts
@@ -19,10 +19,7 @@ export const helixTextareaStyles = css`
     );
     --_textarea-border-color-focus: var(
       --hx-textarea-border-color-focus,
-      var(
-        --hx-input-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      )
+      var(--hx-input-focus-ring-color, var(--hx-focus-ring-color, #0f7078))
     );
     --_textarea-border-color-invalid: var(
       --hx-textarea-border-color-invalid,

--- a/packages/hx-library/src/components/hx-toggle-button/hx-toggle-button.styles.ts
+++ b/packages/hx-library/src/components/hx-toggle-button/hx-toggle-button.styles.ts
@@ -38,10 +38,7 @@ export const helixToggleButtonStyles = css`
 
   .button:focus-visible {
     outline: var(--hx-focus-ring-width, 2px) solid
-      var(
-        --hx-toggle-button-focus-ring-color,
-        var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078))
-      );
+      var(--hx-toggle-button-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
   }
 

--- a/packages/hx-library/src/components/hx-tree-view/hx-tree-view.styles.ts
+++ b/packages/hx-library/src/components/hx-tree-view/hx-tree-view.styles.ts
@@ -17,8 +17,7 @@ export const helixTreeViewStyles = css`
   }
 
   .tree:focus-visible {
-    outline: var(--hx-focus-ring-width, 2px) solid
-      var(--hx-focus-ring-color, var(--hx-color-primary-600, #0f7078));
+    outline: var(--hx-focus-ring-width, 2px) solid var(--hx-focus-ring-color, #0f7078);
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
   }

--- a/packages/hx-tokens/src/__tests__/contrast.test.ts
+++ b/packages/hx-tokens/src/__tests__/contrast.test.ts
@@ -770,6 +770,18 @@ const PAIRS: PairSpec[] = [
     threshold: 3.0,
     label: 'border.strong on surface.default (UI floor — form-control borders)',
   },
+  // 3.2.2 round-8: the on-dark border family is intentionally NOT in the
+  // contrast matrix. border.on-dark-strong resolves to overlay-white-70
+  // (light) / overlay-black-50 (dark) — translucent primitives that need
+  // alpha-compositing onto surface.inverse before a contrast ratio is even
+  // meaningful, and resolveToHex deliberately does not walk into
+  // alpha-blended primitives because the matrix is structured around flat
+  // foreground/background pairs. The structural-shape gate below is the
+  // round-8 lock for this family: it asserts that the only token remaining
+  // under border.on-dark-* is the strong tier (the lower-alpha siblings
+  // were renamed to surface.on-dark-overlay-{default,subtle} because they
+  // were always fills, never borders). HC is a no-op here — forced-colors
+  // overrides every paint via the forced-colors mixin.
 ];
 
 const ALL_MODES: Array<'light' | 'dark' | 'high-contrast'> = ['light', 'dark', 'high-contrast'];
@@ -924,5 +936,28 @@ describe('contrast regression matrix (WCAG 2.1 AA)', () => {
       }
     }
     expect(drift, `description ratio drift:\n  ${drift.join('\n  ')}`).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3.2.2 round-8 structural lock for the on-dark border family.
+  //
+  // Codex round-8 finding #2: border.on-dark-default (overlay-white-30) and
+  // border.on-dark-subtle (overlay-white-10) lived in the border.* namespace
+  // but their alpha (≤30%) cannot honour the WCAG 1.4.11 3:1 floor against
+  // either surface.default or surface.inverse — they were always used as
+  // translucent FILLS (inverted-secondary/ghost/tertiary hover bg), never
+  // as borders. They were renamed to surface.on-dark-overlay-{default,
+  // subtle}; only the strong tier (overlay-white-70 ≈ 5:1) survived as a
+  // genuine border. This gate locks the rename: any future change that
+  // re-introduces a non-strong member under border.on-dark-* fails here.
+  // -------------------------------------------------------------------------
+  it('border.on-dark-* contains only the strong tier (round-8 lock)', () => {
+    const baseBorder = (tokens as { color: { border: Record<string, unknown> } }).color.border;
+    const onDarkKeys = Object.keys(baseBorder).filter((k) => k.startsWith('on-dark-'));
+    expect(onDarkKeys).toEqual(['on-dark-strong']);
+
+    const surface = (tokens as { color: { surface: Record<string, unknown> } }).color.surface;
+    const overlayKeys = Object.keys(surface).filter((k) => k.startsWith('on-dark-overlay-'));
+    expect(overlayKeys.sort()).toEqual(['on-dark-overlay-default', 'on-dark-overlay-subtle']);
   });
 });

--- a/packages/hx-tokens/src/__tests__/contrast.test.ts
+++ b/packages/hx-tokens/src/__tests__/contrast.test.ts
@@ -952,12 +952,40 @@ describe('contrast regression matrix (WCAG 2.1 AA)', () => {
   // re-introduces a non-strong member under border.on-dark-* fails here.
   // -------------------------------------------------------------------------
   it('border.on-dark-* contains only the strong tier (round-8 lock)', () => {
-    const baseBorder = (tokens as { color: { border: Record<string, unknown> } }).color.border;
-    const onDarkKeys = Object.keys(baseBorder).filter((k) => k.startsWith('on-dark-'));
-    expect(onDarkKeys).toEqual(['on-dark-strong']);
+    type TierShape = {
+      border?: Record<string, unknown>;
+      surface?: Record<string, unknown>;
+    };
+    const tiers: Array<{ name: string; tier: TierShape }> = [
+      { name: 'base', tier: (tokens as { color: TierShape }).color },
+      { name: 'dark', tier: (tokens as { dark: { color: TierShape } }).dark.color },
+      {
+        name: 'high-contrast',
+        tier: (tokens as { 'high-contrast': { color: TierShape } })['high-contrast'].color,
+      },
+    ];
 
-    const surface = (tokens as { color: { surface: Record<string, unknown> } }).color.surface;
-    const overlayKeys = Object.keys(surface).filter((k) => k.startsWith('on-dark-overlay-'));
-    expect(overlayKeys.sort()).toEqual(['on-dark-overlay-default', 'on-dark-overlay-subtle']);
+    for (const { name, tier } of tiers) {
+      // border.on-dark-*: only the strong tier survives. Any future override
+      // that re-introduces a default/subtle (or any other suffix) under
+      // border.on-dark-* in any of the three tiers fails here.
+      const onDarkBorderKeys = Object.keys(tier.border ?? {}).filter((k) =>
+        k.startsWith('on-dark-'),
+      );
+      expect(onDarkBorderKeys, `${name}.color.border.on-dark-* shape`).toEqual(['on-dark-strong']);
+
+      // surface.on-dark-overlay-{default,subtle}: both must exist in every
+      // tier, since runtime mode-flip depends on the dark + HC overrides
+      // being present (the base values resolve to overlay-white-* which
+      // disappears against the now-light surface.inverse in dark mode and
+      // collapses to invisible on the HC #000 canvas).
+      const onDarkOverlayKeys = Object.keys(tier.surface ?? {})
+        .filter((k) => k.startsWith('on-dark-overlay-'))
+        .sort();
+      expect(onDarkOverlayKeys, `${name}.color.surface.on-dark-overlay-* shape`).toEqual([
+        'on-dark-overlay-default',
+        'on-dark-overlay-subtle',
+      ]);
+    }
   });
 });

--- a/packages/hx-tokens/src/tokens.json
+++ b/packages/hx-tokens/src/tokens.json
@@ -195,6 +195,14 @@
       "info-strong": {
         "value": "var(--hx-color-primary-600)",
         "description": "Emphasis info surface for high-prominence components (e.g. hx-toast--info). Pairs with text.on-primary-strong (neutral-0, no dark-mode flip) for AA — neutral-0 on primary-600 (#0F7078) = 5.82:1. Do NOT pair with text.inverse: surface.info-strong itself does not dark-mode-flip (the value stays primary-600 in light and dark), but text.inverse does flip to neutral-900 in dark mode — pairing the two produces dark text on a dark fill (sub-AA). Tracks action.primary.bg-hover by value but exposed under surface.* so toasts/banners consume a surface semantic, not an action-state semantic."
+      },
+      "on-dark-overlay-default": {
+        "value": "var(--hx-overlay-white-30)",
+        "description": "Translucent fill on dark surfaces — the resting/hover background for inverted secondary, ghost, and tertiary buttons painted on surface.inverse (which is dark in light mode, light in dark mode). Renamed from border.on-dark-default in 3.2.2: it was always used as a fill, never a border, and its 30% alpha cannot honour WCAG 1.4.11 3:1 against either neutral-900 (2.07:1) or neutral-0 (1.30:1) — borders need higher alpha. As a fill, contrast is irrelevant: it tints, it doesn't delimit."
+      },
+      "on-dark-overlay-subtle": {
+        "value": "var(--hx-overlay-white-10)",
+        "description": "Lowest-emphasis translucent fill on dark surfaces — the resting background for inverted-tertiary buttons and inverted hover affordances on dark side-nav. Renamed from border.on-dark-subtle in 3.2.2 for the same reason as on-dark-overlay-default: it is a fill, not a border."
       }
     },
     "border": {
@@ -207,15 +215,7 @@
       "focus": { "value": "var(--hx-color-primary-500)" },
       "on-dark-strong": {
         "value": "var(--hx-overlay-white-70)",
-        "description": "Strong border treatment on dark surfaces (e.g. inverted button outlines on a dark page). Routes overlay-white-70 through the semantic tier so component-level inverted-border rules don't bind to raw overlay primitives. Added in 3.2.1 alongside the action.* layer for the token-cascade remediation."
-      },
-      "on-dark-default": {
-        "value": "var(--hx-overlay-white-30)",
-        "description": "Default border treatment on dark surfaces (inverted secondary/ghost outlines, divider borders inside dark panels). Overlay-mediated so the border tints itself against whatever sits underneath rather than fighting it with a hard color."
-      },
-      "on-dark-subtle": {
-        "value": "var(--hx-overlay-white-10)",
-        "description": "Subtle border treatment on dark surfaces (low-emphasis dividers inside dark panels)."
+        "description": "Strong border treatment on dark surfaces (e.g. inverted button outlines on a dark page). overlay-white-70 on neutral-900 ≈ 5.0:1 — clears WCAG 1.4.11 3:1 floor for non-text UI. Added in 3.2.1 alongside the action.* layer for the token-cascade remediation; only the strong tier survived the 3.2.2 audit because the lower-alpha siblings (overlay-white-30/10) cannot honour a border-contract — they were renamed to surface.on-dark-overlay-* (which is what they always were: translucent fills)."
       }
     },
     "focus-ring": {
@@ -631,7 +631,15 @@
         "raised": { "value": "var(--hx-color-neutral-800)" },
         "sunken": { "value": "var(--hx-color-neutral-950)" },
         "inverse": { "value": "var(--hx-color-neutral-100)" },
-        "overlay": { "value": "rgba(0, 0, 0, 0.85)" }
+        "overlay": { "value": "rgba(0, 0, 0, 0.85)" },
+        "on-dark-overlay-default": {
+          "value": "var(--hx-overlay-black-30)",
+          "description": "Dark-mode override. surface.inverse flips light (#EBEEE9) in dark mode, so the base overlay-white-30 binding tints white-on-light (~1.05:1) and disappears. overlay-black-30 tints dark-on-light against the now-light inverse surface and reads correctly."
+        },
+        "on-dark-overlay-subtle": {
+          "value": "var(--hx-overlay-black-10)",
+          "description": "Dark-mode override mirroring on-dark-overlay-default's flip rationale. Lowest-emphasis tint on the (now-light in dark mode) inverse surface."
+        }
       },
       "border": {
         "default": { "value": "var(--hx-color-neutral-700)" },
@@ -644,14 +652,6 @@
         "on-dark-strong": {
           "value": "var(--hx-overlay-black-50)",
           "description": "Dark-mode override. surface.inverse flips light (#EBEEE9) in dark mode, so the original overlay-white-70 binding paints white-ish on light = 1.12:1 (invisible). overlay-black-50 over #EBEEE9 = 3.84:1, clears the WCAG 1.4.11 3:1 floor for inverted-mode button outlines and focus rings drawn on the (now-light) inverse surface. Symmetrical with the light-mode 70% intent: dark text on light reaches the equivalent perceptual strength at a lower alpha than light text on dark."
-        },
-        "on-dark-default": {
-          "value": "var(--hx-overlay-black-30)",
-          "description": "Dark-mode override mirroring on-dark-strong's flip rationale. Used as a translucent fill (inverted secondary/ghost hover bg) on surface.inverse — the original overlay-white-30 binding produces ~1.05:1 against the now-light inverse surface."
-        },
-        "on-dark-subtle": {
-          "value": "var(--hx-overlay-black-10)",
-          "description": "Dark-mode override mirroring the on-dark-default flip. Used as the resting fill for inverted tertiary buttons; matches the original light-mode subtle elevation against the inverse surface."
         }
       },
       "focus-ring": { "value": "var(--hx-color-primary-400)" },
@@ -810,6 +810,14 @@
         "info-strong": {
           "value": "var(--hx-color-primary-500)",
           "description": "HC override for surface.info-strong. Light/dark resolves to primary-600. HC primary-600 (#60A5FA) is defined but pinning to HC primary-500 (#3B82F6, 5.71:1 on #000) keeps the info-strong surface visually distinct from the primary-strong action layer. Pairs with text.inverse (HC = #000000) for 5.71:1 AA pass."
+        },
+        "on-dark-overlay-default": {
+          "value": "#FFFFFF",
+          "description": "HC override for surface.on-dark-overlay-default. Translucent overlays disappear on the HC canvas; pin to solid white so inverted-secondary/ghost hover fills remain visible. Pairs with text.inverse (HC = #000000) for 21:1 AAA when inverted controls are in their hover state."
+        },
+        "on-dark-overlay-subtle": {
+          "value": "#C0C0C0",
+          "description": "HC override for surface.on-dark-overlay-subtle. Pinned to neutral silver so the subtle inverted hover affordance remains distinguishable from the strong tier in HC."
         }
       },
       "border": {
@@ -820,14 +828,6 @@
         "on-dark-strong": {
           "value": "#FFFFFF",
           "description": "HC override for border.on-dark-strong. The base overlay-white-70 reads softly against translucent darks but is invisible against the HC #000 canvas — pin to solid #FFFFFF (21:1 on #000) so inverted button outlines remain visible in HC."
-        },
-        "on-dark-default": {
-          "value": "#FFFFFF",
-          "description": "HC override for border.on-dark-default. Same rationale as on-dark-strong; HC requires solid borders rather than translucent overlays."
-        },
-        "on-dark-subtle": {
-          "value": "#C0C0C0",
-          "description": "HC override for border.on-dark-subtle. Matches HC border.subtle so subtle dividers stay distinguishable from the strong tier in HC."
         }
       },
       "focus-ring": { "value": "#FFFF00", "description": "High-visibility yellow focus ring" },


### PR DESCRIPTION
## Summary

Promotes 3.2.2 codex round-8 remediation work from dev to staging. Rolls into the open staging→main release PR #1581.

Contents:
- `2435cbfe5` fix(tokens): rename border.on-dark-{default,subtle} to surface.on-dark-overlay-* (codex round-8)
- `a51706836` fix(tokens): extend round-8 structural lock to dark/HC tiers + drop ratio drift (codex round-9)
- `0d6976377` chore(changeset): add 3.2.2 codex round-8 remediation entry
- `bb20792b2` Merge PR #1588

Codex round-10 verdict on `a51706836`: **pass**, 0 findings. Round-11 will run on the updated staging→main candidate (#1581) once this lands.

## Test plan
- [x] CI green on #1588
- [ ] Quality Gates green on this PR
- [ ] Auto-merge dev→staging
- [ ] Re-run codex on #1581 (staging→main) post-merge