### PR TITLE
chore(release): add 3.3.1 release manifest

### DIFF
--- a/docs/releases/3.3.1-manifest.json
+++ b/docs/releases/3.3.1-manifest.json
@@ -1,0 +1,82 @@
+{
+  "tag": "@helixui/library@3.3.1",
+  "commit_sha": "97a027315b40762614655ce1d2306e0e30923c6b",
+  "ref": "refs/heads/main",
+  "repository": "bookedsolidtech/helix",
+  "published_at": "2026-05-03T13:57:55.211Z",
+  "publisher": "himerus",
+  "ci_run_id": "25281051967",
+  "ci_run_url": "https://github.com/bookedsolidtech/helix/actions/runs/25281051967",
+  "packages": {
+    "@helixui/library": "3.3.1",
+    "@helixui/tokens": "3.3.1",
+    "@helixui/react": "3.3.1"
+  },
+  "changeset_files": [],
+  "published_packages": [
+    {
+      "name": "@helixui/library",
+      "version": "3.3.1"
+    },
+    {
+      "name": "@helixui/react",
+      "version": "3.3.1"
+    },
+    {
+      "name": "@helixui/tokens",
+      "version": "3.3.1"
+    }
+  ],
+  "merged_prs_since_last_tag": [
+    1619,
+    1618,
+    1617,
+    1616,
+    1601,
+    1600,
+    1604,
+    1603,
+    1602
+  ],
+  "last_tag": "@helixui/library@3.3.0",
+  "cem_sha256": "e9b11dcfa1b63d4978deced676e429b6f073c9523c481b2024eb8d92f12d9506",
+  "cdn_budget_snapshot": {
+    "comment": "CDN bundle size budgets for @helixui/library (gzipped bytes). Enforced in CI by scripts/check-cdn-size.mjs. Changes require code review and a justification in the PR description. The CDN build emits several artifacts with different size profiles — this file tracks per-artifact budgets rather than a single aggregate ceiling so drift in one strategy (A vs B) is surfaced precisely.",
+    "rationale": "Measured from packages/hx-library/dist/cdn/ on main at v2.1.2 (full JS=183.4 KB, full CSS=46.3 KB, core JS=8.4 KB, Strategy A=229.7 KB). Re-baselined 2026-04-25 after the 3.2.0 component-tier + palette expansion landed (full JS climbed to ~200.4 KB gz with the 3.2.1 token-cascade remediation). Ceilings give ~5-15% headroom for near-term component additions without being a floor. Warnings trigger at roughly half that headroom for early-signal drift.",
+    "budgets": {
+      "fullBundleJs": {
+        "file": "helix-{version}.min.js",
+        "description": "Strategy A full self-contained JS bundle (all 81 components + Lit).",
+        "ceilingBytes": 215040,
+        "warnBytes": 204800,
+        "currentBytes": 205210,
+        "currentNote": "200.4 KB gz at 3.2.1 head (was 183.4 KB at v2.1.2; 3.2.0 added the component-tier expansion, palette refresh, and forced-colors mixin family)"
+      },
+      "fullBundleCss": {
+        "file": "helix-{version}.min.css",
+        "description": "Strategy A full CSS bundle (all component shadow-root-adoptable CSS).",
+        "ceilingBytes": 61440,
+        "warnBytes": 56320,
+        "currentBytes": 52224,
+        "currentNote": "51.0 KB gz at 3.2.1 head (was 46.3 KB at v2.1.2; 3.2.0 palette refresh + forced-colors mixin set added ~5 KB)"
+      },
+      "coreBundleJs": {
+        "file": "helix-core-{version}.min.js",
+        "description": "Strategy B shared Lit runtime (loaded once, cached across components).",
+        "ceilingBytes": 12288,
+        "warnBytes": 10240,
+        "currentBytes": 8602,
+        "currentNote": "8.4 KB gz at v2.1.2"
+      },
+      "strategyATotal": {
+        "description": "Aggregate Strategy A consumer payload (full JS + full CSS). This is what a page that loads the full bundle actually downloads.",
+        "ceilingBytes": 276480,
+        "warnBytes": 261120,
+        "currentBytes": 257434,
+        "currentNote": "251.4 KB gz at 3.2.1 head (was 229.7 KB at v2.1.2; tracks fullBundleJs + fullBundleCss growth from the 3.2.0 expansion)"
+      }
+    }
+  },
+  "coderabbit_final_review_sha": null,
+  "notes": "Emitted by scripts/generate-release-manifest.mjs during the publish workflow after changesets/action publishes to npm. Committed back to main via a dedicated step in publish.yml — not part of the version-bump PR."
+}


### PR DESCRIPTION
Post-publish manifest for `3.3.1`. Auto-opened by the publish workflow after npm publish succeeded. Documentation only — safe to auto-merge.