### PR TITLE
promote: dev → staging — 3.2.2 round-14 codex remediation

### DIFF
--- a/.changeset/3-2-2-codex-round-14-remediation.md
+++ b/.changeset/3-2-2-codex-round-14-remediation.md
@@ -8,7 +8,7 @@ Closes 3 codex round-14 findings (1 high, 2 medium) on the staging→main candid
 
 **Finding 1 [correctness high] — `hx-side-nav` `@supports color-mix()` block shadowed the round-12 deprecated-first chain.**
 
-Round-12 added a deprecated-first fallback chain on `.side-nav__toggle:hover` so consumer overrides on either `--hx-color-border-on-dark-subtle` (3.2.0/3.2.1 published name) or `--hx-color-surface-on-dark-overlay-subtle` (canonical 3.2.2 name) reach paint. But the immediately-following `@supports (color: color-mix(...))` block unconditionally overwrote `background-color` with `color-mix(in srgb, currentColor 15%, transparent)` — making the round-12 fix dead code in any browser supporting `color-mix()` (~96% of the modern web).
+Round-12 added a deprecated-first fallback chain on `.side-nav__toggle:hover` so consumer overrides on either `--hx-color-border-on-dark-subtle` (3.2.0/3.2.1 published name) or `--hx-color-surface-on-dark-overlay-subtle` (canonical 3.2.2 name) reach paint. But the immediately-following `@supports (color: color-mix(...))` block unconditionally overwrote `background-color` with `color-mix(in srgb, currentColor 15%, transparent)` — making the round-12 fix dead code in any browser supporting `color-mix()` (Chrome/Edge 111+, Firefox 113+, Safari 16.2+ — ≈98–99% of global users as of April 2026).
 
 **Fix:** Folded `color-mix()` into the variable chain as the final fallback arm so consumer overrides win on the modern path too:
 

--- a/.changeset/3-2-2-codex-round-14-remediation.md
+++ b/.changeset/3-2-2-codex-round-14-remediation.md
@@ -1,0 +1,43 @@
+---
+'@helixui/library': patch
+---
+
+3.2.2 codex round-14 remediation — side-nav `@supports color-mix` chain fold + deprecated `@cssprop` restoration
+
+Closes 3 codex round-14 findings (1 high, 2 medium) on the staging→main candidate. Rolls into the same 3.2.2 patch.
+
+**Finding 1 [correctness high] — `hx-side-nav` `@supports color-mix()` block shadowed the round-12 deprecated-first chain.**
+
+Round-12 added a deprecated-first fallback chain on `.side-nav__toggle:hover` so consumer overrides on either `--hx-color-border-on-dark-subtle` (3.2.0/3.2.1 published name) or `--hx-color-surface-on-dark-overlay-subtle` (canonical 3.2.2 name) reach paint. But the immediately-following `@supports (color: color-mix(...))` block unconditionally overwrote `background-color` with `color-mix(in srgb, currentColor 15%, transparent)` — making the round-12 fix dead code in any browser supporting `color-mix()` (~96% of the modern web).
+
+**Fix:** Folded `color-mix()` into the variable chain as the final fallback arm so consumer overrides win on the modern path too:
+
+```css
+@supports (color: color-mix(in srgb, red 50%, blue)) {
+  .side-nav__toggle:hover {
+    background-color: var(
+      --hx-color-border-on-dark-subtle,
+      var(
+        --hx-color-surface-on-dark-overlay-subtle,
+        color-mix(in srgb, currentColor 15%, transparent)
+      )
+    );
+  }
+}
+```
+
+**Finding 2 [api-design medium] — Deprecated `@cssprop` entries dropped from CEM in a patch release.**
+
+Round-8 renamed `--hx-color-border-on-dark-{default,subtle}` to `--hx-color-surface-on-dark-overlay-*`. Round-12 preserved consumer-override compatibility at the consume sites (deprecated-first fallback chain), but the `@cssprop` JSDoc on `hx-button.ts` and `hx-side-nav.ts` was *replaced* (not augmented) — public CEM/Storybook autodocs/IDE intellisense no longer documented the deprecated names. For a 3.x patch release that explicitly preserves the deprecated names through the runtime fallback chain until 4.0.0 removal, dropping them from the published API metadata is a consumer-facing surface reduction.
+
+**Fix:** Re-added `@cssprop` entries with `DEPRECATED 3.2.2` markers and explicit removal guidance:
+
+- `hx-button.ts` — added `--hx-color-border-on-dark-{subtle,default}` deprecated entries
+- `hx-side-nav.ts` — added `--hx-color-border-on-dark-subtle` deprecated entry
+- CEM regenerated; the Custom Elements Manifest now documents the deprecated names alongside the canonical replacements until 4.0.0.
+
+**Finding 3 [test-gap medium] — Hover-skip justification invalidated by Finding 1.**
+
+The `default` chain coverage comment in `dark-mode-resolution.test.ts` claimed the side-nav consume site was covered by "the same safety [grep + structural lock]" as the button rest-state tests. Pre-round-15, that premise was broken because the `@supports color-mix()` override bypassed the token chain entirely on the dominant runtime path — grep over the rest-state declaration could not detect that paint diverged under `:hover`.
+
+**Fix:** Comment updated to reflect that post-round-15 fold, the `@supports`-gated override path also reads both deprecated and canonical names, restoring the documented safety. (Per Codex resolution path option (a) — once Finding 1 is fixed, the existing structural-shape lock + file-level grep coverage becomes valid.)

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-04-26T15:26:25.292Z",
+  "generatedAt": "2026-04-26T18:21:13.364Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.2.0",
   "tokensVersion": "3.2.0",
