### PR TITLE
fix(tokens): codex round-11 remediation — backwards-compat aliases + variant convention docs

### DIFF
--- a/.changeset/3-2-2-codex-round-11-remediation.md
+++ b/.changeset/3-2-2-codex-round-11-remediation.md
@@ -1,0 +1,28 @@
+---
+'@helixui/tokens': patch
+'@helixui/library': patch
+---
+
+3.2.2 codex round-11 remediation — backwards-compat aliases + variant override-path documentation
+
+Closes 2 medium codex round-11 findings on the staging→main candidate. Rolls into the same 3.2.2 patch.
+
+**Finding 2 [api-design] — Backwards-compat aliases for renamed border-on-dark tokens.**
+
+`--hx-color-border-on-dark-default` and `--hx-color-border-on-dark-subtle` shipped in `@helixui/tokens@3.2.0` and `@3.2.1`. Round-8 renamed them to `--hx-color-surface-on-dark-overlay-{default,subtle}` because the original names lied about their behavior — translucent fills, never borders, sub-3:1 alpha. A patch-level rename without aliases would silently break any consumer theme that set the old names as overrides.
+
+Restored the old names in `tokens.json` as deprecated aliases that resolve through the new surface tokens across all three tiers (base / dark / high-contrast). `dist/tokens.css` now emits both name pairs, so existing consumer overrides continue to apply unchanged. Marked deprecated in description fields; removal scheduled for 4.0.0.
+
+The round-8 structural-shape lock in `contrast.test.ts` was extended to:
+- assert the new `border.on-dark-*` shape `['on-dark-default', 'on-dark-strong', 'on-dark-subtle']` across all 3 tiers
+- assert each alias resolves through the surface namespace (catches any future regression that re-introduces a non-aliased border under that name with raw sub-3:1 alpha).
+
+**Finding 1 [api-design] — Inverted-primary override path documentation.**
+
+Codex flagged that the new `:host([inverted]) .button--primary` rest-state rule binds `--hx-button-bg` at descendant scope, shadowing host-level consumer overrides of that property. Investigation found:
+
+- This shadow behavior is the **established variant convention** across the entire `hx-button` cascade. Every `.button--{variant}` rule (light primary at line 89, danger at line 120, secondary, tertiary, ghost) binds `--hx-button-bg` directly with the same descendant-scope shadowing. The new inverted-primary rest rule matches this convention symmetrically.
+- The documented consumer override path for any `--hx-color-action-{variant}-bg*` paint is the upstream semantic, not `--hx-button-bg`. For inverted-primary at rest, that's `--hx-color-action-primary-bg-inverted-rest` (parallel to light primary's `--hx-color-action-primary-bg`).
+- An attempted "cascade-preserving self-fallback" form `var(--hx-button-bg, var(--semantic, hex))` was implemented and reverted: per W3C css-variables-1 §3, a custom property referencing itself in its own value forms a cycle and becomes invalid at computed-value time. The attempted fix would have invalidated `--hx-button-bg` entirely, breaking the documented semantic override path that `dark-mode-resolution.test.ts` pins.
+
+Resolution: kept the direct-binding form, expanded the inline comment to cite the variant convention and the override-path test that pins it. The original 3.2.2 changeset's "consumers must override the upstream semantic" wording remains accurate but is reframed here as documenting an existing pattern rather than introducing a new restriction. No source change to the rule itself; the override path was, and remains, `--hx-color-action-primary-bg-inverted-rest`.

