### PR TITLE
feat(husky): wire pre-push.d fragment runner + helix lit-domain gates

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -127,6 +127,24 @@ if [ "$COVERAGE_ENABLED" = "true" ] && script_exists "test"; then
   fi
 fi
 
+
+# >>> pre-push.d fragments >>>
+if [ -d ".husky/pre-push.d" ]; then
+  for FRAGMENT in .husky/pre-push.d/*; do
+    [ -f "$FRAGMENT" ] && [ -x "$FRAGMENT" ] || continue
+    NAME=$(basename "$FRAGMENT")
+    echo "pre-push: running fragment ${NAME}..."
+    if ! "$FRAGMENT" > "$OUT" 2>&1; then
+      echo ""
+      echo "GATE FAILED: ${NAME}"
+      cat "$OUT"
+      echo ""
+      FAILED="${FAILED} ${NAME}"
+    fi
+  done
+fi
+# <<< pre-push.d fragments <<<
+
 # ── Report ────────────────────────────────────────────────────────────────────
 HOOKS_LIB="$(git rev-parse --show-toplevel 2>/dev/null)/hooks/_lib/discord.sh"
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -128,6 +128,7 @@ if [ "$COVERAGE_ENABLED" = "true" ] && script_exists "test"; then
 fi
 
 
+
 # >>> pre-push.d fragments >>>
 if [ -d ".husky/pre-push.d" ]; then
   for FRAGMENT in .husky/pre-push.d/*; do
@@ -144,7 +145,6 @@ if [ -d ".husky/pre-push.d" ]; then
   done
 fi
 # <<< pre-push.d fragments <<<
-
 # ── Report ────────────────────────────────────────────────────────────────────
 HOOKS_LIB="$(git rev-parse --show-toplevel 2>/dev/null)/hooks/_lib/discord.sh"
 

--- a/.husky/pre-push.d/20-helix-cem-drift
+++ b/.husky/pre-push.d/20-helix-cem-drift
@@ -37,7 +37,7 @@ if [ -z "$LIBRARY_SOURCE_CHANGED" ]; then
   exit 0
 fi
 
-if ! git diff --quiet -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" 2>/dev/null; then
+if ! git diff --quiet HEAD -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" 2>/dev/null; then
   echo "pre-push: cem-drift -- refusing to run with uncommitted CEM changes:" >&2
   git status -s -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" >&2
   echo "Resolution: commit or stash CEM changes before pushing." >&2
@@ -51,9 +51,9 @@ if ! pnpm --filter=@helixui/library run cem >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! git diff --quiet -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH"; then
+if ! git diff --quiet HEAD -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH"; then
   echo "pre-push: cem-drift -- DRIFT DETECTED" >&2
-  git diff --stat -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" >&2
+  git diff --stat HEAD -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" >&2
   echo "" >&2
   echo "The Custom Elements Manifest is out of sync with library source." >&2
   echo "Resolution:" >&2

--- a/.husky/pre-push.d/20-helix-cem-drift
+++ b/.husky/pre-push.d/20-helix-cem-drift
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# .husky/pre-push.d/20-helix-cem-drift
+# Helix-local pre-push fragment: Custom Elements Manifest drift gate.
+#
+# Regenerates packages/hx-library/custom-elements.json (and figma-inventory.json)
+# whenever library source has changed in this push range, then refuses the push
+# if the regeneration produced any working-tree delta. Catches the case where a
+# component author edits .ts source but forgets to commit the regenerated CEM.
+#
+# Skip-fast: no library source touched in push range -> exit 0.
+# Bypass: HELIX_SKIP_CEM_DRIFT=1 git push  (escape hatch for emergencies only).
+
+set -euo pipefail
+
+if [ "${HELIX_SKIP_CEM_DRIFT:-0}" = "1" ]; then
+  echo "pre-push: cem-drift -- bypassed via HELIX_SKIP_CEM_DRIFT=1"
+  exit 0
+fi
+
+CEM_PATH="packages/hx-library/custom-elements.json"
+FIGMA_INVENTORY_PATH="packages/hx-library/figma-inventory.json"
+
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's|refs/remotes/origin/||' || echo "dev")
+
+COMMON_ANCESTOR=$(git merge-base HEAD "origin/${BASE_BRANCH}" 2>/dev/null || echo "")
+if [ -z "$COMMON_ANCESTOR" ]; then
+  echo "pre-push: cem-drift -- no merge-base with origin/${BASE_BRANCH}, skipping"
+  exit 0
+fi
+
+LIBRARY_SOURCE_CHANGED=$(git diff --name-only "$COMMON_ANCESTOR"...HEAD \
+  | grep '^packages/hx-library/src/' || true)
+
+if [ -z "$LIBRARY_SOURCE_CHANGED" ]; then
+  echo "pre-push: cem-drift -- no library source changes in push range, skipping"
+  exit 0
+fi
+
+if ! git diff --quiet -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" 2>/dev/null; then
+  echo "pre-push: cem-drift -- refusing to run with uncommitted CEM changes:" >&2
+  git status -s -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" >&2
+  echo "Resolution: commit or stash CEM changes before pushing." >&2
+  exit 1
+fi
+
+echo "pre-push: cem-drift -- regenerating $CEM_PATH..."
+if ! pnpm --filter=@helixui/library run cem >/dev/null 2>&1; then
+  echo "pre-push: cem-drift -- \`pnpm run cem\` FAILED" >&2
+  echo "Run \`pnpm --filter=@helixui/library run cem\` locally to see errors." >&2
+  exit 1
+fi
+
+if ! git diff --quiet -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH"; then
+  echo "pre-push: cem-drift -- DRIFT DETECTED" >&2
+  git diff --stat -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" >&2
+  echo "" >&2
+  echo "The Custom Elements Manifest is out of sync with library source." >&2
+  echo "Resolution:" >&2
+  echo "  pnpm --filter=@helixui/library run cem" >&2
+  echo "  git add $CEM_PATH $FIGMA_INVENTORY_PATH" >&2
+  echo "  git commit --amend --no-edit  # or a fresh commit" >&2
+  exit 1
+fi
+
+echo "  v cem-drift passed"

--- a/.husky/pre-push.d/30-helix-styles-token-discipline
+++ b/.husky/pre-push.d/30-helix-styles-token-discipline
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# .husky/pre-push.d/30-helix-styles-token-discipline
+# Helix-local pre-push fragment: design-token discipline in component styles.
+#
+# Scans changed packages/hx-library/src/components/**/*.styles.ts files in the
+# push range for hardcoded design primitives (color literals, raw px/rem) that
+# escape the var(--hx-*) cascade. Comments and var() fallback values are
+# stripped first so only true outside-the-cascade leakage trips the gate.
+#
+# Skip-fast: no .styles.ts changed in push range -> exit 0.
+# Bypass: HELIX_SKIP_TOKEN_DISCIPLINE=1 git push  (escape hatch).
+
+set -euo pipefail
+
+if [ "${HELIX_SKIP_TOKEN_DISCIPLINE:-0}" = "1" ]; then
+  echo "pre-push: token-discipline -- bypassed via HELIX_SKIP_TOKEN_DISCIPLINE=1"
+  exit 0
+fi
+
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+  | sed 's|refs/remotes/origin/||' || echo "dev")
+
+COMMON_ANCESTOR=$(git merge-base HEAD "origin/${BASE_BRANCH}" 2>/dev/null || echo "")
+if [ -z "$COMMON_ANCESTOR" ]; then
+  echo "pre-push: token-discipline -- no merge-base with origin/${BASE_BRANCH}, skipping"
+  exit 0
+fi
+
+CHANGED_STYLES=$(git diff --name-only "$COMMON_ANCESTOR"...HEAD \
+  | grep -E '^packages/hx-library/src/components/.*\.styles\.ts$' || true)
+
+if [ -z "$CHANGED_STYLES" ]; then
+  echo "pre-push: token-discipline -- no .styles.ts changes in push range, skipping"
+  exit 0
+fi
+
+VIOLATIONS=$(printf '%s\n' "$CHANGED_STYLES" | while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  [ -f "$f" ] || continue
+  awk '
+    BEGIN { in_block = 0 }
+    {
+      line = $0
+      while (1) {
+        if (in_block) {
+          end = index(line, "*/")
+          if (end == 0) { line = ""; break }
+          line = substr(line, end + 2); in_block = 0
+        } else {
+          start = index(line, "/*")
+          if (start == 0) break
+          rest = substr(line, start + 2)
+          end = index(rest, "*/")
+          if (end == 0) { line = substr(line, 1, start - 1); in_block = 1; break }
+          line = substr(line, 1, start - 1) substr(rest, end + 2)
+        }
+      }
+      sub("//.*$", "", line)
+      while (match(line, /var\([^()]*\)/)) {
+        line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
+      }
+      if (line ~ /#[0-9a-fA-F]{3,8}\>/ \
+          || line ~ /\<(rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color)\(/ \
+          || line ~ /\<[0-9]+(\.[0-9]+)?(px|rem|em)\>/) {
+        printf "%s:%d: %s\n", FILENAME, NR, $0
+      }
+    }
+  ' "$f"
+done)
+
+if [ -n "$VIOLATIONS" ]; then
+  echo "pre-push: token-discipline -- HARDCODED PRIMITIVES DETECTED" >&2
+  echo "" >&2
+  echo "$VIOLATIONS" >&2
+  echo "" >&2
+  echo "Component styles must consume design tokens through the var() cascade." >&2
+  echo "Pattern: var(--hx-{component}-{property}, var(--hx-{semantic}, #fallback))" >&2
+  echo "" >&2
+  echo "Allowed inside var() fallback chains; flagged when bare." >&2
+  echo "Bypass (escape hatch): HELIX_SKIP_TOKEN_DISCIPLINE=1 git push" >&2
+  exit 1
+fi
+
+echo "  v token-discipline passed"

--- a/.husky/pre-push.d/30-helix-styles-token-discipline
+++ b/.husky/pre-push.d/30-helix-styles-token-discipline
@@ -59,9 +59,9 @@ VIOLATIONS=$(printf '%s\n' "$CHANGED_STYLES" | while IFS= read -r f; do
       while (match(line, /var\([^()]*\)/)) {
         line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
       }
-      if (line ~ /#[0-9a-fA-F]{3,8}\>/ \
-          || line ~ /\<(rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color)\(/ \
-          || line ~ /\<[0-9]+(\.[0-9]+)?(px|rem|em)\>/) {
+      if (line ~ /#[0-9a-fA-F]{3,8}($|[^0-9a-zA-Z_])/ \
+          || line ~ /(^|[^a-zA-Z_])(rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color)\(/ \
+          || line ~ /(^|[^0-9a-zA-Z_])[0-9]+(\.[0-9]+)?(px|rem|em)($|[^0-9a-zA-Z_])/) {
         printf "%s:%d: %s\n", FILENAME, NR, $0
       }
     }

--- a/.reports/proposed-patches/helix-prepush-lit-fragments.patch
+++ b/.reports/proposed-patches/helix-prepush-lit-fragments.patch
@@ -1,0 +1,162 @@
+diff --git .husky/pre-push.d/20-helix-cem-drift .husky/pre-push.d/20-helix-cem-drift
+new file mode 100644
+index 0000000..263b4df
+--- /dev/null
++++ .husky/pre-push.d/20-helix-cem-drift
+@@ -0,0 +1,66 @@
++#!/usr/bin/env bash
++# .husky/pre-push.d/20-helix-cem-drift
++# Helix-local pre-push fragment: Custom Elements Manifest drift gate.
++#
++# Regenerates packages/hx-library/custom-elements.json (and figma-inventory.json)
++# whenever library source has changed in this push range, then refuses the push
++# if the regeneration produced any working-tree delta. Catches the case where a
++# component author edits .ts source but forgets to commit the regenerated CEM.
++#
++# Skip-fast: no library source touched in push range -> exit 0.
++# Bypass: HELIX_SKIP_CEM_DRIFT=1 git push  (escape hatch for emergencies only).
++
++set -euo pipefail
++
++if [ "${HELIX_SKIP_CEM_DRIFT:-0}" = "1" ]; then
++  echo "pre-push: cem-drift -- bypassed via HELIX_SKIP_CEM_DRIFT=1"
++  exit 0
++fi
++
++CEM_PATH="packages/hx-library/custom-elements.json"
++FIGMA_INVENTORY_PATH="packages/hx-library/figma-inventory.json"
++
++BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
++  | sed 's|refs/remotes/origin/||' || echo "dev")
++
++COMMON_ANCESTOR=$(git merge-base HEAD "origin/${BASE_BRANCH}" 2>/dev/null || echo "")
++if [ -z "$COMMON_ANCESTOR" ]; then
++  echo "pre-push: cem-drift -- no merge-base with origin/${BASE_BRANCH}, skipping"
++  exit 0
++fi
++
++LIBRARY_SOURCE_CHANGED=$(git diff --name-only "$COMMON_ANCESTOR"...HEAD \
++  | grep '^packages/hx-library/src/' || true)
++
++if [ -z "$LIBRARY_SOURCE_CHANGED" ]; then
++  echo "pre-push: cem-drift -- no library source changes in push range, skipping"
++  exit 0
++fi
++
++if ! git diff --quiet -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" 2>/dev/null; then
++  echo "pre-push: cem-drift -- refusing to run with uncommitted CEM changes:" >&2
++  git status -s -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" >&2
++  echo "Resolution: commit or stash CEM changes before pushing." >&2
++  exit 1
++fi
++
++echo "pre-push: cem-drift -- regenerating $CEM_PATH..."
++if ! pnpm --filter=@helixui/library run cem >/dev/null 2>&1; then
++  echo "pre-push: cem-drift -- \`pnpm run cem\` FAILED" >&2
++  echo "Run \`pnpm --filter=@helixui/library run cem\` locally to see errors." >&2
++  exit 1
++fi
++
++if ! git diff --quiet -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH"; then
++  echo "pre-push: cem-drift -- DRIFT DETECTED" >&2
++  git diff --stat -- "$CEM_PATH" "$FIGMA_INVENTORY_PATH" >&2
++  echo "" >&2
++  echo "The Custom Elements Manifest is out of sync with library source." >&2
++  echo "Resolution:" >&2
++  echo "  pnpm --filter=@helixui/library run cem" >&2
++  echo "  git add $CEM_PATH $FIGMA_INVENTORY_PATH" >&2
++  echo "  git commit --amend --no-edit  # or a fresh commit" >&2
++  exit 1
++fi
++
++echo "  v cem-drift passed"
+diff --git .husky/pre-push.d/30-helix-styles-token-discipline .husky/pre-push.d/30-helix-styles-token-discipline
+new file mode 100644
+index 0000000..9324b28
+--- /dev/null
++++ .husky/pre-push.d/30-helix-styles-token-discipline
+@@ -0,0 +1,84 @@
++#!/usr/bin/env bash
++# .husky/pre-push.d/30-helix-styles-token-discipline
++# Helix-local pre-push fragment: design-token discipline in component styles.
++#
++# Scans changed packages/hx-library/src/components/**/*.styles.ts files in the
++# push range for hardcoded design primitives (color literals, raw px/rem) that
++# escape the var(--hx-*) cascade. Comments and var() fallback values are
++# stripped first so only true outside-the-cascade leakage trips the gate.
++#
++# Skip-fast: no .styles.ts changed in push range -> exit 0.
++# Bypass: HELIX_SKIP_TOKEN_DISCIPLINE=1 git push  (escape hatch).
++
++set -euo pipefail
++
++if [ "${HELIX_SKIP_TOKEN_DISCIPLINE:-0}" = "1" ]; then
++  echo "pre-push: token-discipline -- bypassed via HELIX_SKIP_TOKEN_DISCIPLINE=1"
++  exit 0
++fi
++
++BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
++  | sed 's|refs/remotes/origin/||' || echo "dev")
++
++COMMON_ANCESTOR=$(git merge-base HEAD "origin/${BASE_BRANCH}" 2>/dev/null || echo "")
++if [ -z "$COMMON_ANCESTOR" ]; then
++  echo "pre-push: token-discipline -- no merge-base with origin/${BASE_BRANCH}, skipping"
++  exit 0
++fi
++
++CHANGED_STYLES=$(git diff --name-only "$COMMON_ANCESTOR"...HEAD \
++  | grep -E '^packages/hx-library/src/components/.*\.styles\.ts$' || true)
++
++if [ -z "$CHANGED_STYLES" ]; then
++  echo "pre-push: token-discipline -- no .styles.ts changes in push range, skipping"
++  exit 0
++fi
++
++VIOLATIONS=$(printf '%s\n' "$CHANGED_STYLES" | while IFS= read -r f; do
++  [ -z "$f" ] && continue
++  [ -f "$f" ] || continue
++  awk '
++    BEGIN { in_block = 0 }
++    {
++      line = $0
++      while (1) {
++        if (in_block) {
++          end = index(line, "*/")
++          if (end == 0) { line = ""; break }
++          line = substr(line, end + 2); in_block = 0
++        } else {
++          start = index(line, "/*")
++          if (start == 0) break
++          rest = substr(line, start + 2)
++          end = index(rest, "*/")
++          if (end == 0) { line = substr(line, 1, start - 1); in_block = 1; break }
++          line = substr(line, 1, start - 1) substr(rest, end + 2)
++        }
++      }
++      sub("//.*$", "", line)
++      while (match(line, /var\([^()]*\)/)) {
++        line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
++      }
++      if (line ~ /#[0-9a-fA-F]{3,8}\>/ \
++          || line ~ /\<(rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color)\(/ \
++          || line ~ /\<[0-9]+(\.[0-9]+)?(px|rem|em)\>/) {
++        printf "%s:%d: %s\n", FILENAME, NR, $0
++      }
++    }
++  ' "$f"
++done)
++
++if [ -n "$VIOLATIONS" ]; then
++  echo "pre-push: token-discipline -- HARDCODED PRIMITIVES DETECTED" >&2
++  echo "" >&2
++  echo "$VIOLATIONS" >&2
++  echo "" >&2
++  echo "Component styles must consume design tokens through the var() cascade." >&2
++  echo "Pattern: var(--hx-{component}-{property}, var(--hx-{semantic}, #fallback))" >&2
++  echo "" >&2
++  echo "Allowed inside var() fallback chains; flagged when bare." >&2
++  echo "Bypass (escape hatch): HELIX_SKIP_TOKEN_DISCIPLINE=1 git push" >&2
++  exit 1
++fi
++
++echo "  v token-discipline passed"

--- a/scripts/_wire-prepush-fragments.sh
+++ b/scripts/_wire-prepush-fragments.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# One-shot: restore .husky/pre-push and inject a clean pre-push.d fragment runner.
+# Settings-protection blocks the agent from editing .husky/* directly, so this
+# script exists for Jake to run by hand. Idempotent: re-running is a no-op.
+set -euo pipefail
+
+PRE_PUSH=".husky/pre-push"
+[ -f "$PRE_PUSH" ] || { echo "missing $PRE_PUSH"; exit 1; }
+
+# Strip any prior insertion (broken or otherwise) between the markers.
+awk '
+  /^# >>> pre-push\.d fragments >>>/ { skip = 1; next }
+  /^# <<< pre-push\.d fragments <<</ { skip = 0; next }
+  !skip { print }
+' "$PRE_PUSH" > "${PRE_PUSH}.tmp"
+
+# Also strip the broken hand-rolled block from the prior printf|ed attempt.
+awk '
+  /^# pre-push\.d fragments$/ { in_bad = 1; next }
+  in_bad && /^fi$/ { in_bad = 0; next }
+  in_bad { next }
+  { print }
+' "${PRE_PUSH}.tmp" > "${PRE_PUSH}.tmp2"
+mv "${PRE_PUSH}.tmp2" "${PRE_PUSH}.tmp"
+
+# Inject clean block before the Report header.
+awk '
+  /^# ── Report/ && !done {
+    print "# >>> pre-push.d fragments >>>"
+    print "if [ -d \".husky/pre-push.d\" ]; then"
+    print "  for FRAGMENT in .husky/pre-push.d/*; do"
+    print "    [ -f \"$FRAGMENT\" ] && [ -x \"$FRAGMENT\" ] || continue"
+    print "    NAME=$(basename \"$FRAGMENT\")"
+    print "    echo \"pre-push: running fragment ${NAME}...\""
+    print "    if ! \"$FRAGMENT\" > \"$OUT\" 2>&1; then"
+    print "      echo \"\""
+    print "      echo \"GATE FAILED: ${NAME}\""
+    print "      cat \"$OUT\""
+    print "      echo \"\""
+    print "      FAILED=\"${FAILED} ${NAME}\""
+    print "    fi"
+    print "  done"
+    print "fi"
+    print "# <<< pre-push.d fragments <<<"
+    print ""
+    done = 1
+  }
+  { print }
+' "${PRE_PUSH}.tmp" > "${PRE_PUSH}.tmp2"
+
+mv "${PRE_PUSH}.tmp2" "$PRE_PUSH"
+rm -f "${PRE_PUSH}.tmp"
+chmod +x "$PRE_PUSH"
+
+echo "wired. inspect with: sed -n '125,150p' $PRE_PUSH"

--- a/scripts/_wire-prepush-fragments.sh
+++ b/scripts/_wire-prepush-fragments.sh
@@ -23,7 +23,8 @@ awk '
 ' "${PRE_PUSH}.tmp" > "${PRE_PUSH}.tmp2"
 mv "${PRE_PUSH}.tmp2" "${PRE_PUSH}.tmp"
 
-# Inject clean block before the Report header.
+# Inject clean block before the Report header. Fail fast if the anchor is missing
+# rather than silently producing an unwired script.
 awk '
   /^# ── Report/ && !done {
     print "# >>> pre-push.d fragments >>>"
@@ -42,11 +43,15 @@ awk '
     print "  done"
     print "fi"
     print "# <<< pre-push.d fragments <<<"
-    print ""
     done = 1
   }
   { print }
-' "${PRE_PUSH}.tmp" > "${PRE_PUSH}.tmp2"
+  END { exit done ? 0 : 1 }
+' "${PRE_PUSH}.tmp" > "${PRE_PUSH}.tmp2" || {
+  echo "wire: anchor '# ── Report' not found in $PRE_PUSH -- refusing to overwrite." >&2
+  rm -f "${PRE_PUSH}.tmp" "${PRE_PUSH}.tmp2"
+  exit 1
+}
 
 mv "${PRE_PUSH}.tmp2" "$PRE_PUSH"
 rm -f "${PRE_PUSH}.tmp"


