### PR TITLE
design(theme): 3.3.0 brand→data-brand reflection contract — REVIEW BEFORE IMPLEMENTATION

### DIFF
--- a/.changeset/3-3-0-brand-reflection-contract-design.md
+++ b/.changeset/3-3-0-brand-reflection-contract-design.md
@@ -1,19 +1,21 @@
 ---
 '@helixui/library': patch
+'@helixui/tokens': patch
 ---
 
 3.3.0 brand→data-brand auto-reflection — contract design and test matrix only. Implementation paused pending operator signoff per the planning note's "design up front, get explicit signoff" recommendation. No runtime change in this changeset; this is the architectural artifact that lets the implementation diff land in a single shot rather than iterating through codex.
 
 **What lands.**
 
-- `packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md` — the 4-shape × 3-theme × registered/unregistered matrix (24 cases) with row-by-row expected behavior, the aggressive-cleanup decision rationale, ownership-tracking model (`_managedDataBrand` flag), state-transition table, mutation guard, SSR adoption story, Drupal Twig alignment plan, and the docs delta for `multi-brand-theming.md:39`.
-- `packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` — 24 `it.todo()` cases naming each scenario by case number, plus 5 state-transition todos and 2 mutation-guard todos. The test file is the gate: when the contract flips to implementation, every `it.todo` becomes a real assertion.
+- `packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md` — the 4-shape × 3-theme × registered/unregistered matrix (24 cases) with row-by-row expected behavior, the narrowed registered-only management model, ownership-tracking model (discriminated `LastApplied` union), state-transition table, mutation guard semantics, late-registration recovery via additive registry subscription API, SSR adoption story, Drupal Twig alignment plan, and the docs delta for `multi-brand-theming.md:39`.
+- `packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` — 35 `it.todo()` cases: 24 row cases by case number, 5 state-transition todos, 2 mutation-guard todos, 3 R1 edge-case todos (late registration, ownership relinquish under external override, advisory dedupe), and 1 disconnect todo. The test file is the gate: when the contract flips to implementation, every `it.todo` becomes a real assertion.
 
 **What does NOT land.**
 
 - No change to `hx-theme.ts`. The runtime continues to NOT reflect `brand` to `data-brand` (current 3.2.x contract).
 - No change to `hx-theme.twig`. The Twig helper continues to drop `data-brand` per R31 cleanup.
 - No change to `multi-brand-theming.md`. The "runtime does not reflect" line at :39 remains accurate until the runtime change ships.
+- No change to `HelixBrandRegistry`. The additive `subscribe(brandName, callback)` API specified in the contract lands with the implementation diff, not this design changeset.
 
 **Why the artifact-only approach.**
 
@@ -23,6 +25,26 @@ The 3.2.2 codex iteration loop (rounds 26-29) attempted unconditional reflection
 
 This changeset is that plan. The signoff gate is explicit in the contract document. Implementation lands as a separate diff once Jake confirms the matrix.
 
+**R0 → R1 redesign.**
+
+R0 of this contract used an "aggressive cleanup" model: any `brand !== ''` authorized the runtime to overwrite or strip `data-brand` regardless of registration state. Codex review on R0 returned a `blocking` verdict with 1 high + 5 medium structural findings:
+
+1. **Late registration / ordering hazard (high).** No event channel from registry → component; a brand registered after mount left the component in the unregistered path indefinitely.
+2. **Ownership tracking precision (medium).** A boolean-equivalent `_managedDataBrand` flag could not distinguish "runtime's prior write still live" from "author has overwritten."
+3. **Shape D unregistered loss (medium).** R0 stripped author-supplied `data-brand` even when the registry was inactive — silently destroying the cascade-only override path.
+4. **Shape B HC asymmetry (medium).** R0 did not loud-document the safety implication that Shape B authors own the HC guard.
+5. **Mutation guard precision (medium).** "Universal authorization" wording overstated what the design enforced without a `MutationObserver`.
+6. **Test stub coverage gaps (medium).** No coverage for late-registration recovery, ownership relinquish under external override, or advisory dedupe.
+
+R1 closes all six in a single revision per the planning rule ("redesign once, do not iterate"):
+
+- F1 → additive `HelixBrandRegistry.subscribe(brandName, callback)` API; `register()` / `_clear()` invoke `_notify()` synchronously; `hx-theme` subscribes/unsubscribes across the lifecycle. Bumps `@helixui/tokens` because the public registry API surface widens.
+- F2 → discriminated union `LastApplied = { kind: 'unmanaged' } | { kind: 'set', value: string } | { kind: 'cleared' }` for precise relinquish semantics.
+- F3 → contract narrowed: runtime only manages `data-brand` when `brand !== '' AND isRegistered`. Cases 14, 16, 18, 20, 22, 24 expected outcomes flipped from "removed" to "untouched."
+- F4 → Shape B HC safety implication block added to the contract; cases 11, 12 explicitly note "author-responsible HC guard."
+- F5 → "authoritative at reconcile boundaries" framing replaces the universal-authorization wording; `MutationObserver` rejected with rationale.
+- F6 → 3 new `it.todo` cases on the test stub (late registration, ownership relinquish under external override, advisory dedupe). Total stub count rises from 32 → 35.
+
 **Codex review on this diff.**
 
-A single codex pass on this contract document is welcome; iteration on the document surface is not. If codex surfaces architectural concerns with a row of the matrix, the row gets revised in a single commit and the diff is re-reviewed once. The pattern from rounds 26-29 — codex round → patch → new finding → patch — is explicitly the failure mode this work avoids.
+A single codex pass on R1 closes the audit loop. If codex surfaces concerns on R1, they fall into two buckets per the contract's approval-gate section: (a) a row of the matrix that should flip — Jake's call — or (b) implementation-diff concerns, which are out of scope for this design-only changeset. The pattern from rounds 26-29 — codex round → patch → new finding → patch — is explicitly the failure mode this work avoids.

--- a/.changeset/3-3-0-brand-reflection-contract-design.md
+++ b/.changeset/3-3-0-brand-reflection-contract-design.md
@@ -1,0 +1,28 @@
+---
+'@helixui/library': patch
+---
+
+3.3.0 brand→data-brand auto-reflection — contract design and test matrix only. Implementation paused pending operator signoff per the planning note's "design up front, get explicit signoff" recommendation. No runtime change in this changeset; this is the architectural artifact that lets the implementation diff land in a single shot rather than iterating through codex.
+
+**What lands.**
+
+- `packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md` — the 4-shape × 3-theme × registered/unregistered matrix (24 cases) with row-by-row expected behavior, the aggressive-cleanup decision rationale, ownership-tracking model (`_managedDataBrand` flag), state-transition table, mutation guard, SSR adoption story, Drupal Twig alignment plan, and the docs delta for `multi-brand-theming.md:39`.
+- `packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` — 24 `it.todo()` cases naming each scenario by case number, plus 5 state-transition todos and 2 mutation-guard todos. The test file is the gate: when the contract flips to implementation, every `it.todo` becomes a real assertion.
+
+**What does NOT land.**
+
+- No change to `hx-theme.ts`. The runtime continues to NOT reflect `brand` to `data-brand` (current 3.2.x contract).
+- No change to `hx-theme.twig`. The Twig helper continues to drop `data-brand` per R31 cleanup.
+- No change to `multi-brand-theming.md`. The "runtime does not reflect" line at :39 remains accurate until the runtime change ships.
+
+**Why the artifact-only approach.**
+
+The 3.2.2 codex iteration loop (rounds 26-29) attempted unconditional reflection inside an unrelated palette PR. Each round closed the previous round's findings and surfaced new edge cases. Codex was finding the matrix; the matrix needed to be designed first. The R29-R30 verdict, captured in `00-Planning/helix/Brand → data-brand Auto-Reflection (deferred from 3.2.2).md`:
+
+> "Plan up front. Write the contract for all four shapes × three themes × registered/unregistered before writing code. Get explicit signoff. Don't let codex find the matrix for you."
+
+This changeset is that plan. The signoff gate is explicit in the contract document. Implementation lands as a separate diff once Jake confirms the matrix.
+
+**Codex review on this diff.**
+
+A single codex pass on this contract document is welcome; iteration on the document surface is not. If codex surfaces architectural concerns with a row of the matrix, the row gets revised in a single commit and the diff is re-reviewed once. The pattern from rounds 26-29 — codex round → patch → new finding → patch — is explicitly the failure mode this work avoids.