@@ -2956,6 +2956,16 @@
         {
           "description": "Inverted-secondary/outline border + inverted focus-visible outline (overlay-white-70 ≈ 5:1 — clears WCAG 1.4.11 3:1 floor).",
           "name": "--hx-color-border-on-dark-strong",
+          "figmaBinding": null
+        },
+        {
+          "description": "DEPRECATED 3.2.2; renamed to --hx-color-surface-on-dark-overlay-subtle (the value paints a translucent fill, not a border). Consume sites read both names via deprecated-first fallback so existing overrides keep working until removal in 4.0.0.",
+          "name": "--hx-color-border-on-dark-subtle",
+          "figmaBinding": null
+        },
+        {
+          "description": "DEPRECATED 3.2.2; renamed to --hx-color-surface-on-dark-overlay-default (the value paints a translucent fill, not a border). Consume sites read both names via deprecated-first fallback so existing overrides keep working until removal in 4.0.0.",
+          "name": "--hx-color-border-on-dark-default",
           "figmaBinding": null
         }
       ],
@@ -17683,6 +17693,11 @@
         {
           "description": "Toggle button hover surface (overlay-white-10 primitive — translucent fill, not a border).",
           "name": "--hx-color-surface-on-dark-overlay-subtle",
+          "figmaBinding": null
+        },
+        {
+          "description": "DEPRECATED 3.2.2; renamed to --hx-color-surface-on-dark-overlay-subtle (the value paints a translucent fill, not a border). Toggle-hover rule reads both names via deprecated-first fallback so existing overrides keep working until removal in 4.0.0.",
+          "name": "--hx-color-border-on-dark-subtle",
           "figmaBinding": null
         }
       ],

--- a/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
+++ b/packages/hx-library/src/components/__tests__/dark-mode-resolution.test.ts
@@ -227,15 +227,17 @@ describe('dark-mode token resolution', () => {
   });
 
   /**
-   * `default` chain coverage note: the four `:hover` consume sites (inverted
-   * secondary/tertiary/ghost/outline) reuse the identical token-fallback shape
+   * `default` chain coverage note: the four `:hover` consume sites in
+   * hx-button.styles.ts (inverted secondary/tertiary/ghost/outline) and the
+   * .side-nav__toggle:hover rule in hx-side-nav.styles.ts (incl. the round-15
+   * @supports color-mix fold) all reuse the identical token-fallback shape
    * that the subtle-chain rest-state tests above exercise. Synthesizing :hover
-   * paint in vitest browser mode is unreliable here (variant rest state has no
+   * paint in vitest browser mode is unreliable (variant rest state has no
    * --hx-button-bg binding, so a hover-only rebind doesn't surface as a stable
    * backgroundColor delta we can assert without coupling to hover internals).
    * Coverage falls back to the `contrast.test.ts` structural-shape lock plus
-   * file-level grep that every rule reads both names — the same safety the
-   * side-nav consume site relies on.
+   * file-level grep — every rule (rest-state path AND `@supports`-gated
+   * override path on side-nav) reads BOTH the deprecated and canonical names.
    */
 
 });