--- a/packages/hx-library/src/components/hx-button/hx-button.styles.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.styles.ts
@@ -274,8 +274,16 @@ export const helixButtonStyles = css`
      so dark mode can flip the fill to primary-600. surface.inverse becomes light
      (#EBEEE9) in dark mode; primary-500 on #EBEEE9 = 2.94:1 (sub-3:1 UI floor
      fail for the inverted-button boundary). primary-600 on #EBEEE9 = 4.97:1
-     (AA pass). Light mode tracks action.primary.bg (primary-500, 5.20:1 on
-     dark surface.inverse). */
+     (AA pass). Light mode tracks action.primary.bg-inverted-rest's base value
+     (primary-500, 5.20:1 on dark surface.inverse).
+
+     Override path note (codex round-11): this binds --hx-button-bg directly,
+     matching the cascade convention every other .button--{variant} rule uses
+     (light primary at line 89, danger at 120, secondary, tertiary, ghost). The
+     consumer override path for inverted-primary rest is
+     --hx-color-action-primary-bg-inverted-rest, NOT --hx-button-bg — the same
+     pattern as light primary (consumers override --hx-color-action-primary-bg).
+     Pinned by dark-mode-resolution.test.ts:185-197 across both modes. */
   :host([inverted]) .button--primary {
     --hx-button-bg: var(--hx-color-action-primary-bg-inverted-rest, #429797);
   }

--- a/packages/hx-tokens/src/__tests__/contrast.test.ts
+++ b/packages/hx-tokens/src/__tests__/contrast.test.ts
@@ -948,13 +948,26 @@ describe('contrast regression matrix (WCAG 2.1 AA)', () => {
   // translucent FILLS (inverted-secondary/ghost/tertiary hover bg), never
   // as borders. They were renamed to surface.on-dark-overlay-{default,
   // subtle}; only the strong tier (overlay-white-70 ≈ 5:1) survived as a
-  // genuine border. This gate locks the rename: any future change that
-  // re-introduces a non-strong member under border.on-dark-* fails here.
+  // genuine border that can stand on its own.
+  //
+  // Round-11 finding #2 added back deprecated *aliases* under border.on-dark-
+  // {default,subtle} that resolve through the new surface.on-dark-overlay-*
+  // tokens — restores the published CSS variable names for any consumer who
+  // set them as theme overrides in 3.2.0 / 3.2.1. Aliases are deprecated and
+  // scheduled for removal in 4.0.0.
+  //
+  // The structural lock therefore allows:
+  //   border.on-dark-strong   — canonical strong border
+  //   border.on-dark-default  — DEPRECATED alias → surface.on-dark-overlay-default
+  //   border.on-dark-subtle   — DEPRECATED alias → surface.on-dark-overlay-subtle
+  // and asserts each alias resolves through the surface.* namespace (i.e. is
+  // a real alias and not a regressed independent value with sub-3:1 alpha).
   // -------------------------------------------------------------------------
-  it('border.on-dark-* contains only the strong tier (round-8 lock)', () => {
+  it('border.on-dark-* shape: strong + deprecated aliases (round-8/11 lock)', () => {
+    type TokenLike = { value?: string };
     type TierShape = {
-      border?: Record<string, unknown>;
-      surface?: Record<string, unknown>;
+      border?: Record<string, TokenLike>;
+      surface?: Record<string, TokenLike>;
     };
     const tiers: Array<{ name: string; tier: TierShape }> = [
       { name: 'base', tier: (tokens as { color: TierShape }).color },
@@ -966,13 +979,26 @@ describe('contrast regression matrix (WCAG 2.1 AA)', () => {
     ];
 
     for (const { name, tier } of tiers) {
-      // border.on-dark-*: only the strong tier survives. Any future override
-      // that re-introduces a default/subtle (or any other suffix) under
-      // border.on-dark-* in any of the three tiers fails here.
-      const onDarkBorderKeys = Object.keys(tier.border ?? {}).filter((k) =>
-        k.startsWith('on-dark-'),
-      );
-      expect(onDarkBorderKeys, `${name}.color.border.on-dark-* shape`).toEqual(['on-dark-strong']);
+      const onDarkBorderKeys = Object.keys(tier.border ?? {})
+        .filter((k) => k.startsWith('on-dark-'))
+        .sort();
+      expect(onDarkBorderKeys, `${name}.color.border.on-dark-* shape`).toEqual([
+        'on-dark-default',
+        'on-dark-strong',
+        'on-dark-subtle',
+      ]);
+
+      // The deprecated default/subtle aliases must resolve through the
+      // renamed surface.* tokens — never through a raw overlay-* primitive
+      // that would re-introduce sub-3:1 alpha as an apparent border value.
+      expect(
+        tier.border?.['on-dark-default']?.value,
+        `${name}.color.border.on-dark-default must alias surface.on-dark-overlay-default`,
+      ).toBe('var(--hx-color-surface-on-dark-overlay-default)');
+      expect(
+        tier.border?.['on-dark-subtle']?.value,
+        `${name}.color.border.on-dark-subtle must alias surface.on-dark-overlay-subtle`,
+      ).toBe('var(--hx-color-surface-on-dark-overlay-subtle)');
 
       // surface.on-dark-overlay-{default,subtle}: both must exist in every
       // tier, since runtime mode-flip depends on the dark + HC overrides

--- a/packages/hx-tokens/src/tokens.json
+++ b/packages/hx-tokens/src/tokens.json
@@ -216,6 +216,14 @@
       "on-dark-strong": {
         "value": "var(--hx-overlay-white-70)",
         "description": "Strong border treatment on dark surfaces (e.g. inverted button outlines on a dark page). overlay-white-70 on neutral-900 ≈ 5.0:1 — clears WCAG 1.4.11 3:1 floor for non-text UI. Added in 3.2.1 alongside the action.* layer for the token-cascade remediation; only the strong tier survived the 3.2.2 audit because the lower-alpha siblings (overlay-white-30/10) cannot honour a border-contract — they were renamed to surface.on-dark-overlay-* (which is what they always were: translucent fills)."
+      },
+      "on-dark-default": {
+        "value": "var(--hx-color-surface-on-dark-overlay-default)",
+        "description": "DEPRECATED 3.2.2 — alias for surface.on-dark-overlay-default. Originally shipped 3.2.1 under the border.* family but it was always used as a translucent fill, never a border, and its 30% alpha cannot honour WCAG 1.4.11 3:1. Renamed to surface.on-dark-overlay-default in 3.2.2; this alias preserves the published CSS variable name (`--hx-color-border-on-dark-default`) for consumers who set it as a theme override. Scheduled for removal in 4.0.0."
+      },
+      "on-dark-subtle": {
+        "value": "var(--hx-color-surface-on-dark-overlay-subtle)",
+        "description": "DEPRECATED 3.2.2 — alias for surface.on-dark-overlay-subtle. Originally shipped 3.2.1 under the border.* family but it was always used as a translucent fill, never a border, and its 10% alpha cannot honour WCAG 1.4.11 3:1. Renamed to surface.on-dark-overlay-subtle in 3.2.2; this alias preserves the published CSS variable name (`--hx-color-border-on-dark-subtle`) for consumers who set it as a theme override. Scheduled for removal in 4.0.0."
       }
     },
     "focus-ring": {
@@ -652,6 +660,14 @@
         "on-dark-strong": {
           "value": "var(--hx-overlay-black-50)",
           "description": "Dark-mode override. surface.inverse flips light (#EBEEE9) in dark mode, so the original overlay-white-70 binding paints white-ish on light = 1.12:1 (invisible). overlay-black-50 over #EBEEE9 = 3.84:1, clears the WCAG 1.4.11 3:1 floor for inverted-mode button outlines and focus rings drawn on the (now-light) inverse surface. Symmetrical with the light-mode 70% intent: dark text on light reaches the equivalent perceptual strength at a lower alpha than light text on dark."
+        },
+        "on-dark-default": {
+          "value": "var(--hx-color-surface-on-dark-overlay-default)",
+          "description": "DEPRECATED 3.2.2 — dark-mode alias preserving the published `--hx-color-border-on-dark-default` for backwards compatibility. Resolves to the renamed surface.on-dark-overlay-default token in dark mode (overlay-black-30). Removal scheduled for 4.0.0."
+        },
+        "on-dark-subtle": {
+          "value": "var(--hx-color-surface-on-dark-overlay-subtle)",
+          "description": "DEPRECATED 3.2.2 — dark-mode alias preserving the published `--hx-color-border-on-dark-subtle` for backwards compatibility. Resolves to the renamed surface.on-dark-overlay-subtle token in dark mode (overlay-black-10). Removal scheduled for 4.0.0."
         }
       },
       "focus-ring": { "value": "var(--hx-color-primary-400)" },
@@ -828,6 +844,14 @@
         "on-dark-strong": {
           "value": "#FFFFFF",
           "description": "HC override for border.on-dark-strong. The base overlay-white-70 reads softly against translucent darks but is invisible against the HC #000 canvas — pin to solid #FFFFFF (21:1 on #000) so inverted button outlines remain visible in HC."
+        },
+        "on-dark-default": {
+          "value": "var(--hx-color-surface-on-dark-overlay-default)",
+          "description": "DEPRECATED 3.2.2 — HC alias preserving the published `--hx-color-border-on-dark-default` for backwards compatibility. Resolves to the renamed surface.on-dark-overlay-default token in HC mode (#FFFFFF). Removal scheduled for 4.0.0."
+        },
+        "on-dark-subtle": {
+          "value": "var(--hx-color-surface-on-dark-overlay-subtle)",
+          "description": "DEPRECATED 3.2.2 — HC alias preserving the published `--hx-color-border-on-dark-subtle` for backwards compatibility. Resolves to the renamed surface.on-dark-overlay-subtle token in HC mode (#C0C0C0). Removal scheduled for 4.0.0."
         }
       },
       "focus-ring": { "value": "#FFFF00", "description": "High-visibility yellow focus ring" },


### PR DESCRIPTION
## Summary

Closes 2 medium codex round-11 findings on the staging→main candidate (#1581). Rolls into the same 3.2.2 patch.

**Finding 2 [api-design] — Backwards-compat aliases for renamed border-on-dark tokens.**
- Restored `--hx-color-border-on-dark-{default,subtle}` in `tokens.json` as deprecated aliases that resolve through `--hx-color-surface-on-dark-overlay-{default,subtle}` across all 3 tiers (base / dark / HC).
- Preserves consumer theme overrides set against the names published in 3.2.0 / 3.2.1.
- Marked deprecated in description fields; removal scheduled for 4.0.0.
- Extended round-8 structural-shape lock test to assert the new shape AND verify each alias resolves through the surface namespace.

**Finding 1 [api-design] — Inverted-primary override path: documentation-only.**
- The new `:host([inverted]) .button--primary` rest-state rule binds `--hx-button-bg` matching the established variant convention (light primary line 89, danger 120, secondary, tertiary, ghost — all bind `--hx-button-bg` directly with the same descendant-scope shadowing).
- Consumer override path is the upstream semantic `--hx-color-action-primary-bg-inverted-rest`, pinned by `dark-mode-resolution.test.ts:185-197` across both modes.
- An attempted "cascade-preserving self-fallback" form `var(--hx-button-bg, var(--semantic, hex))` was reverted: per W3C css-variables-1 §3, self-reference forms a cycle and invalidates the property at computed-value time, breaking the documented override path.
- Expanded inline comment to cite the convention and the override-path test.

## Test plan
- [x] `pnpm --filter=@helixui/tokens test` — 217/217
- [x] `pnpm --filter=@helixui/library test -- hx-button` — 153/153
- [x] `pnpm --filter=@helixui/library test -- dark-mode-resolution` — 12/12 (all 3 inverted-primary semantic-override tests pass)
- [ ] CI green on this PR
- [ ] Auto-merge dev → staging → re-codex round-12

## Codex history
- Rounds 1–7: addressed in #1577, #1579, #1582, #1584, #1586
- Round 8 (4 findings): addressed in #1588 (taxonomy rename + 20-component focus-ring fallback collapse + JSDoc + structural lock test)
- Round 9 (2 concerns): addressed in same PR as round 8 (3-tier structural lock + ratio drift)
- Round 10: pass, 0 findings on feature branch
- Round 11 (2 medium concerns): this PR