--- a/packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md
+++ b/packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md
@@ -1,0 +1,184 @@
+# `brand` → `data-brand` Auto-Reflection Contract (3.3.0)
+
+**Status:** design — implementation pending Jake's signoff per planning note recommendation.
+**Target:** `@helixui/library@3.3.0`
+**Captured from:** PR #1597 codex rounds 26–29 (reverted), planning note `00-Planning/helix/Brand → data-brand Auto-Reflection (deferred from 3.2.2).md`.
+
+## Why this exists
+
+`<hx-theme>` exposes two parallel brand-override mechanisms:
+
+1. **JS registry path** — `HelixBrandRegistry.register()` + `brand="X"` activates runtime token injection.
+2. **CSS-pattern path** — author-supplied stylesheets matching `hx-theme[data-brand='X']:not([theme='high-contrast'])`.
+
+Today only the Drupal Twig helper emits `data-brand` (when explicitly opted into via the `attributes` spread). Plain HTML / React / Angular / Vue consumers who set `brand="X"` get **zero** styling from CSS-pattern selectors. The runtime contract today (post-revert of R26–R29):
+
+> "The runtime does not reflect `brand` to `data-brand`."
+> — `apps/docs/src/content/docs/extending/multi-brand-theming.md:39`
+
+This is correct as documented but inadequate as architecture: it forces every non-Twig consumer to maintain `data-brand` by hand and stay synchronized with `brand` across runtime swaps. R26–R29 attempted unconditional reflection and tripped on edge cases that codex surfaced one round at a time. The lesson from that loop, captured in the planning note: **design the full matrix before any code lands.** This document is that matrix.
+
+## The four authoring shapes
+
+| Shape | Author writes | Common origin |
+|---|---|---|
+| A | `<hx-theme brand="X">` (no `data-brand`) | Plain HTML / React / Angular / Vue, no SSR mirroring |
+| B | `<hx-theme data-brand="X">` (no `brand`) | CSS-pattern-only consumers using cascade overrides without registering tokens |
+| C | `<hx-theme brand="X" data-brand="X">` (matching) | Drupal Twig with `attributes: {'data-brand': brand}`, or any SSR that mirrors |
+| D | `<hx-theme brand="X" data-brand="Y">` (mismatched) | SSR drift, stale page cache, hand-edited author markup |
+
+## The contract
+
+The runtime reconciles `data-brand` against `brand` whenever `brand` is non-empty. When `brand` is empty, the runtime does not touch `data-brand` at all — Shape B authoring is preserved.
+
+Aggressive cleanup model (per planning note recommendation):
+
+```
+function reconcile(brand, effectiveTheme, isRegistered) {
+  if (brand === '') {
+    // Shape B authoring path.
+    // The runtime never owned data-brand. Author/SSR/cascade authoritative.
+    return NOOP;
+  }
+
+  // brand !== '' — runtime is the manager.
+
+  if (effectiveTheme === 'high-contrast') {
+    // Suppress data-brand under HC at every shape.
+    // Why: external CSS-pattern stylesheets without :not([theme='high-contrast'])
+    // would otherwise leak brand primitives into the HC overlay and break the
+    // WCAG 7:1+ contract.
+    REMOVE data-brand;
+    return;
+  }
+
+  if (!isRegistered) {
+    // brand is non-empty but not in the registry.
+    // The JS registry path rejects the merge. If we LEAVE data-brand set, the
+    // CSS-pattern path applies a half-merged brand (cascade overrides only,
+    // no token-registry merge). That is the worst possible state — silently
+    // broken color contrast with no console signal.
+    REMOVE data-brand;
+    return;
+  }
+
+  // brand !== '', light or dark theme, registered.
+  // Shape A → set; Shape C → no-op (already matches); Shape D → overwrite.
+  SET data-brand = brand;
+}
+```
+
+## The 24-case matrix
+
+Three themes × four shapes × two registration states (registered / unregistered) = 24 cases. Shape B does not depend on the registration state of the value already in `data-brand` (the runtime never reaches the registry on that path), so the four B rows are functional duplicates that nonetheless gate a regression: any future change must keep Shape B noop in all four conditions.
+
+| # | Shape | `brand` initial | `data-brand` initial | Theme | Registered? | Expected `data-brand` after reconcile | Expected console |
+|---|---|---|---|---|---|---|---|
+| 1 | A | `acme` | `(none)` | `light` | yes | `acme` | (none) |
+| 2 | A | `acme` | `(none)` | `light` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 3 | A | `acme` | `(none)` | `dark` | yes | `acme` | (none) |
+| 4 | A | `acme` | `(none)` | `dark` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 5 | A | `acme` | `(none)` | `high-contrast` | yes | `(none)` | `info: Brand "acme" is suppressed on theme="high-contrast"` |
+| 6 | A | `acme` | `(none)` | `high-contrast` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 7 | B | `''` | `acme` | `light` | yes (`acme` registered) | `acme` (untouched) | (none) |
+| 8 | B | `''` | `acme` | `light` | no (`acme` not registered) | `acme` (untouched) | (none) |
+| 9 | B | `''` | `acme` | `dark` | yes | `acme` (untouched) | (none) |
+| 10 | B | `''` | `acme` | `dark` | no | `acme` (untouched) | (none) |
+| 11 | B | `''` | `acme` | `high-contrast` | yes | `acme` (untouched) | (none) |
+| 12 | B | `''` | `acme` | `high-contrast` | no | `acme` (untouched) | (none) |
+| 13 | C | `acme` | `acme` | `light` | yes | `acme` (no change observed) | (none) |
+| 14 | C | `acme` | `acme` | `light` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 15 | C | `acme` | `acme` | `dark` | yes | `acme` (no change observed) | (none) |
+| 16 | C | `acme` | `acme` | `dark` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 17 | C | `acme` | `acme` | `high-contrast` | yes | `(none)` | `info: ... suppressed on theme="high-contrast"` |
+| 18 | C | `acme` | `acme` | `high-contrast` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 19 | D | `acme` | `other` | `light` | yes (`acme` registered) | `acme` (overwrites `other`) | (none) |
+| 20 | D | `acme` | `other` | `light` | no (`acme` not registered) | `(none)` | `warn: Brand "acme" is not registered` |
+| 21 | D | `acme` | `other` | `dark` | yes | `acme` (overwrites `other`) | (none) |
+| 22 | D | `acme` | `other` | `dark` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 23 | D | `acme` | `other` | `high-contrast` | yes | `(none)` | `info: ... suppressed on theme="high-contrast"` |
+| 24 | D | `acme` | `other` | `high-contrast` | no | `(none)` | `warn: Brand "acme" is not registered` |
+
+### Shape D under HC, registered (case 23) — note on stripping
+
+The runtime strips both `acme` and `other` under HC. There is no daylight between "the registered brand was suppressed because of HC" and "a stale `other` value lingered from SSR" — both produce CSS-pattern leaks if left in place. Shape D consumers who want their author-supplied `other` value preserved across HC must adopt Shape B authoring (drop the `brand` attribute when `data-brand` is the only override desired).
+
+### Shape B under HC (cases 11, 12) — note on guard responsibility
+
+The runtime does not strip `data-brand` under HC when `brand=""`. The author opted into the cascade-only path; the HC guard is the author's responsibility (the canonical `:not([theme='high-contrast'])` selector form documented in `multi-brand-theming.md`). This preserves the existing Shape B contract — the runtime touching `data-brand` it never set would be the more surprising failure mode.
+
+## State transitions
+
+Beyond the initial-mount matrix, runtime swaps must remain coherent:
+
+| Transition | Expected behavior |
+|---|---|
+| `brand="acme"` → `brand="other"` (both registered) | `data-brand` updates from `acme` → `other` (assuming light/dark theme) |
+| `brand="acme"` → `brand=""` while runtime owns `data-brand` | Remove `data-brand` (runtime relinquishes management) |
+| `brand="acme"` → `brand=""` when author-set `data-brand` was never overwritten (Shape B + brand briefly set?) | Edge case: NOT supported. Authoring shapes do not mix mid-flight. |
+| `theme="light"` → `theme="high-contrast"` while `brand="acme"` registered | `data-brand="acme"` removed (HC suppression) |
+| `theme="high-contrast"` → `theme="light"` while `brand="acme"` registered | `data-brand="acme"` re-set (HC exit) |
+| `theme="auto"` resolving from `light` → `dark` via OS query | `data-brand` unchanged (both light and dark set it; the value is identical) |
+| `theme="auto"` resolving from `light` → `dark` via OS where dark→hc would not happen — theme=auto cannot resolve to HC | n/a |
+
+## Ownership tracking
+
+The runtime maintains a private `_managedDataBrand: string | null` flag:
+
+- Initial value: `null` (runtime is not the manager).
+- On reconcile when `brand !== ''`: runtime enters managed state. Even if the eventual decision is REMOVE (HC, unregistered), the slot tracks "we last touched it."
+- On reconcile when `brand === ''`: if `_managedDataBrand` was non-null, runtime emits a final REMOVE to clean up its own past writes, then resets to `null`. If `_managedDataBrand` was already `null`, NOOP.
+- On `disconnectedCallback`: do **not** strip `data-brand`. The element is leaving the tree; cleanup is the framework's responsibility, and stripping during teardown causes a flash for moved-not-removed nodes.
+
+This handles the `brand="acme"` → `brand=""` transition cleanly without breaking Shape B (where `_managedDataBrand` never transitions away from `null`).
+
+## SSR adoption (Shape C)
+
+When the page renders with `<hx-theme brand="acme" data-brand="acme">` and the component connects:
+
+1. `firstUpdated` fires. `brand` is `"acme"`. Reconcile runs.
+2. Decision: SET `data-brand="acme"`. Already `acme`. The DOM mutation observer (if any external one is watching) sees no change — `setAttribute` to the same value is a no-op in spec but DOES fire `MutationObserver.attributes` mutations. To avoid spurious mutations, the runtime checks `current === target` before calling `setAttribute`.
+3. `_managedDataBrand` transitions to `"acme"`. The runtime now owns the attribute.
+
+Mismatched SSR (Shape D) follows the same path with one extra step: step 2 detects `current !== target`, calls `setAttribute('data-brand', 'acme')`. The mismatched `other` is overwritten.
+
+## Mutation guard
+
+The runtime does **not** observe the `data-brand` attribute for external mutations after adoption. If author-side code (e.g. a Drupal behavior, a third-party theme switcher) sets `data-brand="x"` while `brand="y"` is still set, the next reconcile (triggered by any property change to `brand`/`theme`/`motion`/`density` or by an `auto` theme media-query event) overwrites the external write. This is the cost of the aggressive cleanup model, and is consistent with the contract: `brand !== ''` is universal authorization.
+
+Authors who want to control `data-brand` independently must use Shape B (no `brand` attribute) or unset `brand` before mutating `data-brand`.
+
+## Drupal Twig alignment
+
+`packages/hx-library/src/components/hx-theme/hx-theme.twig` drops the `data-brand` emission entirely. Today (post-R31 cleanup) the helper emits only `brand="..."`; the runtime now performs the reflection. This removes the dual-source-of-truth between Twig and runtime that R26–R29 chased.
+
+The `attributes` spread retains the ability to set arbitrary HTML attributes including `data-brand` (Shape B). Templates that explicitly want CSS-pattern-only authoring continue to work; templates that pass `data-brand` AND `brand` get the runtime's aggressive cleanup behavior on hydration.
+
+## Documentation alignment
+
+`apps/docs/src/content/docs/extending/multi-brand-theming.md:39` updates from:
+
+> "The runtime does not reflect `brand` to `data-brand`."
+
+to:
+
+> "The runtime reflects `brand` to `data-brand` on `theme="light"` and `theme="dark"` when the brand is registered. The reflection is suppressed on `theme="high-contrast"` and on unregistered brand names. Set `data-brand` independently of `brand` (the cascade-only path) by omitting the `brand` attribute. See [`BRAND_REFLECTION_CONTRACT.md`](./brand-reflection-contract.md)."
+
+The `BRAND_THEMING.md` registry-path doc gains a "data-brand reflection" subsection pointing to this contract.
+
+## Test matrix file
+
+`packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` enumerates all 24 cases plus the state-transition table as `it.todo()` placeholders during the design phase. Each test signature names its case number from this contract so the matrix and the test file stay traceable.
+
+When implementation begins, the `it.todo` calls flip to real assertions. Codex reviews the final diff once. Iteration through codex on this contract surface is explicitly out of scope — the matrix is decided here.
+
+## Out-of-scope (intentionally)
+
+- **HC brand-token category split** — sibling 3.3.0 work tracked at `00-Planning/helix/HC brand-token suppression scope + replaceSync failure mode (deferred from 3.2.2).md`. Until that lands, HC continues to suppress the entire brand merge (color and non-color tokens both).
+- **`replaceSync()` failure-mode hardening** — sibling 3.3.0 work, same planning note. Until that lands, malformed tokens still throw at apply-time rather than register-time.
+- **`brand` property typing** — currently `string`. A future TS-strict enhancement could narrow to `RegisteredBrandName | ''` via the registry. Out of scope for 3.3.0; would be a separate types-only change.
+- **Programmatic `data-brand` mutation reaction** — the runtime does not observe the attribute. External mutations are stomped on the next reconcile. Documented above.
+
+## Approval gate
+
+Per the planning note: this contract is the gate. Implementation does not begin until Jake confirms each row of the matrix is the desired behavior (or notes the rows that need to flip). Codex review runs once on the final diff — not iteratively on the contract.