--- a/packages/hx-library/src/components/hx-button/hx-button.ts
+++ b/packages/hx-library/src/components/hx-button/hx-button.ts
@@ -74,6 +74,8 @@ export interface HxButtonClickDetail {
  * @cssprop [--hx-color-surface-on-dark-overlay-subtle] - Inverted-tertiary resting fill (overlay-white-10 — translucent fill, not a border).
  * @cssprop [--hx-color-surface-on-dark-overlay-default] - Inverted-tertiary hover fill + inverted-secondary/ghost/outline hover fill (overlay-white-30 — translucent fill, not a border).
  * @cssprop [--hx-color-border-on-dark-strong] - Inverted-secondary/outline border + inverted focus-visible outline (overlay-white-70 ≈ 5:1 — clears WCAG 1.4.11 3:1 floor).
+ * @cssprop [--hx-color-border-on-dark-subtle] - DEPRECATED 3.2.2; renamed to --hx-color-surface-on-dark-overlay-subtle (the value paints a translucent fill, not a border). Consume sites read both names via deprecated-first fallback so existing overrides keep working until removal in 4.0.0.
+ * @cssprop [--hx-color-border-on-dark-default] - DEPRECATED 3.2.2; renamed to --hx-color-surface-on-dark-overlay-default (the value paints a translucent fill, not a border). Consume sites read both names via deprecated-first fallback so existing overrides keep working until removal in 4.0.0.
  */
 @customElement('hx-button')
 export class HelixButton extends mixinDelegatesAria(HelixElement) {

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.styles.ts
@@ -126,8 +126,16 @@ export const helixSideNavStyles = css`
   }
 
   @supports (color: color-mix(in srgb, red 50%, blue)) {
+    /* Fold color-mix() into the same deprecated-first chain so consumer
+       overrides on either token reach paint on the modern path too. */
     .side-nav__toggle:hover {
-      background-color: color-mix(in srgb, currentColor 15%, transparent);
+      background-color: var(
+        --hx-color-border-on-dark-subtle,
+        var(
+          --hx-color-surface-on-dark-overlay-subtle,
+          color-mix(in srgb, currentColor 15%, transparent)
+        )
+      );
     }
   }
 

--- a/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
+++ b/packages/hx-library/src/components/hx-side-nav/hx-side-nav.ts
@@ -38,6 +38,7 @@ import { helixSideNavStyles } from './hx-side-nav.styles.js';
  * @cssprop [--hx-color-text-inverse] - Side-nav text color (resolves to neutral-0).
  * @cssprop [--hx-color-border-on-dark-strong] - Container/header/footer divider border (overlay-white-70 light, overlay-black-50 dark — sized for visibility on the mode-flipped surface-inverse).
  * @cssprop [--hx-color-surface-on-dark-overlay-subtle] - Toggle button hover surface (overlay-white-10 primitive — translucent fill, not a border).
+ * @cssprop [--hx-color-border-on-dark-subtle] - DEPRECATED 3.2.2; renamed to --hx-color-surface-on-dark-overlay-subtle (the value paints a translucent fill, not a border). Toggle-hover rule reads both names via deprecated-first fallback so existing overrides keep working until removal in 4.0.0.
  */
 @customElement('hx-side-nav')
 export class HelixSideNav extends HelixElement {


### PR DESCRIPTION
## Summary

Promotes 3.2.2 round-14 codex remediation from dev to staging (3 findings: 1 high, 2 medium — all fixed in PR #1594).

## Commits ahead of staging

- `8d50797c1` docs(changeset): coderabbit nit on round-14 changeset (color-mix support figure)
- `e254b72cb` fix(library): codex round-14 — fold color-mix into token chain + restore deprecated cssprop entries

## Findings remediated (all 3)

1. **HIGH** — `hx-side-nav` `@supports color-mix()` block was unconditionally overwriting `.side-nav__toggle:hover` background, shadowing the round-12 deprecated-first chain on ~98-99% of browsers. Folded `color-mix()` into the variable chain.
2. **MEDIUM** — Restored deprecated `@cssprop` entries on `hx-button.ts` + `hx-side-nav.ts` with `DEPRECATED 3.2.2` markers; CEM regenerated.
3. **MEDIUM** — Updated dark-mode-resolution.test.ts coverage-note comment to reflect the round-15 fold restored the documented safety net.

## Test plan

- [ ] Quality Gates green on staging
- [ ] Round-15 codex review (`/codex-review main`) passes against staging→main candidate
- [ ] Open staging→main PR (Jake to click merge — no auto-merge)