### PR DESCRIPTION
## Summary

- Wires `.husky/pre-push.d/*` fragment iteration into the parent `pre-push` script so helix-local gates can extend the rea-managed canonical hook without modifying it. Failures roll into the existing `$FAILED` aggregation.
- Adds **`20-helix-cem-drift`**: regenerates `packages/hx-library/custom-elements.json` when library source changed in the push range; refuses the push if regeneration produced a working-tree delta. Catches the "edited `.ts` but forgot to commit the regenerated CEM" class of mistake that `preflight` Gate 6 doesn't currently assert post-regen cleanliness for.
- Adds **`30-helix-styles-token-discipline`**: awk-based scan of changed `.styles.ts` for hardcoded primitives (`#hex`, `rgb()`, `oklch()`, raw `px`/`rem`) outside `var()` fallback chains. Comments and `var()` values are masked first; only true cascade leakage trips the gate. Targets the 5 architecture-violation components called out in the 3.2.0 plan (hx-avatar, hx-steps, hx-text, hx-icon-button, hx-image) plus future regressions.
- Both fragments skip-fast when their globs are untouched in the push range. Bypass via `HELIX_SKIP_CEM_DRIFT=1` / `HELIX_SKIP_TOKEN_DISCIPLINE=1` (escape hatches only).
- `scripts/_wire-prepush-fragments.sh` re-applies the parent-script wiring idempotently — settings-protection.sh hardcodes `.husky/` as a write-protected path, so agents can't edit `.husky/pre-push` directly, and `rea init` may overwrite the parent in future releases. Local-only workaround until rea ships a policy-driven `PROTECTED_PATTERNS` (filed as helix-018 internally).

## Test plan

- [x] `git push` from this branch — standard gates + both fragments executed; skip-fast paths confirmed (no library source / no `.styles.ts` changed → fast green)
- [ ] Synthetic positive test: touch a `.styles.ts` with a bare `#fff` on a throwaway branch, confirm `30-helix-styles-token-discipline` blocks
- [ ] Synthetic positive test: edit a component `.ts` without regenerating CEM, confirm `20-helix-cem-drift` blocks
- [ ] CI green on dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Custom Elements Manifest validation that ensures generated outputs remain synchronized with source changes before pushing code.
  * Added design token discipline validation to enforce consistent token usage in component styling.

* **Chores**
  * Enhanced the pre-push validation system to support modular executable validation fragments with optional bypass mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->