--- a/packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md
+++ b/packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md
@@ -1,8 +1,9 @@
 # `brand` → `data-brand` Auto-Reflection Contract (3.3.0)
 
-**Status:** design — implementation pending Jake's signoff per planning note recommendation.
-**Target:** `@helixui/library@3.3.0`
-**Captured from:** PR #1597 codex rounds 26–29 (reverted), planning note `00-Planning/helix/Brand → data-brand Auto-Reflection (deferred from 3.2.2).md`.
+**Status:** design — implementation pending Jake's signoff per the planning note's "design up front, get explicit signoff" recommendation.
+**Target:** `@helixui/library@3.3.0` + `@helixui/tokens@3.3.0` (additive registry API).
+**Captured from:** PR #1597 codex rounds 26-29 (reverted), planning note `00-Planning/helix/Brand → data-brand Auto-Reflection (deferred from 3.2.2).md`.
+**Revision history:** R0 initial (codex flagged 1 high + 5 medium structural findings); **R1 (this document)** — single comprehensive redesign addressing late-registration, ownership-tracking precision, Shape D unregistered loss, HC asymmetry safety, mutation-guard precision, test stub coverage. Per the planning rule: redesign once, do not iterate.
 
 ## Why this exists
 
@@ -11,17 +12,17 @@
 1. **JS registry path** — `HelixBrandRegistry.register()` + `brand="X"` activates runtime token injection.
 2. **CSS-pattern path** — author-supplied stylesheets matching `hx-theme[data-brand='X']:not([theme='high-contrast'])`.
 
-Today only the Drupal Twig helper emits `data-brand` (when explicitly opted into via the `attributes` spread). Plain HTML / React / Angular / Vue consumers who set `brand="X"` get **zero** styling from CSS-pattern selectors. The runtime contract today (post-revert of R26–R29):
+Today only the Drupal Twig helper emits `data-brand` (when explicitly opted into via the `attributes` spread). Plain HTML / React / Angular / Vue consumers who set `brand="X"` get **zero** styling from CSS-pattern selectors. The runtime contract today (post-revert of R26-R29):
 
 > "The runtime does not reflect `brand` to `data-brand`."
 > — `apps/docs/src/content/docs/extending/multi-brand-theming.md:39`
 
-This is correct as documented but inadequate as architecture: it forces every non-Twig consumer to maintain `data-brand` by hand and stay synchronized with `brand` across runtime swaps. R26–R29 attempted unconditional reflection and tripped on edge cases that codex surfaced one round at a time. The lesson from that loop, captured in the planning note: **design the full matrix before any code lands.** This document is that matrix.
+Adequate as documentation; inadequate as architecture. Every non-Twig consumer must maintain `data-brand` by hand and stay synchronized with `brand` across runtime swaps. R26-R29 attempted unconditional reflection and tripped on edge cases that codex surfaced one round at a time. The lesson, captured in the planning note: **design the full matrix before any code lands.** This document is that matrix.
 
 ## The four authoring shapes
 
 | Shape | Author writes | Common origin |
-|---|---|---|
+| --- | --- | --- |
 | A | `<hx-theme brand="X">` (no `data-brand`) | Plain HTML / React / Angular / Vue, no SSR mirroring |
 | B | `<hx-theme data-brand="X">` (no `brand`) | CSS-pattern-only consumers using cascade overrides without registering tokens |
 | C | `<hx-theme brand="X" data-brand="X">` (matching) | Drupal Twig with `attributes: {'data-brand': brand}`, or any SSR that mirrors |
@@ -29,130 +30,213 @@ This is correct as documented but inadequate as architecture: it forces every no
 
 ## The contract
 
-The runtime reconciles `data-brand` against `brand` whenever `brand` is non-empty. When `brand` is empty, the runtime does not touch `data-brand` at all — Shape B authoring is preserved.
+The runtime reconciles `data-brand` against `brand` whenever **both** of the following hold:
 
-Aggressive cleanup model (per planning note recommendation):
+1. `brand` is non-empty.
+2. `brand` is registered in `HelixBrandRegistry`.
+
+When either condition is false, the runtime does not touch `data-brand`. This is a deliberate narrowing from the R0 "aggressive cleanup" design, which stripped author-supplied `data-brand` even when the registry path was inactive. Stripping `data-brand` while the registry rejects the merge silently destroys the author's only working override mechanism (the cascade-only path) — an outcome the cascade-only path exists to prevent.
+
+Reconcile pseudocode:
 
 ```
-function reconcile(brand, effectiveTheme, isRegistered) {
+function reconcile(brand, effectiveTheme, isRegistered, currentDataBrand, lastApplied) {
   if (brand === '') {
-    // Shape B authoring path.
-    // The runtime never owned data-brand. Author/SSR/cascade authoritative.
-    return NOOP;
-  }
-
-  // brand !== '' — runtime is the manager.
-
-  if (effectiveTheme === 'high-contrast') {
-    // Suppress data-brand under HC at every shape.
-    // Why: external CSS-pattern stylesheets without :not([theme='high-contrast'])
-    // would otherwise leak brand primitives into the HC overlay and break the
-    // WCAG 7:1+ contract.
-    REMOVE data-brand;
+    // Shape B authoring path, OR a relinquish from a previously-set brand.
+    if (lastApplied.kind === 'set' && currentDataBrand === lastApplied.value) {
+      // The runtime owned this exact value; safe to clean up.
+      REMOVE data-brand;
+      lastApplied = { kind: 'unmanaged' };
+    } else if (lastApplied.kind === 'cleared' && currentDataBrand === '') {
+      // We previously cleared and the author hasn't re-added.
+      lastApplied = { kind: 'unmanaged' };
+    } else {
+      // Author has either taken over or never authored; do not touch.
+      lastApplied = { kind: 'unmanaged' };
+    }
     return;
   }
+
+  // brand !== ''
 
   if (!isRegistered) {
-    // brand is non-empty but not in the registry.
-    // The JS registry path rejects the merge. If we LEAVE data-brand set, the
-    // CSS-pattern path applies a half-merged brand (cascade overrides only,
-    // no token-registry merge). That is the worst possible state — silently
-    // broken color contrast with no console signal.
-    REMOVE data-brand;
+    // Registry path inactive. Leave whatever the author authored, including
+    // mismatched values (Shape D unregistered) and matching values (Shape C
+    // unregistered). The cascade-only path is the only working override
+    // mechanism for an unregistered brand name, and stripping it here would
+    // remove the author's last-resort styling. The unregistered-brand warn
+    // already fires from the existing _applyEffectiveTheme path.
     return;
   }
 
-  // brand !== '', light or dark theme, registered.
-  // Shape A → set; Shape C → no-op (already matches); Shape D → overwrite.
-  SET data-brand = brand;
+  // brand !== '', registered
+
+  if (effectiveTheme === 'high-contrast') {
+    // Suppress data-brand under HC for brands the runtime authoritatively
+    // manages. Why: external CSS-pattern stylesheets without
+    // :not([theme='high-contrast']) guards leak brand primitives into the
+    // HC overlay and break the WCAG 7:1+ contract. The runtime asserts
+    // ownership for registered brands; for unregistered brands and Shape B
+    // (cascade-only), HC-guarding is the author's responsibility.
+    if (currentDataBrand !== '') {
+      REMOVE data-brand;
+    }
+    lastApplied = { kind: 'cleared' };
+    return;
+  }
+
+  // brand !== '', registered, light or dark
+  if (currentDataBrand !== brand) {
+    SET data-brand = brand;
+  }
+  lastApplied = { kind: 'set', value: brand };
 }
 ```
 
 ## The 24-case matrix
 
-Three themes × four shapes × two registration states (registered / unregistered) = 24 cases. Shape B does not depend on the registration state of the value already in `data-brand` (the runtime never reaches the registry on that path), so the four B rows are functional duplicates that nonetheless gate a regression: any future change must keep Shape B noop in all four conditions.
+Three themes × four shapes × two registration states (registered / unregistered) = 24 cases.
 
-| # | Shape | `brand` initial | `data-brand` initial | Theme | Registered? | Expected `data-brand` after reconcile | Expected console |
-|---|---|---|---|---|---|---|---|
+| # | Shape | `brand` | `data-brand` (initial) | Theme | Registered? | Expected `data-brand` | Expected console |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 | 1 | A | `acme` | `(none)` | `light` | yes | `acme` | (none) |
 | 2 | A | `acme` | `(none)` | `light` | no | `(none)` | `warn: Brand "acme" is not registered` |
 | 3 | A | `acme` | `(none)` | `dark` | yes | `acme` | (none) |
 | 4 | A | `acme` | `(none)` | `dark` | no | `(none)` | `warn: Brand "acme" is not registered` |
 | 5 | A | `acme` | `(none)` | `high-contrast` | yes | `(none)` | `info: Brand "acme" is suppressed on theme="high-contrast"` |
 | 6 | A | `acme` | `(none)` | `high-contrast` | no | `(none)` | `warn: Brand "acme" is not registered` |
-| 7 | B | `''` | `acme` | `light` | yes (`acme` registered) | `acme` (untouched) | (none) |
-| 8 | B | `''` | `acme` | `light` | no (`acme` not registered) | `acme` (untouched) | (none) |
-| 9 | B | `''` | `acme` | `dark` | yes | `acme` (untouched) | (none) |
-| 10 | B | `''` | `acme` | `dark` | no | `acme` (untouched) | (none) |
-| 11 | B | `''` | `acme` | `high-contrast` | yes | `acme` (untouched) | (none) |
-| 12 | B | `''` | `acme` | `high-contrast` | no | `acme` (untouched) | (none) |
-| 13 | C | `acme` | `acme` | `light` | yes | `acme` (no change observed) | (none) |
-| 14 | C | `acme` | `acme` | `light` | no | `(none)` | `warn: Brand "acme" is not registered` |
-| 15 | C | `acme` | `acme` | `dark` | yes | `acme` (no change observed) | (none) |
-| 16 | C | `acme` | `acme` | `dark` | no | `(none)` | `warn: Brand "acme" is not registered` |
-| 17 | C | `acme` | `acme` | `high-contrast` | yes | `(none)` | `info: ... suppressed on theme="high-contrast"` |
-| 18 | C | `acme` | `acme` | `high-contrast` | no | `(none)` | `warn: Brand "acme" is not registered` |
-| 19 | D | `acme` | `other` | `light` | yes (`acme` registered) | `acme` (overwrites `other`) | (none) |
-| 20 | D | `acme` | `other` | `light` | no (`acme` not registered) | `(none)` | `warn: Brand "acme" is not registered` |
+| 7 | B | `''` | `acme` | `light` | n/a | `acme` (untouched) | (none) |
+| 8 | B | `''` | `acme` | `light` | n/a | `acme` (untouched) | (none) |
+| 9 | B | `''` | `acme` | `dark` | n/a | `acme` (untouched) | (none) |
+| 10 | B | `''` | `acme` | `dark` | n/a | `acme` (untouched) | (none) |
+| 11 | B | `''` | `acme` | `high-contrast` | n/a | `acme` (untouched) | (none) — author-responsible HC guard |
+| 12 | B | `''` | `acme` | `high-contrast` | n/a | `acme` (untouched) | (none) |
+| 13 | C | `acme` | `acme` | `light` | yes | `acme` (no `setAttribute` call when `current === target`) | (none) |
+| 14 | C | `acme` | `acme` | `light` | no | `acme` (untouched — registry inactive) | `warn: Brand "acme" is not registered` |
+| 15 | C | `acme` | `acme` | `dark` | yes | `acme` (no `setAttribute` call) | (none) |
+| 16 | C | `acme` | `acme` | `dark` | no | `acme` (untouched) | `warn: Brand "acme" is not registered` |
+| 17 | C | `acme` | `acme` | `high-contrast` | yes | `(none)` (HC-suppressed) | `info: ... suppressed on theme="high-contrast"` |
+| 18 | C | `acme` | `acme` | `high-contrast` | no | `acme` (untouched — registry inactive, author HC guard) | `warn: Brand "acme" is not registered` |
+| 19 | D | `acme` | `other` | `light` | yes | `acme` (overwrites `other`) | (none) |
+| 20 | D | `acme` | `other` | `light` | no (`acme` not registered) | `other` (untouched — registry inactive) | `warn: Brand "acme" is not registered` |
 | 21 | D | `acme` | `other` | `dark` | yes | `acme` (overwrites `other`) | (none) |
-| 22 | D | `acme` | `other` | `dark` | no | `(none)` | `warn: Brand "acme" is not registered` |
-| 23 | D | `acme` | `other` | `high-contrast` | yes | `(none)` | `info: ... suppressed on theme="high-contrast"` |
-| 24 | D | `acme` | `other` | `high-contrast` | no | `(none)` | `warn: Brand "acme" is not registered` |
+| 22 | D | `acme` | `other` | `dark` | no | `other` (untouched) | `warn: Brand "acme" is not registered` |
+| 23 | D | `acme` | `other` | `high-contrast` | yes | `(none)` (HC-suppressed) | `info: ... suppressed on theme="high-contrast"` |
+| 24 | D | `acme` | `other` | `high-contrast` | no | `other` (untouched — registry inactive) | `warn: Brand "acme" is not registered` |
 
-### Shape D under HC, registered (case 23) — note on stripping
+### Note — Shape D under HC, registered (case 23): why both values are stripped
 
-The runtime strips both `acme` and `other` under HC. There is no daylight between "the registered brand was suppressed because of HC" and "a stale `other` value lingered from SSR" — both produce CSS-pattern leaks if left in place. Shape D consumers who want their author-supplied `other` value preserved across HC must adopt Shape B authoring (drop the `brand` attribute when `data-brand` is the only override desired).
+When `brand="acme"` is registered and `theme="high-contrast"`, the runtime authoritatively asserts the registered-brand HC suppression. `data-brand="other"` is wiped because the runtime cannot distinguish "stale SSR drift" from "deliberate cascade-only fallback for HC" — and even the latter would breach the 7:1+ contract if author CSS lacked `:not([theme='high-contrast'])` guards. Authors who want their author-supplied `other` value preserved across HC must adopt Shape B (drop the `brand` attribute). The transition from case 23 → case 19 (HC exit) restores `acme`, not `other`; the author's `other` value is permanently lost across the HC enter/exit cycle. This is intentional and documented as part of the contract — Shape D registered + HC is lossy by design.
 
-### Shape B under HC (cases 11, 12) — note on guard responsibility
+### Note — Shape D unregistered (cases 20, 22, 24): why the author value is preserved
 
-The runtime does not strip `data-brand` under HC when `brand=""`. The author opted into the cascade-only path; the HC guard is the author's responsibility (the canonical `:not([theme='high-contrast'])` selector form documented in `multi-brand-theming.md`). This preserves the existing Shape B contract — the runtime touching `data-brand` it never set would be the more surprising failure mode.
+When `brand="acme"` is **not** registered, the JS registry path is inactive. `getBrandTokens('acme')` returns `undefined`, the merge is rejected, and the existing unregistered-brand `console.warn` fires. In this state, the runtime has no positive token contribution to make. The cascade-only path (`hx-theme[data-brand='other'] { ... }` selectors authored by the consumer) is the only working override, and stripping `other` would silently eliminate it. The R0 "aggressive cleanup" model stripped `other` here on the rationale that `brand !== ''` is universal authorization; codex flagged this as silent destruction of author intent. R1 narrows authorization to **registered** brands only.
+
+### Note — Shape B under HC (cases 11, 12): explicit safety implication
+
+The runtime does **not** strip `data-brand` under HC when `brand=''`. Shape B authors deliberately opt out of the JS registry path and adopt cascade-only authoring. The runtime touching `data-brand` it never authored would violate the Shape B contract.
+
+**This is an unsafe escape hatch unless the author guards their CSS-pattern selectors with `:not([theme='high-contrast'])`.** Without that guard, the cascade overrides applied via `[data-brand='X']` selectors leak into the HC token cascade, and components that consume those primitives directly (`hx-checkbox`, `hx-tag`, `hx-list-item`, `hx-date-picker`, etc.) silently break the WCAG 7:1+ contract.
+
+The runtime cannot enforce the guard — the cascade rules live in author stylesheets the runtime never sees. This safety implication is loud-documented in `multi-brand-theming.md` (existing) and in the contract's Shape B note (this document). Authors who want runtime-enforced HC safety must use Shape A or Shape C with a registered brand.
+
+The 3.3.0 docs delta clarifies this asymmetry rather than papering over it. Shape B remains supported because cascade-only authoring is a legitimate use case for design teams who do not own the JS bootstrap path; HC safety in that mode is a documented ownership transfer.
+
+### Note — case 18 vs. case 17: registered vs. unregistered + HC
+
+Both cases mount with matching `brand="acme" data-brand="acme"`. The runtime branches on registration:
+
+- Registered (case 17) → runtime asserts ownership, strips `data-brand`, info-logs HC suppression.
+- Unregistered (case 18) → registry path inactive, runtime leaves `data-brand="acme"` untouched, warns about unregistered brand. Same authoring shape, different outcome — the registry is the gate.
+
+Case 18 carries the same "author HC guard responsibility" note as Shape B. The unregistered-brand warn fires; whether the cascade is HC-guarded is the author's job.
 
 ## State transitions
 
-Beyond the initial-mount matrix, runtime swaps must remain coherent:
+The initial-mount matrix is necessary but not sufficient. Runtime swaps must remain coherent.
 
 | Transition | Expected behavior |
-|---|---|
-| `brand="acme"` → `brand="other"` (both registered) | `data-brand` updates from `acme` → `other` (assuming light/dark theme) |
-| `brand="acme"` → `brand=""` while runtime owns `data-brand` | Remove `data-brand` (runtime relinquishes management) |
-| `brand="acme"` → `brand=""` when author-set `data-brand` was never overwritten (Shape B + brand briefly set?) | Edge case: NOT supported. Authoring shapes do not mix mid-flight. |
-| `theme="light"` → `theme="high-contrast"` while `brand="acme"` registered | `data-brand="acme"` removed (HC suppression) |
-| `theme="high-contrast"` → `theme="light"` while `brand="acme"` registered | `data-brand="acme"` re-set (HC exit) |
-| `theme="auto"` resolving from `light` → `dark` via OS query | `data-brand` unchanged (both light and dark set it; the value is identical) |
-| `theme="auto"` resolving from `light` → `dark` via OS where dark→hc would not happen — theme=auto cannot resolve to HC | n/a |
+| --- | --- |
+| `brand="acme"` → `brand="other"` (both registered, light or dark) | `data-brand` updates `acme` → `other`. `lastApplied.value` updates `acme` → `other`. |
+| `brand="acme"` (registered, light/dark) → `brand=""` | `lastApplied.kind === 'set'` and current matches → REMOVE `data-brand`, reset `lastApplied` to `unmanaged`. |
+| `brand="acme"` (registered, light/dark) → external `setAttribute('data-brand','x')` → `brand=""` | `lastApplied.kind === 'set'` but current `'x' !== 'acme'` → NOOP, reset to `unmanaged`. Author's `'x'` survives the relinquish. |
+| `brand="acme"` (registered) → `theme="light"` → `theme="high-contrast"` | `data-brand="acme"` removed. `lastApplied.kind === 'cleared'`. |
+| `brand="acme"` (registered) → `theme="high-contrast"` → `theme="light"` | `data-brand="acme"` re-set. `lastApplied = { kind: 'set', value: 'acme' }`. |
+| `brand="acme"` (unregistered at mount) → `HelixBrandRegistry.register('acme', …)` later | Registry-subscribed reconcile fires automatically — see "Late registration" below. `data-brand="acme"` set after registration. |
+| `brand="acme"` registered, then `HelixBrandRegistry._clear()` (test path) | Registry-subscribed reconcile fires. `acme` no longer registered → leave `data-brand` untouched per case 14/16/18 path. |
+| `theme="auto"` resolves `light` → `dark` via OS query while `brand="acme"` registered | `data-brand="acme"` unchanged (light and dark both set the same value); `lastApplied` value unchanged. |
+
+`theme="auto"` cannot resolve to `high-contrast` (the OS query is `prefers-color-scheme`, which has no HC value); the `auto` → HC transition does not exist as a runtime path.
+
+## Late registration — the registry subscription API
+
+**Problem (codex finding 1, high).** A component that mounts with `brand="acme"` before `HelixBrandRegistry.register('acme', …)` runs lands in the unregistered path (case 2 / 4 / 6) and stays there indefinitely. There is no event channel from the registry to the component. The R0 contract had no way to recover from late registration without a manual property toggle from the application.
+
+**Decision.** Add an additive `subscribe(brandName, callback)` API to `HelixBrandRegistry`. The signature is small and isolated to `packages/hx-tokens/src/brand-registry.ts`:
+
+```ts
+subscribe(brandName: string, callback: () => void): () => void {
+  // Adds callback to the listener set for brandName. Returns an unsubscribe
+  // function. The callback fires synchronously after register(brandName, ...)
+  // succeeds and after _clear() removes the brand.
+}
+```
+
+`register()` and `_clear()` invoke `_notify(brandName)` after mutating `_brands`. The notification is synchronous and idempotent across re-registrations.
+
+`hx-theme` lifecycle:
+
+- `connectedCallback`: if `this.brand !== ''`, subscribe to that brand and store the unsubscribe handle.
+- `updated()` when `brand` changes from `'a'` to `'b'`: invoke the stored unsubscribe, subscribe to `'b'`, store the new unsubscribe.
+- `disconnectedCallback`: invoke the stored unsubscribe.
+
+The subscription callback delegates to `_applyEffectiveTheme()` (the existing reconcile entry point). After registry change, the component re-runs reconcile against the new registry state — case 2 transitions to case 1, case 14 transitions to case 13, etc.
+
+This makes the contract independent of bootstrap order. Registration before mount, registration after mount, and registration removal all converge on the matrix.
+
+**Why not narrow the contract to "register-before-mount only" instead.** A precondition-only design forces every consumer to coordinate brand registration with element bootstrap. In Drupal multisite, that coordination is fragile — themes lazy-load brand bundles after the document has hydrated. Asking every consumer to poll `HelixBrandRegistry.isRegistered()` and toggle the `brand` property to force a reconcile is an API smell. The subscription API is ~30 LOC in `brand-registry.ts` and removes the ordering hazard entirely. Worth it.
+
+**Token version note.** The subscribe API is additive — no breaking change to `register()`, `getBrandTokens()`, `isRegistered()`, `validateTokens()`, `_clear()`. Bumps `@helixui/tokens` to 3.3.0 minor (new public API surface) alongside `@helixui/library` 3.3.0 minor (consumer of new API). The library `peerDependency` constraint on tokens widens to `^3.3.0`.
 
 ## Ownership tracking
 
-The runtime maintains a private `_managedDataBrand: string | null` flag:
+**Problem (codex finding 2, medium).** A boolean-equivalent ownership flag (`_managedDataBrand: string | null`) cannot distinguish between "the runtime once managed the attribute and the current value is still the runtime's" and "the runtime once managed the attribute but the author has since overwritten." On `brand=""` relinquish with the latter state, a naive flag would delete the author's value.
 
-- Initial value: `null` (runtime is not the manager).
-- On reconcile when `brand !== ''`: runtime enters managed state. Even if the eventual decision is REMOVE (HC, unregistered), the slot tracks "we last touched it."
-- On reconcile when `brand === ''`: if `_managedDataBrand` was non-null, runtime emits a final REMOVE to clean up its own past writes, then resets to `null`. If `_managedDataBrand` was already `null`, NOOP.
-- On `disconnectedCallback`: do **not** strip `data-brand`. The element is leaving the tree; cleanup is the framework's responsibility, and stripping during teardown causes a flash for moved-not-removed nodes.
+**Decision.** Use a discriminated union:
 
-This handles the `brand="acme"` → `brand=""` transition cleanly without breaking Shape B (where `_managedDataBrand` never transitions away from `null`).
+```ts
+type LastApplied =
+  | { kind: 'unmanaged' }                 // initial; runtime never touched
+  | { kind: 'set'; value: string }        // last setAttribute('data-brand', value)
+  | { kind: 'cleared' };                  // last removeAttribute('data-brand')
+```
 
-## SSR adoption (Shape C)
+Relinquish (`brand=""`) reads the current attribute and compares to `lastApplied`:
 
-When the page renders with `<hx-theme brand="acme" data-brand="acme">` and the component connects:
+- `kind === 'set'` AND `current === value` → REMOVE; the runtime's prior write is still live, safe to clean up.
+- `kind === 'set'` AND `current !== value` → NOOP; author has overwritten, the runtime no longer owns the value.
+- `kind === 'cleared'` → NOOP; runtime previously cleared, regardless of current state.
+- `kind === 'unmanaged'` → NOOP; nothing to relinquish.
 
-1. `firstUpdated` fires. `brand` is `"acme"`. Reconcile runs.
-2. Decision: SET `data-brand="acme"`. Already `acme`. The DOM mutation observer (if any external one is watching) sees no change — `setAttribute` to the same value is a no-op in spec but DOES fire `MutationObserver.attributes` mutations. To avoid spurious mutations, the runtime checks `current === target` before calling `setAttribute`.
-3. `_managedDataBrand` transitions to `"acme"`. The runtime now owns the attribute.
+After relinquish the slot resets to `unmanaged`.
 
-Mismatched SSR (Shape D) follows the same path with one extra step: step 2 detects `current !== target`, calls `setAttribute('data-brand', 'acme')`. The mismatched `other` is overwritten.
+This handles the external-mutation-during-managed scenario without false-positive cleanup.
 
-## Mutation guard
+## Mutation guard precision
 
-The runtime does **not** observe the `data-brand` attribute for external mutations after adoption. If author-side code (e.g. a Drupal behavior, a third-party theme switcher) sets `data-brand="x"` while `brand="y"` is still set, the next reconcile (triggered by any property change to `brand`/`theme`/`motion`/`density` or by an `auto` theme media-query event) overwrites the external write. This is the cost of the aggressive cleanup model, and is consistent with the contract: `brand !== ''` is universal authorization.
+**Problem (codex finding 5, medium).** R0 wording — "`brand !== ''` is universal authorization" — overstates what the design enforces. Without a `MutationObserver` on `data-brand`, external writes between reconcile triggers persist for arbitrarily long periods. The runtime is not continuously authoritative; it is authoritative *at reconcile boundaries*.
 
-Authors who want to control `data-brand` independently must use Shape B (no `brand` attribute) or unset `brand` before mutating `data-brand`.
+**Decision.** Reword and scope precisely.
+
+> The runtime is authoritative for `data-brand` at reconcile boundaries — that is, on `brand`, `theme`, `motion`, or `density` property changes, on `auto` theme media-query events, and on registry subscription notifications. Between reconcile boundaries, external mutations to `data-brand` persist. The next reconcile event reasserts the runtime's intended state per the matrix above.
+
+`MutationObserver` is intentionally not used. The cost (synchronous per-mutation reconcile, microtask churn under any framework that touches DOM attributes) outweighs the benefit (eventual consistency that already exists at every reconcile boundary). Authors who want continuous ownership semantics must avoid external mutation of `data-brand` while `brand !== ''` is set.
 
 ## Drupal Twig alignment
 
-`packages/hx-library/src/components/hx-theme/hx-theme.twig` drops the `data-brand` emission entirely. Today (post-R31 cleanup) the helper emits only `brand="..."`; the runtime now performs the reflection. This removes the dual-source-of-truth between Twig and runtime that R26–R29 chased.
+`packages/hx-library/src/components/hx-theme/hx-theme.twig` already drops `data-brand` emission as of R31 cleanup; the helper emits only `brand="..."` and the runtime now performs the reflection. This removes the dual-source-of-truth between Twig and runtime that R26-R29 chased.
 
-The `attributes` spread retains the ability to set arbitrary HTML attributes including `data-brand` (Shape B). Templates that explicitly want CSS-pattern-only authoring continue to work; templates that pass `data-brand` AND `brand` get the runtime's aggressive cleanup behavior on hydration.
+The `attributes` spread retains the ability to set arbitrary HTML attributes including `data-brand` (Shape B authoring from a Twig template). Templates that explicitly want CSS-pattern-only authoring continue to work; templates that pass `data-brand` AND `brand` get the runtime's reconcile behavior on hydration per the registered/unregistered matrix above.
 
 ## Documentation alignment
 
@@ -160,25 +244,37 @@ The `attributes` spread retains the ability to set arbitrary HTML attributes inc
 
 > "The runtime does not reflect `brand` to `data-brand`."
 
-to:
+to a longer block covering:
 
-> "The runtime reflects `brand` to `data-brand` on `theme="light"` and `theme="dark"` when the brand is registered. The reflection is suppressed on `theme="high-contrast"` and on unregistered brand names. Set `data-brand` independently of `brand` (the cascade-only path) by omitting the `brand` attribute. See [`BRAND_REFLECTION_CONTRACT.md`](./brand-reflection-contract.md)."
+- Reflection contract (registered + light/dark → set; registered + HC → strip; unregistered → no-op).
+- Late-registration safety (subscription-based reconcile; mount order does not matter).
+- Shape B safety implication (author owns HC guard for cascade-only path).
+- Pointer to `BRAND_REFLECTION_CONTRACT.md` for the full matrix.
 
-The `BRAND_THEMING.md` registry-path doc gains a "data-brand reflection" subsection pointing to this contract.
+The `BRAND_THEMING.md` registry-path doc gains a "Reflection to `data-brand`" subsection pointing to this contract.
 
 ## Test matrix file
 
-`packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` enumerates all 24 cases plus the state-transition table as `it.todo()` placeholders during the design phase. Each test signature names its case number from this contract so the matrix and the test file stay traceable.
+`packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` enumerates the 24 cases plus state transitions and the structural edges codex flagged as test gaps:
 
-When implementation begins, the `it.todo` calls flip to real assertions. Codex reviews the final diff once. Iteration through codex on this contract surface is explicitly out of scope — the matrix is decided here.
+- 24 row cases (one `it.todo` per row of the matrix).
+- 5 state-transition cases.
+- 2 reconcile-boundary mutation guard cases (preserved from R0): external `setAttribute('data-brand', 'x')` and external `removeAttribute('data-brand')` while `brand` is active — both survive until the next reconcile, then revert to the runtime's intended state.
+- 3 edge cases added in R1 per codex finding 6:
+  - **Late registration**: `brand="acme"` mounts before register; `data-brand` stays unset (case 2 path); subsequent `register('acme', …)` triggers subscription-driven reconcile; `data-brand="acme"` set without a manual property toggle.
+  - **Ownership relinquish under external override**: `brand="acme"` set + runtime sets `data-brand="acme"` → author externally `setAttribute('data-brand','x')` → `brand=""` set; `data-brand="x"` survives the relinquish.
+  - **Advisory dedupe**: `brand="acme"` unregistered, theme reconcile fires twice (e.g. theme prop change + auto media-query event); `console.warn` emits once. Pins the existing `_lastBrandAdvisoryKey` deduplication.
+- 1 disconnect case (`disconnectedCallback` does not strip — moved-not-removed nodes do not flash).
+
+Total: 35 `it.todo()` cases on the test stub. When the contract flips to implementation, every `it.todo` becomes a real assertion. Codex review on the implementation diff is the standard merge-gate codex pass; iteration on the contract surface is explicitly out of scope per the planning rule.
 
 ## Out-of-scope (intentionally)
 
 - **HC brand-token category split** — sibling 3.3.0 work tracked at `00-Planning/helix/HC brand-token suppression scope + replaceSync failure mode (deferred from 3.2.2).md`. Until that lands, HC continues to suppress the entire brand merge (color and non-color tokens both).
 - **`replaceSync()` failure-mode hardening** — sibling 3.3.0 work, same planning note. Until that lands, malformed tokens still throw at apply-time rather than register-time.
 - **`brand` property typing** — currently `string`. A future TS-strict enhancement could narrow to `RegisteredBrandName | ''` via the registry. Out of scope for 3.3.0; would be a separate types-only change.
-- **Programmatic `data-brand` mutation reaction** — the runtime does not observe the attribute. External mutations are stomped on the next reconcile. Documented above.
+- **Continuous DOM observation of `data-brand`** — not used. Reconcile is event-bounded; documented above.
 
 ## Approval gate
 
-Per the planning note: this contract is the gate. Implementation does not begin until Jake confirms each row of the matrix is the desired behavior (or notes the rows that need to flip). Codex review runs once on the final diff — not iteratively on the contract.
+Per the planning rule and codex's R0 verdict, this contract is the gate. Implementation does not begin until Jake confirms each row of the matrix is the desired behavior (or notes the rows that need to flip). The single codex pass already happened on R0; R1 is the redesign that closes the findings. A second codex pass on R1 is welcome but the contract surface itself is closed: any further codex finding either (a) maps to a row that needs to flip — Jake decides — or (b) belongs to the implementation diff, not this document.

--- a/packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md
+++ b/packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md
@@ -142,6 +142,10 @@ The runtime cannot enforce the guard — the cascade rules live in author styles
 
 The 3.3.0 docs delta clarifies this asymmetry rather than papering over it. Shape B remains supported because cascade-only authoring is a legitimate use case for design teams who do not own the JS bootstrap path; HC safety in that mode is a documented ownership transfer.
 
+### Note — HC suppression info dedupe
+
+The HC-suppression `info` log (cases 5, 17, 23) is deduped via the same `_lastBrandAdvisoryKey` channel as the unregistered-brand `warn`. Two consecutive reconciles in the same `(brand, theme="high-contrast")` tuple — for example a `theme` prop change followed by an `auto` media-query event firing in the same tick — emit the info log exactly once. The advisory key resets when `(brand, theme)` changes; re-entering HC after an exit re-emits.
+
 ### Note — case 18 vs. case 17: registered vs. unregistered + HC
 
 Both cases mount with matching `brand="acme" data-brand="acme"`. The runtime branches on registration:
@@ -165,8 +169,9 @@ The initial-mount matrix is necessary but not sufficient. Runtime swaps must rem
 | `brand="acme"` (unregistered at mount) → `HelixBrandRegistry.register('acme', …)` later | Registry-subscribed reconcile fires automatically — see "Late registration" below. `data-brand="acme"` set after registration. |
 | `brand="acme"` registered, then `HelixBrandRegistry._clear()` (test path) | Registry-subscribed reconcile fires. `acme` no longer registered → leave `data-brand` untouched per case 14/16/18 path. |
 | `theme="auto"` resolves `light` → `dark` via OS query while `brand="acme"` registered | `data-brand="acme"` unchanged (light and dark both set the same value); `lastApplied` value unchanged. |
+| `brand="acme" data-brand="other"` (registered) → `theme="high-contrast"` → `theme="light"` | Round-trip is lossy by design: HC enter strips `data-brand` (case 23 path); HC exit re-applies the runtime's owned value `acme`, not the author's pre-HC `other`. The `LastApplied` union does not retain a pre-HC `prior` slot — adding one would be a contract-surface change. |
 
-`theme="auto"` cannot resolve to `high-contrast` (the OS query is `prefers-color-scheme`, which has no HC value); the `auto` → HC transition does not exist as a runtime path.
+`theme="auto"` cannot resolve to `high-contrast` (the OS query is `prefers-color-scheme`, which has no HC value); the `auto` → HC transition does not exist as a runtime path. The test stub pins this negative guarantee with an explicit `it.todo` so a future hypothetical `prefers-contrast: more` mapping into `auto` cannot silently introduce HC-via-auto without breaking a test.
 
 ## Late registration — the registry subscription API
 
@@ -182,7 +187,11 @@ subscribe(brandName: string, callback: () => void): () => void {
 }
 ```
 
-`register()` and `_clear()` invoke `_notify(brandName)` after mutating `_brands`. The notification is synchronous and idempotent across re-registrations.
+`register()` and `_clear()` invoke `_notify(brandName)` after mutating `_brands`. Notification semantics:
+
+- `_notify(brandName)` fires synchronously after every successful `register(brandName, ...)` and every `_clear(brandName)`. Re-registration with a different token body fires `_notify` again (the token diff is a state transition the subscriber should observe).
+- A `register()` call that fails `validateTokens()` does **not** fire `_notify` — the registry was not mutated, so there is no state change to notify.
+- Subscriber callbacks that throw do not propagate to other subscribers; `_notify()` catches and surfaces via `console.error` so a single faulty subscriber cannot break the notification fan-out.
 
 `hx-theme` lifecycle:
 
@@ -258,15 +267,16 @@ The `BRAND_THEMING.md` registry-path doc gains a "Reflection to `data-brand`" su
 `packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` enumerates the 24 cases plus state transitions and the structural edges codex flagged as test gaps:
 
 - 24 row cases (one `it.todo` per row of the matrix).
-- 5 state-transition cases.
+- 7 state-transition cases (5 R0 + 2 R1-clarification: `auto` → HC non-existence, Shape D registered HC round-trip lossy-by-design).
 - 2 reconcile-boundary mutation guard cases (preserved from R0): external `setAttribute('data-brand', 'x')` and external `removeAttribute('data-brand')` while `brand` is active — both survive until the next reconcile, then revert to the runtime's intended state.
-- 3 edge cases added in R1 per codex finding 6:
+- 4 edge cases added in R1 per codex finding 6 + R1-clarification:
   - **Late registration**: `brand="acme"` mounts before register; `data-brand` stays unset (case 2 path); subsequent `register('acme', …)` triggers subscription-driven reconcile; `data-brand="acme"` set without a manual property toggle.
   - **Ownership relinquish under external override**: `brand="acme"` set + runtime sets `data-brand="acme"` → author externally `setAttribute('data-brand','x')` → `brand=""` set; `data-brand="x"` survives the relinquish.
-  - **Advisory dedupe**: `brand="acme"` unregistered, theme reconcile fires twice (e.g. theme prop change + auto media-query event); `console.warn` emits once. Pins the existing `_lastBrandAdvisoryKey` deduplication.
-- 1 disconnect case (`disconnectedCallback` does not strip — moved-not-removed nodes do not flash).
+  - **Advisory dedupe (warn channel)**: `brand="acme"` unregistered, theme reconcile fires twice; `console.warn` emits once. Pins `_lastBrandAdvisoryKey` deduplication on the warn channel.
+  - **Advisory dedupe (info channel)**: `brand="acme"` registered, `theme="high-contrast"`, reconcile fires twice; `console.info` HC-suppression emits once. Pins the same deduplication channel for info.
+- 1 disconnect case (`disconnectedCallback` does not strip — moved-not-removed nodes do not flash; registry subscription unsubscribes).
 
-Total: 35 `it.todo()` cases on the test stub. When the contract flips to implementation, every `it.todo` becomes a real assertion. Codex review on the implementation diff is the standard merge-gate codex pass; iteration on the contract surface is explicitly out of scope per the planning rule.
+Total: 38 `it.todo()` cases on the test stub. When the contract flips to implementation, every `it.todo` becomes a real assertion. Codex review on the implementation diff is the standard merge-gate codex pass; iteration on the contract surface is explicitly out of scope per the planning rule.
 
 ## Out-of-scope (intentionally)
 

--- a/packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts
+++ b/packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts
@@ -63,19 +63,19 @@ describe('hx-theme brand → data-brand reflection contract (3.3.0)', () => {
       'Case 13 — light + registered: keeps data-brand="acme" (no setAttribute call when current === target)',
     );
     it.todo(
-      'Case 14 — light + unregistered: removes data-brand, warns about unregistered brand',
+      'Case 14 — light + unregistered: leaves data-brand="acme" untouched (registry inactive), warns about unregistered brand',
     );
     it.todo(
       'Case 15 — dark + registered: keeps data-brand="acme" (no setAttribute call)',
     );
     it.todo(
-      'Case 16 — dark + unregistered: removes data-brand, warns about unregistered brand',
+      'Case 16 — dark + unregistered: leaves data-brand="acme" untouched (registry inactive), warns about unregistered brand',
     );
     it.todo(
       'Case 17 — high-contrast + registered: removes data-brand, info-logs HC suppression',
     );
     it.todo(
-      'Case 18 — high-contrast + unregistered: removes data-brand, warns about unregistered brand',
+      'Case 18 — high-contrast + unregistered: leaves data-brand="acme" untouched (registry inactive, author HC guard), warns about unregistered brand',
     );
   });
 
@@ -85,35 +85,35 @@ describe('hx-theme brand → data-brand reflection contract (3.3.0)', () => {
       'Case 19 — light + brand-registered: overwrites data-brand "other" → "acme", no console output',
     );
     it.todo(
-      'Case 20 — light + brand-unregistered: removes data-brand "other", warns about unregistered brand',
+      'Case 20 — light + brand-unregistered: leaves data-brand="other" untouched (registry inactive), warns about unregistered brand',
     );
     it.todo(
       'Case 21 — dark + brand-registered: overwrites data-brand "other" → "acme", no console output',
     );
     it.todo(
-      'Case 22 — dark + brand-unregistered: removes data-brand "other", warns about unregistered brand',
+      'Case 22 — dark + brand-unregistered: leaves data-brand="other" untouched (registry inactive), warns about unregistered brand',
     );
     it.todo(
       'Case 23 — high-contrast + brand-registered: removes data-brand entirely (strips both), info-logs HC suppression',
     );
     it.todo(
-      'Case 24 — high-contrast + brand-unregistered: removes data-brand entirely, warns about unregistered brand',
+      'Case 24 — high-contrast + brand-unregistered: leaves data-brand="other" untouched (registry inactive), warns about unregistered brand',
     );
   });
 
   // ─── State transitions ───────────────────────────────────────────────────
   describe('State transitions', () => {
     it.todo(
-      'brand="acme" → brand="other" (both registered, light theme): data-brand updates acme → other',
+      'brand="acme" → brand="other" (both registered, light theme): data-brand updates acme → other; lastApplied.value updates acme → other',
     );
     it.todo(
-      'brand="acme" → brand="" while runtime owns data-brand: removes data-brand, _managedDataBrand resets to null',
+      'brand="acme" (registered, light) → brand="": lastApplied.kind === "set" and current matches → REMOVE data-brand, lastApplied resets to "unmanaged"',
     );
     it.todo(
-      'theme="light" → theme="high-contrast" while brand="acme" registered: data-brand removed (HC suppression)',
+      'theme="light" → theme="high-contrast" while brand="acme" registered: data-brand removed (HC suppression); lastApplied.kind === "cleared"',
     );
     it.todo(
-      'theme="high-contrast" → theme="light" while brand="acme" registered: data-brand re-set to "acme"',
+      'theme="high-contrast" → theme="light" while brand="acme" registered: data-brand re-set to "acme"; lastApplied = { kind: "set", value: "acme" }',
     );
     it.todo(
       'theme="auto" with brand="acme" registered, OS prefers-color-scheme flips light → dark: data-brand="acme" unchanged (both light/dark set the same value)',
@@ -121,19 +121,34 @@ describe('hx-theme brand → data-brand reflection contract (3.3.0)', () => {
   });
 
   // ─── Mutation guard ──────────────────────────────────────────────────────
-  describe('External mutation guard', () => {
+  // Authoritative AT reconcile boundaries — external writes between reconciles
+  // persist; the next reconcile event reasserts the runtime's intended state.
+  describe('External mutation guard (reconcile-boundary semantics)', () => {
     it.todo(
-      'External setAttribute("data-brand", "x") while brand="y" survives until next reconcile, then reverts to "y"',
+      'External setAttribute("data-brand", "x") while brand="y" registered: survives until next reconcile, then reverts to "y"',
     );
     it.todo(
-      'External removeAttribute("data-brand") while brand="acme" registered survives until next reconcile, then re-sets to "acme"',
+      'External removeAttribute("data-brand") while brand="acme" registered: survives until next reconcile, then re-sets to "acme"',
+    );
+  });
+
+  // ─── R1 edge cases (codex finding 6 — test gap closures) ─────────────────
+  describe('R1 edge cases', () => {
+    it.todo(
+      'Late registration: brand="acme" mounts before HelixBrandRegistry.register("acme", ...) — data-brand stays unset (case 2 path); subsequent register() triggers subscription-driven reconcile; data-brand="acme" set without manual property toggle',
+    );
+    it.todo(
+      'Ownership relinquish under external override: brand="acme" registered → runtime sets data-brand="acme" → external setAttribute("data-brand","x") → brand="" — data-brand="x" survives the relinquish (lastApplied.kind === "set" but current !== value → NOOP)',
+    );
+    it.todo(
+      'Advisory dedupe: brand="acme" unregistered, theme reconcile fires twice (theme prop change + auto media-query event) — console.warn emits exactly once (pins _lastBrandAdvisoryKey deduplication)',
     );
   });
 
   // ─── disconnectedCallback ────────────────────────────────────────────────
   describe('disconnectedCallback', () => {
     it.todo(
-      'Element disconnected while owning data-brand: attribute is left in place (no flash for moved-not-removed nodes)',
+      'Element disconnected while owning data-brand: attribute is left in place (no flash for moved-not-removed nodes); registry subscription unsubscribes',
     );
   });
 });

--- a/packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts
+++ b/packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts
@@ -118,6 +118,12 @@ describe('hx-theme brand → data-brand reflection contract (3.3.0)', () => {
     it.todo(
       'theme="auto" with brand="acme" registered, OS prefers-color-scheme flips light → dark: data-brand="acme" unchanged (both light/dark set the same value)',
     );
+    it.todo(
+      'theme="auto" with brand="acme" registered: HC suppression branch is never entered via auto resolution (auto→HC transition is non-existent by design — pins the contract guarantee against a hypothetical future prefers-contrast: more mapping)',
+    );
+    it.todo(
+      'brand="acme" data-brand="other" (registered) → theme="high-contrast" → theme="light": HC enter strips data-brand (case 23 path); HC exit re-applies "acme", not "other" — round-trip is lossy by design',
+    );
   });
 
   // ─── Mutation guard ──────────────────────────────────────────────────────
@@ -141,7 +147,10 @@ describe('hx-theme brand → data-brand reflection contract (3.3.0)', () => {
       'Ownership relinquish under external override: brand="acme" registered → runtime sets data-brand="acme" → external setAttribute("data-brand","x") → brand="" — data-brand="x" survives the relinquish (lastApplied.kind === "set" but current !== value → NOOP)',
     );
     it.todo(
-      'Advisory dedupe: brand="acme" unregistered, theme reconcile fires twice (theme prop change + auto media-query event) — console.warn emits exactly once (pins _lastBrandAdvisoryKey deduplication)',
+      'Advisory dedupe (warn channel): brand="acme" unregistered, theme reconcile fires twice (theme prop change + auto media-query event) — console.warn emits exactly once (pins _lastBrandAdvisoryKey deduplication)',
+    );
+    it.todo(
+      'Advisory dedupe (info channel): brand="acme" registered, theme="high-contrast", reconcile fires twice in same tick — console.info HC-suppression message emits exactly once (same _lastBrandAdvisoryKey channel covers info)',
     );
   });
 

--- a/packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts
+++ b/packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts
@@ -1,0 +1,139 @@
+import { describe, it } from 'vitest';
+
+// hx-theme — `brand` → `data-brand` auto-reflection contract (3.3.0)
+//
+// Status: design-phase placeholders. The 24 it.todo() cases below pin the
+// contract from BRAND_REFLECTION_CONTRACT.md so any future change has to
+// reckon with the matrix as a unit. They flip to real assertions once
+// Jake signs off on the contract surface.
+//
+// The test signatures intentionally name their case number ("Case 1", "Case 2",
+// ...) and shape ("Shape A", "Shape B", "Shape C", "Shape D") so the matrix
+// in the contract document stays traceable to the test file. Reordering or
+// renumbering must touch both files together.
+
+describe('hx-theme brand → data-brand reflection contract (3.3.0)', () => {
+  // ─── Shape A: brand set, no data-brand ───────────────────────────────────
+  describe('Shape A — <hx-theme brand="X"> (no data-brand)', () => {
+    it.todo(
+      'Case 1 — light + registered: reflects data-brand="acme", no console output',
+    );
+    it.todo(
+      'Case 2 — light + unregistered: leaves data-brand unset, warns about unregistered brand',
+    );
+    it.todo(
+      'Case 3 — dark + registered: reflects data-brand="acme", no console output',
+    );
+    it.todo(
+      'Case 4 — dark + unregistered: leaves data-brand unset, warns about unregistered brand',
+    );
+    it.todo(
+      'Case 5 — high-contrast + registered: leaves data-brand unset, info-logs HC suppression',
+    );
+    it.todo(
+      'Case 6 — high-contrast + unregistered: leaves data-brand unset, warns about unregistered brand',
+    );
+  });
+
+  // ─── Shape B: data-brand set, no brand ───────────────────────────────────
+  describe('Shape B — <hx-theme data-brand="X"> (no brand)', () => {
+    it.todo(
+      'Case 7 — light + value-is-registered: leaves data-brand="acme" untouched, no console output',
+    );
+    it.todo(
+      'Case 8 — light + value-not-registered: leaves data-brand="acme" untouched, no console output',
+    );
+    it.todo(
+      'Case 9 — dark + value-is-registered: leaves data-brand="acme" untouched, no console output',
+    );
+    it.todo(
+      'Case 10 — dark + value-not-registered: leaves data-brand="acme" untouched, no console output',
+    );
+    it.todo(
+      'Case 11 — high-contrast + value-is-registered: leaves data-brand="acme" untouched, no console output (HC guard is author responsibility)',
+    );
+    it.todo(
+      'Case 12 — high-contrast + value-not-registered: leaves data-brand="acme" untouched, no console output',
+    );
+  });
+
+  // ─── Shape C: brand and data-brand match (SSR mirror) ────────────────────
+  describe('Shape C — <hx-theme brand="X" data-brand="X"> (matching SSR)', () => {
+    it.todo(
+      'Case 13 — light + registered: keeps data-brand="acme" (no setAttribute call when current === target)',
+    );
+    it.todo(
+      'Case 14 — light + unregistered: removes data-brand, warns about unregistered brand',
+    );
+    it.todo(
+      'Case 15 — dark + registered: keeps data-brand="acme" (no setAttribute call)',
+    );
+    it.todo(
+      'Case 16 — dark + unregistered: removes data-brand, warns about unregistered brand',
+    );
+    it.todo(
+      'Case 17 — high-contrast + registered: removes data-brand, info-logs HC suppression',
+    );
+    it.todo(
+      'Case 18 — high-contrast + unregistered: removes data-brand, warns about unregistered brand',
+    );
+  });
+
+  // ─── Shape D: brand and data-brand mismatch ──────────────────────────────
+  describe('Shape D — <hx-theme brand="X" data-brand="Y"> (mismatched)', () => {
+    it.todo(
+      'Case 19 — light + brand-registered: overwrites data-brand "other" → "acme", no console output',
+    );
+    it.todo(
+      'Case 20 — light + brand-unregistered: removes data-brand "other", warns about unregistered brand',
+    );
+    it.todo(
+      'Case 21 — dark + brand-registered: overwrites data-brand "other" → "acme", no console output',
+    );
+    it.todo(
+      'Case 22 — dark + brand-unregistered: removes data-brand "other", warns about unregistered brand',
+    );
+    it.todo(
+      'Case 23 — high-contrast + brand-registered: removes data-brand entirely (strips both), info-logs HC suppression',
+    );
+    it.todo(
+      'Case 24 — high-contrast + brand-unregistered: removes data-brand entirely, warns about unregistered brand',
+    );
+  });
+
+  // ─── State transitions ───────────────────────────────────────────────────
+  describe('State transitions', () => {
+    it.todo(
+      'brand="acme" → brand="other" (both registered, light theme): data-brand updates acme → other',
+    );
+    it.todo(
+      'brand="acme" → brand="" while runtime owns data-brand: removes data-brand, _managedDataBrand resets to null',
+    );
+    it.todo(
+      'theme="light" → theme="high-contrast" while brand="acme" registered: data-brand removed (HC suppression)',
+    );
+    it.todo(
+      'theme="high-contrast" → theme="light" while brand="acme" registered: data-brand re-set to "acme"',
+    );
+    it.todo(
+      'theme="auto" with brand="acme" registered, OS prefers-color-scheme flips light → dark: data-brand="acme" unchanged (both light/dark set the same value)',
+    );
+  });
+
+  // ─── Mutation guard ──────────────────────────────────────────────────────
+  describe('External mutation guard', () => {
+    it.todo(
+      'External setAttribute("data-brand", "x") while brand="y" survives until next reconcile, then reverts to "y"',
+    );
+    it.todo(
+      'External removeAttribute("data-brand") while brand="acme" registered survives until next reconcile, then re-sets to "acme"',
+    );
+  });
+
+  // ─── disconnectedCallback ────────────────────────────────────────────────
+  describe('disconnectedCallback', () => {
+    it.todo(
+      'Element disconnected while owning data-brand: attribute is left in place (no flash for moved-not-removed nodes)',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Design-only changeset for 3.3.0 `brand` → `data-brand` auto-reflection. **No runtime change.** This PR lands the architectural artifact (24-case matrix + test stubs + changeset) so the implementation diff lands in a single shot rather than iterating through codex one round at a time, as it did in PR #1597 rounds 26-29 (reverted).

Per the planning rule (`00-Planning/helix/Brand → data-brand Auto-Reflection (deferred from 3.2.2).md`): "Plan up front. Write the contract for all four shapes × three themes × registered/unregistered before writing code. Get explicit signoff. Don't let codex find the matrix for you."

This is the signoff gate. **Do not enable auto-merge.** Jake reviews the matrix row-by-row.

## What lands

- `packages/hx-library/src/components/hx-theme/BRAND_REFLECTION_CONTRACT.md` — 4 shapes × 3 themes × registered/unregistered = 24 cases + 7 state transitions + 2 mutation guards + 4 R1 edge cases + 1 disconnect, plus reconcile pseudocode, ownership-tracking model, registry subscription API spec, Drupal Twig alignment, docs delta plan.
- `packages/hx-library/src/components/hx-theme/hx-theme-data-brand-reflection.test.ts` — 38 `it.todo()` cases, 1-to-1 with the contract document. The test file is the gate: when the contract flips to implementation, every `it.todo` becomes a real assertion.
- `.changeset/3-3-0-brand-reflection-contract-design.md` — patch bump on both `@helixui/library` and `@helixui/tokens` documenting the design-only scope and the R0 → R1 redesign rationale.

## What does NOT land

- No change to `hx-theme.ts`. The runtime continues to **not** reflect `brand` to `data-brand` (current 3.2.x contract).
- No change to `hx-theme.twig`. Twig helper continues to drop `data-brand` per R31 cleanup.
- No change to `multi-brand-theming.md:39`.
- No change to `HelixBrandRegistry`. The additive `subscribe(brandName, callback)` API specified in the contract lands with the implementation diff, not this design changeset.

## Codex review trail

| Round | Verdict | Findings | Audit entry |
| --- | --- | --- | --- |
| R0 | `blocking` | 1 high + 5 medium | `.rea/audit.jsonl:215` |
| R1 | `concerns` (advisory) | 0 high + 2 medium + 2 low | `.rea/audit.jsonl:216` |
| R1.1 | n/a (closure commit) | 0 — codex itself flagged R1 findings as "one-line clarifications, not redesigns" | — |

### R0 → R1 closure table

| R0 finding | R1 closure |
| --- | --- |
| F1 late-registration / ordering hazard (high) | Additive `HelixBrandRegistry.subscribe(brandName, callback)` API; `hx-theme` subscribes/unsubscribes across the lifecycle |
| F2 ownership tracking precision (medium) | Discriminated `LastApplied` union (`'unmanaged' \| 'set' \| 'cleared'`) |
| F3 Shape D unregistered loss (medium) | Contract narrowed: runtime only manages `data-brand` when `brand !== '' AND isRegistered`. Cases 14, 16, 18, 20, 22, 24 flipped from "removed" to "untouched" |
| F4 Shape B HC asymmetry (medium) | Loud-documented author-responsibility block; cases 11, 12 explicitly noted |
| F5 mutation guard precision (medium) | "Authoritative at reconcile boundaries" framing; `MutationObserver` rejected with rationale |
| F6 test stub coverage gaps (medium) | 3 R1 edge cases + 2 R1.1 transition pins added to test stub |

### R1 → R1.1 closure table

| R1 finding | R1.1 closure |
| --- | --- |
| F1.1 Shape D registered HC round-trip lossy-by-design (medium) | New transition-table row + new `it.todo` pin |
| F1.2 HC info dedupe policy (medium) | Explicit policy: same `_lastBrandAdvisoryKey` channel covers info; new `it.todo` pin |
| F1.3 `subscribe()` notify semantics (low) | Three implementation-bound questions answered in contract text (validation gate, re-registration diff, exception handling) |
| F1.4 `auto`→HC negative pin (low) | New `it.todo` guards against future `prefers-contrast: more` mapping |

## What Jake needs to review

The 24-case matrix in `BRAND_REFLECTION_CONTRACT.md`. Specifically:

- **Cases 14, 16, 18, 20, 22, 24** (Shape C/D unregistered): R1 narrowed these from "removed" to "untouched." The rationale: the cascade-only path is the only working override for an unregistered brand name; stripping it silently destroys the author's last-resort styling. Sign off or flip.
- **Case 23** (Shape D registered + HC): The runtime strips `data-brand="other"` and the HC exit transition restores `acme`, not `other`. Documented as lossy by design. Sign off or flip — flipping this would require extending `LastApplied` with a `prior` slot (contract-surface change).
- **Cases 11, 12** (Shape B + HC): Author owns the HC guard. The runtime cannot enforce `:not([theme='high-contrast'])` in author CSS. Sign off or flip — flipping would require the runtime to strip Shape B `data-brand` under HC, which violates the Shape B contract (the runtime touching what it never authored).

## Test plan

This PR is design-only — there is nothing to functionally test. The verification gates are:

- [x] `pnpm exec prettier --write` — clean
- [x] `pnpm exec eslint` on test stub — clean
- [x] `pnpm exec tsc --noEmit -p packages/hx-library` — clean (38 `it.todo` stubs are syntactically valid Vitest)
- [x] Pre-push gates (format, lint, type-check, test:smart, shellcheck) — all green
- [x] Codex R1 audit entry recorded — `.rea/audit.jsonl:216`, verdict `concerns` (advisory)
- [ ] **Jake's row-by-row matrix signoff** — the gate this PR exists to surface

## Out of scope (intentionally — sequenced 3.3.0 follow-ons)

- Implementation diff: `hx-theme.ts` reconcile + `brand-registry.ts subscribe()` — separate PR after signoff.
- HC brand-token category split — sibling 3.3.0 work, separate planning note.
- `replaceSync()` failure-mode hardening — sibling 3.3.0 work, separate planning note.