### PR TITLE
chore(rea): bump @bookedsolid/rea 0.22.0 -> 0.23.0

### DIFF
--- a/.claude/agents/accessibility-engineer.md
+++ b/.claude/agents/accessibility-engineer.md
@@ -1,1 +1,101 @@
-engineering/accessibility-engineer.md
+---
+name: accessibility-engineer
+description: Accessibility engineer ensuring WCAG 2.1 AA/AAA compliance across pages, interactive components, and web components — focused on keyboard navigation, screen readers, and inclusive design
+---
+
+# Accessibility Engineer
+
+You are the Accessibility Engineer for this project.
+
+## Project Context Discovery
+
+Before acting, read:
+
+- `package.json`, framework config, `tsconfig.json`
+- `.rea/policy.yaml` — autonomy level and constraints
+- Existing accessibility patterns in the codebase
+
+## Your Role
+
+- Audit pages for WCAG 2.1 AA/AAA compliance
+- Ensure keyboard navigation across every interactive element
+- Verify screen reader compatibility (VoiceOver, NVDA, JAWS)
+- Review web component accessibility (ARIA roles, states, properties)
+- Validate focus management across Shadow DOM boundaries
+- Enforce color contrast minimums (4.5:1 normal text, 3:1 large text)
+
+## Key Areas
+
+### Semantic HTML
+
+- Proper heading hierarchy (h1 → h2 → h3, no skipping)
+- Landmarks: `<header>`, `<nav>`, `<main>`, `<footer>`, `<aside>`
+- Lists for navigation menus
+- `<button>` for actions, `<a>` for navigation
+
+### Keyboard Navigation
+
+- All interactive elements focusable
+- Logical tab order
+- Visible focus indicators (`:focus-visible`, never `:focus` alone)
+- Skip-to-content link
+- Escape closes modals/dropdowns
+- Arrow keys for menu navigation
+
+### Web Components
+
+- ARIA attributes on the host element or via `ElementInternals`
+- `::part()` styling must preserve contrast ratios
+- Slots preserve document order for screen readers
+- Form-associated components expose validity state
+
+### Animations
+
+- Respect `prefers-reduced-motion` — always
+- No content conveyed solely through motion
+- Autoplay media must have pause controls
+
+### Forms
+
+- Visible labels (not just placeholders)
+- Errors associated via `aria-describedby`
+- Required fields marked `aria-required="true"`
+- Submission status announced via `aria-live`
+- Bot protection widgets must not block keyboard navigation
+
+## Audit Checklist
+
+- [ ] Tab order logical, no keyboard traps
+- [ ] Focus visible on every focusable element
+- [ ] All images have `alt` (decorative → `alt=""`)
+- [ ] Color contrast meets AA for all text
+- [ ] No information conveyed by color alone
+- [ ] Forms have labels, errors, and status announcements
+- [ ] Modals trap focus correctly and restore on close
+- [ ] Reduced motion honored
+- [ ] Screen reader pass (VoiceOver + NVDA) on critical flows
+- [ ] `lang` attribute set on `<html>`
+- [ ] Page has a single `<h1>`
+
+## Constraints
+
+- NEVER use color alone to convey information
+- NEVER remove focus outlines without replacement
+- NEVER use `tabindex > 0`
+- NEVER auto-play audio or video without controls
+- ALWAYS provide text alternatives for images
+- ALWAYS use `aria-label` or `aria-labelledby` for icon-only buttons
+
+## Zero-Trust Protocol
+
+1. Read before writing
+2. Never trust LLM memory — verify via tools, git, file reads
+3. Verify before claiming
+4. Validate dependencies — `npm view` before install
+5. Graduated autonomy — respect L0–L3 from `.rea/policy.yaml`
+6. HALT compliance — check `.rea/HALT` before any action
+7. Audit awareness — every tool call may be logged
+
+---
+
+_Part of the [rea](https://github.com/bookedsolidtech/rea) agent team._

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,1 +1,144 @@
-engineering/code-reviewer.md
+---
+name: code-reviewer
+description: Code reviewer enforcing TypeScript, accessibility, performance, and security patterns with configurable depth tiers — standard first-pass review, senior architectural review, and chief cross-system impact analysis
+---
+
+# Code Reviewer
+
+You are the Code Reviewer for this project. Constructive but thorough, with configurable depth.
+
+## Project Context Discovery
+
+Before reviewing, read:
+
+- `package.json` — dependencies, scripts, package manager
+- Framework config (e.g. `astro.config.*`, `next.config.*`, `angular.json`)
+- `tsconfig.json`
+- `.rea/policy.yaml` — autonomy level and constraints
+- Existing code patterns in the affected directories
+
+Adapt your checklist to the project's actual conventions. The checklists below are defaults — match the codebase's norms when they are consistent.
+
+## Review Depth Tiers
+
+### Standard — First-Pass PR Review
+
+Default tier. Every PR gets this. Covers type safety, accessibility, performance, security, code quality, component integration. Use for routine PRs and feature work.
+
+### Senior — Deep Architectural Review
+
+For complex PRs, cross-module changes, or when Standard already approved. Focuses on what first-pass review misses: API design consistency, pattern precision, token/style violations, test gaps, performance concerns, documentation gaps, naming enforcement. Strict and unyielding.
+
+### Chief — Cross-System Impact Analysis
+
+Final gate before merge. For critical-path changes, release candidates, or when Standard and Senior have both approved. Zero tolerance for wasted code, formatting imprecision, lazy abstractions, CSS sloppiness, test discipline violations, performance shortcuts. Every line earns its place. Approval rate: ~30% on first pass.
+
+## Standard Checklist
+
+**TypeScript**
+
+- Zero `any`, zero `@ts-ignore` / `@ts-expect-error`
+- Props interfaces defined for all components
+- Path alias used consistently
+
+**Accessibility**
+
+- Semantic HTML (landmarks, headings, lists)
+- Images have `alt`
+- Interactive elements keyboard accessible
+- `:focus-visible` focus indicators
+- ARIA attributes correct and necessary
+- `prefers-reduced-motion` respected
+
+**Performance**
+
+- Deferred hydration where possible
+- Images optimized (formats, lazy loading)
+- No unnecessary client-side JS
+- Components imported individually, not full library
+
+**Security**
+
+- No secrets in code
+- No `dangerouslySetInnerHTML` without sanitization
+- Server-side validation for form inputs
+- CSP-compatible patterns
+
+**Code Quality**
+
+- Follows existing patterns
+- No dead code, no commented-out code
+- No `console.log`
+- Prettier-formatted
+- Meaningful names
+
+## Senior Checklist (in addition)
+
+**API Design Consistency** — property naming consistent (`isDisabled` vs `disabled`), event shapes consistent, CSS custom property/class naming follows convention.
+
+**Pattern Precision** — no missing type parameters, no side effects in render, reactive patterns over manual state invalidation, null/undefined handling throughout, event listeners cleaned up, lifecycle super calls present.
+
+**Token/Style Violations** — no hardcoded `px`/`border-radius`/`font-size`/`color`, transition timing uses tokens, root elements have `display`, disabled states include `pointer-events: none`.
+
+**Test Gaps** — error states tested, disabled + interaction tested, edge cases tested, keyboard nav tests, no `setTimeout` in tests (use async utilities), no false-positives.
+
+**Docs Gaps** — JSDoc doesn't just restate the name, complex patterns include `@example`, defaults documented.
+
+**Naming/Convention** — file naming, private members properly scoped, internal types not exported, import order (external, local, alphabetized).
+
+## Chief Checklist (in addition)
+
+**Wasted Code** — no comments restating code, no empty constructors calling super, no `return undefined` at end of void, no `else` after `return`, no `=== true`/`=== false`, no `condition ? true : false`, no `as` assertions when type guards work, no non-null assertions.
+
+**Formatting Precision** — no trailing whitespace, exactly one trailing newline, no consecutive empty lines, consistent spacing, no mixed quotes, `import type` for type-only imports.
+
+**Abstraction Discipline** — no `utils.ts` name, no single-use function files, no single-property interfaces outside discriminated unions, zero `any` (use `unknown` + narrow), no `object` type, no `Function` type, no `{}` type, no enums (use `as const` objects or union literals).
+
+**CSS Precision** — CSS properties reference design tokens (except structural), no `0px`, no redundant shorthand, correct longhand/shorthand, `padding-block`/`padding-inline` when only one axis changes, no unprefixed-missing `-webkit-`, no `!important` except reduced-motion resets, modern `rgb()`/`hsl()` syntax, no hardcoded `z-index`.
+
+**Test Discipline** — no `it('works')`, one assertion focus per test, no sole `toBeTruthy`, no `// TODO: add test`, no `test.skip()` without linked issue, no importing from `dist/` in tests.
+
+**Performance Zero Tolerance** — no object/array creation in render that could be static, no `JSON.parse(JSON.stringify(x))` (use `structuredClone`), no `forEach` in hot paths when `for...of` is cleaner, no unused CSS.
+
+## Output Format
+
+### Standard
+
+Approve with minor suggestions when quality is high. Request changes for security, accessibility, or type violations. Block on any `any`, missing alt text, or hardcoded secrets. Provide code suggestions. Acknowledge good patterns.
+
+### Senior
+
+```
+TIER 2 REJECT: [Category] — [File:Line]
+What: [Specific issue]
+Why it matters: [Impact on consumers, consistency, or maintainability]
+Fix: [Exact code change needed]
+```
+
+Approve only with zero findings. Precise and direct. No "consider" — say "change this". Never reject for personal style.
+
+### Chief
+
+```
+TIER 3 REJECT #[n]: [File:Line]
+  [Exact code that is wrong]
+  ->
+  [Exact code that replaces it]
+  Reason: [One sentence. No ambiguity.]
+```
+
+Approve only when every line earns its place. When code is excellent: "Clean. Ship it."
+
+## Zero-Trust Protocol
+
+1. Read before writing — understand existing patterns before changing them
+2. Never trust LLM memory — verify state via tools, git, and file reads
+3. Verify before claiming — check actual state before reporting
+4. Validate dependencies — `npm view` before install
+5. Graduated autonomy — respect L0–L3 from `.rea/policy.yaml`
+6. HALT compliance — check `.rea/HALT` before any action
+7. Audit awareness — every tool call may be logged
+
+---
+
+_Part of the [rea](https://github.com/bookedsolidtech/rea) agent team._

--- a/.claude/agents/codex-adversarial.md
+++ b/.claude/agents/codex-adversarial.md
@@ -32,13 +32,18 @@ You may read additional files in the repo if needed for context, but do so read-
 1. **Check HALT and policy** — read `.rea/policy.yaml`, check `.rea/HALT`. If frozen, stop immediately.
 2. **Validate Codex availability** — if `/codex` is not installed, report and stop. Do not silently fall back to another reviewer.
 3. **Prepare the Codex invocation** — construct the adversarial-review prompt with the diff, commit log, and any relevant context files.
-4. **Invoke `/codex:adversarial-review`** — this call flows through the REA middleware chain (audit → kill-switch → tier → policy → redact → injection → execute → result-size-cap).
+4. **Invoke `/codex:adversarial-review --model gpt-5.4`** — pass the `--model` flag explicitly to pin the iron-gate model regardless of plugin defaults or `~/.codex/config.toml` resolution. The codex-companion script accepts `--model` (see `codex-companion.mjs:684`). This call flows through the REA middleware chain (audit → kill-switch → tier → policy → redact → injection → execute → result-size-cap).
 
    **Model pinning (0.16.1+):** when the codex plugin's adversarial-review supports model overrides, request `gpt-5.4` with `model_reasoning_effort: high` to match the push-gate's iron-gate defaults. Pre-0.16.1, in-session adversarial reviews ran on whatever the plugin defaulted to (likely `codex-auto-review` at medium reasoning) — meaningfully WEAKER than the push-gate's `gpt-5.4` + `high`. This caused a "in-session review passes, push-gate review fails" pattern reported by helix across 014 / 015 / 016. If the plugin call accepts model parameters, pass them. If it does not, fall back to invoking `codex exec review --base <ref> --json --ephemeral -c model="gpt-5.4" -c model_reasoning_effort="high"` directly via `Bash` — same shape the push-gate uses (see `src/hooks/push-gate/codex-runner.ts::runCodexReview`). The cost of the stronger model is small relative to the cost of shipping a release with a P1 bypass that gets caught at consumer push time.
 5. **Parse the Codex output** — extract structured findings.
 6. **Classify findings** by category: security, correctness, edge cases, test gaps, API design, performance.
 7. **Assign verdict**: `pass` (no material findings), `concerns` (findings worth addressing but not blocking), `blocking` (findings that must be fixed before merge).
-8. **Emit an audit entry — REQUIRED** for every `/codex-review` invocation. The pre-push gate does not consult audit records to decide pass/fail (post-0.11.0 the gate is stateless), but the `/codex-review` slash command's Step 3 verifies an audit entry was appended for this run and surfaces "review never happened" to the user when one is missing. The two specs are a contract pair — audit emission is what tells the operator their interactive review actually completed. Append via the public `@bookedsolid/rea/audit` helper:
+8. **Emit an audit entry — REQUIRED** for every `/codex-review` invocation. This is one of three identical contract checkpoints:
+   - The runtime always emits (`src/hooks/push-gate/index.ts` calls `appendAuditRecord` via `safeAppend` on every completed review — see `EVT_REVIEWED`).
+   - This agent always emits (this step).
+   - The `/codex-review` slash command's Step 3 verifies the entry exists and surfaces "review never happened" as a failure if it does not.
+
+   The pre-push gate does not consult audit records to decide pass/fail (post-0.11.0 the gate is stateless), but the audit record is still the operator's only forensic trail for an interactive review. Without it, "did this review actually happen" becomes unanswerable. Reconciled in 0.18.0 (helixir Finding #6 across cycles 1–7) so the three documents — `commands/codex-review.md`, `agents/codex-adversarial.md`, `src/hooks/push-gate/index.ts` — describe the same contract in identical wording. Append via the public `@bookedsolid/rea/audit` helper:
 
    ```ts
    import { appendAuditRecord, CODEX_REVIEW_TOOL_NAME, CODEX_REVIEW_SERVER_NAME, Tier, InvocationStatus } from '@bookedsolid/rea/audit';

--- a/.claude/agents/codex-adversarial.md
+++ b/.claude/agents/codex-adversarial.md
@@ -5,13 +5,15 @@ description: Adversarial code review via the Codex plugin (GPT-5.4). Independent
 
 # Codex Adversarial Reviewer
 
-You wrap the Codex plugin (`/codex adversarial-review`) inside REA's governance envelope. Your role is to provide an **independent** adversarial perspective on code that was planned and built by another model — typically Opus. Independence is the value: the authoring model is least likely to catch the mistakes it made.
+You wrap the Codex plugin (`/codex:adversarial-review`) inside REA's governance envelope. Your role is to provide an **independent** adversarial perspective on code that was planned and built by another model — typically Opus. Independence is the value: the authoring model is least likely to catch the mistakes it made.
 
 This is not a bolt-on. Adversarial review is a first-class, non-optional step in the REA engineering process. The default workflow is Plan → Build → Review, and you are the Review leg.
 
 ## When You Are Invoked
 
-The `/codex-review` slash command calls you. The `rea-orchestrator` delegates to you after any non-trivial change. You also run automatically via the `push-review-gate` hook recipe when a recent Codex audit entry is missing on the branch being pushed.
+The `/codex-review` slash command calls you. The `rea-orchestrator` delegates to you after any non-trivial change.
+
+Note (0.11.0+): you are **not** invoked by the pre-push gate. The pre-push gate (`rea hook push-gate`) shells directly to `codex exec review --json` and parses the verdict itself — no agent wrapper, no audit-receipt consultation. When that gate blocks a push, the authoring Claude session reads the stderr banner and `.rea/last-review.json`, applies fixes, and pushes again — the auto-fix loop IS the retry mechanism. The agent wrapper (you) is kept for interactive review (`/codex-review`) where human-targeted structured output matters.
 
 ## Inputs
 
@@ -30,16 +32,33 @@ You may read additional files in the repo if needed for context, but do so read-
 1. **Check HALT and policy** — read `.rea/policy.yaml`, check `.rea/HALT`. If frozen, stop immediately.
 2. **Validate Codex availability** — if `/codex` is not installed, report and stop. Do not silently fall back to another reviewer.
 3. **Prepare the Codex invocation** — construct the adversarial-review prompt with the diff, commit log, and any relevant context files.
-4. **Invoke `/codex adversarial-review`** — this call flows through the REA middleware chain (audit → kill-switch → tier → policy → redact → injection → execute → result-size-cap).
+4. **Invoke `/codex:adversarial-review`** — this call flows through the REA middleware chain (audit → kill-switch → tier → policy → redact → injection → execute → result-size-cap).
+
+   **Model pinning (0.16.1+):** when the codex plugin's adversarial-review supports model overrides, request `gpt-5.4` with `model_reasoning_effort: high` to match the push-gate's iron-gate defaults. Pre-0.16.1, in-session adversarial reviews ran on whatever the plugin defaulted to (likely `codex-auto-review` at medium reasoning) — meaningfully WEAKER than the push-gate's `gpt-5.4` + `high`. This caused a "in-session review passes, push-gate review fails" pattern reported by helix across 014 / 015 / 016. If the plugin call accepts model parameters, pass them. If it does not, fall back to invoking `codex exec review --base <ref> --json --ephemeral -c model="gpt-5.4" -c model_reasoning_effort="high"` directly via `Bash` — same shape the push-gate uses (see `src/hooks/push-gate/codex-runner.ts::runCodexReview`). The cost of the stronger model is small relative to the cost of shipping a release with a P1 bypass that gets caught at consumer push time.
 5. **Parse the Codex output** — extract structured findings.
 6. **Classify findings** by category: security, correctness, edge cases, test gaps, API design, performance.
 7. **Assign verdict**: `pass` (no material findings), `concerns` (findings worth addressing but not blocking), `blocking` (findings that must be fixed before merge).
-8. **Emit audit entry** — the middleware records the invocation automatically, but include a structured summary in your return so `.rea/audit.jsonl` gets:
-   - `tool: "codex-adversarial-review"`
-   - `head_sha`, `target`
-   - `finding_count`
-   - `verdict`
-   - `summary` (one sentence)
+8. **Emit an audit entry — REQUIRED** for every `/codex-review` invocation. The pre-push gate does not consult audit records to decide pass/fail (post-0.11.0 the gate is stateless), but the `/codex-review` slash command's Step 3 verifies an audit entry was appended for this run and surfaces "review never happened" to the user when one is missing. The two specs are a contract pair — audit emission is what tells the operator their interactive review actually completed. Append via the public `@bookedsolid/rea/audit` helper:
+
+   ```ts
+   import { appendAuditRecord, CODEX_REVIEW_TOOL_NAME, CODEX_REVIEW_SERVER_NAME, Tier, InvocationStatus } from '@bookedsolid/rea/audit';
+
+   await appendAuditRecord(process.cwd(), {
+     tool_name: CODEX_REVIEW_TOOL_NAME,   // "codex.review"
+     server_name: CODEX_REVIEW_SERVER_NAME, // "codex"
+     status: InvocationStatus.Allowed,
+     tier: Tier.Read,
+     metadata: {
+       head_sha: '<git rev-parse HEAD>',
+       target:   '<base ref or SHA diffed against>',
+       finding_count: <total>,
+       verdict:  'pass' | 'concerns' | 'blocking' | 'error',
+       summary:  '<one sentence>',
+     },
+   });
+   ```
+
+   If the Codex plugin call itself flowed through rea middleware (the proxy case), the middleware also writes an envelope record — that is fine, the two are complementary.
 
 ## Finding Shape
 

--- a/.claude/agents/frontend-specialist.md
+++ b/.claude/agents/frontend-specialist.md
@@ -1,1 +1,84 @@
-engineering/frontend-specialist.md
+---
+name: frontend-specialist
+description: Frontend specialist for SSR pages, interactive islands, modern CSS styling, animations, and web component consumption
+---
+
+# Frontend Specialist
+
+You are the frontend specialist for this project, implementing pages, components, and interactive features.
+
+## Project Context Discovery
+
+Before acting, read:
+
+- `package.json` — dependencies and scripts
+- Framework config (`astro.config.*`, `next.config.*`, `angular.json`, etc.)
+- `tsconfig.json`
+- `.rea/policy.yaml` — autonomy level and constraints
+- Existing patterns in `src/pages`, `src/components`, `src/layouts`, `src/styles`
+
+Adapt to the project's actual stack and conventions. Do not impose patterns that diverge from the existing code without explicit direction.
+
+## File Structure (discover, don't assume)
+
+Common layout:
+
+```
+src/
+  pages/          # Page files
+  components/     # UI components
+  layouts/        # Page layouts
+  styles/         # Global styles
+  lib/            # Utilities
+  content/        # Content collections
+```
+
+Confirm the actual layout before creating new files.
+
+## Component Patterns
+
+Follow existing patterns for:
+
+- Page templates
+- Interactive component islands
+- Web component usage
+- Animation patterns — always respect `prefers-reduced-motion`
+- TypeScript strict mode — no `any`, no `@ts-ignore`
+- Path alias usage (e.g., `@/*` → `src/*`)
+
+## Styling
+
+- Use the project's chosen styling approach (Tailwind, CSS modules, plain CSS, etc.) — do not introduce a new one
+- Design tokens over hardcoded colors and sizes
+- Mobile-first responsive
+- Respect reduced-motion for all transitions and animations
+
+## Performance
+
+- Defer hydration where possible (`client:visible`, `client:idle`)
+- Lazy-load images and heavy components
+- Import components individually, not entire libraries
+- Avoid unnecessary client-side JS — prefer SSR and progressive enhancement
+
+## Constraints
+
+- NEVER use inline styles (use the project's styling approach)
+- NEVER skip `prefers-reduced-motion` on animations
+- NEVER use `any` or `@ts-ignore`
+- ALWAYS use semantic HTML (`<button>` not `<div onClick>`)
+- ALWAYS add `alt` text to images
+- ALWAYS use the project's path alias for imports
+
+## Zero-Trust Protocol
+
+1. Read before writing
+2. Never trust LLM memory — verify via tools, git, file reads
+3. Verify before claiming
+4. Validate dependencies — `npm view` before install
+5. Graduated autonomy — respect L0–L3 from `.rea/policy.yaml`
+6. HALT compliance — check `.rea/HALT` before any action
+7. Audit awareness — every tool call may be logged
+
+---
+
+_Part of the [rea](https://github.com/bookedsolidtech/rea) agent team._

--- a/.claude/agents/technical-writer.md
+++ b/.claude/agents/technical-writer.md
@@ -1,1 +1,140 @@
-engineering/technical-writer.md
+---
+name: technical-writer
+description: Senior technical writer creating comprehensive, technically accurate Markdown documentation for APIs, components, and libraries
+---
+
+# Technical Writer
+
+You are the Senior Technical Writer. You create comprehensive, technically accurate documentation.
+
+## Context
+
+- Documentation site (Astro Starlight, Docusaurus, MkDocs, or similar)
+- Target audience: developers consuming the project's APIs, components, or libraries
+- Quality bar: factually accurate, well-organized, validated by domain experts
+
+## Project Context Discovery
+
+Before writing, read:
+
+- `package.json` — what the project actually exports
+- Framework config and docs-site config
+- `.rea/policy.yaml` — autonomy level and constraints
+- Existing documentation patterns
+
+## Your Role
+
+You are the primary documentation author. Draw content from authoritative sources, incorporate architecture decisions, and produce docs that are worthy of the project's quality bar.
+
+## Responsibilities
+
+1. Draft documentation pages following provided outlines
+2. Source content from official documentation (MDN, TypeScript, framework docs) — never speculate
+3. Create accurate, tested code examples
+4. Structure content for scannability (headers, lists, code blocks, tables)
+5. Add proper frontmatter (title, description, sidebar order)
+6. Include internal cross-links
+7. Match depth to topic complexity
+
+## Page Structure
+
+```markdown
+---
+title: [Clear, descriptive title]
+description: [Concise 1-2 sentence summary]
+sidebar:
+  order: [Numeric order within section]
+---
+
+# [Page Title]
+
+[Brief introduction]
+
+## [Section 1]
+
+[Content with examples]
+
+## [Section 2]
+
+[Progressive disclosure: simple → advanced]
+
+## References
+
+- [Official Source 1](URL)
+- [Official Source 2](URL)
+```
+
+## Depth Guidelines
+
+- **Deep dives (2500–4000 words)** — complex topics, architecture decisions, comprehensive integration patterns
+- **Medium guides (1500–2500 words)** — tutorials, step-by-step guides, pattern catalogs
+- **Focused pages (500–1000 words)** — discrete concepts, specific APIs, troubleshooting
+- Match depth to topic importance and complexity
+
+## Code Example Standards
+
+- All TypeScript examples use strict mode
+- All examples pass type checking
+- Include imports where relevant
+- Comment non-obvious behavior
+- Show both simple and advanced usage
+- Include error handling where appropriate
+
+## Quality Gates
+
+1. **Accurate** — every claim verified against official sources
+2. **Tested** — code snippets execute without errors
+3. **Sourced** — references to official docs included
+4. **Organized** — clear headers, scannable structure
+5. **Complete** — no placeholders, no TODOs
+6. **Formatted** — valid Markdown/MDX, proper frontmatter
+7. **Linked** — internal cross-references where relevant
+
+## Writing Style
+
+- **Developer-first** — technical audience, no oversimplification
+- **Concise** — examples over prose
+- **Scannable** — headers, lists, tables, code blocks
+- **Progressive** — start simple, build to advanced
+- **Practical** — real-world usage, not theory
+- **Authoritative** — link to official sources, avoid speculation
+
+## When to Delegate
+
+- Frontend/component fact-checking → `frontend-specialist`
+- Backend/API fact-checking → `backend-engineer`
+- Type-system correctness → `typescript-specialist`
+- Accessibility claims → `accessibility-engineer`
+- Final technical review → `code-reviewer`
+- Adversarial review on docs that describe security-sensitive flows → `codex-adversarial`
+
+## Workflow
+
+1. Receive page outline (title, slug, depth, topics, sources)
+2. Research from specified official sources
+3. Draft following structure guidelines
+4. Create and test code examples
+5. Add frontmatter and internal links
+6. Write to the documentation directory
+7. Return for fact-checking by the relevant domain specialist
+
+## Constraints
+
+- Never invent API shapes, config keys, or CLI flags — verify against source or tests
+- Never include AI attribution lines anywhere in documentation
+- Never commit placeholders or TODOs
+- Always match the existing docs-site conventions for frontmatter, sidebar order, and internal link style
+
+## Zero-Trust Protocol
+
+1. Read before writing
+2. Never trust LLM memory — verify via tools, git, file reads
+3. Verify before claiming
+4. Validate dependencies — `npm view` before install
+5. Graduated autonomy — respect L0–L3 from `.rea/policy.yaml`
+6. HALT compliance — check `.rea/HALT` before any action
+7. Audit awareness — every tool call may be logged
+
+---
+
+_Part of the [rea](https://github.com/bookedsolidtech/rea) agent team._

--- a/.claude/agents/typescript-specialist.md
+++ b/.claude/agents/typescript-specialist.md
@@ -1,1 +1,111 @@
-engineering/typescript-specialist.md
+---
+name: typescript-specialist
+description: TypeScript specialist enforcing strict mode, type system design, declaration files, and type safety across the codebase
+---
+
+# TypeScript Specialist
+
+You are the TypeScript specialist for this project.
+
+## Project Context Discovery
+
+Before acting, read:
+
+- `package.json` — TypeScript version, build scripts
+- `tsconfig.json` — strict flags, path aliases, lib targets
+- Framework config (`astro.config.*`, `next.config.*`, etc.)
+- `.rea/policy.yaml` — autonomy level and constraints
+- Existing type patterns in the codebase
+
+Adapt to the project's actual TypeScript configuration and conventions.
+
+## Your Role
+
+- Enforce `"strict": true` across all code
+- Design type interfaces for components, API responses, content collections
+- Resolve type errors in framework frontmatter, components, and web component consumption
+- Ensure component library types work correctly in JSX/TSX contexts
+- Manage `HTMLElementTagNameMap` declarations for custom elements
+
+## Standards
+
+- Zero `any` — use `unknown` + type guards when the type is truly unknown
+- Zero `@ts-ignore` / `@ts-expect-error` — fix the type, don't suppress
+- Prefer `interface` over `type` for object shapes (better extension)
+- Use `satisfies` for type-safe object literals with inference
+- Use discriminated unions for variant types
+- Use `readonly` for arrays/tuples that should not mutate
+- Use `import type` for type-only imports
+- Export types from barrel files only when consumed externally
+
+## Common Patterns
+
+### Framework Component Props
+
+```typescript
+interface Props {
+  title: string;
+  description?: string;
+  class?: string;
+}
+
+const { title, description, class: className } = Astro.props;
+```
+
+### React Component Props
+
+```typescript
+interface ServiceCardProps {
+  title: string;
+  description: string;
+  icon: IconDefinition;
+  features: readonly string[];
+}
+```
+
+### Custom Element Types
+
+```typescript
+declare namespace astroHTML.JSX {
+  interface IntrinsicElements {
+    'my-button': Record<string, unknown>;
+    'my-nav': Record<string, unknown>;
+  }
+}
+```
+
+### Unknown Narrowing
+
+```typescript
+function isServiceCard(value: unknown): value is ServiceCardProps {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'title' in value &&
+    typeof (value as { title: unknown }).title === 'string'
+  );
+}
+```
+
+## Constraints
+
+- NEVER use `any` — no exceptions
+- NEVER use `@ts-ignore` or `@ts-expect-error` without a linked issue and sunset date
+- NEVER use non-null assertions (`!`) without proving safety
+- NEVER use `object` or `Function` or `{}` as types — use `Record<string, unknown>` or proper interfaces or specific signatures
+- ALWAYS use `readonly` for arrays/tuples that shouldn't mutate
+- ALWAYS type function parameters explicitly on public APIs
+
+## Zero-Trust Protocol
+
+1. Read before writing
+2. Never trust LLM memory — verify via tools, git, file reads
+3. Verify before claiming
+4. Validate dependencies — `npm view` before install
+5. Graduated autonomy — respect L0–L3 from `.rea/policy.yaml`
+6. HALT compliance — check `.rea/HALT` before any action
+7. Audit awareness — every tool call may be logged
+
+---
+
+_Part of the [rea](https://github.com/bookedsolidtech/rea) agent team._

--- a/.claude/commands/codex-review.md
+++ b/.claude/commands/codex-review.md
@@ -55,17 +55,21 @@ Invoke the `codex-adversarial` agent with:
 
 The agent wraps `/codex:adversarial-review` and returns structured findings.
 
-## Step 3 — (Optional) verify audit entry
+## Step 3 — Verify audit entry — REQUIRED
 
-Audit emission is **optional** in 0.11.0+. The pre-push gate is stateless and does not consult audit records to decide pass/fail; the agent's structured findings ARE the review. The agent will append an audit entry when it helps forensic traceability (intermittent verdicts, review-history audits) but its absence is not a failure.
+The `codex-adversarial` agent **MUST** emit an audit entry for every invocation. This is the same contract documented in `agents/codex-adversarial.md` Step 4 and matches the runtime behavior of `rea hook push-gate` (which always calls `appendAuditRecord` on a completed review — see `src/hooks/push-gate/index.ts`'s `EVT_REVIEWED` path).
 
-If you want to confirm an entry was written for this run:
+Verify the entry was written:
 
 ```bash
 tail -n 1 .rea/audit.jsonl
 ```
 
-A `codex-adversarial-review` entry with `head_sha`, `target`, `finding_count`, and `verdict` fields is informative — but DO NOT treat its absence as a failure. The review happened if the agent returned text. (Pre-0.15.0 this step was a hard verification gate that contradicted the agent's "audit optional" contract — see Helix Finding 3, 2026-05-03.)
+The expected entry has `tool_name: "codex.review"`, `server_name: "codex"`, and `metadata` containing `head_sha`, `target`, `finding_count`, and `verdict`. If the entry is missing, the review **did not complete its contract** — surface that to the user as a failure.
+
+**Why audit emission is required even though the pre-push gate is stateless:** the 0.11.0 push-gate decides pass/fail on Codex's live verdict, not on a receipt in the audit log — but the audit record is still the operator's only forensic trail for an interactive `/codex-review` run. Without it, "did this review actually happen" becomes unanswerable, which is exactly the failure mode helixir flagged across rounds 65/66/73 in the 0.13–0.17 cycle. Runtime always emits; the agent always emits; the slash command verifies. Three checkpoints, one contract.
+
+(Earlier docs in 0.15+ said this step was "optional"; that wording contradicted both the agent's Step 4 and the runtime behavior of `safeAppend` in `src/hooks/push-gate/index.ts`. Reconciled in 0.18.0 — helixir Finding #6 across cycles 1–7.)
 
 ## Step 4 — Report
 

--- a/.claude/commands/codex-review.md
+++ b/.claude/commands/codex-review.md
@@ -2,17 +2,17 @@
 description: Run an adversarial review of the current branch via the Codex plugin (GPT-5.4). First-class step in the REA engineering process.
 argument-hint: "[diff-target]"
 allowed-tools:
-  - Agent
   - Bash(git diff:*)
   - Bash(git log:*)
   - Bash(git branch:*)
   - Bash(git rev-parse:*)
   - Read
+  - Agent
 ---
 
 # /codex-review — Adversarial Review via Codex
 
-Invokes the Codex plugin (`/codex adversarial-review`) on the current branch's diff, captures the result, and records it to the REA audit log. Adversarial review by an independent model (GPT-5.4) is a **first-class, non-optional step** in the REA engineering process — it is the counterweight to Opus-authored code.
+Invokes the Codex plugin (`/codex:adversarial-review`) on the current branch's diff, captures the result, and records it to the REA audit log. Adversarial review by an independent model (GPT-5.4) is a **first-class, non-optional step** in the REA engineering process — it is the counterweight to Opus-authored code.
 
 ## Why this exists
 
@@ -53,25 +53,19 @@ Invoke the `codex-adversarial` agent with:
 - The commit log summary
 - The full diff text
 
-The agent wraps `/codex adversarial-review` and returns structured findings.
+The agent wraps `/codex:adversarial-review` and returns structured findings.
 
-## Step 3 — Record to audit log
+## Step 3 — (Optional) verify audit entry
 
-Every Codex invocation produces an audit entry. The `codex-adversarial` agent writes it via the middleware chain automatically, but verify the entry was recorded:
+Audit emission is **optional** in 0.11.0+. The pre-push gate is stateless and does not consult audit records to decide pass/fail; the agent's structured findings ARE the review. The agent will append an audit entry when it helps forensic traceability (intermittent verdicts, review-history audits) but its absence is not a failure.
+
+If you want to confirm an entry was written for this run:
 
 ```bash
 tail -n 1 .rea/audit.jsonl
 ```
 
-The entry must include:
-
-- `tool: "codex-adversarial-review"`
-- `head_sha: <SHA>`
-- `target: <ref>`
-- `finding_count: <N>`
-- `verdict: pass | concerns | blocking`
-
-If the audit entry is missing, report it clearly — do not proceed as if the review happened.
+A `codex-adversarial-review` entry with `head_sha`, `target`, `finding_count`, and `verdict` fields is informative — but DO NOT treat its absence as a failure. The review happened if the agent returned text. (Pre-0.15.0 this step was a hard verification gate that contradicted the agent's "audit optional" contract — see Helix Finding 3, 2026-05-03.)
 
 ## Step 4 — Report
 
@@ -91,12 +85,10 @@ If the verdict is `blocking`, state plainly: "Do not merge until the blocking fi
 
 ## Pre-merge usage
 
-The recommended BST workflow runs `/codex-review` twice:
+This command is the **interactive** Codex adversarial review. The **pre-push** gate at `rea hook push-gate` runs Codex independently on every push — you do not need to run `/codex-review` to "prime" the push-gate. The two are complementary:
 
-1. After implementation, on the feature branch — catches issues early
-2. Immediately before merge, on the PR branch — records a fresh audit entry that the `push-review-gate` hook can check for freshness
-
-Both invocations are cheap. Run both.
+- `/codex-review` — rich, interactive review output in the chat. Use during implementation to catch issues early, at review checkpoints, or whenever you want Codex's read on a specific diff.
+- `rea hook push-gate` (wired to `.husky/pre-push`) — fresh Codex review on every push. If Codex surfaces blocking/concerns findings, the push exits 2; Claude reads `.rea/last-review.json`, fixes, and pushes again.
 
 ## Constraints
 

--- a/.claude/commands/freeze.md
+++ b/.claude/commands/freeze.md
@@ -3,6 +3,7 @@ description: Activate the REA kill switch — writes .rea/HALT with a reason, bl
 argument-hint: "<reason>"
 allowed-tools:
   - Bash(npx rea freeze:*)
+  - Read
 ---
 
 # /freeze — Activate the Kill Switch

--- a/.claude/commands/review.md
+++ b/.claude/commands/review.md
@@ -7,6 +7,7 @@ allowed-tools:
   - Bash(git branch:*)
   - Bash(git status:*)
   - Read
+  - Agent
 ---
 
 # /review — Code Review on Current Changes

--- a/.claude/hooks/_lib/cmd-segments.sh
+++ b/.claude/hooks/_lib/cmd-segments.sh
@@ -51,6 +51,90 @@
 # do NOT honor `\` escapes; double-quoted spans treat `\"` as a literal
 # `"` and skip past it.
 
+# Unwrap nested shell wrappers — `bash -c 'PAYLOAD'`, `sh -lc "PAYLOAD"`,
+# `zsh -ic 'PAYLOAD'`, etc. Emits the input string AS-IS plus each inner
+# PAYLOAD as a separate line. Pre-0.17.0 the splitter never parsed
+# inside wrapped quotes, so `bash -c 'git push --force'` produced a
+# single segment whose first token was `bash` — defeating every check
+# that uses `any_segment_starts_with`. This helper makes the inner
+# payload visible as its own segment, so every existing detection rule
+# fires uniformly on wrapped and unwrapped commands.
+#
+# Closes helix-017 #1, #2, #3 (0.16.2):
+#   - `bash -lc 'git push --force origin HEAD'`  → payload now seen by H1
+#   - `bash -c 'printf x > .rea/HALT'`           → payload now seen by bash-gate
+#   - `bash -lc 'npm install some-package'`      → payload now seen by audit-gate
+#
+# Recognized wrapper shape (case-insensitive shell name):
+#   (bash|sh|zsh|dash|ksh) [optional -flags...] (-c|-lc|-lic|-ic|-cl|-cli) (QUOTED_ARG)
+#
+# QUOTED_ARG can be single- or double-quoted. Single-quote bodies have no
+# escape semantics. Double-quote bodies treat \" and \\ as literal
+# escapes (per POSIX). Multiple wrappers per command-line are handled
+# (e.g. `foo; bash -c 'bar' && sh -c 'baz'` emits both `bar` and `baz`).
+#
+# Limitation: ONE level of unwrapping. A wrapper inside a wrapper
+# (`bash -c "bash -c 'innermost'"`) emits only the second-level payload
+# (`bash -c 'innermost'`), not the third-level. This is enough for
+# every consumer-reported bypass; deeper nesting can be added later
+# without changing the contract.
+_rea_unwrap_nested_shells() {
+  local cmd="$1"
+  printf '%s\n' "$cmd"
+  printf '%s' "$cmd" | awk '
+    BEGIN {
+      # Wrapper-prefix regex: shell-name + optional flag tokens + -c-style flag.
+      # Each flag token is `-` followed by 1+ letters and trailing space.
+      WRAP = "(^|[[:space:]&|;])(bash|sh|zsh|dash|ksh)([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-(c|lc|lic|ic|cl|cli|li|il)[[:space:]]+"
+    }
+    {
+      rest = $0
+      while (length(rest) > 0) {
+        if (! match(rest, WRAP)) break
+        # Tail begins immediately after the matched wrapper prefix.
+        tail = substr(rest, RSTART + RLENGTH)
+        first = substr(tail, 1, 1)
+        if (first == "'\''") {
+          # Single-quoted body: no escape semantics; runs to next `'"'"'`.
+          body = substr(tail, 2)
+          end = index(body, "'\''")
+          if (end == 0) { rest = substr(tail, 2); continue }
+          payload = substr(body, 1, end - 1)
+          print payload
+          rest = substr(body, end + 1)
+          continue
+        }
+        if (first == "\"") {
+          # Double-quoted body: \" and \\ are literal escapes.
+          body = substr(tail, 2)
+          n = length(body)
+          j = 1
+          out = ""
+          closed = 0
+          while (j <= n) {
+            c = substr(body, j, 1)
+            if (c == "\\" && j < n) {
+              nxt = substr(body, j + 1, 1)
+              if (nxt == "\"" || nxt == "\\") { out = out nxt; j += 2; continue }
+              out = out c nxt
+              j += 2
+              continue
+            }
+            if (c == "\"") { closed = j; break }
+            out = out c
+            j++
+          }
+          if (closed == 0) { rest = substr(tail, 2); continue }
+          print out
+          rest = substr(body, closed + 1)
+          continue
+        }
+        # Non-quoted argument — proceed past the matched prefix only.
+        rest = tail
+      }
+    }'
+}
+
 # Split $1 on shell command separators. Emits one segment per line on
 # stdout (empty segments preserved). Used by both higher-level helpers
 # below; not generally called by hooks directly.
@@ -103,7 +187,14 @@ _rea_split_segments() {
   # splitting so quoted prose no longer over-splits and anchors trigger
   # words at the head of phantom segments. See header comment for the
   # full rationale.
-  printf '%s' "$cmd" \
+  #
+  # 0.17.0 helix-017 #1-#3 fix: unwrap `bash -c 'PAYLOAD'` style
+  # wrappers BEFORE the quote-mask + split passes. The unwrap step
+  # emits the original line plus each inner PAYLOAD as separate
+  # records; the existing pipeline then quote-masks and splits each
+  # record independently. Inner payload anchors trigger words for the
+  # `any_segment_*` checks downstream.
+  _rea_unwrap_nested_shells "$cmd" \
     | awk '
         BEGIN {
           SC  = "__REA_SEP_SC_a8f2c1__"

--- a/.claude/hooks/_lib/cmd-segments.sh
+++ b/.claude/hooks/_lib/cmd-segments.sh
@@ -33,17 +33,23 @@
 #     form matches PATTERN (a `grep -qiE` extended regex). Returns 1
 #     if no segment matches.
 #
-# Quoting awareness: the splitter is NOT quote-aware. A separator inside
-# a quoted string would be split. This is INTENTIONAL and SAFE: the
-# segments-vs-callback contract is "find segments that anchor on a
-# trigger word." Over-splitting produces extra segments that don't
-# anchor; they're ignored. Under-splitting (treating a quoted separator
-# as part of one segment) is what the original bug was. The trade-off
-# explicitly accepts over-splitting.
+# Quoting awareness (0.16.3 helix-016.1 #2 fix): the splitter masks
+# shell separators that occur INSIDE matched `"..."` and `'...'` quote
+# spans before splitting. Earlier versions split on every unescaped
+# `&`/`;`/`|`/newline regardless of quote context, which produced
+# false-positive segment boundaries inside quoted prose:
 #
-# Quoting note for future maintainers: do not "fix" the over-splitting
-# without breaking the security property. Quote-aware splitting in pure
-# bash is a real lift; if needed it should move to a Node helper.
+#   echo "release note & git push --force now"
+#
+# The pre-fix splitter broke that into two segments and the H1 force-push
+# detector anchored on `git push --force` at the head of segment 2 — a
+# real false positive helix reproduced spontaneously during diagnostic
+# work. The fix walks the input once, replaces in-quote separators with
+# multi-byte sentinels (impossible-to-collide forms), splits on the
+# remaining un-quoted separators, then restores the sentinels back to
+# their literal characters in the surviving segments. Single-quoted spans
+# do NOT honor `\` escapes; double-quoted spans treat `\"` as a literal
+# `"` and skip past it.
 
 # Split $1 on shell command separators. Emits one segment per line on
 # stdout (empty segments preserved). Used by both higher-level helpers
@@ -53,6 +59,22 @@ _rea_split_segments() {
   # GNU sed and BSD sed both honor `s/PATTERN/\n/g` with `-E` for ERE.
   # We use printf+sed instead of bash IFS=$'...' read so the splitter
   # behaves identically across BSD and GNU sed.
+  #
+  # Pipeline overview (post-0.16.3 quote-mask):
+  #   1. awk one-pass mask: replace `;` `&` `|` `\n` INSIDE matched
+  #      `"..."` / `'...'` spans with multi-byte sentinels so the
+  #      separator-splitting passes below ignore them. Single-quoted
+  #      spans have no escape semantics; double-quoted spans treat
+  #      `\"` as a literal quote and continue inside the span.
+  #   2. existing `>|` swap (preserves the bash noclobber-override
+  #      operator across the splitting passes).
+  #   3. existing `&&` swap (so step 4 doesn't break compound `&&`
+  #      operators apart while still splitting on bare `&`).
+  #   4. sed split on `||`, `;`, bare `|`, bare `&`.
+  #   5. unswap `&&` / `>|` placeholders.
+  #   6. restore the in-quote sentinels back to literal chars so each
+  #      surviving segment sees its quoted prose intact (downstream
+  #      hooks regex against the segments and need the literal bytes).
   #
   # 0.16.0 codex P1 fix (helix-015 #3): the prior sed split on bare `|`
   # which broke bash's `>|` (noclobber-override redirect) into two
@@ -77,12 +99,130 @@ _rea_split_segments() {
   # token is `sleep`, and `any_segment_starts_with($CMD, 'git push')`
   # missed the force-push entirely. Add `&` to the separator set, but
   # AFTER `&&` is already swapped out so we don't break it apart.
-  printf '%s\n' "$cmd" \
+  # 0.16.3 helix-016.1 #2 fix: quote-mask in-quote separators before
+  # splitting so quoted prose no longer over-splits and anchors trigger
+  # words at the head of phantom segments. See header comment for the
+  # full rationale.
+  printf '%s' "$cmd" \
+    | awk '
+        BEGIN {
+          SC  = "__REA_SEP_SC_a8f2c1__"
+          AMP = "__REA_SEP_AMP_a8f2c1__"
+          PIPE = "__REA_SEP_PIPE_a8f2c1__"
+          NL  = "__REA_SEP_NL_a8f2c1__"
+        }
+        {
+          line = $0
+          out = ""
+          i = 1
+          n = length(line)
+          mode = 0  # 0=plain, 1=double, 2=single
+          while (i <= n) {
+            ch = substr(line, i, 1)
+            if (mode == 0) {
+              if (ch == "\"") { mode = 1; out = out ch; i++; continue }
+              if (ch == "'\''") { mode = 2; out = out ch; i++; continue }
+              out = out ch
+              i++
+              continue
+            }
+            if (mode == 2) {
+              # Single quotes: no escape semantics. Only `'\''` ends.
+              if (ch == "'\''") { mode = 0; out = out ch; i++; continue }
+              if (ch == ";")    { out = out SC;   i++; continue }
+              if (ch == "&")    { out = out AMP;  i++; continue }
+              if (ch == "|")    { out = out PIPE; i++; continue }
+              # awk record-mode: literal newlines inside single-quoted
+              # heredoc bodies arrive as separate records; mask is
+              # per-record so they remain separators across records by
+              # design (the original splitter behavior).
+              out = out ch
+              i++
+              continue
+            }
+            # mode == 1 (double-quoted)
+            if (ch == "\\" && i < n) {
+              # Preserve `\"` and `\\` escape sequences literally; do not
+              # exit the double-quoted span on the escaped quote.
+              nxt = substr(line, i + 1, 1)
+              out = out ch nxt
+              i += 2
+              continue
+            }
+            if (ch == "\"") { mode = 0; out = out ch; i++; continue }
+            if (ch == ";")  { out = out SC;   i++; continue }
+            if (ch == "&")  { out = out AMP;  i++; continue }
+            if (ch == "|")  { out = out PIPE; i++; continue }
+            out = out ch
+            i++
+          }
+          print out
+        }' \
     | sed -E 's/>\|/__REA_GTPIPE_a8f2c1__/g' \
     | sed -E 's/&&/__REA_LOGAND_a8f2c1__/g' \
     | sed -E 's/(\|\||;|\||&)/\n/g' \
     | sed -E 's/__REA_LOGAND_a8f2c1__/\n/g' \
-    | sed -E 's/__REA_GTPIPE_a8f2c1__/>|/g'
+    | sed -E 's/__REA_GTPIPE_a8f2c1__/>|/g' \
+    | sed -E 's/__REA_SEP_SC_a8f2c1__/;/g; s/__REA_SEP_AMP_a8f2c1__/\&/g; s/__REA_SEP_PIPE_a8f2c1__/|/g; s/__REA_SEP_NL_a8f2c1__/\n/g'
+}
+
+# Apply only the quote-mask preprocessing pass. Returns the input with
+# in-quote `;`/`&`/`|`/newline replaced by sentinels but WITHOUT splitting
+# on the un-masked operators. Useful for multi-segment-property checks
+# (H12 curl-pipe-shell) that need to scan the whole command-line as one
+# string while still ignoring in-quote prose. Restores quoted-content
+# pipe to a placeholder (`__REA_INQUOTE_PIPE__`) so a regex against the
+# masked output can match a real `|` token without false-positiving on
+# in-quote `|` characters.
+quote_masked_cmd() {
+  local cmd="$1"
+  printf '%s' "$cmd" \
+    | awk '
+        BEGIN {
+          INQ_PIPE = "__REA_INQUOTE_PIPE_a8f2c1__"
+          INQ_SC   = "__REA_INQUOTE_SC_a8f2c1__"
+          INQ_AMP  = "__REA_INQUOTE_AMP_a8f2c1__"
+        }
+        {
+          line = $0
+          out = ""
+          i = 1
+          n = length(line)
+          mode = 0
+          while (i <= n) {
+            ch = substr(line, i, 1)
+            if (mode == 0) {
+              if (ch == "\"") { mode = 1; out = out ch; i++; continue }
+              if (ch == "'\''") { mode = 2; out = out ch; i++; continue }
+              out = out ch
+              i++
+              continue
+            }
+            if (mode == 2) {
+              if (ch == "'\''") { mode = 0; out = out ch; i++; continue }
+              if (ch == "|") { out = out INQ_PIPE; i++; continue }
+              if (ch == ";") { out = out INQ_SC;   i++; continue }
+              if (ch == "&") { out = out INQ_AMP;  i++; continue }
+              out = out ch
+              i++
+              continue
+            }
+            if (ch == "\\" && i < n) {
+              out = out ch substr(line, i + 1, 1)
+              i += 2
+              continue
+            }
+            if (ch == "\"") { mode = 0; out = out ch; i++; continue }
+            if (ch == "|") { out = out INQ_PIPE; i++; continue }
+            if (ch == ";") { out = out INQ_SC;   i++; continue }
+            if (ch == "&") { out = out INQ_AMP;  i++; continue }
+            out = out ch
+            i++
+          }
+          # awk auto-appends a newline on `print`; strip it so the
+          # caller gets exactly what was passed in.
+          printf "%s", out
+        }'
 }
 
 # Strip leading whitespace and well-known command prefixes from a single

--- a/.claude/hooks/_lib/cmd-segments.sh
+++ b/.claude/hooks/_lib/cmd-segments.sh
@@ -73,6 +73,20 @@
 # escapes (per POSIX). Multiple wrappers per command-line are handled
 # (e.g. `foo; bash -c 'bar' && sh -c 'baz'` emits both `bar` and `baz`).
 #
+# 0.18.0 helix-020 G1.A fix: the unwrap pass scans a QUOTE-MASKED form
+# of the input, not the raw input. Pre-fix, a quoted argument that
+# MENTIONED a wrapper (e.g. `git commit -m "docs: mention bash -c 'npm
+# install left-pad'"`) would emit a phantom inner-payload segment, and
+# `dependency-audit-gate.sh` would block the innocent commit. The
+# quote-mask layer (the same one `_rea_split_segments` uses) replaces
+# all in-quote separators AND in-quote single/double quote characters
+# with multi-byte sentinels — so the wrapper regex can no longer match
+# inside an outer quoted span. The unwrapped payload itself is still
+# emitted from the un-masked input by recomputing offsets back to the
+# raw string, so escape semantics inside legitimate wrappers stay
+# correct. We only need the mask to suppress matching; the captured
+# payload is read off the original string.
+#
 # Limitation: ONE level of unwrapping. A wrapper inside a wrapper
 # (`bash -c "bash -c 'innermost'"`) emits only the second-level payload
 # (`bash -c 'innermost'`), not the third-level. This is enough for
@@ -81,32 +95,130 @@
 _rea_unwrap_nested_shells() {
   local cmd="$1"
   printf '%s\n' "$cmd"
-  printf '%s' "$cmd" | awk '
+  # Build a mask where in-quote `"` `'` `;` `&` `|` characters are
+  # replaced with multi-byte sentinels so the wrapper regex below
+  # cannot match wrapper syntax that lives inside outer quoted prose.
+  # We also mask the in-quote QUOTE characters themselves so the awk
+  # body's quote-state heuristic (which looks at the byte immediately
+  # after the matched wrapper-prefix region) cannot mistake an inner
+  # quote for a payload-opening quote. Sentinel bytes are aligned to
+  # be the same width as their original character (single-byte) so
+  # offsets into the raw string remain valid for payload extraction.
+  #
+  # Approach: rather than synthesize a per-byte sentinel of width 1,
+  # we run the awk wrapper-scan against a SEPARATE masked stream and
+  # then translate matched RSTART/RLENGTH offsets back to the original
+  # string. We do that by passing both strings into awk (raw via stdin,
+  # masked via -v MASKED) and tracking the same index across both —
+  # since the mask substitutes single bytes with single bytes only
+  # (placeholder bytes drawn from the C0 control-character range) the
+  # offsets line up.
+  #
+  # Placeholder bytes — chosen from the C0 control range so they
+  # cannot appear in real shell input under UTF-8 (NUL, BEL, VT, FF
+  # are reserved by some shells; we use SOH/STX/ETX/ENQ/ACK which are
+  # not assigned operational meaning by any shell we ship with).
+  #   \x01 SOH — replaces in-quote `"`
+  #   \x02 STX — replaces in-quote `'`
+  #   \x03 ETX — replaces in-quote `;`
+  #   \x05 ENQ — replaces in-quote `&`
+  #   \x06 ACK — replaces in-quote `|`
+  local masked
+  masked=$(printf '%s' "$cmd" | awk '
+    {
+      line = $0
+      out = ""
+      i = 1
+      n = length(line)
+      mode = 0
+      while (i <= n) {
+        ch = substr(line, i, 1)
+        if (mode == 0) {
+          if (ch == "\"") { mode = 1; out = out ch; i++; continue }
+          if (ch == "'\''") { mode = 2; out = out ch; i++; continue }
+          out = out ch
+          i++
+          continue
+        }
+        if (mode == 2) {
+          if (ch == "'\''") { mode = 0; out = out "\002"; i++; continue }
+          if (ch == ";") { out = out "\003"; i++; continue }
+          if (ch == "&") { out = out "\005"; i++; continue }
+          if (ch == "|") { out = out "\006"; i++; continue }
+          if (ch == "\"") { out = out "\001"; i++; continue }
+          out = out ch
+          i++
+          continue
+        }
+        # mode == 1 (double-quoted)
+        if (ch == "\\" && i < n) {
+          # Preserve the escape pair literally — width preserved.
+          nxt = substr(line, i + 1, 1)
+          out = out ch nxt
+          i += 2
+          continue
+        }
+        if (ch == "\"") { mode = 0; out = out "\001"; i++; continue }
+        if (ch == ";") { out = out "\003"; i++; continue }
+        if (ch == "&") { out = out "\005"; i++; continue }
+        if (ch == "|") { out = out "\006"; i++; continue }
+        if (ch == "'\''") { out = out "\002"; i++; continue }
+        out = out ch
+        i++
+      }
+      printf "%s", out
+    }')
+  # Pass both raw and masked into awk. Wrapper-regex matches against the
+  # masked form; payload extraction reads the raw form using the same
+  # offsets. Because the mask is byte-for-byte width-preserving, the
+  # same RSTART/RLENGTH applies to both.
+  printf '' | awk -v raw="$cmd" -v masked="$masked" '
     BEGIN {
       # Wrapper-prefix regex: shell-name + optional flag tokens + -c-style flag.
       # Each flag token is `-` followed by 1+ letters and trailing space.
+      # NOTE: matches only OUTSIDE outer quoted spans because in-quote
+      # `"`, `'\''`, `;`, `&`, `|` are masked out in `masked`. The leading
+      # alternation `(^|[[:space:]&|;])` therefore cannot anchor on a
+      # masked separator, and the shell-name token itself can no longer
+      # appear adjacent to a masked quote-introducer.
       WRAP = "(^|[[:space:]&|;])(bash|sh|zsh|dash|ksh)([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-(c|lc|lic|ic|cl|cli|li|il)[[:space:]]+"
-    }
-    {
-      rest = $0
-      while (length(rest) > 0) {
-        if (! match(rest, WRAP)) break
-        # Tail begins immediately after the matched wrapper prefix.
-        tail = substr(rest, RSTART + RLENGTH)
-        first = substr(tail, 1, 1)
-        if (first == "'\''") {
-          # Single-quoted body: no escape semantics; runs to next `'"'"'`.
-          body = substr(tail, 2)
+      # Track the cursor in BOTH raw and masked. Because the mask is
+      # byte-for-byte width-preserving, the same RSTART/RLENGTH applies
+      # to both — but each iteration of the loop must SLICE both strings
+      # by the same amount so subsequent matches see synchronized tails.
+      mrest = masked
+      rrest = raw
+      while (length(mrest) > 0) {
+        if (! match(mrest, WRAP)) break
+        # Tail begins immediately after the matched wrapper prefix in
+        # BOTH strings (offsets line up — mask is width-preserving).
+        mtail = substr(mrest, RSTART + RLENGTH)
+        rtail = substr(rrest, RSTART + RLENGTH)
+        # The wrapper-payload-introducing quote must be a REAL outer
+        # quote — i.e. not a masked in-quote sentinel. Probe the raw
+        # form for the introducer character, which the mask preserved
+        # verbatim only when it was an outer quote.
+        first = substr(rtail, 1, 1)
+        mfirst = substr(mtail, 1, 1)
+        if (first == "'\''" && mfirst == "'\''") {
+          # Single-quoted body: no escape semantics; runs to next `'\''`.
+          body = substr(rtail, 2)
+          mbody = substr(mtail, 2)
           end = index(body, "'\''")
-          if (end == 0) { rest = substr(tail, 2); continue }
+          if (end == 0) {
+            mrest = substr(mtail, 2)
+            rrest = substr(rtail, 2)
+            continue
+          }
           payload = substr(body, 1, end - 1)
           print payload
-          rest = substr(body, end + 1)
+          mrest = substr(mbody, end + 1)
+          rrest = substr(body, end + 1)
           continue
         }
-        if (first == "\"") {
+        if (first == "\"" && mfirst == "\"") {
           # Double-quoted body: \" and \\ are literal escapes.
-          body = substr(tail, 2)
+          body = substr(rtail, 2)
           n = length(body)
           j = 1
           out = ""
@@ -124,15 +236,27 @@ _rea_unwrap_nested_shells() {
             out = out c
             j++
           }
-          if (closed == 0) { rest = substr(tail, 2); continue }
+          if (closed == 0) {
+            mrest = substr(mtail, 2)
+            rrest = substr(rtail, 2)
+            continue
+          }
           print out
-          rest = substr(body, closed + 1)
+          # Skip past the opening `"` (1 byte) AND the closing `"` (1
+          # byte at body[closed], i.e. mtail[closed+1]). Cursor lands
+          # at mtail[closed+2].
+          mrest = substr(mtail, closed + 2)
+          rrest = substr(rtail, closed + 2)
           continue
         }
         # Non-quoted argument — proceed past the matched prefix only.
-        rest = tail
+        mrest = mtail
+        rrest = rtail
       }
-    }'
+    }
+    # Empty action with no input rules — explicitly drive the loop from
+    # END so awk does not require any input records.
+    END {}'
 }
 
 # Split $1 on shell command separators. Emits one segment per line on

--- a/.claude/hooks/_lib/cmd-segments.sh
+++ b/.claude/hooks/_lib/cmd-segments.sh
@@ -181,7 +181,14 @@ _rea_unwrap_nested_shells() {
       # alternation `(^|[[:space:]&|;])` therefore cannot anchor on a
       # masked separator, and the shell-name token itself can no longer
       # appear adjacent to a masked quote-introducer.
-      WRAP = "(^|[[:space:]&|;])(bash|sh|zsh|dash|ksh)([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-(c|lc|lic|ic|cl|cli|li|il)[[:space:]]+"
+      # 0.19.0 security review M1: extend the shell-name set to cover
+      # every commonly-installed POSIX-style shell. mksh / oksh / yash /
+      # posh ship on minimal containers, csh/tcsh on legacy macOS,
+      # fish on dev workstations. Each accepts -c with a quoted body.
+      # NOTE: pwsh (PowerShell) uses -Command / -EncodedCommand and is
+      # NOT covered here. Adding pwsh requires a separate code path
+      # because EncodedCommand base64-decodes at runtime.
+      WRAP = "(^|[[:space:]&|;])(bash|sh|zsh|dash|ksh|mksh|oksh|posh|yash|csh|tcsh|fish)([[:space:]]+-[a-zA-Z]+)*[[:space:]]+-(c|lc|lic|ic|cl|cli|li|il)[[:space:]]+"
       # Track the cursor in BOTH raw and masked. Because the mask is
       # byte-for-byte width-preserving, the same RSTART/RLENGTH applies
       # to both — but each iteration of the loop must SLICE both strings

--- a/.claude/hooks/_lib/cmd-segments.sh
+++ b/.claude/hooks/_lib/cmd-segments.sh
@@ -183,6 +183,34 @@ any_segment_raw_matches() {
   return 1
 }
 
+# Return 0 if any single segment of $1 (after prefix-stripping) matches
+# BOTH extended regex $2 AND extended regex $3. Case-insensitive. Returns
+# 1 if no single segment matches both patterns.
+#
+# Use this when two patterns must co-occur within the SAME shell command
+# segment to constitute a detection — e.g. env-file-protection's
+# "utility + .env-filename" rule. Pre-fix env-file-protection used two
+# independent `any_segment_matches` calls and OR-combined the booleans,
+# which mis-fires across multi-segment constructions like
+# `echo "log: cat is broken" ; touch foo.env` (utility in segment 1,
+# .env name in segment 2 — both flags set, false-positive block).
+#
+# 0.16.2 helix-017 P2 #2 fix.
+any_segment_matches_both() {
+  local cmd="$1"
+  local pattern_a="$2"
+  local pattern_b="$3"
+  local segment stripped
+  while IFS= read -r segment; do
+    stripped=$(_rea_strip_prefix "$segment")
+    if printf '%s' "$stripped" | grep -qiE "$pattern_a" \
+       && printf '%s' "$stripped" | grep -qiE "$pattern_b"; then
+      return 0
+    fi
+  done < <(_rea_split_segments "$cmd")
+  return 1
+}
+
 # Return 0 if any segment of $1 (after prefix-stripping) STARTS WITH
 # the extended regex $2. Case-insensitive. Returns 1 if no segment
 # starts with the pattern.

--- a/.claude/hooks/_lib/cmd-segments.sh
+++ b/.claude/hooks/_lib/cmd-segments.sh
@@ -87,14 +87,29 @@
 # correct. We only need the mask to suppress matching; the captured
 # payload is read off the original string.
 #
-# Limitation: ONE level of unwrapping. A wrapper inside a wrapper
-# (`bash -c "bash -c 'innermost'"`) emits only the second-level payload
-# (`bash -c 'innermost'`), not the third-level. This is enough for
-# every consumer-reported bypass; deeper nesting can be added later
-# without changing the contract.
+# 0.21.2 helix-022 #3: recurse to fixed point with depth bound 8.
+# Pre-fix the function did exactly ONE level of unwrap, so
+# `bash -lc "bash -lc 'printf x > .rea/HALT'"` emitted the
+# middle wrapper as a segment but NEVER the inner `printf x > ...`.
+# Now each extracted payload is re-fed through the unwrap until
+# either no payload is found (fixed point) or depth 8 is reached.
+# Depth limit prevents pathological inputs; on overflow the helper
+# emits a stderr advisory but does not refuse — caller falls back
+# to logical-form-only enforcement of the partial unwrap.
 _rea_unwrap_nested_shells() {
+  _rea_unwrap_at_depth "$1" 0
+}
+
+_rea_unwrap_at_depth() {
   local cmd="$1"
+  local depth="$2"
+  local max_depth=8
   printf '%s\n' "$cmd"
+  if [[ $depth -ge $max_depth ]]; then
+    printf 'rea: nested-shell unwrap depth limit (%d) reached on payload %.80s...\n' \
+      "$max_depth" "$cmd" >&2
+    return 0
+  fi
   # Build a mask where in-quote `"` `'` `;` `&` `|` characters are
   # replaced with multi-byte sentinels so the wrapper regex below
   # cannot match wrapper syntax that lives inside outer quoted prose.
@@ -172,7 +187,10 @@ _rea_unwrap_nested_shells() {
   # masked form; payload extraction reads the raw form using the same
   # offsets. Because the mask is byte-for-byte width-preserving, the
   # same RSTART/RLENGTH applies to both.
-  printf '' | awk -v raw="$cmd" -v masked="$masked" '
+  #
+  # 0.21.2: capture payloads to a local var; iterate to recurse.
+  local _unwrap_payloads
+  _unwrap_payloads=$(printf '' | awk -v raw="$cmd" -v masked="$masked" '
     BEGIN {
       # Wrapper-prefix regex: shell-name + optional flag tokens + -c-style flag.
       # Each flag token is `-` followed by 1+ letters and trailing space.
@@ -263,7 +281,14 @@ _rea_unwrap_nested_shells() {
     }
     # Empty action with no input rules — explicitly drive the loop from
     # END so awk does not require any input records.
-    END {}'
+    END {}')
+  # Recurse on each extracted payload with depth+1.
+  if [[ -n "$_unwrap_payloads" ]]; then
+    while IFS= read -r _unwrap_p; do
+      [[ -z "$_unwrap_p" ]] && continue
+      _rea_unwrap_at_depth "$_unwrap_p" $((depth + 1))
+    done <<< "$_unwrap_payloads"
+  fi
 }
 
 # Split $1 on shell command separators. Emits one segment per line on

--- a/.claude/hooks/_lib/cmd-segments.sh
+++ b/.claude/hooks/_lib/cmd-segments.sh
@@ -1,0 +1,208 @@
+# shellcheck shell=bash
+# hooks/_lib/cmd-segments.sh — shell-segment splitting for Bash-tier hooks.
+#
+# Background: hooks that gate `Bash` tool calls grep `.tool_input.command`
+# for danger words (`rm -rf`, `git restore`, `pnpm install`, etc.). Pre-
+# 0.15.0 every hook ran a single `grep -qE PATTERN "$cmd"` against the
+# whole command string. That false-positives on heredoc bodies and
+# commit messages where the trigger word appears inside content rather
+# than as a command:
+#
+#   git commit -m "$(cat <<'EOF'
+#   docs: explain why we don't run rm -rf node_modules in CI
+#   EOF
+#   )"
+#
+# The unanchored regex matches `rm -rf` inside the heredoc body and the
+# hook blocks a perfectly safe commit. Hit during the 2026-05-03 session
+# repeatedly — the pattern that motivated dependency-audit-gate's 0.15.0
+# segment-split fix.
+#
+# This helper exposes two primitives every Bash-tier hook should use:
+#
+#   for_each_segment "$CMD" CALLBACK
+#     Splits $CMD on shell command separators (`;`, `&&`, `||`, `|`,
+#     newlines) and invokes CALLBACK with each segment as $1, plus the
+#     leading-prefix-stripped form as $2 (with `sudo`/`exec`/`time`/
+#     `then`/`do`/env-var-assignment prefixes removed). Returns 0 if
+#     CALLBACK returned 0 for every segment, or the first non-zero
+#     CALLBACK exit otherwise.
+#
+#   any_segment_matches "$CMD" PATTERN
+#     Iterates segments and returns 0 if any segment's prefix-stripped
+#     form matches PATTERN (a `grep -qiE` extended regex). Returns 1
+#     if no segment matches.
+#
+# Quoting awareness: the splitter is NOT quote-aware. A separator inside
+# a quoted string would be split. This is INTENTIONAL and SAFE: the
+# segments-vs-callback contract is "find segments that anchor on a
+# trigger word." Over-splitting produces extra segments that don't
+# anchor; they're ignored. Under-splitting (treating a quoted separator
+# as part of one segment) is what the original bug was. The trade-off
+# explicitly accepts over-splitting.
+#
+# Quoting note for future maintainers: do not "fix" the over-splitting
+# without breaking the security property. Quote-aware splitting in pure
+# bash is a real lift; if needed it should move to a Node helper.
+
+# Split $1 on shell command separators. Emits one segment per line on
+# stdout (empty segments preserved). Used by both higher-level helpers
+# below; not generally called by hooks directly.
+_rea_split_segments() {
+  local cmd="$1"
+  # GNU sed and BSD sed both honor `s/PATTERN/\n/g` with `-E` for ERE.
+  # We use printf+sed instead of bash IFS=$'...' read so the splitter
+  # behaves identically across BSD and GNU sed.
+  #
+  # 0.16.0 codex P1 fix (helix-015 #3): the prior sed split on bare `|`
+  # which broke bash's `>|` (noclobber-override redirect) into two
+  # segments — `printf x >` then ` .rea/HALT`. The redirect detector
+  # then never saw a complete `>|` operator and the bash-gate let the
+  # write through.
+  #
+  # 0.16.0 codex P2-1 fix: the placeholder must NOT collide with any
+  # legal byte the agent could supply. The earlier `\x01` (SOH) is a
+  # legal UTF-8 byte and rare-but-possible in commands; if a payload
+  # contained `\x01` literally, the third sed pass would manufacture
+  # a `>|` operator that wasn't in the original — corrupting downstream
+  # parsing in either fail-open or fail-closed directions depending on
+  # what came after. The new sentinel `__REA_GTPIPE_a8f2c1__` is
+  # multi-byte alphanumeric, impossible to collide with shell input
+  # under any encoding we care about (any agent that intentionally
+  # included this string would already be obviously trying to confuse
+  # the splitter — and even then, the worst case is fail-closed).
+  # 0.16.1 helix-016 P1 fix: also split on single `&` (background-process
+  # operator). Pre-fix the splitter only broke on `&&|||;|`; a command like
+  # `sleep 1 & git push --force` was treated as ONE segment whose first
+  # token is `sleep`, and `any_segment_starts_with($CMD, 'git push')`
+  # missed the force-push entirely. Add `&` to the separator set, but
+  # AFTER `&&` is already swapped out so we don't break it apart.
+  printf '%s\n' "$cmd" \
+    | sed -E 's/>\|/__REA_GTPIPE_a8f2c1__/g' \
+    | sed -E 's/&&/__REA_LOGAND_a8f2c1__/g' \
+    | sed -E 's/(\|\||;|\||&)/\n/g' \
+    | sed -E 's/__REA_LOGAND_a8f2c1__/\n/g' \
+    | sed -E 's/__REA_GTPIPE_a8f2c1__/>|/g'
+}
+
+# Strip leading whitespace and well-known command prefixes from a single
+# segment. Returns the prefix-stripped form on stdout. Examples:
+#   "  sudo pnpm install foo"        → "pnpm install foo"
+#   "NODE_ENV=production pnpm add x" → "pnpm add x"
+#   "then pnpm add lodash"           → "pnpm add lodash"
+_rea_strip_prefix() {
+  local seg="$1"
+  # Trim leading whitespace.
+  seg="${seg#"${seg%%[![:space:]]*}"}"
+  # Strip ONE prefix at a time, looping. This handles compounds like
+  # `sudo NODE_ENV=production pnpm add foo`.
+  while :; do
+    case "$seg" in
+      sudo[[:space:]]*|exec[[:space:]]*|time[[:space:]]*|then[[:space:]]*|do[[:space:]]*|else[[:space:]]*)
+        # Drop the prefix word and any subsequent whitespace.
+        seg="${seg#* }"
+        seg="${seg#"${seg%%[![:space:]]*}"}"
+        ;;
+      *)
+        # Env-var assignment prefix (`KEY=value `) — only strip if the
+        # token before the first space looks like NAME=value.
+        if [[ "$seg" =~ ^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]+ ]]; then
+          seg="${seg#* }"
+          seg="${seg#"${seg%%[![:space:]]*}"}"
+        else
+          break
+        fi
+        ;;
+    esac
+  done
+  printf '%s' "$seg"
+}
+
+# Iterate every segment of $1 and invoke $2 (a function name) with the
+# raw segment as $1 and the prefix-stripped form as $2. The callback's
+# return value is honored: a non-zero return aborts the iteration and
+# becomes the helper's return value.
+for_each_segment() {
+  local cmd="$1"
+  local callback="$2"
+  local segment stripped rc
+  while IFS= read -r segment; do
+    stripped=$(_rea_strip_prefix "$segment")
+    "$callback" "$segment" "$stripped"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      return "$rc"
+    fi
+  done < <(_rea_split_segments "$cmd")
+  return 0
+}
+
+# Return 0 if any segment of $1 (after prefix-stripping) matches the
+# extended regex $2 ANYWHERE (not anchored). Case-insensitive. Returns 1
+# if no segment matches.
+#
+# Use this for patterns that may legitimately appear mid-segment, e.g.
+# `Co-Authored-By:` in a commit message body. For "is the segment a
+# call to <command>" use `any_segment_starts_with` instead — that
+# anchors on the start so `echo "rm -rf foo"` doesn't trip an
+# `rm -rf` detector.
+any_segment_matches() {
+  local cmd="$1"
+  local pattern="$2"
+  local segment stripped
+  while IFS= read -r segment; do
+    stripped=$(_rea_strip_prefix "$segment")
+    if printf '%s' "$stripped" | grep -qiE "$pattern"; then
+      return 0
+    fi
+  done < <(_rea_split_segments "$cmd")
+  return 1
+}
+
+# Return 0 if any segment of $1 (RAW — no prefix-stripping) matches the
+# extended regex $2. Use this for checks where the prefix itself IS the
+# signal — e.g. H10's `HUSKY=0 git commit` detection (the prefix-stripper
+# would strip the `HUSKY=0` before any_segment_matches sees it). Also
+# right for H15 (`REA_BYPASS=...`) and H16 (alias/function defs).
+#
+# 0.16.1 helix-016 sibling fix: H10 baseline corpus regressed from
+# 0.15.0 because it migrated to `any_segment_matches` which strips
+# env-var prefixes. The check needs the raw segment to fire.
+any_segment_raw_matches() {
+  local cmd="$1"
+  local pattern="$2"
+  local segment
+  while IFS= read -r segment; do
+    # Trim leading whitespace for clean anchor matching, but otherwise
+    # leave the segment intact (env-var assignments preserved).
+    segment="${segment#"${segment%%[![:space:]]*}"}"
+    if printf '%s' "$segment" | grep -qiE "$pattern"; then
+      return 0
+    fi
+  done < <(_rea_split_segments "$cmd")
+  return 1
+}
+
+# Return 0 if any segment of $1 (after prefix-stripping) STARTS WITH
+# the extended regex $2. Case-insensitive. Returns 1 if no segment
+# starts with the pattern.
+#
+# This is the right shape for "is this segment a call to <command>"
+# checks. `echo "rm -rf foo"` does NOT trigger an `rm -rf` detector
+# because the segment starts with `echo`, not `rm`. Compare to
+# `any_segment_matches`, which matches anywhere in the segment and
+# would fire on the echo'd argument.
+any_segment_starts_with() {
+  local cmd="$1"
+  local pattern="$2"
+  local segment stripped
+  while IFS= read -r segment; do
+    stripped=$(_rea_strip_prefix "$segment")
+    # `^` anchor + caller pattern. `(?:)` non-capturing group not
+    # supported in BSD ERE; we use a simple literal `^` prepend.
+    if printf '%s' "$stripped" | grep -qiE "^${pattern}"; then
+      return 0
+    fi
+  done < <(_rea_split_segments "$cmd")
+  return 1
+}

--- a/.claude/hooks/_lib/common.sh
+++ b/.claude/hooks/_lib/common.sh
@@ -87,7 +87,12 @@ triage_score() {
   local diff_input
   diff_input=$(cat)
   local line_count
-  line_count=$(printf '%s' "$diff_input" | grep -cE '^\+[^+]|^-[^-]' 2>/dev/null || echo "0")
+  # Defect K (rea#62) sibling: see `hooks/commit-review-gate.sh` for the
+  # full bug rationale. `|| echo "0"` captures "0\n0" on no-match, which
+  # breaks arithmetic comparisons downstream. `|| true` + bash default keeps
+  # the branch arithmetic-safe.
+  line_count=$(printf '%s' "$diff_input" | grep -cE '^\+[^+]|^-[^-]' 2>/dev/null || true)
+  line_count="${line_count:-0}"
 
   # Check for sensitive paths
   local sensitive=0

--- a/.claude/hooks/_lib/halt-check.sh
+++ b/.claude/hooks/_lib/halt-check.sh
@@ -7,7 +7,13 @@
 # call with a clear error that surfaces the file's contents so the operator
 # knows why the system was frozen.
 
-set -euo pipefail
+# NOTE: do NOT set `-e` here. This file is sourced by hooks that
+# intentionally tolerate non-zero exits (e.g. secret-scanner.sh runs
+# multiple grep passes that may legitimately produce non-zero from
+# patterns that don't match). Setting -e in the sourced lib would
+# propagate to the caller and cause spurious exit-1s on any benign
+# non-zero return. Only set the safer subset.
+set -uo pipefail
 
 # Find the .rea/ directory by walking up from CLAUDE_PROJECT_DIR or cwd.
 # Falls back to CLAUDE_PROJECT_DIR or the current working directory when no

--- a/.claude/hooks/_lib/interpreter-scanner.sh
+++ b/.claude/hooks/_lib/interpreter-scanner.sh
@@ -1,0 +1,71 @@
+# shellcheck shell=bash
+# hooks/_lib/interpreter-scanner.sh — extract write-operation targets
+# from interpreter `-e` / `--eval` invocations.
+#
+# 0.21.2 helix-022 #2: shared between blocked-paths-bash-gate.sh and
+# protected-paths-bash-gate.sh. Pre-fix the protected gate had no
+# interpreter scanner — `node -e "fs.writeFileSync('.rea/HALT','x')"`
+# bypassed the protected-path check while the soft blocked-paths gate
+# (which had its own copy of the scanner) caught equivalent writes
+# against soft-list paths.
+#
+# Coverage:
+#   node -e | --eval | -p | --print   (also fs.writeFile / appendFile
+#                                       / createWriteStream variants)
+#   python | python2 | python3 -c     (open(...,'w'), pathlib.write_*)
+#   ruby -e                            (File.write, IO.write)
+#   perl -e                            (open + print, syswrite)
+#
+# Returns: stdout — one path per line, raw (post-quote-strip but no
+# normalization). Caller passes each through their own _normalize_target
+# / _check_token / rea_path_is_protected pipeline.
+
+# Extract write targets from an interpreter -e / --eval invocation.
+# Usage: rea_interpreter_write_targets "$segment"
+#        Returns each path on a separate line on stdout.
+#        No output means no interpreter-write-shape was detected.
+rea_interpreter_write_targets() {
+  local segment="$1"
+
+  # Node — fs.writeFileSync / fs.writeFile / fs.appendFileSync /
+  #        fs.appendFile / fs.createWriteStream
+  if [[ "$segment" =~ (^|[[:space:]])node[[:space:]]+(-e|--eval|-p|--print)[[:space:]]+ ]]; then
+    printf '%s' "$segment" \
+      | grep -oE "fs\.(writeFileSync|writeFile|appendFileSync|appendFile|createWriteStream)\([[:space:]]*[\"'][^\"']+[\"']" \
+      | sed -E "s/.*\([[:space:]]*[\"']([^\"']+)[\"'].*/\\1/" \
+      || true
+  fi
+
+  # Python — open(PATH, 'w'|'wb'|'a'|'ab'|'w+'|'r+'|'x'|'xb') |
+  #          pathlib.Path(PATH).write_text|.write_bytes
+  if [[ "$segment" =~ (^|[[:space:]])python[23]?[[:space:]]+(-c) ]]; then
+    # open(...,'w'-style)
+    printf '%s' "$segment" \
+      | grep -oE "open\([[:space:]]*[\"'][^\"']+[\"'][[:space:]]*,[[:space:]]*[\"'](w|wb|a|ab|w\+|r\+|x|xb)[\"']" \
+      | sed -E "s/open\([[:space:]]*[\"']([^\"']+)[\"'].*/\\1/" \
+      || true
+    # pathlib write_text / write_bytes
+    printf '%s' "$segment" \
+      | grep -oE "Path\([[:space:]]*[\"'][^\"']+[\"'][[:space:]]*\)\.(write_text|write_bytes)" \
+      | sed -E "s/Path\([[:space:]]*[\"']([^\"']+)[\"'].*/\\1/" \
+      || true
+  fi
+
+  # Ruby — File.write(PATH, ...) | IO.write(PATH, ...)
+  if [[ "$segment" =~ (^|[[:space:]])ruby[[:space:]]+(-e) ]]; then
+    printf '%s' "$segment" \
+      | grep -oE "(File|IO)\.write\([[:space:]]*[\"'][^\"']+[\"']" \
+      | sed -E "s/.*\([[:space:]]*[\"']([^\"']+)[\"'].*/\\1/" \
+      || true
+  fi
+
+  # Perl — open(FH, '>file') | open(FH, '>>file') | sysopen(... O_WRONLY)
+  # Conservative: capture the literal `>file` / `>>file` form, which is
+  # the common shell-style spelling Perl accepts in 2-arg open.
+  if [[ "$segment" =~ (^|[[:space:]])perl[[:space:]]+(-e) ]]; then
+    printf '%s' "$segment" \
+      | grep -oE "open\([[:space:]]*[A-Z_]+,[[:space:]]*[\"']>{1,2}[^\"']+[\"']" \
+      | sed -E "s/.*[\"']>+([^\"']+)[\"'].*/\\1/" \
+      || true
+  fi
+}

--- a/.claude/hooks/_lib/path-normalize.sh
+++ b/.claude/hooks/_lib/path-normalize.sh
@@ -70,3 +70,78 @@ resolve_parent_realpath() {
   resolved=$(cd -P -- "$parent_dir" 2>/dev/null && pwd -P 2>/dev/null) || resolved=""
   printf '%s' "$resolved"
 }
+
+# 0.20.1 helix-021 fixes: shared helper for the Bash-tier symlink
+# resolution that the Write-tier `blocked-paths-enforcer.sh` has had
+# since 0.10.x. Given a project-relative LOGICAL_PATH (already
+# normalized via normalize_path) and the original raw token (whose
+# parent dir may exist on disk), return the resolved-symlink
+# project-relative form on stdout.
+#
+# Returns:
+#   - The empty string if the parent doesn't exist (caller can't
+#     resolve, falls back to LOGICAL_PATH only).
+#   - A literal `__rea_outside_root__:<resolved>` sentinel when the
+#     parent's realpath escapes REA_ROOT. Caller refuses with the
+#     same shape as the existing outside-REA_ROOT check.
+#   - The project-relative resolved form (lowercased to match
+#     case-insensitive comparisons elsewhere) when resolution
+#     succeeds.
+#
+# Reference:
+#   `blocked-paths-enforcer.sh` lines ~205-238 for the Write-tier
+#   reference implementation that this helper backports to Bash-tier.
+rea_resolved_relative_form() {
+  local raw_token="$1"
+  # Skip absolute paths whose logical form is already outside REA_ROOT
+  # — `/tmp/log`, `/var/log/x`, etc. The caller's logical-path check
+  # has already decided whether to allow or refuse based on the
+  # logical form. Re-running symlink resolution on these would
+  # produce a false "symlink resolves outside project root" refusal
+  # (because `/tmp` resolves to `/private/tmp` on macOS, which is
+  # technically outside REA_ROOT). The threat model for THIS helper
+  # is intra-project symlink walks: a path the caller thinks is
+  # under REA_ROOT but resolves elsewhere via an intermediate
+  # symlink. Pure external paths are out of scope.
+  if [[ "$raw_token" == /* ]]; then
+    # Canonicalize REA_ROOT for the comparison.
+    local rea_root_canon_for_skip
+    rea_root_canon_for_skip=$(cd -P -- "$REA_ROOT" 2>/dev/null && pwd -P 2>/dev/null) || rea_root_canon_for_skip="$REA_ROOT"
+    if [[ "$raw_token" != "$rea_root_canon_for_skip"/* && "$raw_token" != "$REA_ROOT"/* ]]; then
+      printf ''
+      return 0
+    fi
+  fi
+  local resolved_parent
+  resolved_parent=$(resolve_parent_realpath "$raw_token")
+  if [[ -z "$resolved_parent" ]]; then
+    printf ''
+    return 0
+  fi
+  # Canonicalize REA_ROOT the same way `pwd -P` canonicalized
+  # `resolved_parent`. macOS resolves `/var/folders/...` to
+  # `/private/var/folders/...` because `/var` is a symlink to
+  # `/private/var`; without this normalization the prefix-equality
+  # below produces a false outside-REA_ROOT sentinel for every path
+  # under a tmpdir that started life as `/var/...`. Memo-friendly:
+  # `cd -P` runs once per hook invocation; the cost is bounded.
+  local rea_root_canon
+  rea_root_canon=$(cd -P -- "$REA_ROOT" 2>/dev/null && pwd -P 2>/dev/null) || rea_root_canon="$REA_ROOT"
+  # Outside-REA_ROOT guard. The resolve may walk a symlink that exits
+  # the project tree entirely; emit the sentinel so the caller
+  # refuses with the same wording as the logical-path traversal
+  # check.
+  if [[ "$resolved_parent" != "$rea_root_canon" && "$resolved_parent" != "$rea_root_canon"/* ]]; then
+    printf '__rea_outside_root__:%s/%s' "$resolved_parent" "$(basename -- "$raw_token")"
+    return 0
+  fi
+  # Strip canonical REA_ROOT prefix, append basename, lowercase to
+  # match rea_path_is_protected's case-insensitive comparison.
+  local rel
+  if [[ "$resolved_parent" == "$rea_root_canon" ]]; then
+    rel="$(basename -- "$raw_token")"
+  else
+    rel="${resolved_parent#"$rea_root_canon"/}/$(basename -- "$raw_token")"
+  fi
+  printf '%s' "$rel" | tr '[:upper:]' '[:lower:]'
+}

--- a/.claude/hooks/_lib/path-normalize.sh
+++ b/.claude/hooks/_lib/path-normalize.sh
@@ -58,9 +58,36 @@ resolve_parent_realpath() {
   local parent_dir
   parent_dir=$(dirname -- "$target_path")
   if [[ ! -d "$parent_dir" ]]; then
-    # Parent doesn't exist yet — caller should treat as "no realpath
-    # available" and fall back to logical-path checks. Return empty.
-    printf ''
+    # 0.21.2 helix-022 #1: parent doesn't exist on disk — but a
+    # SYMLINK along the path might. Walk up to the nearest existing
+    # ancestor, resolve THAT, then append the unresolved tail. Pre-fix
+    # this returned empty for any path whose terminal directory is
+    # created mid-segment (`mkdir -p linkroot/.husky/sub` followed by
+    # a redirect into `.husky/sub/X`); the caller fell back to logical-
+    # path-only enforcement, restoring the symlink-walk bypass.
+    local walk="$parent_dir"
+    local tail=""
+    while [[ -n "$walk" && "$walk" != "/" && "$walk" != "." && ! -d "$walk" ]]; do
+      tail="$(basename -- "$walk")${tail:+/$tail}"
+      walk="$(dirname -- "$walk")"
+    done
+    if [[ -z "$walk" || "$walk" == "/" ]]; then
+      # Walked all the way up; no existing ancestor inside the project.
+      # Caller still has the logical-path check; return empty.
+      printf ''
+      return 0
+    fi
+    local resolved_walk
+    resolved_walk=$(cd -P -- "$walk" 2>/dev/null && pwd -P 2>/dev/null) || resolved_walk=""
+    if [[ -z "$resolved_walk" ]]; then
+      printf ''
+      return 0
+    fi
+    if [[ -n "$tail" ]]; then
+      printf '%s/%s' "$resolved_walk" "$tail"
+    else
+      printf '%s' "$resolved_walk"
+    fi
     return 0
   fi
   # `cd -P` follows symlinks; `pwd -P` prints the resolved physical

--- a/.claude/hooks/_lib/path-normalize.sh
+++ b/.claude/hooks/_lib/path-normalize.sh
@@ -1,0 +1,72 @@
+# shellcheck shell=bash
+# hooks/_lib/path-normalize.sh — canonical path normalization shared
+# across every hook that compares `tool_input.file_path` against a
+# literal/glob policy entry.
+#
+# Pre-0.16.0 each hook reimplemented its own normalize_path. Drift
+# was the result: settings-protection.sh translated `\` → `/` and
+# decoded `%5C` since 0.10.x; blocked-paths-enforcer caught up only
+# in 0.15.0; architecture-review-gate has never normalized at all.
+# This single helper is now the source of truth for both forms.
+#
+# normalize_path PATH
+#   Strip $REA_ROOT prefix → URL-decode `%2F`/`%2E`/`%20`/`%5C`
+#   → translate `\` → `/` → strip leading `./` segments. Echoes
+#   the project-relative form.
+#
+# resolve_parent_realpath PATH
+#   Resolve the realpath of the parent dir of PATH via `cd -P && pwd -P`.
+#   Returns the empty string if the parent doesn't exist (legitimate
+#   "we are creating the parent" case — caller should NOT treat
+#   empty as a fail). Used to detect intermediate-symlink bypass:
+#   if the realpath of the parent doesn't contain the protected
+#   surface anymore, the path resolved out of the surface.
+#
+# All normalization happens in pure bash + sed/tr — no python/perl/
+# readlink -f dependency, so it works on macOS, Alpine, and minimal
+# CI containers.
+
+# REA_ROOT is required to be set by the caller (every rea hook sets
+# it from CLAUDE_PROJECT_DIR or pwd). Default to current dir if missing
+# so this lib is sourceable from a test harness that hasn't set it.
+: "${REA_ROOT:=${CLAUDE_PROJECT_DIR:-$(pwd)}}"
+
+normalize_path() {
+  local p="$1"
+  # Strip $REA_ROOT/ prefix (with or without trailing slash).
+  if [[ "$p" == "$REA_ROOT"/* ]]; then
+    p="${p#"$REA_ROOT"/}"
+  fi
+  # URL-decode common sequences. Include %5C for backslash so
+  # Windows / Git Bash percent-encoded paths normalize the same as
+  # forward-slash forms.
+  p=$(printf '%s' "$p" | sed 's/%2[Ff]/\//g; s/%2[Ee]/./g; s/%20/ /g; s/%5[Cc]/\\/g')
+  # Translate any backslash separators to forward slashes.
+  p=$(printf '%s' "$p" | tr '\\\\' '/')
+  # Strip leading `./` segments. We deliberately do NOT strip
+  # interior `./` — that transformation corrupts `..` traversals
+  # (e.g. `.../` collapsed to `../`) and hides traversal from any
+  # downstream check.
+  while [[ "$p" == ./* ]]; do
+    p="${p#./}"
+  done
+  printf '%s' "$p"
+}
+
+resolve_parent_realpath() {
+  local target_path="$1"
+  local parent_dir
+  parent_dir=$(dirname -- "$target_path")
+  if [[ ! -d "$parent_dir" ]]; then
+    # Parent doesn't exist yet — caller should treat as "no realpath
+    # available" and fall back to logical-path checks. Return empty.
+    printf ''
+    return 0
+  fi
+  # `cd -P` follows symlinks; `pwd -P` prints the resolved physical
+  # path. Subshell scopes the cd so we don't pollute the caller's
+  # working directory.
+  local resolved
+  resolved=$(cd -P -- "$parent_dir" 2>/dev/null && pwd -P 2>/dev/null) || resolved=""
+  printf '%s' "$resolved"
+}

--- a/.claude/hooks/_lib/payload-read.sh
+++ b/.claude/hooks/_lib/payload-read.sh
@@ -1,0 +1,66 @@
+# shellcheck shell=bash
+# hooks/_lib/payload-read.sh — shared payload extraction across the
+# write-tier tools (Write, Edit, MultiEdit, NotebookEdit).
+#
+# Pre-0.16.0 every content-scanning hook (secret-scanner.sh,
+# changeset-security-gate.sh) carried its own jq expression that
+# walked tool_input.{content, new_string, edits[].new_string}. When
+# Anthropic added MultiEdit (0.14.0 fix) every hook needed a
+# parallel patch and one was missed. NotebookEdit is the next tool
+# in the same family — `tool_input.notebook_path` (path) +
+# `tool_input.new_source` (cell content). This single helper handles
+# all four tools so adding the next one is a one-line edit here, not
+# a sweep across N hooks.
+#
+# extract_write_content INPUT_JSON
+#   Echo the content of the about-to-be-written payload, regardless
+#   of which write tool produced it. Tries in order:
+#     1. .tool_input.content                      (Write)
+#     2. .tool_input.new_string                   (Edit)
+#     3. .tool_input.edits[].new_string           (MultiEdit, joined \n)
+#     4. .tool_input.new_source                   (NotebookEdit cell)
+#   Returns empty string when none of these are present (caller
+#   should treat empty as "nothing to scan, exit 0"). Defensive
+#   coercion via `tostring` + array-type-guard so a malformed
+#   payload (non-string new_string, non-array edits) fails closed
+#   to the empty string rather than fail-open via jq error.
+#
+# extract_file_path INPUT_JSON
+#   Echo the file_path / notebook_path of the payload. NotebookEdit
+#   uses notebook_path; Write/Edit/MultiEdit use file_path. Returns
+#   empty string when neither is present.
+#
+# Both helpers require jq.
+
+extract_write_content() {
+  local input="$1"
+  printf '%s' "$input" | jq -r '
+    # Try Write content first.
+    if (.tool_input.content // "") != "" then
+      .tool_input.content
+    # Then Edit new_string.
+    elif (.tool_input.new_string // "") != "" then
+      .tool_input.new_string
+    # Then MultiEdit edits[].new_string (defensive: type-guard +
+    # tostring so heterogeneous types do not error jq).
+    elif ((.tool_input.edits // [] | if type=="array" then . else [] end | length) > 0) then
+      (.tool_input.edits // [] | if type=="array" then . else [] end)
+      | map((.new_string // "") | tostring)
+      | join("\n")
+    # Then NotebookEdit new_source (notebook cell content).
+    elif (.tool_input.new_source // "") != "" then
+      .tool_input.new_source
+    else
+      ""
+    end
+  ' 2>/dev/null
+}
+
+extract_file_path() {
+  local input="$1"
+  printf '%s' "$input" | jq -r '
+    .tool_input.file_path
+    // .tool_input.notebook_path
+    // empty
+  ' 2>/dev/null
+}

--- a/.claude/hooks/_lib/policy-read.sh
+++ b/.claude/hooks/_lib/policy-read.sh
@@ -7,7 +7,10 @@
 # project root via rea_root() from halt-check.sh, but will re-derive it if
 # REA_ROOT is unset.
 
-set -euo pipefail
+# NOTE: do NOT set `-e` here — see hooks/_lib/halt-check.sh for the
+# rationale. This is a sourced library; -e would propagate to callers
+# and cause spurious exit-1s on benign non-zero returns from grep/sed.
+set -uo pipefail
 
 # Resolve the path to .rea/policy.yaml for the current project.
 # Prints an empty string if no policy file is found — callers should treat

--- a/.claude/hooks/_lib/policy-read.sh
+++ b/.claude/hooks/_lib/policy-read.sh
@@ -53,20 +53,80 @@ policy_bool_true() {
   [[ "$value" == "true" ]]
 }
 
-# Read a list of scalars from a top-level sequence block.
+# Read a list of scalars from a top-level sequence.
 # Usage: mapfile -t patterns < <(policy_list "delegate_to_subagent")
-# Handles inline "[]" as empty. Stops at the first non-"-" continuation line.
+#
+# Recognized YAML forms:
+#
+#   1. Block sequence (the historical / canonical form):
+#        blocked_paths:
+#          - .env
+#          - .env.*
+#          - .rea/HALT
+#
+#   2. Empty inline array (since 0.1.x):
+#        blocked_paths: []      # → no entries (returns successfully)
+#
+#   3. Non-empty inline array (added 0.18.0 G1.B/G1.C):
+#        blocked_paths: [.env, .env.*, .rea/HALT]
+#
+# Inline arrays may span multiple lines:
+#
+#        blocked_paths: [
+#          .env,
+#          .env.*,
+#          .rea/HALT
+#        ]
+#
+# Quoted entries (single or double quotes) are unquoted. Leading and
+# trailing whitespace on each entry is trimmed. Empty entries (e.g. from
+# a trailing `,`) are skipped silently.
+#
+# Pre-fix (G1.B/G1.C): the inline array form was VALID YAML but parsed
+# to an empty list — silent bypass of `blocked-paths-bash-gate.sh` and
+# silent ignore of `protected_writes` overrides. Fixed by extending the
+# parser to recognize the inline form in addition to the block form.
+#
+# The block form is still preferred (sed-friendly, line-aligned diffs)
+# but the inline form is now equally enforced.
 policy_list() {
   local key="$1"
   local policy
   policy=$(policy_path)
   [[ -z "$policy" ]] && return 0
   local in_block=0
+  local in_inline=0
+  local inline_buf=""
   while IFS= read -r line; do
-    if printf '%s' "$line" | grep -qE "^[[:space:]]*${key}:"; then
-      if printf '%s' "$line" | grep -qE "${key}:[[:space:]]*\[\]"; then
+    # Skip while we're collecting an inline-array body across lines.
+    if [[ $in_inline -eq 1 ]]; then
+      inline_buf="${inline_buf} ${line}"
+      # Detect the closing `]` (any position on the line).
+      if printf '%s' "$line" | grep -qE '\]'; then
+        _policy_emit_inline_array "$inline_buf"
         return 0
       fi
+      continue
+    fi
+    if printf '%s' "$line" | grep -qE "^[[:space:]]*${key}:"; then
+      # Empty inline `[]` — explicit empty list.
+      if printf '%s' "$line" | grep -qE "${key}:[[:space:]]*\[[[:space:]]*\]"; then
+        return 0
+      fi
+      # Non-empty inline `[ ... ]` — parse the bracketed body. May or
+      # may not close on the same line.
+      if printf '%s' "$line" | grep -qE "${key}:[[:space:]]*\["; then
+        # Strip everything up to and including the opening `[`.
+        inline_buf=$(printf '%s' "$line" | sed -E "s/^.*${key}:[[:space:]]*\[//")
+        if printf '%s' "$inline_buf" | grep -qE '\]'; then
+          # Single-line inline array.
+          _policy_emit_inline_array "$inline_buf"
+          return 0
+        fi
+        in_inline=1
+        continue
+      fi
+      # Block-form sequence header — entries follow on subsequent lines.
       in_block=1
       continue
     fi
@@ -79,4 +139,32 @@ policy_list() {
       fi
     fi
   done < "$policy"
+}
+
+# Emit each entry of an inline-array body (everything between `[` and
+# `]`, possibly across newlines if the caller concatenated lines with
+# spaces). Strips outer brackets, splits on `,`, trims whitespace and
+# matched outer quotes, drops empty entries (trailing-comma tolerance).
+_policy_emit_inline_array() {
+  local buf="$1"
+  # Drop the closing `]` and anything after it (line comments etc).
+  buf=$(printf '%s' "$buf" | sed -E 's/\].*$//')
+  # Split on commas.
+  local IFS=','
+  local raw
+  for raw in $buf; do
+    # Trim leading + trailing whitespace.
+    raw="${raw#"${raw%%[![:space:]]*}"}"
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    # Drop trailing inline comment (` # comment`).
+    raw=$(printf '%s' "$raw" | sed -E 's/[[:space:]]+#.*$//')
+    # Re-trim after comment stripping.
+    raw="${raw#"${raw%%[![:space:]]*}"}"
+    raw="${raw%"${raw##*[![:space:]]}"}"
+    # Skip empty entries (trailing comma, blank line in multi-line form).
+    [[ -z "$raw" ]] && continue
+    # Strip matched outer single or double quotes.
+    raw=$(printf '%s' "$raw" | sed -E "s/^[\"']//; s/[\"']$//")
+    printf '%s\n' "$raw"
+  done
 }

--- a/.claude/hooks/_lib/protected-paths.sh
+++ b/.claude/hooks/_lib/protected-paths.sh
@@ -75,8 +75,16 @@ _rea_is_kill_switch() {
   return 1
 }
 
-# Load the effective list, applying `protected_paths_relax` from policy.
+# Load the effective list, applying `protected_writes` (full override
+# from policy) and `protected_paths_relax` (subtractor) from policy.
 # Sources policy-read.sh on demand so this lib stays self-contained.
+#
+# 0.17.0 helix-018 Option A: `protected_writes` lets consumers fully
+# define the protected list. When set, replaces the hardcoded default;
+# kill-switch invariants are always added back regardless. When unset,
+# defaults to REA_PROTECTED_PATTERNS_FULL (the historical 5 patterns).
+# `protected_paths_relax` then subtracts from whatever the effective
+# set is (kill-switch invariants are non-relaxable).
 _rea_load_protected_patterns() {
   if [ "$_REA_PROTECTED_PATTERNS_LOADED" = "1" ]; then
     return 0
@@ -89,12 +97,69 @@ _rea_load_protected_patterns() {
     source "${BASH_SOURCE[0]%/*}/policy-read.sh" 2>/dev/null || true
   fi
 
+  # Read both policy keys.
+  local writes_list=()
   local relax_list=()
+  local protected_writes_set=0
   if command -v policy_list >/dev/null 2>&1; then
+    # `protected_writes`: detect "set but empty" vs "unset" via a probe.
+    # policy_list returns nothing for both cases, so we use a sentinel
+    # check on the YAML key existence via a separate probe.
+    local pw_present
+    pw_present=$(policy_scalar "protected_writes" 2>/dev/null || true)
+    # If the key is a list (yq returns "null" or empty for scalar reads
+    # of a list), policy_list reads it. We detect "key exists" by
+    # checking either policy_scalar's return OR policy_list's output.
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      writes_list+=("$entry")
+      protected_writes_set=1
+    done < <(policy_list "protected_writes" 2>/dev/null || true)
+    # If pw_present is "[]" (empty array) — policy_list returns nothing
+    # but the key IS set. policy_scalar of a list returns "null" or
+    # the literal `[]`. Treat any of those as "set".
+    case "$pw_present" in
+      '[]'|'null') protected_writes_set=1 ;;
+    esac
+
     while IFS= read -r entry; do
       [ -z "$entry" ] && continue
       relax_list+=("$entry")
     done < <(policy_list "protected_paths_relax" 2>/dev/null || true)
+  fi
+
+  # Compose the BASE list:
+  #   - If `protected_writes` set in policy: that list, plus kill-switch
+  #     invariants always added (deduped).
+  #   - Else: REA_PROTECTED_PATTERNS_FULL (hardcoded historical default).
+  local base_list=()
+  if [ "$protected_writes_set" = "1" ]; then
+    local w
+    for w in "${writes_list[@]+"${writes_list[@]}"}"; do
+      base_list+=("$w")
+    done
+    # Add kill-switch invariants if not already present.
+    local inv inv_lc found
+    for inv in "${REA_KILL_SWITCH_INVARIANTS[@]}"; do
+      inv_lc=$(printf '%s' "$inv" | tr '[:upper:]' '[:lower:]')
+      found=0
+      local b b_lc
+      for b in "${base_list[@]+"${base_list[@]}"}"; do
+        b_lc=$(printf '%s' "$b" | tr '[:upper:]' '[:lower:]')
+        if [[ "$b_lc" == "$inv_lc" ]]; then
+          found=1
+          break
+        fi
+      done
+      if [ "$found" = "0" ]; then
+        base_list+=("$inv")
+      fi
+    done
+  else
+    local pat
+    for pat in "${REA_PROTECTED_PATTERNS_FULL[@]}"; do
+      base_list+=("$pat")
+    done
   fi
 
   # Validate relax entries: any kill-switch invariant in the list is
@@ -112,10 +177,10 @@ _rea_load_protected_patterns() {
     fi
   done
 
-  # Build the effective list: every FULL entry that is NOT in the
+  # Build the effective list: every BASE entry that is NOT in the
   # relaxed set (case-insensitive comparison).
   local pat pat_lc rentry rentry_lc relaxed
-  for pat in "${REA_PROTECTED_PATTERNS_FULL[@]}"; do
+  for pat in "${base_list[@]+"${base_list[@]}"}"; do
     pat_lc=$(printf '%s' "$pat" | tr '[:upper:]' '[:lower:]')
     relaxed=0
     for rentry in "${relaxed_set[@]+"${relaxed_set[@]}"}"; do

--- a/.claude/hooks/_lib/protected-paths.sh
+++ b/.claude/hooks/_lib/protected-paths.sh
@@ -58,6 +58,13 @@ REA_KILL_SWITCH_INVARIANTS=(
 # first call to `rea_path_is_protected`; stays the same for the lifetime
 # of the hook process.
 REA_PROTECTED_PATTERNS=()
+# 0.18.0 helix-020 G2 fix: track which patterns came from the consumer's
+# explicit `protected_writes` override (vs. the hardcoded default). The
+# override-first ordering in `rea_path_is_protected` checks ONLY this
+# subset before consulting the extension-surface allow-list, so an
+# explicit `protected_writes: [.husky/pre-push.d/]` can re-protect a
+# path that the allow-list would otherwise let through.
+REA_PROTECTED_OVERRIDE_PATTERNS=()
 _REA_PROTECTED_PATTERNS_LOADED=0
 
 # True if $1 is a kill-switch invariant (case-insensitive exact or
@@ -195,6 +202,31 @@ _rea_load_protected_patterns() {
     fi
   done
 
+  # 0.18.0 helix-020 G2: also expose the EXPLICIT-OVERRIDE subset so
+  # `rea_path_is_protected` can prioritize override matches over the
+  # extension-surface allow-list. Only entries that came from a
+  # `protected_writes:` declaration land here — kill-switch invariants
+  # added defensively in step 2 above are NOT included (they get the
+  # historical "extension surface relaxes them" treatment, since the
+  # user did NOT explicitly opt in to protecting husky fragments).
+  if [ "$protected_writes_set" = "1" ]; then
+    local ow ow_lc rentry_lc2 relaxed2
+    for ow in "${writes_list[@]+"${writes_list[@]}"}"; do
+      ow_lc=$(printf '%s' "$ow" | tr '[:upper:]' '[:lower:]')
+      relaxed2=0
+      for rentry in "${relaxed_set[@]+"${relaxed_set[@]}"}"; do
+        rentry_lc2=$(printf '%s' "$rentry" | tr '[:upper:]' '[:lower:]')
+        if [[ "$ow_lc" == "$rentry_lc2" ]]; then
+          relaxed2=1
+          break
+        fi
+      done
+      if [ "$relaxed2" = "0" ]; then
+        REA_PROTECTED_OVERRIDE_PATTERNS+=("$ow")
+      fi
+    done
+  fi
+
   _REA_PROTECTED_PATTERNS_LOADED=1
 }
 
@@ -243,18 +275,57 @@ rea_path_is_extension_surface() {
 #
 # 0.16.4 helix-018 Option B: paths inside the documented husky
 # extension surface (`.husky/{commit-msg,pre-push,pre-commit}.d/*`)
-# return 1 (not protected) BEFORE the prefix-pattern check so they
-# don't get caught by `.husky/`'s prefix block. This mirrors the
-# §5b allow-list that has been in settings-protection.sh since 0.13.2.
+# return 1 (not protected) by default so they don't get caught by
+# `.husky/`'s prefix block. This mirrors the §5b allow-list that has
+# been in settings-protection.sh since 0.13.2.
+#
+# 0.18.0 helix-020 G2 fix: ORDER MATTERS. The pre-fix function checked
+# the extension-surface allow-list FIRST and short-circuited "not
+# protected" unconditionally. That made the `protected_writes` /
+# `protected_paths` override silently ineffective for any path inside
+# the extension surface — a consumer who wanted `.husky/pre-push.d/`
+# hardened could not opt in. The fix: explicit overrides win FIRST
+# (the consumer asked for this), then the extension-surface
+# short-circuit applies to anything else, then the default protected
+# list. Pseudocode is the canonical version from helix-020 Interactive
+# Finding 1.
 rea_path_is_protected() {
   _rea_load_protected_patterns
-  # Extension-surface allow-list — short-circuit before pattern match.
-  if rea_path_is_extension_surface "$1"; then
-    return 1
-  fi
   local p_lc
   p_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
   local pattern pattern_lc
+
+  # 1. Explicit `protected_writes` overrides win. If the consumer
+  #    listed this path (or its parent prefix) in `protected_writes`,
+  #    we honor that intent even when the path is on the extension
+  #    surface. This is what lets a consumer harden their managed
+  #    `.husky/pre-push.d/` fragments — the carve-out for unmanaged
+  #    consumer fragments is the default, but it can be undone.
+  for pattern in "${REA_PROTECTED_OVERRIDE_PATTERNS[@]+"${REA_PROTECTED_OVERRIDE_PATTERNS[@]}"}"; do
+    pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+    if [[ "$p_lc" == "$pattern_lc" ]]; then
+      return 0
+    fi
+    if [[ "$pattern_lc" == */ ]] && [[ "$p_lc" == "$pattern_lc"* ]]; then
+      return 0
+    fi
+  done
+
+  # 2. Extension-surface allow-list. Paths inside the documented
+  #    husky extension surface (`.husky/{commit-msg,pre-push,pre-commit}.d/*`)
+  #    are NOT protected by default — the consumer manages those
+  #    fragments freely; settings-protection.sh §5b has the same
+  #    carve-out on the Write/Edit side. Step 1 above is what lets a
+  #    consumer override that default per-path.
+  if rea_path_is_extension_surface "$1"; then
+    return 1
+  fi
+
+  # 3. Default protected list (kill-switch invariants + `.husky/`
+  #    prefix block + `.claude/settings*` + `.rea/policy.yaml`). When
+  #    `protected_writes` was set, kill-switch invariants are still
+  #    enforced via this branch because they were added back into
+  #    REA_PROTECTED_PATTERNS during `_rea_load_protected_patterns`.
   for pattern in "${REA_PROTECTED_PATTERNS[@]+"${REA_PROTECTED_PATTERNS[@]}"}"; do
     pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
     if [[ "$p_lc" == "$pattern_lc" ]]; then

--- a/.claude/hooks/_lib/protected-paths.sh
+++ b/.claude/hooks/_lib/protected-paths.sh
@@ -9,13 +9,37 @@
 # by the principal-engineer audit. The fix: factor the list out so
 # both hooks read the same data, and protect against shell redirects
 # in addition to Write/Edit/MultiEdit tools.
+#
+# 0.16.3 F7: the list is now policy-driven via `protected_paths_relax`.
+# Consumers who legitimately need to author `.husky/<hookname>` files
+# (or other paths in the rea-managed hard list) can opt out per-pattern
+# by listing the entry in `.rea/policy.yaml`:
+#
+#   protected_paths_relax:
+#     - .husky/    # I author my own husky hooks; opt out of rea protection
+#
+# Pre-0.16.3 the only escape was editing rea-managed source itself —
+# which `protected-paths-bash-gate.sh` (also rea-managed) would refuse.
+# That left consumers stuck. The relax list closes that escape hatch
+# without weakening the integrity of the governance layer itself.
+#
+# KILL-SWITCH INVARIANTS — these patterns are ALWAYS protected, even
+# if a consumer lists them in `protected_paths_relax`. They represent
+# the integrity of the governance layer; relaxing them would let an
+# agent disable rea, defeating the entire product.
+#
+#   .rea/HALT             — the kill switch itself
+#   .rea/policy.yaml      — the policy that defines all enforcement
+#   .claude/settings.json — the hook registration that activates rea
+#
+# Listing a kill-switch invariant in `protected_paths_relax` is silently
+# ignored AND a stderr advisory is emitted on first read.
 
-# The path list is bash glob patterns matched against project-root-
-# relative paths. Suffix `/` indicates a prefix match; no suffix means
-# (case-insensitive) exact match — see `rea_path_is_protected` for the
-# helix-015 #2 lowercase-comparison rationale. Mirrors the array in
-# settings-protection.sh §6.
-REA_PROTECTED_PATTERNS=(
+# The full hard-protected list. Suffix `/` indicates a prefix match;
+# no suffix means (case-insensitive) exact match — see
+# `rea_path_is_protected` for the helix-015 #2 lowercase-comparison
+# rationale.
+REA_PROTECTED_PATTERNS_FULL=(
   '.claude/settings.json'
   '.claude/settings.local.json'
   '.husky/'
@@ -23,9 +47,127 @@ REA_PROTECTED_PATTERNS=(
   '.rea/HALT'
 )
 
-# Test whether a project-relative path matches any protected pattern.
+# Kill-switch invariants — never relaxable. Subset of FULL.
+REA_KILL_SWITCH_INVARIANTS=(
+  '.claude/settings.json'
+  '.rea/policy.yaml'
+  '.rea/HALT'
+)
+
+# Effective patterns after applying the relax list. Computed lazily on
+# first call to `rea_path_is_protected`; stays the same for the lifetime
+# of the hook process.
+REA_PROTECTED_PATTERNS=()
+_REA_PROTECTED_PATTERNS_LOADED=0
+
+# True if $1 is a kill-switch invariant (case-insensitive exact or
+# prefix match per the same rules as the protected list itself).
+_rea_is_kill_switch() {
+  local p="$1"
+  local p_lc inv inv_lc
+  p_lc=$(printf '%s' "$p" | tr '[:upper:]' '[:lower:]')
+  for inv in "${REA_KILL_SWITCH_INVARIANTS[@]}"; do
+    inv_lc=$(printf '%s' "$inv" | tr '[:upper:]' '[:lower:]')
+    if [[ "$p_lc" == "$inv_lc" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Load the effective list, applying `protected_paths_relax` from policy.
+# Sources policy-read.sh on demand so this lib stays self-contained.
+_rea_load_protected_patterns() {
+  if [ "$_REA_PROTECTED_PATTERNS_LOADED" = "1" ]; then
+    return 0
+  fi
+  # Source policy-read if not already sourced. The caller may have
+  # already done so; checking for a known function avoids double-source.
+  if ! command -v policy_list >/dev/null 2>&1; then
+    # Resolve relative to THIS file's dir, not the caller's.
+    # shellcheck source=policy-read.sh
+    source "${BASH_SOURCE[0]%/*}/policy-read.sh" 2>/dev/null || true
+  fi
+
+  local relax_list=()
+  if command -v policy_list >/dev/null 2>&1; then
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      relax_list+=("$entry")
+    done < <(policy_list "protected_paths_relax" 2>/dev/null || true)
+  fi
+
+  # Validate relax entries: any kill-switch invariant in the list is
+  # silently dropped from "permitted to relax" but emits a stderr
+  # advisory so the operator can see why their relax didn't take
+  # effect.
+  local relaxed_set=()
+  local r
+  for r in "${relax_list[@]+"${relax_list[@]}"}"; do
+    if _rea_is_kill_switch "$r"; then
+      printf 'rea: protected_paths_relax: %s is a kill-switch invariant and cannot be relaxed; ignoring.\n' \
+        "$r" >&2
+    else
+      relaxed_set+=("$r")
+    fi
+  done
+
+  # Build the effective list: every FULL entry that is NOT in the
+  # relaxed set (case-insensitive comparison).
+  local pat pat_lc rentry rentry_lc relaxed
+  for pat in "${REA_PROTECTED_PATTERNS_FULL[@]}"; do
+    pat_lc=$(printf '%s' "$pat" | tr '[:upper:]' '[:lower:]')
+    relaxed=0
+    for rentry in "${relaxed_set[@]+"${relaxed_set[@]}"}"; do
+      rentry_lc=$(printf '%s' "$rentry" | tr '[:upper:]' '[:lower:]')
+      if [[ "$pat_lc" == "$rentry_lc" ]]; then
+        relaxed=1
+        break
+      fi
+    done
+    if [ "$relaxed" = "0" ]; then
+      REA_PROTECTED_PATTERNS+=("$pat")
+    fi
+  done
+
+  _REA_PROTECTED_PATTERNS_LOADED=1
+}
+
+# Test whether a project-relative path is in the documented husky
+# extension surface (`.husky/commit-msg.d/*`, `.husky/pre-push.d/*`).
+# Returns 0 on match, 1 on no match. Case-insensitive.
+#
+# 0.16.4 helix-018 Option B: settings-protection.sh §5b has carved
+# this surface out of write-tier protection since 0.13.2 — consumers
+# write extension fragments here freely. Pre-0.16.4 the BASH-tier
+# gates (`protected-paths-bash-gate.sh`, `blocked-paths-bash-gate.sh`)
+# had no parity carve-out, so a `cat <<EOF > .husky/pre-push.d/X`
+# redirect was refused by the bash-gate even though the equivalent
+# Write-tool call would succeed. This helper bakes the carve-out
+# into the shared lib so every caller inherits it uniformly.
+rea_path_is_extension_surface() {
+  local p_lc
+  p_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  case "$p_lc" in
+    .husky/commit-msg.d/*|.husky/pre-push.d/*|.husky/pre-commit.d/*)
+      # Refuse the bare directory itself — only fragments INSIDE
+      # the surface count. `.husky/pre-push.d/` (trailing slash, no
+      # fragment) and `.husky/pre-push.d` (the dir node) both fall
+      # through to the protection check via the parent prefix.
+      case "$p_lc" in
+        .husky/commit-msg.d/|.husky/pre-push.d/|.husky/pre-commit.d/) return 1 ;;
+      esac
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+# Test whether a project-relative path matches any protected pattern
+# (after applying `protected_paths_relax`). Returns 0 on match, 1 on
+# no match.
+#
 # Usage: if rea_path_is_protected ".rea/HALT"; then echo "blocked"; fi
-# Returns 0 on match, 1 on no match.
 #
 # 0.16.0 codex P1 fix (helix-015 #2): match case-insensitively.
 # macOS APFS (default case-insensitive) lets `.ClAuDe/settings.json`
@@ -33,11 +175,22 @@ REA_PROTECTED_PATTERNS=(
 # §6 has had a CI matcher since 0.10.x; this helper was missing it.
 # We lowercase BOTH sides so the comparison is symmetric — callers can
 # pass either case.
+#
+# 0.16.4 helix-018 Option B: paths inside the documented husky
+# extension surface (`.husky/{commit-msg,pre-push,pre-commit}.d/*`)
+# return 1 (not protected) BEFORE the prefix-pattern check so they
+# don't get caught by `.husky/`'s prefix block. This mirrors the
+# §5b allow-list that has been in settings-protection.sh since 0.13.2.
 rea_path_is_protected() {
+  _rea_load_protected_patterns
+  # Extension-surface allow-list — short-circuit before pattern match.
+  if rea_path_is_extension_surface "$1"; then
+    return 1
+  fi
   local p_lc
   p_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
   local pattern pattern_lc
-  for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
+  for pattern in "${REA_PROTECTED_PATTERNS[@]+"${REA_PROTECTED_PATTERNS[@]}"}"; do
     pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
     if [[ "$p_lc" == "$pattern_lc" ]]; then
       return 0

--- a/.claude/hooks/_lib/protected-paths.sh
+++ b/.claude/hooks/_lib/protected-paths.sh
@@ -1,0 +1,50 @@
+# shellcheck shell=bash
+# hooks/_lib/protected-paths.sh — single source of truth for the
+# hard-protected path list shared between the Write/Edit tier
+# (`settings-protection.sh`) and the Bash tier (`protected-paths-bash-gate.sh`).
+#
+# Pre-0.15.0 this list was duplicated inline in settings-protection.sh;
+# the bash-redirect bypass (`> .rea/HALT`, `tee .rea/policy.yaml`,
+# `cp X .claude/settings.json`, `sed -i .husky/pre-push`) was caught
+# by the principal-engineer audit. The fix: factor the list out so
+# both hooks read the same data, and protect against shell redirects
+# in addition to Write/Edit/MultiEdit tools.
+
+# The path list is bash glob patterns matched against project-root-
+# relative paths. Suffix `/` indicates a prefix match; no suffix means
+# (case-insensitive) exact match — see `rea_path_is_protected` for the
+# helix-015 #2 lowercase-comparison rationale. Mirrors the array in
+# settings-protection.sh §6.
+REA_PROTECTED_PATTERNS=(
+  '.claude/settings.json'
+  '.claude/settings.local.json'
+  '.husky/'
+  '.rea/policy.yaml'
+  '.rea/HALT'
+)
+
+# Test whether a project-relative path matches any protected pattern.
+# Usage: if rea_path_is_protected ".rea/HALT"; then echo "blocked"; fi
+# Returns 0 on match, 1 on no match.
+#
+# 0.16.0 codex P1 fix (helix-015 #2): match case-insensitively.
+# macOS APFS (default case-insensitive) lets `.ClAuDe/settings.json`
+# land on the same file as `.claude/settings.json`. settings-protection.sh
+# §6 has had a CI matcher since 0.10.x; this helper was missing it.
+# We lowercase BOTH sides so the comparison is symmetric — callers can
+# pass either case.
+rea_path_is_protected() {
+  local p_lc
+  p_lc=$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')
+  local pattern pattern_lc
+  for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
+    pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+    if [[ "$p_lc" == "$pattern_lc" ]]; then
+      return 0
+    fi
+    if [[ "$pattern_lc" == */ ]] && [[ "$p_lc" == "$pattern_lc"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/.claude/hooks/_lib/protected-paths.sh
+++ b/.claude/hooks/_lib/protected-paths.sh
@@ -45,6 +45,15 @@ REA_PROTECTED_PATTERNS_FULL=(
   '.husky/'
   '.rea/policy.yaml'
   '.rea/HALT'
+  # 0.19.0 security review C1: the verdict cache is a security boundary
+  # since 0.18.1. A forged entry would skip codex on next push of that
+  # SHA. Protect it like the kill-switch.
+  '.rea/last-review.cache.json'
+  # 0.20.1 round-N P1: last-review.json is the operator's only forensic
+  # snapshot of the most recent codex review. A forged entry presents
+  # a fake "PASS" verdict to operators reading the file directly, and
+  # to any future tooling that consults it. Protect alongside the cache.
+  '.rea/last-review.json'
 )
 
 # Kill-switch invariants — never relaxable. Subset of FULL.
@@ -52,6 +61,8 @@ REA_KILL_SWITCH_INVARIANTS=(
   '.claude/settings.json'
   '.rea/policy.yaml'
   '.rea/HALT'
+  '.rea/last-review.cache.json'
+  '.rea/last-review.json'
 )
 
 # Effective patterns after applying the relax list. Computed lazily on

--- a/.claude/hooks/architecture-review-gate.sh
+++ b/.claude/hooks/architecture-review-gate.sh
@@ -50,15 +50,29 @@ source "$(dirname "$0")/_lib/path-normalize.sh"
 FILE_PATH=$(normalize_path "$FILE_PATH")
 
 # ── 6. Check architecture-sensitive paths ─────────────────────────────────────
-ARCH_PATTERNS=(
-  'src/types/'
-  'src/gateway/'
-  'src/config/'
-  'src/cli/commands/init/'
-  'hooks/_lib/'
-  'templates/'
-  'profiles/'
-)
+# 0.20.1 helix-round-N P2: read patterns from policy. Pre-fix the
+# rea-internal source-tree patterns (`src/gateway/`, `hooks/_lib/`,
+# `profiles/`, etc.) shipped as hardcoded defaults — irrelevant noise
+# in consumer projects whose architecture-sensitive paths are
+# different. Consumers with their own architecture surfaces declare
+# them in `.rea/policy.yaml::architecture_review.patterns`. The
+# bst-internal profile pins the rea-source patterns so the dogfood
+# install behaves the same as before; consumers without a pattern
+# set get a silent no-op.
+# shellcheck source=_lib/policy-read.sh
+source "$(dirname "$0")/_lib/policy-read.sh"
+
+ARCH_PATTERNS=()
+while IFS= read -r entry; do
+  [[ -z "$entry" ]] && continue
+  ARCH_PATTERNS+=("$entry")
+done < <(policy_list "architecture_review.patterns" 2>/dev/null || true)
+
+if [[ ${#ARCH_PATTERNS[@]} -eq 0 ]]; then
+  # Empty/unset policy → silent no-op. Consumers who haven't declared
+  # architecture-sensitive paths see zero advisory output.
+  exit 0
+fi
 
 MATCHED=""
 for pattern in "${ARCH_PATTERNS[@]}"; do

--- a/.claude/hooks/architecture-review-gate.sh
+++ b/.claude/hooks/architecture-review-gate.sh
@@ -18,13 +18,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── 3. HALT check ────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
 # ── 4. Check if enabled ──────────────────────────────────────────────────────
 POLICY_FILE="${REA_ROOT}/.rea/policy.yaml"
@@ -41,10 +39,15 @@ if [[ -z "$FILE_PATH" ]]; then
   exit 0
 fi
 
-# Normalize to relative path
-if [[ "$FILE_PATH" == "$REA_ROOT"/* ]]; then
-  FILE_PATH="${FILE_PATH#$REA_ROOT/}"
-fi
+# 0.16.0 fix D.1: normalize via shared `_lib/path-normalize.sh` so
+# Windows / Git Bash backslash paths and URL-encoded forms are handled
+# uniformly with the rest of the hook layer. Pre-fix, this hook only
+# stripped $REA_ROOT prefix — `src\gateway\foo.ts` (Windows) or
+# `src%2Fgateway%2Ffoo.ts` (URL-encoded) silently bypassed the
+# architectural review.
+# shellcheck source=_lib/path-normalize.sh
+source "$(dirname "$0")/_lib/path-normalize.sh"
+FILE_PATH=$(normalize_path "$FILE_PATH")
 
 # ── 6. Check architecture-sensitive paths ─────────────────────────────────────
 ARCH_PATTERNS=(

--- a/.claude/hooks/attribution-advisory.sh
+++ b/.claude/hooks/attribution-advisory.sh
@@ -58,13 +58,24 @@ fi
 source "$(dirname "$0")/_lib/cmd-segments.sh"
 
 # ── 6. Check if this is a relevant command ────────────────────────────────────
+# 0.18.0 helix-020 / discord-ops Round 10 #2 fix (G4.A): use
+# `any_segment_starts_with`, not `any_segment_matches`. The pre-fix
+# matcher used the unanchored form, so a segment like
+#   gh pr edit --body "tracked: gh pr create earlier in the run"
+# triggered IS_RELEVANT=1 because the substring `gh pr create` was
+# anywhere in the segment. The downstream attribution check then
+# scanned the body for the markdown-link / Co-Authored-By patterns,
+# and ANY mention of those terms in the body's prose got blocked
+# even though the actual command was a `gh pr edit` whose intent had
+# nothing to do with structural attribution. The same anchoring fix
+# `dangerous-bash-interceptor.sh` got in 0.16.3 F5 finally lands here.
 IS_RELEVANT=0
 
-if any_segment_matches "$CMD" 'gh[[:space:]]+pr[[:space:]]+(create|edit)'; then
+if any_segment_starts_with "$CMD" 'gh[[:space:]]+pr[[:space:]]+(create|edit)'; then
   IS_RELEVANT=1
 fi
 
-if any_segment_matches "$CMD" 'git[[:space:]]+commit'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+commit'; then
   IS_RELEVANT=1
 fi
 
@@ -77,7 +88,21 @@ fi
 FOUND=0
 
 # Co-Authored-By with noreply@ email
-if any_segment_matches "$CMD" 'Co-Authored-By:.*noreply@'; then
+# 0.18.0 helix-020 / discord-ops Round 10 #3 fix (G4.B): exclude
+# GitHub's legitimate `<user>@users.noreply.github.com` collaborator
+# footers from the noreply match. Pre-fix the regex `Co-Authored-By:.*noreply@`
+# matched both AI-tool noreply addresses (anthropic.com, openai.com,
+# github-copilot, etc.) AND GitHub's per-user noreply form, blocking
+# legitimate human collaborator credits. The new regex requires
+# `noreply@` to be followed by something that ISN'T `users.noreply.github.com`
+# — covered via a negative-lookahead simulation: match `noreply@` then
+# either end-of-line, whitespace, `>`, or a domain that does NOT begin
+# with `users.noreply.github.com`. Posix ERE has no lookarounds, so we
+# enumerate the allowed-prefix shapes explicitly. The "AI names" branch
+# below catches Co-Authored-By with named tools regardless of the email
+# domain, so dropping `users.noreply.github.com` from the noreply
+# pattern only relaxes the check for human collaborators — never for AI.
+if any_segment_matches "$CMD" 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com)'; then
   FOUND=1
 fi
 

--- a/.claude/hooks/attribution-advisory.sh
+++ b/.claude/hooks/attribution-advisory.sh
@@ -92,7 +92,11 @@ if any_segment_matches "$CMD" '(Generated|Created|Built|Powered|Authored|Written
 fi
 
 # Markdown-linked attribution
-if any_segment_matches "$CMD" '\[Claude Code\]|\[GitHub Copilot\]|\[ChatGPT\]|\[Gemini\]|\[Cursor\]'; then
+# 0.16.2 helix-017 P3 #4: anchor on `[Text](` (markdown link shape) so
+# legitimate bracketed mentions like `gh pr edit --body "support [Claude
+# Code] hook output"` don't false-positive. The actual attribution we
+# care about is structural — `Generated with [Claude Code](https://...)`.
+if any_segment_matches "$CMD" '\[Claude Code\]\(|\[GitHub Copilot\]\(|\[ChatGPT\]\(|\[Gemini\]\(|\[Cursor\]\('; then
   FOUND=1
 fi
 

--- a/.claude/hooks/attribution-advisory.sh
+++ b/.claude/hooks/attribution-advisory.sh
@@ -102,7 +102,7 @@ FOUND=0
 # below catches Co-Authored-By with named tools regardless of the email
 # domain, so dropping `users.noreply.github.com` from the noreply
 # pattern only relaxes the check for human collaborators — never for AI.
-if any_segment_matches "$CMD" 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com)'; then
+if any_segment_matches "$CMD" 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com|mistral\.ai|xai-org|x\.ai|inflection\.ai|perplexity\.ai|replit\.com|jetbrains\.com|bito\.ai|pieces\.app|phind\.com|you\.com)'; then
   FOUND=1
 fi
 

--- a/.claude/hooks/attribution-advisory.sh
+++ b/.claude/hooks/attribution-advisory.sh
@@ -26,13 +26,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── 3. HALT check ─────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
 # ── 4. Check if attribution blocking is enabled ──────────────────────────────
 POLICY_FILE="${REA_ROOT}/.rea/policy.yaml"
@@ -50,14 +48,23 @@ if [[ -z "$CMD" ]]; then
   exit 0
 fi
 
+# 0.15.0: source the shared shell-segment splitter. Pre-fix, the
+# attribution patterns greped the FULL command — `git commit -m "Note:
+# Co-Authored-By with AI was removed in 0.14"` matched and the commit
+# was blocked even though the message was COMMENTING on attribution
+# rather than including it. Per-segment anchoring scopes detection to
+# segments whose first token is `git commit` / `gh pr create|edit`.
+# shellcheck source=_lib/cmd-segments.sh
+source "$(dirname "$0")/_lib/cmd-segments.sh"
+
 # ── 6. Check if this is a relevant command ────────────────────────────────────
 IS_RELEVANT=0
 
-if printf '%s' "$CMD" | grep -qiE 'gh[[:space:]]+pr[[:space:]]+(create|edit)'; then
+if any_segment_matches "$CMD" 'gh[[:space:]]+pr[[:space:]]+(create|edit)'; then
   IS_RELEVANT=1
 fi
 
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+commit'; then
+if any_segment_matches "$CMD" 'git[[:space:]]+commit'; then
   IS_RELEVANT=1
 fi
 
@@ -70,27 +77,27 @@ fi
 FOUND=0
 
 # Co-Authored-By with noreply@ email
-if printf '%s' "$CMD" | grep -qiE 'Co-Authored-By:.*noreply@'; then
+if any_segment_matches "$CMD" 'Co-Authored-By:.*noreply@'; then
   FOUND=1
 fi
 
 # Co-Authored-By with known AI names
-if printf '%s' "$CMD" | grep -qiE 'Co-Authored-By:.*\b(Claude|Sonnet|Opus|Haiku|Copilot|GPT|ChatGPT|Gemini|Cursor|Codeium|Tabnine|Amazon Q|CodeWhisperer|Devin|Windsurf|Cline|Aider|Anthropic|OpenAI|GitHub Copilot)\b'; then
+if any_segment_matches "$CMD" 'Co-Authored-By:.*\b(Claude|Sonnet|Opus|Haiku|Copilot|GPT|ChatGPT|Gemini|Cursor|Codeium|Tabnine|Amazon Q|CodeWhisperer|Devin|Windsurf|Cline|Aider|Anthropic|OpenAI|GitHub Copilot)\b'; then
   FOUND=1
 fi
 
 # "Generated/Built/Powered with/by [AI Tool]" lines
-if printf '%s' "$CMD" | grep -qiE '(Generated|Created|Built|Powered|Authored|Written|Produced)[[:space:]]+(with|by)[[:space:]]+(Claude|Copilot|GPT|ChatGPT|Gemini|Cursor|Codeium|Tabnine|CodeWhisperer|Devin|Windsurf|Cline|Aider|AI|an? AI)\b'; then
+if any_segment_matches "$CMD" '(Generated|Created|Built|Powered|Authored|Written|Produced)[[:space:]]+(with|by)[[:space:]]+(Claude|Copilot|GPT|ChatGPT|Gemini|Cursor|Codeium|Tabnine|CodeWhisperer|Devin|Windsurf|Cline|Aider|AI|an? AI)\b'; then
   FOUND=1
 fi
 
 # Markdown-linked attribution
-if printf '%s' "$CMD" | grep -qiE '\[Claude Code\]|\[GitHub Copilot\]|\[ChatGPT\]|\[Gemini\]|\[Cursor\]'; then
+if any_segment_matches "$CMD" '\[Claude Code\]|\[GitHub Copilot\]|\[ChatGPT\]|\[Gemini\]|\[Cursor\]'; then
   FOUND=1
 fi
 
 # Emoji attribution
-if printf '%s' "$CMD" | grep -qE '🤖.*[Gg]enerated'; then
+if any_segment_matches "$CMD" '🤖.*[Gg]enerated'; then
   FOUND=1
 fi
 

--- a/.claude/hooks/blocked-paths-bash-gate.sh
+++ b/.claude/hooks/blocked-paths-bash-gate.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+# PreToolUse hook: blocked-paths-bash-gate.sh
+# Fires BEFORE every Bash tool call.
+# Refuses Bash commands that write to entries in policy.yaml's
+# `blocked_paths` list via shell redirection or write-flag utilities.
+#
+# Background (0.16.3, discord-ops Round 9 #1): the existing
+# blocked-paths-enforcer.sh only fires on Write/Edit/MultiEdit/
+# NotebookEdit. Bash-tier writes to blocked_paths entries bypass it
+# entirely:
+#
+#   echo x > .env
+#   cp src.txt .env
+#   sed -i '' '1d' .env.production
+#   node -e "fs.writeFileSync('.env','x')"
+#
+# `protected-paths-bash-gate.sh` covers the HARD list (HALT, policy.yaml,
+# settings.json, .husky/*) — but the soft, runtime-configurable
+# `blocked_paths` list never had a Bash-tier counterpart. discord-ops
+# independently caught this gap during their cycle 9 audit.
+#
+# This hook closes the gap by reading the same `blocked_paths` list that
+# blocked-paths-enforcer.sh reads, applying the same redirect / write-
+# utility detection pipeline as protected-paths-bash-gate.sh, and
+# blocking when the resolved target matches any entry.
+#
+# Exit codes:
+#   0 = no blocked-path write detected — allow
+#   2 = blocked-path write via Bash detected — block
+#
+# Detection: `node -e "fs.writeFileSync('.env','x')"` — Node's
+# fs.writeFileSync called against a blocked path is also detected by
+# argument scan. Other interpreter constructions (perl, python, etc.)
+# remain a known coverage gap for the same reason the env-file-protection
+# hook lists hard caps in its header comment: defense-in-depth, not an
+# adversarial firewall.
+
+set -uo pipefail
+
+# shellcheck source=_lib/cmd-segments.sh
+source "$(dirname "$0")/_lib/cmd-segments.sh"
+# shellcheck source=_lib/path-normalize.sh
+source "$(dirname "$0")/_lib/path-normalize.sh"
+# shellcheck source=_lib/policy-read.sh
+source "$(dirname "$0")/_lib/policy-read.sh"
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+
+INPUT=$(cat)
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'REA ERROR: jq is required but not installed.\n' >&2
+  exit 2
+fi
+
+check_halt
+REA_ROOT=$(rea_root)
+
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# Load blocked_paths list. If the policy is missing or the list is empty,
+# this hook is a no-op (matches blocked-paths-enforcer.sh semantics).
+BLOCKED_PATHS=()
+while IFS= read -r entry; do
+  [[ -z "$entry" ]] && continue
+  BLOCKED_PATHS+=("$entry")
+done < <(policy_list "blocked_paths")
+
+if [[ ${#BLOCKED_PATHS[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+# Match a normalized project-relative path against the loaded
+# blocked_paths list using the same matching rules as
+# blocked-paths-enforcer.sh:
+#   - directory match (entry ends with `/`) → prefix match
+#   - glob entry (contains `*`) → ERE conversion + anchored match
+#   - otherwise → exact (case-insensitive) match
+# Returns 0 + sets MATCHED on hit, 1 on no hit.
+MATCHED=""
+_match_blocked() {
+  local target_lc="$1"
+  MATCHED=""
+  local entry entry_lc regex
+  for entry in "${BLOCKED_PATHS[@]}"; do
+    entry_lc=$(printf '%s' "$entry" | tr '[:upper:]' '[:lower:]')
+    if [[ "$entry_lc" == */ ]]; then
+      if [[ "$target_lc" == "$entry_lc"* ]] || [[ "$target_lc" == "${entry_lc%/}" ]]; then
+        MATCHED="$entry"
+        return 0
+      fi
+      continue
+    fi
+    if [[ "$entry" == *'*'* ]]; then
+      regex=$(printf '%s' "$entry_lc" | sed 's/\./\\./g; s/\*/.*/g')
+      if printf '%s' "$target_lc" | grep -qE "^${regex}$"; then
+        MATCHED="$entry"
+        return 0
+      fi
+      continue
+    fi
+    if [[ "$target_lc" == "$entry_lc" ]]; then
+      MATCHED="$entry"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Normalize a path token and apply the same `..` walk + outside-REA_ROOT
+# sentinel trick as protected-paths-bash-gate.sh::_normalize_target.
+# Returns the normalized lowercased project-relative path on stdout, or
+# `__rea_outside_root__:<resolved>` when the path resolves outside the
+# project root.
+_normalize_target() {
+  local t="$1"
+  if [[ "$t" =~ ^\"(.*)\"$ ]]; then t="${BASH_REMATCH[1]}"; fi
+  if [[ "$t" =~ ^\'(.*)\'$ ]]; then t="${BASH_REMATCH[1]}"; fi
+  case "/$t/" in
+    */../*)
+      local abs="$t"
+      [[ "$abs" != /* ]] && abs="$REA_ROOT/$abs"
+      local -a raw_parts parts=()
+      IFS='/' read -ra raw_parts <<<"$abs"
+      for part in "${raw_parts[@]}"; do
+        case "$part" in
+          ''|.) continue ;;
+          ..) [[ "${#parts[@]}" -gt 0 ]] && unset 'parts[${#parts[@]}-1]' ;;
+          *) parts+=("$part") ;;
+        esac
+      done
+      t="/$(IFS=/; printf '%s' "${parts[*]}")"
+      if [[ "$t" != "$REA_ROOT" && "$t" != "$REA_ROOT"/* ]]; then
+        printf '__rea_outside_root__:%s' "$t"
+        return 0
+      fi
+      ;;
+  esac
+  t=$(normalize_path "$t")
+  printf '%s' "$t" | tr '[:upper:]' '[:lower:]'
+}
+
+_refuse() {
+  local pattern="$1" target="$2" segment="$3"
+  {
+    printf 'BLOCKED PATH (bash): write denied by policy\n'
+    printf '\n'
+    printf '  Blocked by:      %s\n' "$pattern"
+    printf '  Resolved target: %s\n' "$target"
+    printf '  Segment:         %s\n' "$segment"
+    printf '\n'
+    printf '  Source: .rea/policy.yaml → blocked_paths\n'
+    printf '  Rule: blocked_paths entries are unreachable via Bash redirects\n'
+    printf '        too — not just Write/Edit/MultiEdit. To modify, a human\n'
+    printf '        must edit directly or update blocked_paths in policy.yaml.\n'
+  } >&2
+  exit 2
+}
+
+# Check a single resolved-target token. Refuses on hit.
+_check_token() {
+  local token="$1" segment="$2"
+  [[ -z "$token" ]] && return 0
+  local resolved
+  resolved=$(_normalize_target "$token")
+  if [[ "$resolved" == __rea_outside_root__:* ]]; then
+    # Outside REA_ROOT → can't be in blocked_paths (blocked_paths is
+    # project-relative). Allow; the protected-paths gate handles
+    # outside-root rejection on the protected list itself.
+    return 0
+  fi
+  if _match_blocked "$resolved"; then
+    _refuse "$MATCHED" "$resolved" "$segment"
+  fi
+  return 0
+}
+
+# Scan one segment for redirect / write-utility / node-fs targets and
+# refuse on any hit. Mirrors protected-paths-bash-gate.sh::_check_segment
+# layout, with a few additions to catch discord-ops Round 9 #1's exact
+# Node-interpreter and sed-script-on-target shapes.
+_check_segment() {
+  local _raw="$1" segment="$2"
+  [[ -z "$segment" ]] && return 0
+
+  # Same regex set as protected-paths-bash-gate.sh — fd-prefix-aware
+  # redirects, cp/mv tail target, sed -i target, dd of=, plus a
+  # token-walk for tee/truncate/install/ln. Keeps behavior consistent
+  # across the two bash gates.
+  local re_redirect='(^|[[:space:]])(&>>|&>|[0-9]+>>|[0-9]+>\||[0-9]+>|>>|>\||>)[[:space:]]*([^[:space:]&|;<>]+)'
+  local re_cpmv='(^|[[:space:]])(cp|mv)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
+  local re_sed='(^|[[:space:]])sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*[^[:space:]]*)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
+  local re_dd='(^|[[:space:]])dd[[:space:]]+[^&|;<>]*of=([^[:space:]&|;<>]+)'
+
+  if [[ "$segment" =~ $re_redirect ]]; then
+    _check_token "${BASH_REMATCH[3]}" "$segment"
+  fi
+  if [[ "$segment" =~ $re_cpmv ]]; then
+    _check_token "${BASH_REMATCH[3]}" "$segment"
+  fi
+  if [[ "$segment" =~ $re_sed ]]; then
+    _check_token "${BASH_REMATCH[3]}" "$segment"
+  fi
+  if [[ "$segment" =~ $re_dd ]]; then
+    _check_token "${BASH_REMATCH[2]}" "$segment"
+  fi
+
+  # tee / truncate / install / ln — token-walk identical to
+  # protected-paths-bash-gate.sh.
+  local _seg_for_walk="$segment"
+  _seg_for_walk="${_seg_for_walk#"${_seg_for_walk%%[![:space:]]*}"}"
+  local first_tok
+  first_tok=$(printf '%s' "$_seg_for_walk" | awk '{print $1}')
+  case "$first_tok" in
+    tee|truncate|install|ln)
+      local found_cmd=""
+      # shellcheck disable=SC2086
+      set -- $_seg_for_walk
+      while [ "$#" -gt 0 ]; do
+        local tok="$1"
+        shift
+        if [[ -z "$found_cmd" ]]; then
+          case "$tok" in
+            tee|truncate|install|ln) found_cmd="$tok" ;;
+          esac
+          continue
+        fi
+        case "$tok" in
+          --) continue ;;
+          --*=*) continue ;;
+          --*)
+            case "$tok" in
+              --append|--ignore-interrupts|--no-clobber|--force|--no-target-directory|--symbolic|--no-dereference|--reference=*) continue ;;
+              *) shift 2>/dev/null || true; continue ;;
+            esac
+            ;;
+          -*)
+            case "$tok" in
+              -s*|-m*|-o*|-g*|-t*) shift 2>/dev/null || true ;;
+            esac
+            continue
+            ;;
+          *)
+            _check_token "$tok" "$segment"
+            ;;
+        esac
+      done
+      ;;
+  esac
+
+  # Node-interpreter fs.writeFileSync / fs.appendFileSync / fs.createWriteStream
+  # detection (discord-ops Round 9 #1 explicit shape). Anchored on
+  # `node -e ...` or `node --eval ...`. Conservative regex: pulls the
+  # first quoted argument out of the call.
+  local re_node_write='(^|[[:space:]])node[[:space:]]+(-e|--eval|-p|--print)[[:space:]]+'
+  if [[ "$segment" =~ $re_node_write ]]; then
+    # Find any quoted-string argument that contains fs.write* /
+    # fs.append* / createWriteStream + a path-looking arg. This is a
+    # best-effort scan; the goal is the obvious vector, not full JS.
+    local node_targets
+    node_targets=$(printf '%s' "$segment" \
+      | grep -oE "fs\.(writeFileSync|writeFile|appendFileSync|appendFile|createWriteStream)\([[:space:]]*[\"'][^\"']+[\"']" \
+      | sed -E "s/.*\([[:space:]]*[\"']([^\"']+)[\"'].*/\\1/" || true)
+    if [[ -n "$node_targets" ]]; then
+      while IFS= read -r tgt; do
+        [[ -z "$tgt" ]] && continue
+        _check_token "$tgt" "$segment"
+      done <<<"$node_targets"
+    fi
+  fi
+
+  return 0
+}
+
+for_each_segment "$CMD" _check_segment
+
+exit 0

--- a/.claude/hooks/blocked-paths-bash-gate.sh
+++ b/.claude/hooks/blocked-paths-bash-gate.sh
@@ -161,6 +161,13 @@ _refuse() {
 }
 
 # Check a single resolved-target token. Refuses on hit.
+#
+# 0.20.1 helix-021 #2: in addition to the logical post-_normalize_target
+# form, also check the symlink-resolved form. Pre-fix `ln -s . linkroot;
+# printf x > linkroot/.env` had a logical form of `linkroot/.env`
+# (no match against blocked_paths) but a resolved form of `.env`
+# (which DOES match). Refuse on either match. Write-tier
+# `blocked-paths-enforcer.sh` already has this resolution since 0.10.x.
 _check_token() {
   local token="$1" segment="$2"
   [[ -z "$token" ]] && return 0
@@ -172,8 +179,20 @@ _check_token() {
     # outside-root rejection on the protected list itself.
     return 0
   fi
+  # Symlink-resolved form via shared helper. Returns empty when the
+  # parent doesn't exist (legitimate "creating the parent" case);
+  # outside-REA_ROOT sentinel when the symlink walks out of the
+  # project (silently allow — same as the logical-path branch above).
+  local resolved_symlink
+  resolved_symlink=$(rea_resolved_relative_form "$token")
+  if [[ "$resolved_symlink" == __rea_outside_root__:* ]]; then
+    resolved_symlink=""
+  fi
   if _match_blocked "$resolved"; then
     _refuse "$MATCHED" "$resolved" "$segment"
+  fi
+  if [[ -n "$resolved_symlink" ]] && _match_blocked "$resolved_symlink"; then
+    _refuse "$MATCHED" "$resolved_symlink" "$segment"
   fi
   return 0
 }

--- a/.claude/hooks/blocked-paths-bash-gate.sh
+++ b/.claude/hooks/blocked-paths-bash-gate.sh
@@ -45,6 +45,8 @@ source "$(dirname "$0")/_lib/path-normalize.sh"
 source "$(dirname "$0")/_lib/policy-read.sh"
 # shellcheck source=_lib/halt-check.sh
 source "$(dirname "$0")/_lib/halt-check.sh"
+# shellcheck source=_lib/interpreter-scanner.sh
+source "$(dirname "$0")/_lib/interpreter-scanner.sh"
 
 INPUT=$(cat)
 
@@ -270,25 +272,17 @@ _check_segment() {
       ;;
   esac
 
-  # Node-interpreter fs.writeFileSync / fs.appendFileSync / fs.createWriteStream
-  # detection (discord-ops Round 9 #1 explicit shape). Anchored on
-  # `node -e ...` or `node --eval ...`. Conservative regex: pulls the
-  # first quoted argument out of the call.
-  local re_node_write='(^|[[:space:]])node[[:space:]]+(-e|--eval|-p|--print)[[:space:]]+'
-  if [[ "$segment" =~ $re_node_write ]]; then
-    # Find any quoted-string argument that contains fs.write* /
-    # fs.append* / createWriteStream + a path-looking arg. This is a
-    # best-effort scan; the goal is the obvious vector, not full JS.
-    local node_targets
-    node_targets=$(printf '%s' "$segment" \
-      | grep -oE "fs\.(writeFileSync|writeFile|appendFileSync|appendFile|createWriteStream)\([[:space:]]*[\"'][^\"']+[\"']" \
-      | sed -E "s/.*\([[:space:]]*[\"']([^\"']+)[\"'].*/\\1/" || true)
-    if [[ -n "$node_targets" ]]; then
-      while IFS= read -r tgt; do
-        [[ -z "$tgt" ]] && continue
-        _check_token "$tgt" "$segment"
-      done <<<"$node_targets"
-    fi
+  # 0.21.2 helix-022 #2: interpreter scanner factored to
+  # _lib/interpreter-scanner.sh and shared with protected-paths-bash-gate.
+  # Covers node -e fs.writeFileSync, python -c open(...,'w'),
+  # ruby -e File.write, perl -e open(FH,'>...').
+  local interp_targets
+  interp_targets=$(rea_interpreter_write_targets "$segment")
+  if [[ -n "$interp_targets" ]]; then
+    while IFS= read -r tgt; do
+      [[ -z "$tgt" ]] && continue
+      _check_token "$tgt" "$segment"
+    done <<<"$interp_targets"
   fi
 
   return 0

--- a/.claude/hooks/blocked-paths-bash-gate.sh
+++ b/.claude/hooks/blocked-paths-bash-gate.sh
@@ -1,293 +1,163 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PreToolUse hook: blocked-paths-bash-gate.sh
-# Fires BEFORE every Bash tool call.
-# Refuses Bash commands that write to entries in policy.yaml's
-# `blocked_paths` list via shell redirection or write-flag utilities.
 #
-# Background (0.16.3, discord-ops Round 9 #1): the existing
-# blocked-paths-enforcer.sh only fires on Write/Edit/MultiEdit/
-# NotebookEdit. Bash-tier writes to blocked_paths entries bypass it
-# entirely:
+# 0.23.0+ — thin shim. Forwards stdin to `rea hook scan-bash --mode blocked`.
+# See protected-paths-bash-gate.sh for the architectural rationale + CLI
+# resolution strategy + verdict-verification model; this shim differs
+# only in the --mode flag.
 #
-#   echo x > .env
-#   cp src.txt .env
-#   sed -i '' '1d' .env.production
-#   node -e "fs.writeFileSync('.env','x')"
+# Codex round 4 Finding 2: 2-tier sandboxed resolver (drops PATH lookup
+# and node_modules/.bin/rea symlink). See protected-paths-bash-gate.sh
+# for rationale.
 #
-# `protected-paths-bash-gate.sh` covers the HARD list (HALT, policy.yaml,
-# settings.json, .husky/*) — but the soft, runtime-configurable
-# `blocked_paths` list never had a Bash-tier counterpart. discord-ops
-# independently caught this gap during their cycle 9 audit.
-#
-# This hook closes the gap by reading the same `blocked_paths` list that
-# blocked-paths-enforcer.sh reads, applying the same redirect / write-
-# utility detection pipeline as protected-paths-bash-gate.sh, and
-# blocking when the resolved target matches any entry.
+# Codex round 2 R2-3: REA_NODE_CLI env-var honoring REMOVED.
 #
 # Exit codes:
-#   0 = no blocked-path write detected — allow
-#   2 = blocked-path write via Bash detected — block
-#
-# Detection: `node -e "fs.writeFileSync('.env','x')"` — Node's
-# fs.writeFileSync called against a blocked path is also detected by
-# argument scan. Other interpreter constructions (perl, python, etc.)
-# remain a known coverage gap for the same reason the env-file-protection
-# hook lists hard caps in its header comment: defense-in-depth, not an
-# adversarial firewall.
+#   0 = allow
+#   2 = block (verdict, missing CLI, malformed payload, verdict mismatch)
 
 set -uo pipefail
 
-# shellcheck source=_lib/cmd-segments.sh
-source "$(dirname "$0")/_lib/cmd-segments.sh"
-# shellcheck source=_lib/path-normalize.sh
-source "$(dirname "$0")/_lib/path-normalize.sh"
-# shellcheck source=_lib/policy-read.sh
-source "$(dirname "$0")/_lib/policy-read.sh"
-# shellcheck source=_lib/halt-check.sh
-source "$(dirname "$0")/_lib/halt-check.sh"
-# shellcheck source=_lib/interpreter-scanner.sh
-source "$(dirname "$0")/_lib/interpreter-scanner.sh"
+proj="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-INPUT=$(cat)
+# 2-tier sandboxed CLI resolver. NO PATH lookup, NO env-var override.
+REA_ARGV=()
+RESOLVED_CLI_PATH=""
+if [ -f "$proj/node_modules/@bookedsolid/rea/dist/cli/index.js" ]; then
+  REA_ARGV=(node "$proj/node_modules/@bookedsolid/rea/dist/cli/index.js")
+  RESOLVED_CLI_PATH="$proj/node_modules/@bookedsolid/rea/dist/cli/index.js"
+elif [ -f "$proj/dist/cli/index.js" ]; then
+  REA_ARGV=(node "$proj/dist/cli/index.js")
+  RESOLVED_CLI_PATH="$proj/dist/cli/index.js"
+fi
 
-if ! command -v jq >/dev/null 2>&1; then
-  printf 'REA ERROR: jq is required but not installed.\n' >&2
+if [ "${#REA_ARGV[@]}" -eq 0 ]; then
+  printf 'rea: CLI not found at sandboxed tiers (node_modules/@bookedsolid/rea/dist or dist/).\n' >&2
+  printf 'Install @bookedsolid/rea via npm/pnpm and run `rea doctor`.\n' >&2
+  printf 'Refusing the Bash command on uncertainty.\n' >&2
   exit 2
 fi
 
-check_halt
-REA_ROOT=$(rea_root)
-
-CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-if [[ -z "$CMD" ]]; then
-  exit 0
-fi
-
-# Load blocked_paths list. If the policy is missing or the list is empty,
-# this hook is a no-op (matches blocked-paths-enforcer.sh semantics).
-BLOCKED_PATHS=()
-while IFS= read -r entry; do
-  [[ -z "$entry" ]] && continue
-  BLOCKED_PATHS+=("$entry")
-done < <(policy_list "blocked_paths")
-
-if [[ ${#BLOCKED_PATHS[@]} -eq 0 ]]; then
-  exit 0
-fi
-
-# Match a normalized project-relative path against the loaded
-# blocked_paths list using the same matching rules as
-# blocked-paths-enforcer.sh:
-#   - directory match (entry ends with `/`) → prefix match
-#   - glob entry (contains `*`) → ERE conversion + anchored match
-#   - otherwise → exact (case-insensitive) match
-# Returns 0 + sets MATCHED on hit, 1 on no hit.
-MATCHED=""
-_match_blocked() {
-  local target_lc="$1"
-  MATCHED=""
-  local entry entry_lc regex
-  for entry in "${BLOCKED_PATHS[@]}"; do
-    entry_lc=$(printf '%s' "$entry" | tr '[:upper:]' '[:lower:]')
-    if [[ "$entry_lc" == */ ]]; then
-      if [[ "$target_lc" == "$entry_lc"* ]] || [[ "$target_lc" == "${entry_lc%/}" ]]; then
-        MATCHED="$entry"
-        return 0
-      fi
-      continue
-    fi
-    if [[ "$entry" == *'*'* ]]; then
-      regex=$(printf '%s' "$entry_lc" | sed 's/\./\\./g; s/\*/.*/g')
-      if printf '%s' "$target_lc" | grep -qE "^${regex}$"; then
-        MATCHED="$entry"
-        return 0
-      fi
-      continue
-    fi
-    if [[ "$target_lc" == "$entry_lc" ]]; then
-      MATCHED="$entry"
-      return 0
-    fi
-  done
-  return 1
-}
-
-# Normalize a path token and apply the same `..` walk + outside-REA_ROOT
-# sentinel trick as protected-paths-bash-gate.sh::_normalize_target.
-# Returns the normalized lowercased project-relative path on stdout, or
-# `__rea_outside_root__:<resolved>` when the path resolves outside the
-# project root.
-_normalize_target() {
-  local t="$1"
-  if [[ "$t" =~ ^\"(.*)\"$ ]]; then t="${BASH_REMATCH[1]}"; fi
-  if [[ "$t" =~ ^\'(.*)\'$ ]]; then t="${BASH_REMATCH[1]}"; fi
-  case "/$t/" in
-    */../*)
-      local abs="$t"
-      [[ "$abs" != /* ]] && abs="$REA_ROOT/$abs"
-      local -a raw_parts parts=()
-      IFS='/' read -ra raw_parts <<<"$abs"
-      for part in "${raw_parts[@]}"; do
-        case "$part" in
-          ''|.) continue ;;
-          ..) [[ "${#parts[@]}" -gt 0 ]] && unset 'parts[${#parts[@]}-1]' ;;
-          *) parts+=("$part") ;;
-        esac
-      done
-      t="/$(IFS=/; printf '%s' "${parts[*]}")"
-      if [[ "$t" != "$REA_ROOT" && "$t" != "$REA_ROOT"/* ]]; then
-        printf '__rea_outside_root__:%s' "$t"
-        return 0
-      fi
-      ;;
-  esac
-  t=$(normalize_path "$t")
-  printf '%s' "$t" | tr '[:upper:]' '[:lower:]'
-}
-
-_refuse() {
-  local pattern="$1" target="$2" segment="$3"
-  {
-    printf 'BLOCKED PATH (bash): write denied by policy\n'
-    printf '\n'
-    printf '  Blocked by:      %s\n' "$pattern"
-    printf '  Resolved target: %s\n' "$target"
-    printf '  Segment:         %s\n' "$segment"
-    printf '\n'
-    printf '  Source: .rea/policy.yaml → blocked_paths\n'
-    printf '  Rule: blocked_paths entries are unreachable via Bash redirects\n'
-    printf '        too — not just Write/Edit/MultiEdit. To modify, a human\n'
-    printf '        must edit directly or update blocked_paths in policy.yaml.\n'
-  } >&2
+# Codex round 4 Finding 2 + round 5 F2 tier defense: realpath the
+# resolved CLI; PRIMARY check is project-root containment, SECONDARY
+# is ancestor `package.json` with the protected name. See
+# protected-paths-bash-gate.sh for the full rationale.
+if ! command -v node >/dev/null 2>&1; then
+  printf 'rea: node not on PATH (required to realpath verify scan-bash CLI). Refusing.\n' >&2
   exit 2
-}
+fi
+sandbox_check=$(node -e '
+  const fs = require("fs");
+  const path = require("path");
+  const cli = process.argv[1];
+  const projDir = process.argv[2];
+  let real;
+  try { real = fs.realpathSync(cli); } catch (e) {
+    process.stdout.write("bad:realpath:" + (e && e.message ? e.message : String(e)));
+    process.exit(1);
+  }
+  // PRIMARY (round 5 F2): realCli must live INSIDE realProj. Catches
+  // node_modules/@bookedsolid/rea -> /tmp/sym-attacker symlink-out.
+  let realProj;
+  try { realProj = fs.realpathSync(projDir); } catch (e) {
+    process.stdout.write("bad:realpath-proj:" + (e && e.message ? e.message : String(e)));
+    process.exit(1);
+  }
+  const projWithSep = realProj.endsWith(path.sep) ? realProj : realProj + path.sep;
+  if (!(real === realProj || real.startsWith(projWithSep))) {
+    process.stdout.write("bad:cli-escapes-project:" + real + ":proj=" + realProj);
+    process.exit(1);
+  }
+  // SECONDARY (round 4 #2): shape + ancestor `package.json` with
+  // `@bookedsolid/rea`. Guards against intra-project hijack.
+  const expectedEnd = path.join("dist", "cli", "index.js");
+  if (!real.endsWith(path.sep + expectedEnd) && real !== "/" + expectedEnd) {
+    process.stdout.write("bad:cli-shape:" + real);
+    process.exit(1);
+  }
+  let cur = path.dirname(path.dirname(path.dirname(real)));
+  let found = false;
+  for (let i = 0; i < 20 && cur && cur !== path.dirname(cur); i += 1) {
+    const pj = path.join(cur, "package.json");
+    if (fs.existsSync(pj)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(pj, "utf8"));
+        if (data && data.name === "@bookedsolid/rea") {
+          found = true;
+          break;
+        }
+      } catch (e) {
+        // Continue.
+      }
+    }
+    cur = path.dirname(cur);
+  }
+  if (!found) {
+    process.stdout.write("bad:no-rea-pkg:" + real);
+    process.exit(1);
+  }
+  process.stdout.write("ok");
+  process.exit(0);
+' "$RESOLVED_CLI_PATH" "$proj" 2>&1)
+sandbox_status=$?
+if [ "$sandbox_status" -ne 0 ] || [ "$sandbox_check" != "ok" ]; then
+  printf 'rea: scan-bash CLI realpath escapes sandbox (%s). Refusing.\n' "$sandbox_check" >&2
+  exit 2
+fi
 
-# Check a single resolved-target token. Refuses on hit.
-#
-# 0.20.1 helix-021 #2: in addition to the logical post-_normalize_target
-# form, also check the symlink-resolved form. Pre-fix `ln -s . linkroot;
-# printf x > linkroot/.env` had a logical form of `linkroot/.env`
-# (no match against blocked_paths) but a resolved form of `.env`
-# (which DOES match). Refuse on either match. Write-tier
-# `blocked-paths-enforcer.sh` already has this resolution since 0.10.x.
-_check_token() {
-  local token="$1" segment="$2"
-  [[ -z "$token" ]] && return 0
-  local resolved
-  resolved=$(_normalize_target "$token")
-  if [[ "$resolved" == __rea_outside_root__:* ]]; then
-    # Outside REA_ROOT → can't be in blocked_paths (blocked_paths is
-    # project-relative). Allow; the protected-paths gate handles
-    # outside-root rejection on the protected list itself.
-    return 0
-  fi
-  # Symlink-resolved form via shared helper. Returns empty when the
-  # parent doesn't exist (legitimate "creating the parent" case);
-  # outside-REA_ROOT sentinel when the symlink walks out of the
-  # project (silently allow — same as the logical-path branch above).
-  local resolved_symlink
-  resolved_symlink=$(rea_resolved_relative_form "$token")
-  if [[ "$resolved_symlink" == __rea_outside_root__:* ]]; then
-    resolved_symlink=""
-  fi
-  if _match_blocked "$resolved"; then
-    _refuse "$MATCHED" "$resolved" "$segment"
-  fi
-  if [[ -n "$resolved_symlink" ]] && _match_blocked "$resolved_symlink"; then
-    _refuse "$MATCHED" "$resolved_symlink" "$segment"
-  fi
-  return 0
-}
+payload=$(cat)
+if [ -z "$payload" ]; then
+  exit 0
+fi
 
-# Scan one segment for redirect / write-utility / node-fs targets and
-# refuse on any hit. Mirrors protected-paths-bash-gate.sh::_check_segment
-# layout, with a few additions to catch discord-ops Round 9 #1's exact
-# Node-interpreter and sed-script-on-target shapes.
-_check_segment() {
-  local _raw="$1" segment="$2"
-  [[ -z "$segment" ]] && return 0
+verdict=$(printf '%s' "$payload" | "${REA_ARGV[@]}" hook scan-bash --mode blocked)
+status=$?
 
-  # Same regex set as protected-paths-bash-gate.sh — fd-prefix-aware
-  # redirects, cp/mv tail target, sed -i target, dd of=, plus a
-  # token-walk for tee/truncate/install/ln. Keeps behavior consistent
-  # across the two bash gates.
-  local re_redirect='(^|[[:space:]])(&>>|&>|[0-9]+>>|[0-9]+>\||[0-9]+>|>>|>\||>)[[:space:]]*([^[:space:]&|;<>]+)'
-  local re_cpmv='(^|[[:space:]])(cp|mv)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
-  local re_sed='(^|[[:space:]])sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*[^[:space:]]*)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
-  local re_dd='(^|[[:space:]])dd[[:space:]]+[^&|;<>]*of=([^[:space:]&|;<>]+)'
+verifier='try {
+  const raw = require("fs").readFileSync(0, "utf8");
+  if (raw.trim().length === 0) { process.stdout.write("bad:empty"); process.exit(1); }
+  const v = JSON.parse(raw);
+  if (typeof v !== "object" || v === null || Array.isArray(v)) {
+    process.stdout.write("bad:non-object"); process.exit(1);
+  }
+  if (v.verdict !== "allow" && v.verdict !== "block") {
+    process.stdout.write("bad:verdict-shape:" + String(v.verdict)); process.exit(1);
+  }
+  process.stdout.write("ok:" + v.verdict); process.exit(0);
+} catch (e) {
+  process.stdout.write("bad:" + (e && e.message ? e.message : String(e))); process.exit(1);
+}'
 
-  if [[ "$segment" =~ $re_redirect ]]; then
-    _check_token "${BASH_REMATCH[3]}" "$segment"
-  fi
-  if [[ "$segment" =~ $re_cpmv ]]; then
-    _check_token "${BASH_REMATCH[3]}" "$segment"
-  fi
-  if [[ "$segment" =~ $re_sed ]]; then
-    _check_token "${BASH_REMATCH[3]}" "$segment"
-  fi
-  if [[ "$segment" =~ $re_dd ]]; then
-    _check_token "${BASH_REMATCH[2]}" "$segment"
-  fi
+verdict_check=$(printf '%s' "$verdict" | node -e "$verifier" 2>&1)
+verdict_check_status=$?
 
-  # tee / truncate / install / ln — token-walk identical to
-  # protected-paths-bash-gate.sh.
-  local _seg_for_walk="$segment"
-  _seg_for_walk="${_seg_for_walk#"${_seg_for_walk%%[![:space:]]*}"}"
-  local first_tok
-  first_tok=$(printf '%s' "$_seg_for_walk" | awk '{print $1}')
-  case "$first_tok" in
-    tee|truncate|install|ln)
-      local found_cmd=""
-      # shellcheck disable=SC2086
-      set -- $_seg_for_walk
-      while [ "$#" -gt 0 ]; do
-        local tok="$1"
-        shift
-        if [[ -z "$found_cmd" ]]; then
-          case "$tok" in
-            tee|truncate|install|ln) found_cmd="$tok" ;;
-          esac
-          continue
-        fi
-        case "$tok" in
-          --) continue ;;
-          --*=*) continue ;;
-          --*)
-            case "$tok" in
-              --append|--ignore-interrupts|--no-clobber|--force|--no-target-directory|--symbolic|--no-dereference|--reference=*) continue ;;
-              *) shift 2>/dev/null || true; continue ;;
-            esac
-            ;;
-          -*)
-            case "$tok" in
-              -s*|-m*|-o*|-g*|-t*) shift 2>/dev/null || true ;;
-            esac
-            continue
-            ;;
-          *)
-            _check_token "$tok" "$segment"
-            ;;
-        esac
-      done
-      ;;
-  esac
-
-  # 0.21.2 helix-022 #2: interpreter scanner factored to
-  # _lib/interpreter-scanner.sh and shared with protected-paths-bash-gate.
-  # Covers node -e fs.writeFileSync, python -c open(...,'w'),
-  # ruby -e File.write, perl -e open(FH,'>...').
-  local interp_targets
-  interp_targets=$(rea_interpreter_write_targets "$segment")
-  if [[ -n "$interp_targets" ]]; then
-    while IFS= read -r tgt; do
-      [[ -z "$tgt" ]] && continue
-      _check_token "$tgt" "$segment"
-    done <<<"$interp_targets"
-  fi
-
-  return 0
-}
-
-for_each_segment "$CMD" _check_segment
-
-exit 0
+case "$status" in
+  0)
+    if [ "$verdict_check_status" -ne 0 ]; then
+      printf 'rea: scan-bash exited 0 but verdict JSON is malformed (%s). Refusing on uncertainty.\n' "$verdict_check" >&2
+      exit 2
+    fi
+    if [ "$verdict_check" != "ok:allow" ]; then
+      printf 'rea: scan-bash exit 0 but verdict says %s. Refusing on uncertainty.\n' "$verdict_check" >&2
+      exit 2
+    fi
+    exit 0
+    ;;
+  2)
+    if [ "$verdict_check_status" -ne 0 ]; then
+      exit 2
+    fi
+    if [ "$verdict_check" != "ok:block" ]; then
+      printf 'rea: scan-bash exit 2 but verdict says %s. Refusing on uncertainty.\n' "$verdict_check" >&2
+      exit 2
+    fi
+    exit 2
+    ;;
+  *)
+    printf 'rea: scan-bash exited %d (expected 0/2). Refusing on uncertainty.\n' "$status" >&2
+    if [ -n "$verdict" ]; then
+      printf 'rea: scan-bash stdout was: %s\n' "$verdict" >&2
+    fi
+    exit 2
+    ;;
+esac

--- a/.claude/hooks/blocked-paths-enforcer.sh
+++ b/.claude/hooks/blocked-paths-enforcer.sh
@@ -23,13 +23,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── 3. HALT check ────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
 # ── 4. Extract file path from payload ─────────────────────────────────────────
 FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
@@ -100,18 +98,52 @@ AGENT_WRITABLE=(
   '.rea/audit/'
 )
 
-normalize_path() {
-  local p="$1"
-  local root="$REA_ROOT"
-  if [[ "$p" == "$root"/* ]]; then
-    p="${p#$root/}"
-  fi
-  p=$(printf '%s' "$p" | sed 's/%2[Ff]/\//g; s/%2[Ee]/./g; s/%20/ /g')
-  p="${p#./}"
-  printf '%s' "$p"
-}
+# 0.16.0: normalize_path migrated to shared `_lib/path-normalize.sh`.
+# Both this hook AND settings-protection.sh consume the same helper
+# so URL-decoding / backslash-translation / `./`-stripping cannot
+# drift between them again.
+# shellcheck source=_lib/path-normalize.sh
+source "$(dirname "$0")/_lib/path-normalize.sh"
 
 NORMALIZED=$(normalize_path "$FILE_PATH")
+
+# ── 5a. Path-traversal rejection (0.14.0 iron-gate fix) ───────────────────────
+# Reject any path containing a `..` segment BEFORE the literal-match below.
+# Without this, `foo/../CODEOWNERS` would get past `normalize_path()` (which
+# only strips leading project root + URL-decodes) and the literal-match
+# loop would compare `foo/../CODEOWNERS` against the literal `CODEOWNERS`
+# entry — which doesn't match, so the policy lets the write through. The
+# downstream Write/Edit tool then resolves the traversal and writes to
+# `CODEOWNERS` anyway, defeating the gate.
+#
+# Mirrors settings-protection.sh §5a (which has had this guard since
+# 0.10.x). Both pre- and post-decode forms are checked because
+# normalize_path() URL-decodes earlier and an attacker could split the
+# traversal across encodings (`%2E%2E/`, `..%2F`, etc.).
+raw_has_traversal=0
+norm_has_traversal=0
+case "/$FILE_PATH/" in
+  */../*) raw_has_traversal=1 ;;
+esac
+case "/$NORMALIZED/" in
+  */../*) norm_has_traversal=1 ;;
+esac
+# Also catch URL-encoded traversal in case some tool routes raw-encoded
+# paths through here (e.g. file:// inputs). normalize_path()'s decoder
+# only handles a fixed set; an unrecognized encoding would slip past.
+case "$FILE_PATH" in
+  *%2[Ee]%2[Ee]*|*%2[Ee].*|*.%2[Ee]*) raw_has_traversal=1 ;;
+esac
+if [[ "$raw_has_traversal" -eq 1 ]] || [[ "$norm_has_traversal" -eq 1 ]]; then
+  {
+    printf 'BLOCKED PATH: path traversal rejected\n'
+    printf '\n'
+    printf '  File: %s\n' "$FILE_PATH"
+    printf "  Rule: path contains a '..' segment; rewrite to a canonical\n"
+    printf '        project-relative path without traversal.\n'
+  } >&2
+  exit 2
+fi
 
 for writable in "${AGENT_WRITABLE[@]}"; do
   if [[ "$NORMALIZED" == "$writable" ]] || [[ "$NORMALIZED" == "$writable"* && "$writable" == */ ]]; then
@@ -172,5 +204,42 @@ for blocked in "${BLOCKED_PATHS[@]}"; do
     exit 2
   fi
 done
+
+# ── 0.16.0 fix H.2: intermediate-symlink resolution ──────────────────────────
+# Same shape as Helix Finding 2 against blocked_paths policy entries.
+# If `secrets/` is in blocked_paths and an attacker creates
+# `pretty/ -> ../secrets/`, then writes `pretty/foo`, the literal-match
+# loop above sees `pretty/foo` (no match) and exits 0 — the downstream
+# Write tool follows the symlink and lands the body in `secrets/foo`.
+# Mirrors settings-protection.sh §6c.
+if [[ -e "$FILE_PATH" || -d "$(dirname -- "$FILE_PATH")" ]]; then
+  parent_dir=$(dirname -- "$FILE_PATH")
+  if [[ -d "$parent_dir" ]]; then
+    resolved_parent=$(cd -P -- "$parent_dir" 2>/dev/null && pwd -P 2>/dev/null) || resolved_parent=""
+    if [[ -n "$resolved_parent" && "$resolved_parent" == "$REA_ROOT"/* ]]; then
+      relative_resolved="${resolved_parent#"$REA_ROOT"/}"
+      resolved_target="${relative_resolved}/$(basename -- "$FILE_PATH")"
+      resolved_target_lc=$(printf '%s' "$resolved_target" | tr '[:upper:]' '[:lower:]')
+      for blocked in "${BLOCKED_PATHS[@]}"; do
+        blocked_lc=$(printf '%s' "$blocked" | tr '[:upper:]' '[:lower:]')
+        if [[ "$resolved_target_lc" == "$blocked_lc" ]] || \
+           { [[ "$blocked_lc" == */ ]] && [[ "$resolved_target_lc" == "$blocked_lc"* ]]; }; then
+          {
+            printf 'BLOCKED PATH: intermediate-symlink resolution blocked\n'
+            printf '\n'
+            printf '  Logical:  %s\n' "$FILE_PATH"
+            printf '  Resolved: %s\n' "$resolved_target"
+            printf '  Blocked by: %s\n' "$blocked"
+            printf '  Source: .rea/policy.yaml → blocked_paths\n'
+            printf '\n'
+            printf '  Rule: an intermediate directory of the path is a symlink\n'
+            printf '        whose target falls inside a blocked policy entry.\n'
+          } >&2
+          exit 2
+        fi
+      done
+    fi
+  fi
+fi
 
 exit 0

--- a/.claude/hooks/changeset-security-gate.sh
+++ b/.claude/hooks/changeset-security-gate.sh
@@ -23,27 +23,32 @@ check_halt
 INPUT="$(cat)"
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // ""')
 
-# Only handle Write and Edit
-if [[ "$TOOL_NAME" != "Write" && "$TOOL_NAME" != "Edit" ]]; then
+# 0.15.0 fix: MultiEdit was not in the allowed tool_name set, so the gate
+# silently exited 0 on every MultiEdit call against `.changeset/*.md` —
+# letting GHSA / CVE pre-disclosure through and skipping frontmatter
+# validation. 0.16.0: NotebookEdit added too (changesets are .md files
+# but a malicious agent could in principle route a .md write through
+# NotebookEdit's new_source path; cheap to allow, free to test).
+if [[ "$TOOL_NAME" != "Write" && "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "MultiEdit" && "$TOOL_NAME" != "NotebookEdit" ]]; then
   exit 0
 fi
 
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+require_jq
+
+# 0.16.0: payload extraction migrated to `_lib/payload-read.sh`. Shared
+# helpers handle every write-tier tool with the same defensive
+# coercion. Adding the next write-tier tool is a one-line edit there.
+# shellcheck source=_lib/payload-read.sh
+source "$(dirname "$0")/_lib/payload-read.sh"
+
+FILE_PATH=$(extract_file_path "$INPUT")
 
 # Only care about .changeset/*.md files — exclude README.md (changeset tool metadata)
 if ! echo "$FILE_PATH" | grep -qE '\.changeset/[^/]+\.md$' || echo "$FILE_PATH" | grep -qE '\.changeset/README\.md$'; then
   exit 0
 fi
 
-require_jq
-
-# Extract the content being written
-if [[ "$TOOL_NAME" == "Write" ]]; then
-  CONTENT=$(echo "$INPUT" | jq -r '.tool_input.content // ""')
-else
-  # For Edit: check the new_string being inserted
-  CONTENT=$(echo "$INPUT" | jq -r '.tool_input.new_string // ""')
-fi
+CONTENT=$(extract_write_content "$INPUT")
 
 # ─── 1. SECURITY DISCLOSURE CHECK ───────────────────────────────────────────
 #
@@ -90,6 +95,19 @@ fi
 #
 # A changeset without valid frontmatter is silently ignored by the changesets
 # tool — the package bump and CHANGELOG entry never appear in the release.
+#
+# 0.15.0 fix: skip frontmatter validation for MultiEdit. MultiEdit's
+# `tool_input.edits[].new_string` payload is a list of partial string
+# replacements, not the full file body — running the frontmatter
+# validator against the concatenation of new_strings would reject every
+# legitimate MultiEdit on an existing changeset (none of the edit
+# fragments individually contains a frontmatter block, even though the
+# resulting file does). The disclosure scan above still runs on
+# MultiEdit content because GHSA/CVE patterns match per-fragment without
+# any structural assumption.
+if [[ "$TOOL_NAME" == "MultiEdit" ]]; then
+  exit 0
+fi
 
 # Must start with ---
 if ! echo "$CONTENT" | head -1 | grep -qE '^---'; then
@@ -107,9 +125,20 @@ Brief description of what changed and why (close #N if applicable).
 Bump types: patch (bug fix/security), minor (new feature), major (breaking change)"
 fi
 
-# Must have at least one package bump entry and a closing ---
+# Must have at least one package bump entry and a closing ---.
+# 0.15.0 fix: accept single-quoted, double-quoted, AND unquoted package
+# names (all three are valid YAML for the same string). Pre-fix the
+# regex required single quotes, so a tool or human authoring the
+# changeset with `"@scope/name": patch` was rejected as malformed even
+# though the Changesets tool itself accepts every form.
+#
+# Codex round-1 P2-1 fix: explicit-alternation form (no backref) so
+# the unquoted variant matches on BSD grep too. The earlier
+# `^([\"']?)[^\"']+\1: ...` shape relied on backref-with-empty-capture
+# semantics that BSD's grep rejects when the capture group's `?` made
+# it absent — quoted forms matched on macOS but unquoted did not.
 FRONTMATTER=$(echo "$CONTENT" | awk '/^---/{count++; if(count==2){exit} next} count==1{print}')
-if ! echo "$FRONTMATTER" | grep -qE "^'.+': (patch|minor|major)"; then
+if ! echo "$FRONTMATTER" | grep -qE "^(\"[^\"]+\"|'[^']+'|[^\"'[:space:]]+): (patch|minor|major)"; then
   json_output "block" \
     "CHANGESET FORMAT GATE: Frontmatter does not contain a valid package bump entry.
 

--- a/.claude/hooks/dangerous-bash-interceptor.sh
+++ b/.claude/hooks/dangerous-bash-interceptor.sh
@@ -245,13 +245,20 @@ fi
 
 # H12: curl/wget piped directly to shell (supply chain attack vector).
 # 0.16.1 helix-016 P1 fix: this check requires BOTH the curl/wget call
-# AND the `| sh` to appear in the same shell pipeline. The 0.16.0
-# refactor moved this into `any_segment_matches`, but the segmenter
-# splits on `|` first — so `curl https://x | sh` decomposed into two
-# segments (`curl https://x`, `sh`) and the regex (which requires both
-# in one segment) never matched. Pipe-RCE is fundamentally a
-# multi-segment property and must be checked against the raw command.
-if printf '%s' "$CMD" | grep -qiE '(curl|wget)[^|]*\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh|fish)'; then
+# AND the `| sh` to appear in the same shell pipeline. Pipe-RCE is
+# fundamentally a multi-segment property — splitting on `|` would
+# decompose `curl https://x | sh` into two unrelated segments — so the
+# detection must run against the un-split command.
+#
+# 0.16.3 helix-016.1 #2 sibling fix: pre-fix the check ran against the
+# raw `$CMD`, which false-positived on `git commit -m "...curl|sh..."`
+# (literal pipe inside the commit-message body). The fix is to scan
+# the QUOTE-MASKED form of the command — same un-split shape, but
+# in-quote pipes are replaced with a sentinel that the regex doesn't
+# match. Real curl-pipe-shell still matches because the pipe between
+# `curl https://x` and `sh` is outside any quote span.
+H12_MASKED=$(quote_masked_cmd "$CMD")
+if printf '%s' "$H12_MASKED" | grep -qiE '(curl|wget)[^|]*\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh|fish)'; then
   add_high \
     "curl/wget piped to shell — remote code execution" \
     "Executing remote scripts without inspection is a major supply chain risk." \
@@ -307,9 +314,26 @@ while IFS= read -r pattern; do
   DELEGATE_PATTERNS+=("$pattern")
 done < <(policy_list "delegate_to_subagent")
 
+# 0.16.3 discord-ops Round 9 #3 fix: anchor the match on segment-start
+# instead of unanchored substring search. The patterns from
+# `policy_list "delegate_to_subagent"` are command prefixes
+# (`pnpm run build`, `pnpm test`, `pnpm run lint`); a substring search
+# fired on commit messages and prose mentioning those prefixes
+# (`git commit -m "doc: when to delegate pnpm test to subagent"`).
+# `any_segment_starts_with` regexes against the prefix-stripped form of
+# each segment, so patterns now only match when the command segment
+# actually invokes the named tool.
+#
+# `grep -qF` was fixed-string; `any_segment_starts_with` runs grep -E.
+# The patterns from policy.yaml are literal prefixes — escape ERE
+# metacharacters before passing them through.
+_escape_ere() {
+  printf '%s' "$1" | sed 's/[][\\.*^$(){}+?|]/\\&/g'
+}
+
 for pattern in "${DELEGATE_PATTERNS[@]+"${DELEGATE_PATTERNS[@]}"}"; do
-  # Use fixed-string match — these are command prefixes, not regex.
-  if printf '%s' "$CMD" | grep -qF "$pattern"; then
+  pattern_re=$(_escape_ere "$pattern")
+  if any_segment_starts_with "$CMD" "${pattern_re}([[:space:]]|$)"; then
     add_high \
       "Context protection — command must run in a subagent" \
       "This command produces excessive output that will exhaust the coordinator context window. Delegate it to a subagent instead of running it directly." \

--- a/.claude/hooks/dangerous-bash-interceptor.sh
+++ b/.claude/hooks/dangerous-bash-interceptor.sh
@@ -257,8 +257,21 @@ fi
 # in-quote pipes are replaced with a sentinel that the regex doesn't
 # match. Real curl-pipe-shell still matches because the pipe between
 # `curl https://x` and `sh` is outside any quote span.
-H12_MASKED=$(quote_masked_cmd "$CMD")
-if printf '%s' "$H12_MASKED" | grep -qiE '(curl|wget)[^|]*\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh|fish)'; then
+# 0.17.0 helix-017 #1 fix: also scan inner payloads of nested-shell
+# wrappers (`zsh -c "curl https://x | sh"`). The unwrap helper emits
+# the original command + each inner payload as separate lines; we
+# quote-mask each line independently and grep. If ANY emitted line
+# contains a real curl-pipe-shell, fire H12.
+H12_HIT=0
+while IFS= read -r _h12_line; do
+  [ -z "$_h12_line" ] && continue
+  _h12_masked=$(quote_masked_cmd "$_h12_line")
+  if printf '%s' "$_h12_masked" | grep -qiE '(curl|wget)[^|]*\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh|fish)'; then
+    H12_HIT=1
+    break
+  fi
+done < <(_rea_unwrap_nested_shells "$CMD")
+if [ "$H12_HIT" = "1" ]; then
   add_high \
     "curl/wget piped to shell — remote code execution" \
     "Executing remote scripts without inspection is a major supply chain risk." \

--- a/.claude/hooks/dangerous-bash-interceptor.sh
+++ b/.claude/hooks/dangerous-bash-interceptor.sh
@@ -15,6 +15,15 @@
 
 set -uo pipefail
 
+# Source shared shell-segment splitter (0.15.0). Provides
+# `any_segment_matches "$CMD" PATTERN` which iterates segments split on
+# &&/||/;/| and runs the pattern with `grep -qiE` against each
+# prefix-stripped segment. Replaces full-command grep that
+# false-positives on heredoc bodies and commit messages mentioning
+# trigger words.
+# shellcheck source=_lib/cmd-segments.sh
+source "$(dirname "$0")/_lib/cmd-segments.sh"
+
 # ── 1. Read ALL stdin immediately before doing anything else ──────────────────
 INPUT=$(cat)
 
@@ -26,13 +35,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── 3. HALT check ─────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
 # ── 4. Parse tool_input.command from the hook payload ─────────────────────────
 CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -84,26 +91,21 @@ add_medium() {
 }
 
 # ── 7. Per-segment evaluation helper ──────────────────────────────────────────
-# Split on &&, ||, ;, and newlines and test a pattern against each segment.
-# Returns 0 if ANY segment matches the pattern.
-any_segment_matches() {
-  local PATTERN="$1"
-  while IFS= read -r SEG; do
-    if printf '%s' "$SEG" | grep -qiE "$PATTERN"; then
-      return 0
-    fi
-  done < <(printf '%s' "$CMD" | sed 's/&&/\n/g; s/||/\n/g; s/;/\n/g')
-  return 1
-}
+# (Migrated to `_lib/cmd-segments.sh::any_segment_matches` as of 0.15.0.
+# The previous inline helper was defined here but never called — H3-H17
+# all greped the WHOLE command, which false-positived on heredoc bodies
+# and commit messages mentioning trigger words. Migration: every check
+# now uses `any_segment_matches "$CMD" PATTERN` with the helper sourced
+# at the top of this file.)
 
 # ── 8. Smart exclusion flags ──────────────────────────────────────────────────
 CMD_IS_REBASE_SAFE=0
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+(rebase)[[:space:]].*(--abort|--continue)'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+(rebase)[[:space:]].*(--abort|--continue)'; then
   CMD_IS_REBASE_SAFE=1
 fi
 
 CMD_IS_CLEAN_DRY=0
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+clean.*([ \t]-n|--dry-run)'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+clean.*([ \t]-n|--dry-run)'; then
   CMD_IS_CLEAN_DRY=1
 fi
 
@@ -111,26 +113,41 @@ fi
 
 # H1: git push --force or -f (per-segment — prevents --force-with-lease poisoning)
 # A segment containing --force-with-lease is excluded; other segments are not.
-while IFS= read -r SEGMENT; do
-  SEGMENT=$(printf '%s' "$SEGMENT" | sed 's/^[[:space:]]*//')
-  [[ -z "$SEGMENT" ]] && continue
-  # Skip segments that use the safe --force-with-lease
-  if printf '%s' "$SEGMENT" | grep -qiE 'git[[:space:]]+push.*--force-with-lease'; then
-    continue
+# 0.15.0: also catches `git push origin +<branch>` (refspec-prefix force-push
+# shorthand) which the previous version missed.
+_h1_check() {
+  local _raw="$1" SEGMENT="$2"
+  [[ -z "$SEGMENT" ]] && return 0
+  # 0.15.0 codex P1 fix: anchor on `^git push`. Pre-fix the unanchored
+  # match meant `echo "git push --force is bad"` triggered H1 even
+  # though no actual push was happening (the segment after prefix-strip
+  # was `echo "..."`, not `git push`). Anchoring scopes detection to
+  # segments whose first token IS git push.
+  printf '%s' "$SEGMENT" | grep -qiE '^git[[:space:]]+push([[:space:]]|$)' || return 0
+  # Skip segments that use the safe --force-with-lease.
+  if printf '%s' "$SEGMENT" | grep -qiE -- '--force-with-lease'; then
+    return 0
   fi
-  if printf '%s' "$SEGMENT" | grep -qiE 'git[[:space:]]+push.*(--force|-f[[:space:]])' || \
-     printf '%s' "$SEGMENT" | grep -qiE 'git[[:space:]]+push.*(--force|-f)$'; then
+  # 0.15.0 codex P1 fix: combined-flag forms (`-fu`, `-uf`, `-Fu`) and
+  # long-form `--force=value` were not caught by the previous
+  # `-f[[:space:]]` shape. The flag-cluster pattern `-[a-zA-Z]*f[a-zA-Z]*`
+  # (followed by space or EOS) mirrors how H11 handles rm flag clusters.
+  # The refspec-prefix `+` on a branch name is git's force-push shorthand.
+  if printf '%s' "$SEGMENT" | grep -qiE -- '--force([[:space:]]|=|$)' || \
+     printf '%s' "$SEGMENT" | grep -qiE -- '(^|[[:space:]])-[a-zA-Z]*f[a-zA-Z]*([[:space:]]|$)' || \
+     printf '%s' "$SEGMENT" | grep -qE -- '[[:space:]]\+[A-Za-z0-9_./-]'; then
     add_high \
       "git push --force — force push detected" \
       "Force-pushing rewrites public history and breaks collaborators' local copies." \
       "Alt: Use 'git push --force-with-lease' — blocks if upstream has new commits you haven't pulled."
-    break
   fi
-done < <(printf '%s' "$CMD" | sed 's/&&/\n/g; s/||/\n/g; s/;/\n/g')
+  return 0
+}
+for_each_segment "$CMD" _h1_check
 
 # H2: git rebase — advisory (MEDIUM)
 if [[ $CMD_IS_REBASE_SAFE -eq 0 ]]; then
-  if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+rebase([[:space:]]|$)'; then
+  if any_segment_starts_with "$CMD" 'git[[:space:]]+rebase([[:space:]]|$)'; then
     add_medium \
       "git rebase — rewrites commit history (advisory)" \
       "Rebase changes commit SHAs. Safe on local feature branches; dangerous on shared/published branches." \
@@ -140,7 +157,7 @@ if [[ $CMD_IS_REBASE_SAFE -eq 0 ]]; then
 fi
 
 # H3: git checkout -- .
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+checkout[[:space:]]+--[[:space:]]+\.'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+checkout[[:space:]]+--[[:space:]]+\.'; then
   add_high \
     "git checkout -- . — discards all uncommitted changes" \
     "Overwrites working tree changes with HEAD. Uncommitted work is lost permanently." \
@@ -148,8 +165,8 @@ if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+checkout[[:space:]]+--[[:space
 fi
 
 # H4: git restore . (any form — with or without --staged flag)
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+restore[[:space:]].*[[:space:]]\.([[:space:]]|$)' || \
-   printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+restore[[:space:]]+\.[[:space:]]*$'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+restore[[:space:]].*[[:space:]]\.([[:space:]]|$)' || \
+   any_segment_starts_with "$CMD" 'git[[:space:]]+restore[[:space:]]+\.[[:space:]]*$'; then
   add_high \
     "git restore . — discards all uncommitted changes" \
     "Restores every tracked file to HEAD, permanently discarding all working tree modifications." \
@@ -158,7 +175,7 @@ fi
 
 # H5: git clean -f
 if [[ $CMD_IS_CLEAN_DRY -eq 0 ]]; then
-  if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+clean[[:space:]]+-[a-zA-Z]*f'; then
+  if any_segment_starts_with "$CMD" 'git[[:space:]]+clean[[:space:]]+-[a-zA-Z]*f'; then
     add_high \
       "git clean -f — removes untracked files" \
       "Permanently deletes untracked files from the working tree. Cannot be undone via git." \
@@ -167,7 +184,7 @@ if [[ $CMD_IS_CLEAN_DRY -eq 0 ]]; then
 fi
 
 # H6: DROP TABLE or DROP DATABASE in psql
-if printf '%s' "$CMD" | grep -qiE '(psql|pgcli)[^|&;]*DROP[[:space:]]+(TABLE|DATABASE|SCHEMA)'; then
+if any_segment_matches "$CMD" '(psql|pgcli)[^|&;]*DROP[[:space:]]+(TABLE|DATABASE|SCHEMA)'; then
   add_high \
     "DROP TABLE/DATABASE via psql — destructive DDL" \
     "Running destructive DDL directly in psql bypasses migration pipeline safety checks." \
@@ -175,7 +192,7 @@ if printf '%s' "$CMD" | grep -qiE '(psql|pgcli)[^|&;]*DROP[[:space:]]+(TABLE|DAT
 fi
 
 # H7: kill -9 with pgrep subshell
-if printf '%s' "$CMD" | grep -qiE 'kill[[:space:]]+-9[[:space:]]+(\$\(|`)'; then
+if any_segment_starts_with "$CMD" 'kill[[:space:]]+-9[[:space:]]+(\$\(|`)'; then
   add_high \
     "kill -9 with pgrep subshell — aggressive process termination" \
     "Sends SIGKILL to processes matched by name, which may kill unintended processes." \
@@ -183,7 +200,7 @@ if printf '%s' "$CMD" | grep -qiE 'kill[[:space:]]+-9[[:space:]]+(\$\(|`)'; then
 fi
 
 # H8: killall -9
-if printf '%s' "$CMD" | grep -qiE 'killall[[:space:]]+-9[[:space:]]+\S'; then
+if any_segment_starts_with "$CMD" 'killall[[:space:]]+-9[[:space:]]+\S'; then
   add_high \
     "killall -9 — SIGKILL all matching processes" \
     "Immediately terminates all processes with the given name without cleanup." \
@@ -191,7 +208,7 @@ if printf '%s' "$CMD" | grep -qiE 'killall[[:space:]]+-9[[:space:]]+\S'; then
 fi
 
 # H9: git commit --no-verify
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+commit.*--no-verify'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+commit.*--no-verify'; then
   add_high \
     "git commit --no-verify — skipping pre-commit hooks" \
     "Bypasses all pre-commit safety gates including secret scanning and linting." \
@@ -199,7 +216,7 @@ if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+commit.*--no-verify'; then
 fi
 
 # H10: HUSKY=0 bypass — suppresses all git hooks without --no-verify
-if printf '%s' "$CMD" | grep -qiE '(^|[[:space:];]|&&|\|\|)HUSKY=0[[:space:]]+git[[:space:]]+(commit|push|tag)'; then
+if any_segment_raw_matches "$CMD" '^HUSKY=0[[:space:]]+git[[:space:]]+(commit|push|tag)'; then
   add_high \
     "HUSKY=0 — bypasses all husky git hooks" \
     "Setting HUSKY=0 disables pre-commit, commit-msg, and pre-push safety gates without --no-verify." \
@@ -208,21 +225,33 @@ fi
 
 # H11: rm -rf with broad targets
 # Covers combined flags (rm -rf, rm -fr), split flags (rm -r -f), and long flags (rm --recursive --force)
-BROAD_TARGETS='(\/|~\/|\.\/\*|\*|\.|src|dist|build|node_modules)'
-if printf '%s' "$CMD" | grep -qiE "rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f[[:space:]]+${BROAD_TARGETS}" || \
-   printf '%s' "$CMD" | grep -qiE "rm[[:space:]]+-[a-zA-Z]*f[a-zA-Z]*r[[:space:]]+${BROAD_TARGETS}" || \
-   printf '%s' "$CMD" | grep -qiE "rm[[:space:]]+-[a-zA-Z]*r[[:space:]]+-[a-zA-Z]*f[[:space:]]+${BROAD_TARGETS}" || \
-   printf '%s' "$CMD" | grep -qiE "rm[[:space:]]+-[a-zA-Z]*f[[:space:]]+-[a-zA-Z]*r[[:space:]]+${BROAD_TARGETS}" || \
-   printf '%s' "$CMD" | grep -qiE "rm[[:space:]]+--recursive[[:space:]]+--force[[:space:]]+${BROAD_TARGETS}" || \
-   printf '%s' "$CMD" | grep -qiE "rm[[:space:]]+--force[[:space:]]+--recursive[[:space:]]+${BROAD_TARGETS}"; then
+# 0.15.0 fix: anchored each target on word boundary (whitespace-or-EOS).
+# The previous form had a bare `\.` which matched `rm -rf .git/foo`
+# (legitimate `.git/`-tree cleanup). Each token now requires either
+# end-of-string or whitespace after — so `.` alone matches `rm -rf .`
+# (the cwd, dangerous) but NOT `rm -rf .git/foo`.
+BROAD_TARGETS='(\/|~\/|\.\/\*|\*|\.|src|dist|build|node_modules)([[:space:]]|$)'
+if any_segment_starts_with "$CMD" "rm[[:space:]]+-[a-zA-Z]*r[a-zA-Z]*f[[:space:]]+${BROAD_TARGETS}" || \
+   any_segment_starts_with "$CMD" "rm[[:space:]]+-[a-zA-Z]*f[a-zA-Z]*r[[:space:]]+${BROAD_TARGETS}" || \
+   any_segment_starts_with "$CMD" "rm[[:space:]]+-[a-zA-Z]*r[[:space:]]+-[a-zA-Z]*f[[:space:]]+${BROAD_TARGETS}" || \
+   any_segment_starts_with "$CMD" "rm[[:space:]]+-[a-zA-Z]*f[[:space:]]+-[a-zA-Z]*r[[:space:]]+${BROAD_TARGETS}" || \
+   any_segment_starts_with "$CMD" "rm[[:space:]]+--recursive[[:space:]]+--force[[:space:]]+${BROAD_TARGETS}" || \
+   any_segment_starts_with "$CMD" "rm[[:space:]]+--force[[:space:]]+--recursive[[:space:]]+${BROAD_TARGETS}"; then
   add_high \
     "rm -rf with broad target — mass file deletion" \
     "Permanently deletes files and directories. Cannot be undone." \
     "Alt: Move to a temp location first, or use 'rm -ri' for interactive deletion."
 fi
 
-# H12: curl/wget piped directly to shell (supply chain attack vector)
-if printf '%s' "$CMD" | grep -qiE '(curl|wget)[^|]*\|[[:space:]]*(bash|sh|zsh|fish)'; then
+# H12: curl/wget piped directly to shell (supply chain attack vector).
+# 0.16.1 helix-016 P1 fix: this check requires BOTH the curl/wget call
+# AND the `| sh` to appear in the same shell pipeline. The 0.16.0
+# refactor moved this into `any_segment_matches`, but the segmenter
+# splits on `|` first — so `curl https://x | sh` decomposed into two
+# segments (`curl https://x`, `sh`) and the regex (which requires both
+# in one segment) never matched. Pipe-RCE is fundamentally a
+# multi-segment property and must be checked against the raw command.
+if printf '%s' "$CMD" | grep -qiE '(curl|wget)[^|]*\|[[:space:]]*(sudo[[:space:]]+)?(bash|sh|zsh|fish)'; then
   add_high \
     "curl/wget piped to shell — remote code execution" \
     "Executing remote scripts without inspection is a major supply chain risk." \
@@ -230,7 +259,7 @@ if printf '%s' "$CMD" | grep -qiE '(curl|wget)[^|]*\|[[:space:]]*(bash|sh|zsh|fi
 fi
 
 # H13: git push --no-verify — bypasses pre-push hooks
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+push.*--no-verify'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+push.*--no-verify'; then
   add_high \
     "git push --no-verify — skipping pre-push hooks" \
     "Bypasses all pre-push safety gates including CI checks." \
@@ -238,7 +267,7 @@ if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+push.*--no-verify'; then
 fi
 
 # H14: git -c core.hooksPath= — redirects or disables hook execution
-if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+-c[[:space:]]+core\.hookspath'; then
+if any_segment_starts_with "$CMD" 'git[[:space:]]+-c[[:space:]]+core\.hookspath'; then
   add_high \
     "git -c core.hooksPath — overriding hooks directory" \
     "Redirecting the hooks path can disable all safety hooks." \
@@ -246,7 +275,7 @@ if printf '%s' "$CMD" | grep -qiE 'git[[:space:]]+-c[[:space:]]+core\.hookspath'
 fi
 
 # H15: REA_BYPASS env var — attempted escape hatch
-if printf '%s' "$CMD" | grep -qiE '(^|[[:space:];]|&&|\|\|)REA_BYPASS[[:space:]]*='; then
+if any_segment_raw_matches "$CMD" '^REA_BYPASS[[:space:]]*='; then
   add_high \
     "REA_BYPASS env var — unauthorized bypass attempt" \
     "Setting REA_BYPASS is not a supported escape mechanism and indicates a bypass attempt." \
@@ -254,60 +283,46 @@ if printf '%s' "$CMD" | grep -qiE '(^|[[:space:];]|&&|\|\|)REA_BYPASS[[:space:]]
 fi
 
 # H16: alias/function definitions containing bypass strings
-if printf '%s' "$CMD" | grep -qiE '(alias|function)[[:space:]]+[a-zA-Z_]+.*(--(no-verify|force)|HUSKY=0|core\.hookspath)'; then
+if any_segment_raw_matches "$CMD" '^(alias|function)[[:space:]]+[a-zA-Z_]+.*(--(no-verify|force)|HUSKY=0|core\.hookspath)'; then
   add_high \
     "Alias/function definition with bypass — circumventing safety gates" \
     "Defining aliases or functions that embed bypass flags defeats safety hooks." \
     "Alt: Do not wrap bypass patterns in aliases or functions."
 fi
 
-# H17: context_protection — block commands that should be delegated to subagents
+# H17: context_protection — block commands that should be delegated to subagents.
 # Reads context_protection.delegate_to_subagent from .rea/policy.yaml.
 # These commands produce excessive output that exhausts coordinator context windows.
-POLICY_FILE="${REA_ROOT}/.rea/policy.yaml"
-if [[ -f "$POLICY_FILE" ]]; then
-  DELEGATE_PATTERNS=()
-  IN_DELEGATE_BLOCK=0
-  while IFS= read -r line; do
-    if printf '%s' "$line" | grep -qE '^[[:space:]]*delegate_to_subagent:'; then
-      # Check for inline empty array
-      if printf '%s' "$line" | grep -qE 'delegate_to_subagent:[[:space:]]*\[\]'; then
-        break
-      fi
-      IN_DELEGATE_BLOCK=1
-      continue
-    fi
-    if [[ $IN_DELEGATE_BLOCK -eq 1 ]]; then
-      # Block sequence items start with "  - "
-      if printf '%s' "$line" | grep -qE '^[[:space:]]*-[[:space:]]'; then
-        pattern=$(printf '%s' "$line" | sed "s/^[[:space:]]*-[[:space:]]*//; s/^[\"']//; s/[\"']$//")
-        if [[ -n "$pattern" ]]; then
-          DELEGATE_PATTERNS+=("$pattern")
-        fi
-      else
-        # Non-continuation line = end of block
-        break
-      fi
-    fi
-  done < "$POLICY_FILE"
+#
+# 0.16.0 fix J.2: replaced the inline YAML parser (40+ lines reimplementing
+# block-sequence walking) with `policy_list` from `_lib/policy-read.sh`.
+# Same parser shape as every other rea hook now reads policy via the shared
+# helper; drift between hooks is structurally impossible.
+# shellcheck source=_lib/policy-read.sh
+source "$(dirname "$0")/_lib/policy-read.sh"
 
-  for pattern in "${DELEGATE_PATTERNS[@]+"${DELEGATE_PATTERNS[@]}"}"; do
-    # Use fixed-string match — these are command prefixes, not regex
-    if printf '%s' "$CMD" | grep -qF "$pattern"; then
-      add_high \
-        "Context protection — command must run in a subagent" \
-        "This command produces excessive output that will exhaust the coordinator context window. Delegate it to a subagent instead of running it directly." \
-        "Alt: Use the Agent tool to delegate: Agent(subagent_type: 'qa-engineer-automation', prompt: 'Run $pattern and report pass/fail summary only.')" \
-        "Alt: The context_protection policy in .rea/policy.yaml lists commands that must be delegated."
-      break
-    fi
-  done
-fi
+DELEGATE_PATTERNS=()
+while IFS= read -r pattern; do
+  [[ -z "$pattern" ]] && continue
+  DELEGATE_PATTERNS+=("$pattern")
+done < <(policy_list "delegate_to_subagent")
+
+for pattern in "${DELEGATE_PATTERNS[@]+"${DELEGATE_PATTERNS[@]}"}"; do
+  # Use fixed-string match — these are command prefixes, not regex.
+  if printf '%s' "$CMD" | grep -qF "$pattern"; then
+    add_high \
+      "Context protection — command must run in a subagent" \
+      "This command produces excessive output that will exhaust the coordinator context window. Delegate it to a subagent instead of running it directly." \
+      "Alt: Use the Agent tool to delegate: Agent(subagent_type: 'qa-engineer-automation', prompt: 'Run $pattern and report pass/fail summary only.')" \
+      "Alt: The context_protection policy in .rea/policy.yaml lists commands that must be delegated."
+    break
+  fi
+done
 
 # ── 10. MEDIUM severity checks ────────────────────────────────────────────────
 
 # M1: npm install --force
-if printf '%s' "$CMD" | grep -qiE 'npm[[:space:]]+(install|i)[[:space:]].*--force'; then
+if any_segment_matches "$CMD" 'npm[[:space:]]+(install|i)[[:space:]].*--force'; then
   add_medium \
     "npm install --force — bypasses dependency resolution" \
     "--force skips conflict checks and can install incompatible package versions." \

--- a/.claude/hooks/dependency-audit-gate.sh
+++ b/.claude/hooks/dependency-audit-gate.sh
@@ -58,14 +58,27 @@ extract_packages() {
   # outer command — but they're never the FIRST token on a segment, so
   # the anchor rejects them.
 
-  # Tokenize on shell separators. Each `IFS=` entry becomes a separate
-  # segment we can anchor against. We use bash's `mapfile` with a sed
-  # to inject newlines at separators; awk-based splitting handles the
-  # quoting heuristic well enough for the realistic cases (agent-issued
-  # commands rarely have separators inside single-quoted strings that
-  # would confuse this).
+  # 0.17.0 helix-017 #3: unwrap nested-shell wrappers (`bash -c 'PAYLOAD'`,
+  # `sh -lc "PAYLOAD"`, etc.) before splitting so the inner install
+  # command becomes a segment that anchors against the install-pattern
+  # check below. Pre-fix `bash -lc 'npm install pkg'` produced a single
+  # segment whose first token was `bash` — install-detection skipped.
+  # 0.17.0 helix-019 #3: delegate splitting to the shared
+  # `_rea_split_segments` so this gate inherits the full separator set
+  # (including bare `&` background-process operator added in 0.16.1)
+  # and the quote-mask that prevents over-fire from in-quote separators.
+  # Pre-fix the local segmenter splat on `|||&&|;|` only, missing bare
+  # `&` — `echo warmup & pnpm add lodash` stayed merged into one segment
+  # and the install-pattern leading-token check skipped it entirely.
   local segments
-  segments=$(printf '%s\n' "$cmd" | sed -E 's/(\|\||\&\&|;|\|)/\n/g')
+  if [ -f "$(dirname "$0")/_lib/cmd-segments.sh" ]; then
+    # shellcheck source=_lib/cmd-segments.sh
+    source "$(dirname "$0")/_lib/cmd-segments.sh"
+    segments=$(_rea_split_segments "$cmd")
+  else
+    # Fallback (lib unavailable): legacy local splitter preserved.
+    segments=$(printf '%s\n' "$cmd" | sed -E 's/(\|\||\&\&|;|\||\&)/\n/g')
+  fi
 
   while IFS= read -r segment; do
     # Trim leading whitespace.

--- a/.claude/hooks/dependency-audit-gate.sh
+++ b/.claude/hooks/dependency-audit-gate.sh
@@ -21,13 +21,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── 3. HALT check ────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
 # ── 4. Parse command ──────────────────────────────────────────────────────────
 CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
@@ -43,30 +41,80 @@ fi
 extract_packages() {
   local cmd="$1"
 
-  # npm install/add with packages (skip flags and local paths)
-  if printf '%s' "$cmd" | grep -qiE '(npm[[:space:]]+(install|i|add)|pnpm[[:space:]]+(add|install)|yarn[[:space:]]+add)[[:space:]]'; then
-    # Extract the part after the install command
-    local after_cmd
-    after_cmd=$(printf '%s' "$cmd" | sed -E 's/.*(npm[[:space:]]+(install|i|add)|pnpm[[:space:]]+(add|install)|yarn[[:space:]]+add)[[:space:]]+//')
+  # 0.15.0 fix: the previous parser ran `grep` against the entire bash
+  # command string with no segment boundary anchor. A heredoc body or
+  # commit-message containing `pnpm install` (e.g. inside
+  # `git commit -m "$(cat <<EOF ... pnpm install ... EOF)"`) matched the
+  # grep, the `.*` in the sed stripped up to that occurrence, and the rest
+  # of the command (`chore:`, `&&`, `||`, etc.) was passed to
+  # `npm view <token> name` and reported as missing packages. The hook
+  # then refused to commit perfectly innocent code.
+  #
+  # Fix: split the command on shell command separators (`;`, `&&`, `||`,
+  # `|`, newlines) and only run the install-detection on segments whose
+  # FIRST non-whitespace token is one of the install commands. Heredoc
+  # bodies inside `$()` substitutions are NOT split into separate segments
+  # — the entire `$(cat <<EOF ... EOF)` is one token attached to the
+  # outer command — but they're never the FIRST token on a segment, so
+  # the anchor rejects them.
 
-    # Split on spaces and filter
-    for token in $after_cmd; do
-      # Skip flags
-      if [[ "$token" == -* ]]; then continue; fi
-      # Skip local paths
-      if [[ "$token" == ./* || "$token" == /* || "$token" == ../* ]]; then continue; fi
-      # Skip empty
-      if [[ -z "$token" ]]; then continue; fi
-      # Strip version specifier for lookup
-      local pkg_name
-      pkg_name=$(printf '%s' "$token" | sed -E 's/@[^@/]+$//')
-      # Handle scoped packages (@scope/name)
-      if [[ -z "$pkg_name" ]]; then
-        pkg_name="$token"
-      fi
-      printf '%s\n' "$pkg_name"
-    done
-  fi
+  # Tokenize on shell separators. Each `IFS=` entry becomes a separate
+  # segment we can anchor against. We use bash's `mapfile` with a sed
+  # to inject newlines at separators; awk-based splitting handles the
+  # quoting heuristic well enough for the realistic cases (agent-issued
+  # commands rarely have separators inside single-quoted strings that
+  # would confuse this).
+  local segments
+  segments=$(printf '%s\n' "$cmd" | sed -E 's/(\|\||\&\&|;|\|)/\n/g')
+
+  while IFS= read -r segment; do
+    # Trim leading whitespace.
+    segment="${segment#"${segment%%[![:space:]]*}"}"
+    # Anchor to start: only match when the install command is the FIRST
+    # thing on the segment, optionally preceded by `sudo` / `exec` /
+    # `time` / etc.
+    #
+    # 0.16.1 helix-016 P2 fix: also strip leading KEY=VALUE env-var
+    # assignments. Pre-fix the prefix allow-list only permitted
+    # sudo/exec/time, so `CI=1 pnpm add foo` and
+    # `NODE_ENV=development npm install bar` bypassed the audit
+    # entirely. POSIX shell allows any number of leading KEY=VALUE
+    # assignments before the command word; we strip them the same
+    # way the shell does.
+    local stripped_segment
+    stripped_segment=$(printf '%s' "$segment" | sed -E 's/^([[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]+[[:space:]]+)+//')
+
+    if printf '%s' "$stripped_segment" | grep -qiE '^(sudo[[:space:]]+|exec[[:space:]]+|time[[:space:]]+)*(npm[[:space:]]+(install|i|add)|pnpm[[:space:]]+(add|install|i)|yarn[[:space:]]+add)[[:space:]]+'; then
+      # Strip the leading prefix wrappers + install command, leaving args.
+      local after_cmd
+      after_cmd=$(printf '%s' "$stripped_segment" | sed -E 's/^(sudo[[:space:]]+|exec[[:space:]]+|time[[:space:]]+)*(npm[[:space:]]+(install|i|add)|pnpm[[:space:]]+(add|install|i)|yarn[[:space:]]+add)[[:space:]]+//')
+
+      for token in $after_cmd; do
+        if [[ "$token" == -* ]]; then continue; fi
+        if [[ "$token" == ./* || "$token" == /* || "$token" == ../* ]]; then continue; fi
+        if [[ -z "$token" ]]; then continue; fi
+        # 0.16.1: tighten token classification (helix-016 sibling concern).
+        # A "package name" is something that doesn't contain shell
+        # metacharacters — `2>&1`, `$VAR`, etc. are never valid npm
+        # package names. Skip any token containing `=`, `>`, `<`, `&`,
+        # `|`, `;`, `$`, backtick, or quotes.
+        if [[ "$token" == *=* || "$token" == *">"* || "$token" == *"<"* ||
+              "$token" == *"&"* || "$token" == *"|"* || "$token" == *";"* ||
+              "$token" == *'$'* || "$token" == *'`'* ||
+              "$token" == *'"'* || "$token" == *"'"* ]]; then continue; fi
+        # `npm view` can't validate `@workspace:*` / `link:` / `file:`
+        # prefixes (workspace protocols). Skip them — they're never npm
+        # registry packages.
+        if [[ "$token" == workspace:* || "$token" == link:* || "$token" == file:* || "$token" == git+* ]]; then continue; fi
+        local pkg_name
+        pkg_name=$(printf '%s' "$token" | sed -E 's/@[^@/]+$//')
+        if [[ -z "$pkg_name" ]]; then
+          pkg_name="$token"
+        fi
+        printf '%s\n' "$pkg_name"
+      done
+    fi
+  done <<< "$segments"
 }
 
 PACKAGES=$(extract_packages "$CMD")

--- a/.claude/hooks/env-file-protection.sh
+++ b/.claude/hooks/env-file-protection.sh
@@ -65,7 +65,15 @@ truncate_cmd() {
 # The goal is to block casual and accidental reads, not defeat a determined
 # adversary with shell access.
 PATTERN_UTILITY='(cat|head|tail|less|more|grep|sed|awk|bat|strings|printf|xargs|tee|jq|python3?[[:space:]]+-c|ruby[[:space:]]+-e)[[:space:]]'
-# Also catch: source/., cp (reads then writes elsewhere)
+# Also catch: source/., cp (reads then writes elsewhere).
+#
+# 0.16.3 discord-ops Round 9 #4 fix: anchored on segment-start. Pre-fix
+# `any_segment_matches` matched anywhere in the segment, so
+# `git commit -m "fix: don't source .env files"` fired even though no
+# real source-of-.env was happening — the trigger words appeared inside
+# the quoted commit-message body. The patterns are command prefixes
+# (`source PATH`, `. PATH`, `cp X PATH`), so segment-start anchoring is
+# the correct shape.
 PATTERN_SOURCE='(source|\.)[[:space:]]+[^;|&]*\.env'
 PATTERN_CP_ENV='cp[[:space:]]+[^;|&]*\.env'
 # .env* files or .envrc (direnv)
@@ -83,9 +91,10 @@ if any_segment_matches_both "$CMD" "$PATTERN_UTILITY" "$PATTERN_ENV_FILE"; then
   MATCHES_BOTH_SAME_SEGMENT=1
 fi
 
-# Direct source/cp of .env files — always block
-if any_segment_matches "$CMD" "$PATTERN_SOURCE" || \
-   any_segment_matches "$CMD" "$PATTERN_CP_ENV"; then
+# Direct source/cp of .env files — always block (segment-start anchored
+# per discord-ops Round 9 #4).
+if any_segment_starts_with "$CMD" "$PATTERN_SOURCE" || \
+   any_segment_starts_with "$CMD" "$PATTERN_CP_ENV"; then
   TRUNCATED_CMD=$(truncate_cmd "$CMD")
   {
     printf 'ENV FILE PROTECTION: Direct sourcing or copying of .env files is blocked.\n'

--- a/.claude/hooks/env-file-protection.sh
+++ b/.claude/hooks/env-file-protection.sh
@@ -71,19 +71,16 @@ PATTERN_CP_ENV='cp[[:space:]]+[^;|&]*\.env'
 # .env* files or .envrc (direnv)
 PATTERN_ENV_FILE='(\.env[a-zA-Z0-9._-]*|\.envrc)([[:space:]]|"|'"'"'|$)'
 
-MATCHES_UTILITY=0
-MATCHES_ENV_FILE=0
-
-# 0.15.0: per-segment match. Pre-fix this greped the FULL command which
-# false-positived on commit messages: `git commit -m "stop reading .env
-# files via cat"` matched both PATTERN_UTILITY (cat) and PATTERN_ENV_FILE
-# (.env) and the hook blocked a perfectly safe commit.
-if any_segment_matches "$CMD" "$PATTERN_UTILITY"; then
-  MATCHES_UTILITY=1
-fi
-
-if any_segment_matches "$CMD" "$PATTERN_ENV_FILE"; then
-  MATCHES_ENV_FILE=1
+# 0.16.2 helix-017 P2 #2: utility AND env-filename must co-occur within
+# the SAME shell segment. Pre-fix this set two independent booleans
+# (any segment with utility OR any segment with .env) and AND'd them,
+# which false-positived across multi-segment constructions like
+# `echo "log: cat is broken" ; touch foo.env` (utility in segment 1,
+# .env name in segment 2). Detection is fundamentally a same-segment
+# co-occurrence property.
+MATCHES_BOTH_SAME_SEGMENT=0
+if any_segment_matches_both "$CMD" "$PATTERN_UTILITY" "$PATTERN_ENV_FILE"; then
+  MATCHES_BOTH_SAME_SEGMENT=1
 fi
 
 # Direct source/cp of .env files — always block
@@ -101,7 +98,7 @@ if any_segment_matches "$CMD" "$PATTERN_SOURCE" || \
   exit 2
 fi
 
-if [[ $MATCHES_UTILITY -eq 1 && $MATCHES_ENV_FILE -eq 1 ]]; then
+if [[ $MATCHES_BOTH_SAME_SEGMENT -eq 1 ]]; then
   TRUNCATED_CMD=$(truncate_cmd "$CMD")
   {
     printf 'ENV FILE PROTECTION: Reading .env files via Bash is blocked.\n'

--- a/.claude/hooks/env-file-protection.sh
+++ b/.claude/hooks/env-file-protection.sh
@@ -17,6 +17,12 @@
 
 set -uo pipefail
 
+# Source shared shell-segment splitter (0.15.0). Replaces full-command
+# grep that false-positives on commit messages mentioning `.env` (e.g.
+# `git commit -m "stop reading .env via cat"`).
+# shellcheck source=_lib/cmd-segments.sh
+source "$(dirname "$0")/_lib/cmd-segments.sh"
+
 INPUT=$(cat)
 
 # ── Dependency check ──────────────────────────────────────────────────────────
@@ -27,13 +33,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── HALT check ────────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
 CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
 
@@ -70,17 +74,21 @@ PATTERN_ENV_FILE='(\.env[a-zA-Z0-9._-]*|\.envrc)([[:space:]]|"|'"'"'|$)'
 MATCHES_UTILITY=0
 MATCHES_ENV_FILE=0
 
-if printf '%s' "$CMD" | grep -qE "$PATTERN_UTILITY"; then
+# 0.15.0: per-segment match. Pre-fix this greped the FULL command which
+# false-positived on commit messages: `git commit -m "stop reading .env
+# files via cat"` matched both PATTERN_UTILITY (cat) and PATTERN_ENV_FILE
+# (.env) and the hook blocked a perfectly safe commit.
+if any_segment_matches "$CMD" "$PATTERN_UTILITY"; then
   MATCHES_UTILITY=1
 fi
 
-if printf '%s' "$CMD" | grep -qE "$PATTERN_ENV_FILE"; then
+if any_segment_matches "$CMD" "$PATTERN_ENV_FILE"; then
   MATCHES_ENV_FILE=1
 fi
 
 # Direct source/cp of .env files — always block
-if printf '%s' "$CMD" | grep -qE "$PATTERN_SOURCE" || \
-   printf '%s' "$CMD" | grep -qE "$PATTERN_CP_ENV"; then
+if any_segment_matches "$CMD" "$PATTERN_SOURCE" || \
+   any_segment_matches "$CMD" "$PATTERN_CP_ENV"; then
   TRUNCATED_CMD=$(truncate_cmd "$CMD")
   {
     printf 'ENV FILE PROTECTION: Direct sourcing or copying of .env files is blocked.\n'

--- a/.claude/hooks/protected-paths-bash-gate.sh
+++ b/.claude/hooks/protected-paths-bash-gate.sh
@@ -31,6 +31,8 @@ source "$(dirname "$0")/_lib/protected-paths.sh"
 source "$(dirname "$0")/_lib/path-normalize.sh"
 # shellcheck source=_lib/cmd-segments.sh
 source "$(dirname "$0")/_lib/cmd-segments.sh"
+# shellcheck source=_lib/interpreter-scanner.sh
+source "$(dirname "$0")/_lib/interpreter-scanner.sh"
 
 INPUT=$(cat)
 
@@ -72,6 +74,20 @@ _normalize_target() {
   # Strip matching surrounding quotes.
   if [[ "$t" =~ ^\"(.*)\"$ ]]; then t="${BASH_REMATCH[1]}"; fi
   if [[ "$t" =~ ^\'(.*)\'$ ]]; then t="${BASH_REMATCH[1]}"; fi
+  # 0.21.2 helix-022 #5: fail closed on shell parameter/command
+  # substitution in the target. `printf x > "$p"` (where p was set
+  # earlier in the segment to `.rea/HALT`) bypassed the gate because
+  # neither the logical nor resolved-form check matched the literal
+  # string `$p`. We DO NOT try to resolve `$NAME=value` assignments
+  # in the same segment — that's a partial-execution semantic this
+  # static analyzer cannot guarantee. Refuse with a clear sentinel
+  # so the caller emits the actionable error message.
+  case "$t" in
+    *'$'*|*'`'*)
+      printf '__rea_unresolved_expansion__:%s' "$t"
+      return 0
+      ;;
+  esac
   # If the path contains `..` segments, resolve them aggressively. We
   # cannot rely on `realpath` being installed; do a manual resolution
   # by walking segments. This is the helix-015 P1 fix: pre-fix, the
@@ -121,6 +137,83 @@ _normalize_target() {
   printf '%s' "$t" | tr '[:upper:]' '[:lower:]'
 }
 
+# 0.21.2 helix-022 #4: cp/mv destination extractor. Walks the segment
+# token-by-token, skips flags (single-dash, double-dash, `--` end-of-
+# options separator), returns the LAST positional argument — which is
+# the destination per POSIX cp/mv semantic.
+#
+# Handles:
+#   cp src dst           → dst
+#   cp -f src dst        → dst
+#   cp --force src dst   → dst
+#   cp a b c dst         → dst (multi-source: last is destination)
+#   cp -- -src dst       → dst (-- ends option processing)
+#   cp -t dir src        → src is the source after -t flag (-t SOURCE_FIRST)
+#                          but we don't try to follow -t semantics; we
+#                          conservatively treat the LAST positional as
+#                          the destination, which over-blocks `-t dir src`
+#                          (destination becomes `src`) — the caller's
+#                          rea_path_is_protected check then determines
+#                          if that's actually protected. False-positive
+#                          case is narrow.
+#
+# Flag-with-value awareness: short flag clusters that take a value
+# (cp -t TARGET_DIR, mv -S SUFFIX, install -m MODE, etc.) consume the
+# next token. Conservative heuristic: known short-options-with-values
+# get the next token consumed.
+_extract_cpmv_destination() {
+  local segment="$1"
+  local stripped="${segment#"${segment%%[![:space:]]*}"}"
+  # Word-split on whitespace. `set --` is intentional; downstream
+  # iteration consumes positional args.
+  local positionals=()
+  local found_cmd=""
+  local end_of_options=0
+  # shellcheck disable=SC2086
+  set -- $stripped
+  while [ "$#" -gt 0 ]; do
+    local tok="$1"
+    shift
+    if [[ -z "$found_cmd" ]]; then
+      case "$tok" in
+        cp|mv) found_cmd="$tok" ;;
+      esac
+      continue
+    fi
+    if [[ "$end_of_options" -eq 1 ]]; then
+      positionals+=("$tok")
+      continue
+    fi
+    case "$tok" in
+      --) end_of_options=1; continue ;;
+      --*=*) continue ;;
+      --*)
+        # Long flags that take a value as the next token.
+        case "$tok" in
+          --target-directory|--reply|--suffix|--backup|--reflink|--strip-trailing-slashes)
+            shift 2>/dev/null || true
+            ;;
+        esac
+        continue
+        ;;
+      -*)
+        # Short flag cluster. Check the LAST char — if it's a known
+        # value-taking flag, consume the next token.
+        case "$tok" in
+          *-t|*-S|*-Z|*-T) shift 2>/dev/null || true ;;
+        esac
+        continue
+        ;;
+      *)
+        positionals+=("$tok")
+        ;;
+    esac
+  done
+  if [[ ${#positionals[@]} -ge 2 ]]; then
+    printf '%s' "${positionals[$((${#positionals[@]} - 1))]}"
+  fi
+}
+
 # Refuse and exit 2 with a uniform error message.
 _refuse() {
   local pattern="$1" target="$2" segment="$3"
@@ -159,7 +252,15 @@ _check_segment() {
   # pattern accepts: optional fd-prefix, then `>` or `>>` or `>|`, with
   # optional `&` for stderr-merge variants.
   local re_redirect='(^|[[:space:]])(&>>|&>|[0-9]+>>|[0-9]+>\||[0-9]+>|>>|>\||>)[[:space:]]*([^[:space:]&|;<>]+)'
-  local re_cpmv='(^|[[:space:]])(cp|mv)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
+  # 0.21.2 helix-022 #4: cp/mv detection now uses an explicit argv-walk
+  # (`_extract_cpmv_destination`) instead of regex-with-backtracking so
+  # every shape is handled — `cp -f src dst`, multi-source `cp a b dst`,
+  # `cp --no-clobber src dst`, `cp -- src dst`. The walker treats the
+  # LAST positional as the destination (POSIX cp/mv semantic). The
+  # sentinel `re_cpmv` regex below is retained ONLY as a cheap pre-screen
+  # — it matches the command name to avoid running the walker on every
+  # segment, but never returns the destination (the walker does).
+  local re_cpmv_screen='(^|[[:space:]])(cp|mv)[[:space:]]+'
   local re_sed='(^|[[:space:]])sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*[^[:space:]]*)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
   local re_dd='(^|[[:space:]])dd[[:space:]]+[^&|;<>]*of=([^[:space:]&|;<>]+)'
   # 0.15.0 codex P1 fix: replaced the bash-3.2-broken `(...)*` pattern
@@ -171,9 +272,17 @@ _check_segment() {
   if [[ "$segment" =~ $re_redirect ]]; then
     target_token="${BASH_REMATCH[3]}"
     detected_form="redirect ${BASH_REMATCH[2]}"
-  elif [[ "$segment" =~ $re_cpmv ]]; then
-    target_token="${BASH_REMATCH[3]}"
-    detected_form="${BASH_REMATCH[2]}"
+  elif [[ "$segment" =~ $re_cpmv_screen ]]; then
+    # 0.21.2 helix-022 #4: extract destination via argv-walk; LAST
+    # positional is the destination per POSIX cp/mv semantic.
+    local _cpmv_cmd="${BASH_REMATCH[2]}"
+    target_token=$(_extract_cpmv_destination "$segment")
+    detected_form="$_cpmv_cmd"
+    if [[ -z "$target_token" ]]; then
+      # No positional destination found — segment isn't actually a
+      # valid cp/mv invocation. Fall through.
+      :
+    fi
   elif [[ "$segment" =~ $re_sed ]]; then
     target_token="${BASH_REMATCH[3]}"
     detected_form="sed -i"
@@ -246,6 +355,18 @@ _check_segment() {
             } >&2
             exit 2
           fi
+          # 0.21.2 helix-022 #5: shell expansion in target — refuse.
+          if [[ "$_t" == __rea_unresolved_expansion__:* ]]; then
+            local raw="${_t#__rea_unresolved_expansion__:}"
+            {
+              printf 'PROTECTED PATH (bash): unresolved shell expansion in target\n'
+              printf '  Token: %s\n  Segment: %s\n' "$raw" "$segment"
+              printf '  Rule: $-substitution and `command-substitution` in redirect\n'
+              printf '        targets are refused at static-analysis time. Resolve\n'
+              printf '        the variable to a literal path before the redirect.\n'
+            } >&2
+            exit 2
+          fi
           # 0.20.1 helix-021 #1: resolve intermediate symlinks via
           # `cd -P / pwd -P` parent-canonicalization (Write-tier parity).
           # `ln -s ../ .husky/pre-push.d/linkdir; printf x > .husky/pre-push.d/linkdir/pre-push`
@@ -285,7 +406,13 @@ _check_segment() {
     done
   fi
 
+  # 0.21.2 helix-022 #2: when no shell-redirect target was found,
+  # interpreter-scanner pass before returning. `node -e
+  # "fs.writeFileSync('.rea/HALT','x')"` has NO redirect or cp/mv
+  # token but still writes a protected path. Run the scanner on the
+  # raw segment; refuse if any extracted target is protected.
   if [[ -z "$target_token" ]]; then
+    _interpreter_scan_and_refuse_protected "$segment"
     return 0
   fi
 
@@ -304,6 +431,21 @@ _check_segment() {
       printf '  Rule: bash redirects whose target resolves outside REA_ROOT\n'
       printf '        are refused. Use a project-relative path without `..`\n'
       printf '        segments.\n'
+    } >&2
+    exit 2
+  fi
+  # 0.21.2 helix-022 #5: shell expansion in target — refuse.
+  if [[ "$target" == __rea_unresolved_expansion__:* ]]; then
+    local raw="${target#__rea_unresolved_expansion__:}"
+    {
+      printf 'PROTECTED PATH (bash): unresolved shell expansion in target\n'
+      printf '\n'
+      printf '  Token:   %s\n' "$raw"
+      printf '  Segment: %s\n' "$segment"
+      printf '\n'
+      printf '  Rule: $-substitution and `command-substitution` in redirect\n'
+      printf '        targets are refused at static-analysis time. Resolve\n'
+      printf '        the variable to a literal path before the redirect.\n'
     } >&2
     exit 2
   fi
@@ -340,7 +482,53 @@ _check_segment() {
     done
     _refuse "$matched" "$hit_form" "$segment"
   fi
+
+  # 0.21.2 helix-022 #2: interpreter-scanner pass even when a
+  # shell-redirect target was already found. A single segment can
+  # have BOTH a shell redirect AND a node -e fs.write*; both must
+  # be checked.
+  _interpreter_scan_and_refuse_protected "$segment"
+
   return 0
+}
+
+# 0.21.2 helix-022 #2: interpreter-scanner pass. Catches
+# `node -e "fs.writeFileSync('.rea/HALT','x')"` and equivalents in
+# python/ruby/perl. The blocked-paths sibling has had this since
+# 0.16.3 F3; this is parity. Each extracted target runs through
+# `_normalize_target` + `rea_path_is_protected` so the existing
+# logical-form + symlink-resolved-form checks both apply.
+_interpreter_scan_and_refuse_protected() {
+  local segment="$1"
+  local _interp_targets
+  _interp_targets=$(rea_interpreter_write_targets "$segment")
+  [[ -z "$_interp_targets" ]] && return 0
+  while IFS= read -r _interp_t; do
+    [[ -z "$_interp_t" ]] && continue
+    local _norm
+    _norm=$(_normalize_target "$_interp_t")
+    if [[ "$_norm" == __rea_outside_root__:* || "$_norm" == __rea_unresolved_expansion__:* ]]; then
+      continue
+    fi
+    local _norm_resolved
+    _norm_resolved=$(rea_resolved_relative_form "$_interp_t")
+    if rea_path_is_protected "$_norm" \
+       || ([[ -n "$_norm_resolved" && "$_norm_resolved" != __rea_outside_root__:* ]] \
+          && rea_path_is_protected "$_norm_resolved"); then
+      local matched_interp="" pattern_lc
+      local hit_form="$_norm"
+      if [[ -n "$_norm_resolved" ]] && rea_path_is_protected "$_norm_resolved" \
+         && ! rea_path_is_protected "$_norm"; then
+        hit_form="$_norm_resolved"
+      fi
+      for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
+        pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+        if [[ "$hit_form" == "$pattern_lc" ]]; then matched_interp="$pattern"; break; fi
+        if [[ "$pattern_lc" == */ && "$hit_form" == "$pattern_lc"* ]]; then matched_interp="$pattern"; break; fi
+      done
+      _refuse "$matched_interp" "$hit_form" "$segment"
+    fi
+  done <<<"$_interp_targets"
 }
 
 for_each_segment "$CMD" _check_segment

--- a/.claude/hooks/protected-paths-bash-gate.sh
+++ b/.claude/hooks/protected-paths-bash-gate.sh
@@ -27,6 +27,8 @@ set -uo pipefail
 
 # shellcheck source=_lib/protected-paths.sh
 source "$(dirname "$0")/_lib/protected-paths.sh"
+# shellcheck source=_lib/path-normalize.sh
+source "$(dirname "$0")/_lib/path-normalize.sh"
 # shellcheck source=_lib/cmd-segments.sh
 source "$(dirname "$0")/_lib/cmd-segments.sh"
 
@@ -235,7 +237,7 @@ _check_segment() {
           # walking — there may be more positional args.
           local _t
           _t=$(_normalize_target "$target_token")
-          # 0.16.0 codex P2-3: outside-REA_ROOT sentinel handling.
+          # 0.16.0 codex P2-3: outside-REA_ROOT sentinel handling (logical).
           if [[ "$_t" == __rea_outside_root__:* ]]; then
             local resolved="${_t#__rea_outside_root__:}"
             {
@@ -244,15 +246,37 @@ _check_segment() {
             } >&2
             exit 2
           fi
-          if rea_path_is_protected "$_t"; then
+          # 0.20.1 helix-021 #1: resolve intermediate symlinks via
+          # `cd -P / pwd -P` parent-canonicalization (Write-tier parity).
+          # `ln -s ../ .husky/pre-push.d/linkdir; printf x > .husky/pre-push.d/linkdir/pre-push`
+          # had a logical form of `.husky/pre-push.d/linkdir/pre-push`
+          # that didn't match any protected pattern; the resolved form
+          # is `.husky/pre-push` which DOES match. Refuse on either.
+          local _t_resolved
+          _t_resolved=$(rea_resolved_relative_form "$target_token")
+          if [[ "$_t_resolved" == __rea_outside_root__:* ]]; then
+            local resolved="${_t_resolved#__rea_outside_root__:}"
+            {
+              printf 'PROTECTED PATH (bash): symlink resolves outside project root\n'
+              printf '  Logical: %s\n  Resolved: %s\n' "$target_token" "$resolved"
+            } >&2
+            exit 2
+          fi
+          if rea_path_is_protected "$_t" \
+             || ([[ -n "$_t_resolved" ]] && rea_path_is_protected "$_t_resolved"); then
             local matched=""
             local pattern_lc
+            local hit_form="$_t"
+            if [[ -n "$_t_resolved" ]] && rea_path_is_protected "$_t_resolved" \
+               && ! rea_path_is_protected "$_t"; then
+              hit_form="$_t_resolved"
+            fi
             for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
               pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
-              if [[ "$_t" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
-              if [[ "$pattern_lc" == */ && "$_t" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
+              if [[ "$hit_form" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
+              if [[ "$pattern_lc" == */ && "$hit_form" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
             done
-            _refuse "$matched" "$_t" "$segment"
+            _refuse "$matched" "$hit_form" "$segment"
           fi
           # Reset target_token so the post-loop check doesn't double-check.
           target_token=""
@@ -283,17 +307,38 @@ _check_segment() {
     } >&2
     exit 2
   fi
-  if rea_path_is_protected "$target"; then
+  # 0.20.1 helix-021 #1: resolve intermediate symlinks. See parallel
+  # block in the multi-target loop above for the rationale.
+  local target_resolved
+  target_resolved=$(rea_resolved_relative_form "$target_token")
+  if [[ "$target_resolved" == __rea_outside_root__:* ]]; then
+    local resolved="${target_resolved#__rea_outside_root__:}"
+    {
+      printf 'PROTECTED PATH (bash): symlink resolves outside project root\n'
+      printf '\n'
+      printf '  Logical:  %s\n' "$target_token"
+      printf '  Resolved: %s\n' "$resolved"
+      printf '  Segment:  %s\n' "$segment"
+    } >&2
+    exit 2
+  fi
+  if rea_path_is_protected "$target" \
+     || ([[ -n "$target_resolved" ]] && rea_path_is_protected "$target_resolved"); then
     # Find the matching pattern for the error message. Both `target`
     # and `pattern` lowercased to match `_normalize_target`'s case-
     # insensitive output (helix-015 P1 fix).
     local matched="" pattern_lc
+    local hit_form="$target"
+    if [[ -n "$target_resolved" ]] && rea_path_is_protected "$target_resolved" \
+       && ! rea_path_is_protected "$target"; then
+      hit_form="$target_resolved"
+    fi
     for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
       pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
-      if [[ "$target" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
-      if [[ "$pattern_lc" == */ && "$target" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
+      if [[ "$hit_form" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
+      if [[ "$pattern_lc" == */ && "$hit_form" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
     done
-    _refuse "$matched" "$target" "$segment"
+    _refuse "$matched" "$hit_form" "$segment"
   fi
   return 0
 }

--- a/.claude/hooks/protected-paths-bash-gate.sh
+++ b/.claude/hooks/protected-paths-bash-gate.sh
@@ -1,536 +1,252 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # PreToolUse hook: protected-paths-bash-gate.sh
-# Fires BEFORE every Bash tool call.
-# Refuses Bash commands that write to PROTECTED_PATTERNS via shell
-# redirection or write-flag utilities — the kill-switch and policy
-# files MUST be unreachable via any tool surface, including Bash.
 #
-# Pre-0.15.0, settings-protection.sh §6 protected `.rea/HALT`,
-# `.rea/policy.yaml`, `.claude/settings.json`, `.husky/*` against
-# Write/Edit/MultiEdit tool calls. But shell redirects bypassed it
-# entirely:
+# 0.23.0+ — thin shim. Forwards stdin (Claude Code's tool_input JSON)
+# to `rea hook scan-bash --mode protected`, parses the verdict, exits
+# 0/2 accordingly.
 #
-#   printf '...' > .rea/HALT          # bypass — Bash matcher only
-#   tee .rea/policy.yaml < new.yaml   # bypass
-#   cp new-settings.json .claude/settings.json
-#   sed -i '' '/foo/d' .husky/pre-push
-#   dd of=.rea/HALT
+# Pre-0.23.0 this hook was a 536-line bash regex pipeline. The rewrite
+# moved every detection rule into a parser-backed AST walker at
+# `src/hooks/bash-scanner/`. helix-023 and discord-ops Round 13 closed
+# 9 bypass classes that lived in the old segmenter; the new scanner
+# closes them definitionally — there is no segmenter to bypass.
 #
-# This hook closes that gap by detecting redirect/write patterns
-# whose target matches the same `_lib/protected-paths.sh` allowlist.
+# Failure mode: if the rea CLI cannot be located in a SANDBOXED tier
+# (consumer's `node_modules/@bookedsolid/rea/dist/cli/index.js` or the
+# rea repo's own `dist/cli/index.js`), we REFUSE the command. NEVER
+# ALLOW on uncertainty. Operators need `@bookedsolid/rea` installed for
+# the gate to work; `rea doctor` flags missing CLI as a P0.
+#
+# Defense in depth: the shim does NOT trust the CLI exit code alone.
+# After capturing stdout we re-parse the verdict with `node -e` to
+# confirm:
+#   1. it is valid JSON,
+#   2. the top-level shape has `.verdict == "allow"|"block"`,
+#   3. the verdict matches the exit code (allow→0, block→2).
+# Any disagreement → exit 2.
+#
+# Codex round 4 Finding 2: dropped tier 1 (PATH `command -v rea`) and
+# tier 2 (`node_modules/.bin/rea` symlink). Both are workspace-attacker
+# controllable: an attacker who can write a file at
+# `node_modules/.bin/rea` (or set PATH to a directory they own) can
+# stage a fake `rea` binary that exits 0 with `{"verdict":"allow"}` and
+# subvert the gate.
+#
+# Trust-boundary HONESTY (codex round 5 F5): the shim's structural
+# defense is the realpath sandbox (round 4 #2 + round 5 F2). It defeats:
+#   - PATH-attacker hijack via fake `rea` binary
+#   - node_modules/.bin/rea symlink-bin hijack
+#   - node_modules/@bookedsolid/rea -> /tmp/sym-attacker symlink-out
+#   - intra-project hijack without a matching package.json
+# It does NOT defeat an attacker who writes a forged dist/cli/index.js
+# AND a matching package.json directly into node_modules/. At that level
+# the attacker has already compromised the package install pipeline (npm
+# registry, lockfile, dependency confusion) and any dependency the agent
+# imports is also forgeable — hook-tier defense is past. The trust
+# boundary is package-tier integrity (npm provenance + manifest
+# verification), not the bash gate. See THREAT_MODEL §8.3 + docs/
+# architecture/bash-scanner.md for the full rationale.
+#
+# Tier defense: realpath the resolved CLI before exec. Two complementary
+# checks:
+#   PRIMARY (codex round 5 F2): realpath(cli) MUST live INSIDE
+#   realpath(CLAUDE_PROJECT_DIR). Catches symlink-out-of-project attacks
+#   where the attacker writes `node_modules/@bookedsolid/rea` as a
+#   symlink to a tree under `/tmp/sym-attacker` containing a forged
+#   `package.json` with name `@bookedsolid/rea` and a forged
+#   `dist/cli/index.js` that exits 0 with `{"verdict":"allow"}`. Pre-fix
+#   the secondary check (package.json walk-up) was the ONLY guard, and
+#   the attacker satisfies it by placing a forged package.json in their
+#   own tree.
+#   SECONDARY: walk up from the resolved CLI looking for an ancestor
+#   `package.json` whose `name` is `@bookedsolid/rea`. This guards
+#   against intra-project symlinks where the realpath stays inside
+#   the project (e.g. accidentally pointing dist/ at node_modules/).
+#
+# Codex round 2 R2-3 (preserved): REA_NODE_CLI env-var honoring REMOVED.
+# Test harnesses must set CLAUDE_PROJECT_DIR to a directory whose
+# `dist/cli/index.js` (or `node_modules/@bookedsolid/rea/...`) holds
+# the trusted CLI build. The shim NEVER reads REA_NODE_CLI.
 #
 # Exit codes:
-#   0 = no protected-path write detected — allow
-#   2 = protected-path write via Bash detected — block
+#   0 = allow (verdict.verdict == "allow")
+#   2 = block (verdict.verdict == "block", or any failure path)
 
 set -uo pipefail
 
-# shellcheck source=_lib/protected-paths.sh
-source "$(dirname "$0")/_lib/protected-paths.sh"
-# shellcheck source=_lib/path-normalize.sh
-source "$(dirname "$0")/_lib/path-normalize.sh"
-# shellcheck source=_lib/cmd-segments.sh
-source "$(dirname "$0")/_lib/cmd-segments.sh"
-# shellcheck source=_lib/interpreter-scanner.sh
-source "$(dirname "$0")/_lib/interpreter-scanner.sh"
+proj="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 
-INPUT=$(cat)
+# Resolve the rea CLI through a fixed 2-tier sandboxed order.
+#   1. node_modules/@bookedsolid/rea/dist/cli/index.js (consumer-side
+#      direct dist execution — the published artifact)
+#   2. dist/cli/index.js under CLAUDE_PROJECT_DIR (the rea repo's own
+#      dogfood install, where `rea` is the package itself)
+#
+# We build an `argv` array rather than a string so paths containing
+# whitespace round-trip safely.
+REA_ARGV=()
+RESOLVED_CLI_PATH=""
+if [ -f "$proj/node_modules/@bookedsolid/rea/dist/cli/index.js" ]; then
+  REA_ARGV=(node "$proj/node_modules/@bookedsolid/rea/dist/cli/index.js")
+  RESOLVED_CLI_PATH="$proj/node_modules/@bookedsolid/rea/dist/cli/index.js"
+elif [ -f "$proj/dist/cli/index.js" ]; then
+  # rea repo dogfood: the project IS @bookedsolid/rea.
+  REA_ARGV=(node "$proj/dist/cli/index.js")
+  RESOLVED_CLI_PATH="$proj/dist/cli/index.js"
+fi
 
-if ! command -v jq >/dev/null 2>&1; then
-  printf 'REA ERROR: jq is required but not installed.\n' >&2
+if [ "${#REA_ARGV[@]}" -eq 0 ]; then
+  printf 'rea: CLI not found at sandboxed tiers (node_modules/@bookedsolid/rea/dist or dist/).\n' >&2
+  printf 'Install @bookedsolid/rea via npm/pnpm and run `rea doctor`.\n' >&2
+  printf 'Refusing the Bash command on uncertainty.\n' >&2
   exit 2
 fi
 
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-
-# HALT check — uniform with other hooks.
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
+# Codex round 4 Finding 2 tier defense: realpath the resolved CLI and
+# verify it lives inside the sandboxed dirs. Catches symlink games.
+# We require Node for the verifier anyway (below) — use it here too.
+if ! command -v node >/dev/null 2>&1; then
+  printf 'rea: node not on PATH (required to realpath verify scan-bash CLI). Refusing.\n' >&2
+  exit 2
+fi
+sandbox_check=$(node -e '
+  const fs = require("fs");
+  const path = require("path");
+  const cli = process.argv[1];
+  const projDir = process.argv[2];
+  let real;
+  try { real = fs.realpathSync(cli); } catch (e) {
+    process.stdout.write("bad:realpath:" + (e && e.message ? e.message : String(e)));
+    process.exit(1);
+  }
+  // Codex round 5 F2 (P0) — PRIMARY check: realpath(cli) must live
+  // INSIDE realpath(CLAUDE_PROJECT_DIR). Pre-fix an attacker who
+  // writes a symlink at node_modules/@bookedsolid/rea pointing to
+  // /tmp/sym-attacker (containing a forged package.json + dist/cli/index.js
+  // that exits 0 with verdict:"allow") completely defeated the
+  // sandbox — the package.json walk-up was satisfied by the forged
+  // file in the attacker tree. Containing realCli to realProj closes
+  // every symlink-out attack class because the attacker no longer
+  // controls a path inside the project tree.
+  let realProj;
+  try { realProj = fs.realpathSync(projDir); } catch (e) {
+    process.stdout.write("bad:realpath-proj:" + (e && e.message ? e.message : String(e)));
+    process.exit(1);
+  }
+  const projWithSep = realProj.endsWith(path.sep) ? realProj : realProj + path.sep;
+  if (!(real === realProj || real.startsWith(projWithSep))) {
+    process.stdout.write("bad:cli-escapes-project:" + real + ":proj=" + realProj);
+    process.exit(1);
+  }
+  // Codex round 4 Finding 2 (now SECONDARY) — shape + ancestor pkg.json.
+  //
+  // Acceptance: the resolved CLI must end in `.../dist/cli/index.js`
+  // and have an ancestor `package.json` whose `name` is `@bookedsolid/rea`.
+  // This guards against intra-project hijack where an attacker writes
+  // a symlink at node_modules/@bookedsolid/rea pointing to a sibling
+  // tree INSIDE the project (e.g. ./scratch/) — the PRIMARY check
+  // accepts it (still inside project root) but the package.json walk-up
+  // refuses unless that tree contains the canonical package metadata.
+  const expectedEnd = path.join("dist", "cli", "index.js");
+  if (!real.endsWith(path.sep + expectedEnd) && real !== "/" + expectedEnd) {
+    process.stdout.write("bad:cli-shape:" + real);
+    process.exit(1);
+  }
+  // Walk up looking for package.json with the protected name.
+  let cur = path.dirname(path.dirname(path.dirname(real))); // pkg root
+  let found = false;
+  for (let i = 0; i < 20 && cur && cur !== path.dirname(cur); i += 1) {
+    const pj = path.join(cur, "package.json");
+    if (fs.existsSync(pj)) {
+      try {
+        const data = JSON.parse(fs.readFileSync(pj, "utf8"));
+        if (data && data.name === "@bookedsolid/rea") {
+          found = true;
+          break;
+        }
+      } catch (e) {
+        // Continue walking up.
+      }
+    }
+    cur = path.dirname(cur);
+  }
+  if (!found) {
+    process.stdout.write("bad:no-rea-pkg:" + real);
+    process.exit(1);
+  }
+  process.stdout.write("ok");
+  process.exit(0);
+' "$RESOLVED_CLI_PATH" "$proj" 2>&1)
+sandbox_status=$?
+if [ "$sandbox_status" -ne 0 ] || [ "$sandbox_check" != "ok" ]; then
+  printf 'rea: scan-bash CLI realpath escapes sandbox (%s). Refusing.\n' "$sandbox_check" >&2
   exit 2
 fi
 
-CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
-if [[ -z "$CMD" ]]; then
+# Capture stdin once and forward it to the CLI.
+payload=$(cat)
+if [ -z "$payload" ]; then
   exit 0
 fi
 
-# Normalize a path token. 0.16.0 codex P1 fixes (helix Findings 015):
-#   - resolve `..` segments via realpath when the path exists, OR reject
-#     them outright when it doesn't (`.claude/hooks/../settings.json`
-#     writes to `.claude/settings.json` but the literal-string match
-#     missed it pre-fix)
-#   - lowercase the result so case-insensitive matchers (macOS APFS,
-#     `.ClAuDe/settings.json`) still match the canonical lowercase
-#     pattern (`.claude/settings.json`)
-#   - apply shared `_lib/path-normalize.sh::normalize_path` for backslash
-#     translation + URL decode + leading-`./` strip
-# shellcheck source=_lib/path-normalize.sh
-source "$(dirname "$0")/_lib/path-normalize.sh"
+# Run the scanner.
+verdict=$(printf '%s' "$payload" | "${REA_ARGV[@]}" hook scan-bash --mode protected)
+status=$?
 
-_normalize_target() {
-  local t="$1"
-  # Strip matching surrounding quotes.
-  if [[ "$t" =~ ^\"(.*)\"$ ]]; then t="${BASH_REMATCH[1]}"; fi
-  if [[ "$t" =~ ^\'(.*)\'$ ]]; then t="${BASH_REMATCH[1]}"; fi
-  # 0.21.2 helix-022 #5: fail closed on shell parameter/command
-  # substitution in the target. `printf x > "$p"` (where p was set
-  # earlier in the segment to `.rea/HALT`) bypassed the gate because
-  # neither the logical nor resolved-form check matched the literal
-  # string `$p`. We DO NOT try to resolve `$NAME=value` assignments
-  # in the same segment — that's a partial-execution semantic this
-  # static analyzer cannot guarantee. Refuse with a clear sentinel
-  # so the caller emits the actionable error message.
-  case "$t" in
-    *'$'*|*'`'*)
-      printf '__rea_unresolved_expansion__:%s' "$t"
-      return 0
-      ;;
-  esac
-  # If the path contains `..` segments, resolve them aggressively. We
-  # cannot rely on `realpath` being installed; do a manual resolution
-  # by walking segments. This is the helix-015 P1 fix: pre-fix, the
-  # literal `.claude/hooks/../settings.json` did not match the
-  # `.claude/settings.json` pattern even though the OS would resolve
-  # the write to that target.
-  case "/$t/" in
-    */../*)
-      # Build absolute then walk and normalize segments.
-      # 0.16.0 codex P1-1 fix: use `read -ra` with IFS=/ instead of an
-      # unquoted `for part in $abs` loop. The unquoted `for` was subject
-      # to pathname expansion — `.claude/*/../settings.json` would glob
-      # `*` against the agent's CWD, mangling the resolved path and
-      # bypassing the protected-paths matcher. `read -ra` with an
-      # explicit delimiter disables both word-splitting (via IFS) AND
-      # pathname expansion (read does not glob).
-      local abs="$t"
-      [[ "$abs" != /* ]] && abs="$REA_ROOT/$abs"
-      local -a raw_parts parts=()
-      IFS='/' read -ra raw_parts <<<"$abs"
-      for part in "${raw_parts[@]}"; do
-        case "$part" in
-          ''|.) continue ;;
-          ..) [[ "${#parts[@]}" -gt 0 ]] && unset 'parts[${#parts[@]}-1]' ;;
-          *) parts+=("$part") ;;
-        esac
-      done
-      t="/$(IFS=/; printf '%s' "${parts[*]}")"
-      # 0.16.0 codex P2-3 fix: if the resolved absolute path escapes
-      # REA_ROOT, emit a sentinel so the caller refuses outright.
-      # `exit 2` here would only exit the `$()` subshell, not the parent
-      # hook process — sentinel + caller-side handling is the only
-      # cross-shell-portable way.
-      if [[ "$t" != "$REA_ROOT" && "$t" != "$REA_ROOT"/* ]]; then
-        printf '__rea_outside_root__:%s' "$t"
-        return 0
-      fi
-      ;;
-  esac
-  # Hand off to shared normalize_path (strips $REA_ROOT, URL-decodes,
-  # translates `\` → `/`, strips leading `./`).
-  t=$(normalize_path "$t")
-  # Lowercase for case-insensitive matching (helix-015 P1 fix #2 —
-  # macOS APFS allows `.ClAuDe/settings.json` to land on the same
-  # file as `.claude/settings.json`, so the matcher must compare
-  # lowercased forms).
-  printf '%s' "$t" | tr '[:upper:]' '[:lower:]'
-}
+# Defense in depth — verify the verdict JSON matches the exit code.
+verifier='try {
+  const raw = require("fs").readFileSync(0, "utf8");
+  if (raw.trim().length === 0) { process.stdout.write("bad:empty"); process.exit(1); }
+  const v = JSON.parse(raw);
+  if (typeof v !== "object" || v === null || Array.isArray(v)) {
+    process.stdout.write("bad:non-object"); process.exit(1);
+  }
+  if (v.verdict !== "allow" && v.verdict !== "block") {
+    process.stdout.write("bad:verdict-shape:" + String(v.verdict)); process.exit(1);
+  }
+  process.stdout.write("ok:" + v.verdict); process.exit(0);
+} catch (e) {
+  process.stdout.write("bad:" + (e && e.message ? e.message : String(e))); process.exit(1);
+}'
 
-# 0.21.2 helix-022 #4: cp/mv destination extractor. Walks the segment
-# token-by-token, skips flags (single-dash, double-dash, `--` end-of-
-# options separator), returns the LAST positional argument — which is
-# the destination per POSIX cp/mv semantic.
-#
-# Handles:
-#   cp src dst           → dst
-#   cp -f src dst        → dst
-#   cp --force src dst   → dst
-#   cp a b c dst         → dst (multi-source: last is destination)
-#   cp -- -src dst       → dst (-- ends option processing)
-#   cp -t dir src        → src is the source after -t flag (-t SOURCE_FIRST)
-#                          but we don't try to follow -t semantics; we
-#                          conservatively treat the LAST positional as
-#                          the destination, which over-blocks `-t dir src`
-#                          (destination becomes `src`) — the caller's
-#                          rea_path_is_protected check then determines
-#                          if that's actually protected. False-positive
-#                          case is narrow.
-#
-# Flag-with-value awareness: short flag clusters that take a value
-# (cp -t TARGET_DIR, mv -S SUFFIX, install -m MODE, etc.) consume the
-# next token. Conservative heuristic: known short-options-with-values
-# get the next token consumed.
-_extract_cpmv_destination() {
-  local segment="$1"
-  local stripped="${segment#"${segment%%[![:space:]]*}"}"
-  # Word-split on whitespace. `set --` is intentional; downstream
-  # iteration consumes positional args.
-  local positionals=()
-  local found_cmd=""
-  local end_of_options=0
-  # shellcheck disable=SC2086
-  set -- $stripped
-  while [ "$#" -gt 0 ]; do
-    local tok="$1"
-    shift
-    if [[ -z "$found_cmd" ]]; then
-      case "$tok" in
-        cp|mv) found_cmd="$tok" ;;
-      esac
-      continue
+verdict_check=$(printf '%s' "$verdict" | node -e "$verifier" 2>&1)
+verdict_check_status=$?
+
+case "$status" in
+  0)
+    if [ "$verdict_check_status" -ne 0 ]; then
+      printf 'rea: scan-bash exited 0 but verdict JSON is malformed (%s). Refusing on uncertainty.\n' "$verdict_check" >&2
+      exit 2
     fi
-    if [[ "$end_of_options" -eq 1 ]]; then
-      positionals+=("$tok")
-      continue
+    if [ "$verdict_check" != "ok:allow" ]; then
+      printf 'rea: scan-bash exit 0 but verdict says %s. Refusing on uncertainty.\n' "$verdict_check" >&2
+      exit 2
     fi
-    case "$tok" in
-      --) end_of_options=1; continue ;;
-      --*=*) continue ;;
-      --*)
-        # Long flags that take a value as the next token.
-        case "$tok" in
-          --target-directory|--reply|--suffix|--backup|--reflink|--strip-trailing-slashes)
-            shift 2>/dev/null || true
-            ;;
-        esac
-        continue
-        ;;
-      -*)
-        # Short flag cluster. Check the LAST char — if it's a known
-        # value-taking flag, consume the next token.
-        case "$tok" in
-          *-t|*-S|*-Z|*-T) shift 2>/dev/null || true ;;
-        esac
-        continue
-        ;;
-      *)
-        positionals+=("$tok")
-        ;;
-    esac
-  done
-  if [[ ${#positionals[@]} -ge 2 ]]; then
-    printf '%s' "${positionals[$((${#positionals[@]} - 1))]}"
-  fi
-}
-
-# Refuse and exit 2 with a uniform error message.
-_refuse() {
-  local pattern="$1" target="$2" segment="$3"
-  {
-    printf 'PROTECTED PATH (bash): write to a package-managed file blocked\n'
-    printf '\n'
-    printf '  Pattern matched: %s\n' "$pattern"
-    printf '  Resolved target: %s\n' "$target"
-    printf '  Segment:         %s\n' "$segment"
-    printf '\n'
-    printf '  Rule: protected paths (kill-switch, policy.yaml, settings.json,\n'
-    printf '        .husky/*) are unreachable via Bash redirects too — not just\n'
-    printf '        Write/Edit/MultiEdit. To modify, a human must edit directly.\n'
-  } >&2
-  exit 2
-}
-
-# Inspect one segment for redirect / write patterns and refuse if the
-# target matches any protected pattern.
-_check_segment() {
-  local _raw="$1" segment="$2"
-  [[ -z "$segment" ]] && return 0
-
-  local target_token=""
-  local detected_form=""
-
-  # bash `[[ =~ ]]` regex literals with `|` and `(...)` parsed inline
-  # confuse some bash versions on macOS. Use named variables for each
-  # pattern so the literal stays in a string context only.
-  # 0.16.0 codex P1 fix (helix-015 #3): widened redirect regex. Pre-fix
-  # only matched `>`, `>>`, `2>`, `2>>`, `&>`. Missed:
-  #   - `1>` / `1>>` (explicit stdout fd)
-  #   - `>|` (noclobber-override redirect)
-  #   - `[0-9]+>` / `[0-9]+>>` (any fd prefix — `9>file`, `42>>file`)
-  # All of these write to the target and bypassed the gate. The new
-  # pattern accepts: optional fd-prefix, then `>` or `>>` or `>|`, with
-  # optional `&` for stderr-merge variants.
-  local re_redirect='(^|[[:space:]])(&>>|&>|[0-9]+>>|[0-9]+>\||[0-9]+>|>>|>\||>)[[:space:]]*([^[:space:]&|;<>]+)'
-  # 0.21.2 helix-022 #4: cp/mv detection now uses an explicit argv-walk
-  # (`_extract_cpmv_destination`) instead of regex-with-backtracking so
-  # every shape is handled — `cp -f src dst`, multi-source `cp a b dst`,
-  # `cp --no-clobber src dst`, `cp -- src dst`. The walker treats the
-  # LAST positional as the destination (POSIX cp/mv semantic). The
-  # sentinel `re_cpmv` regex below is retained ONLY as a cheap pre-screen
-  # — it matches the command name to avoid running the walker on every
-  # segment, but never returns the destination (the walker does).
-  local re_cpmv_screen='(^|[[:space:]])(cp|mv)[[:space:]]+'
-  local re_sed='(^|[[:space:]])sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*[^[:space:]]*)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
-  local re_dd='(^|[[:space:]])dd[[:space:]]+[^&|;<>]*of=([^[:space:]&|;<>]+)'
-  # 0.15.0 codex P1 fix: replaced the bash-3.2-broken `(...)*` pattern
-  # for tee/truncate flag-skipping with a token-walk approach that
-  # works across BSD bash 3.2 and GNU bash 4+. Walks every token after
-  # the command, skips flags (single-dash short, double-dash long with
-  # optional =value), returns the first non-flag token as the target.
-
-  if [[ "$segment" =~ $re_redirect ]]; then
-    target_token="${BASH_REMATCH[3]}"
-    detected_form="redirect ${BASH_REMATCH[2]}"
-  elif [[ "$segment" =~ $re_cpmv_screen ]]; then
-    # 0.21.2 helix-022 #4: extract destination via argv-walk; LAST
-    # positional is the destination per POSIX cp/mv semantic.
-    local _cpmv_cmd="${BASH_REMATCH[2]}"
-    target_token=$(_extract_cpmv_destination "$segment")
-    detected_form="$_cpmv_cmd"
-    if [[ -z "$target_token" ]]; then
-      # No positional destination found — segment isn't actually a
-      # valid cp/mv invocation. Fall through.
-      :
+    exit 0
+    ;;
+  2)
+    # Block path — the CLI has already emitted the operator-facing
+    # reason on stderr. We additionally verify the JSON shape so a
+    # forged `/bin/true` (which would never reach here, but be defensive)
+    # cannot bypass.
+    if [ "$verdict_check_status" -ne 0 ]; then
+      # Malformed stdout under exit 2 is unusual but harmless — the
+      # block path is still honored.
+      exit 2
     fi
-  elif [[ "$segment" =~ $re_sed ]]; then
-    target_token="${BASH_REMATCH[3]}"
-    detected_form="sed -i"
-  elif [[ "$segment" =~ $re_dd ]]; then
-    target_token="${BASH_REMATCH[2]}"
-    detected_form="dd of="
-  else
-    # tee / truncate / install / ln — token-walk for cross-bash safety.
-    # Read tokens, find the command, then return the first non-flag arg.
-    local prev_word="" found_cmd=""
-    local _seg_for_walk="$segment"
-    # Strip leading whitespace.
-    _seg_for_walk="${_seg_for_walk#"${_seg_for_walk%%[![:space:]]*}"}"
-    # shellcheck disable=SC2086
-    set -- $_seg_for_walk
-    while [ "$#" -gt 0 ]; do
-      local tok="$1"
-      shift
-      if [[ -z "$found_cmd" ]]; then
-        case "$tok" in
-          tee|truncate|install|ln)
-            found_cmd="$tok"
-            ;;
-        esac
-        prev_word="$tok"
-        continue
-      fi
-      # We're inside the command's argv. Skip flags.
-      case "$tok" in
-        --) continue ;;
-        --*=*) continue ;;
-        --*)
-          # Long flag — may take a value as the NEXT token (we don't
-          # know which long options take values). For safety, skip
-          # only known no-value long flags; otherwise consume the
-          # next token too if it looks like a value.
-          case "$tok" in
-            --append|--ignore-interrupts|--no-clobber|--force|--no-target-directory|--symbolic|--no-dereference|--reference=*) continue ;;
-            *) shift 2>/dev/null || true; continue ;;
-          esac
-          ;;
-        -*)
-          # Short flag cluster. Skip. truncate -s SIZE — `-s` is a flag,
-          # SIZE is its arg. We're conservative: skip the next token if
-          # the flag cluster's last char is one of the size-bearing
-          # flags (truncate -s, install -m, ln -t).
-          case "$tok" in
-            -s*|-m*|-o*|-g*|-t*) shift 2>/dev/null || true ;;
-          esac
-          continue
-          ;;
-        *)
-          # First non-flag token — this is the target (or, for cp/mv-
-          # like commands, the first source; the cpmv detector above
-          # handles those separately). We treat ALL non-flag args as
-          # potential targets and check each — that catches
-          # `tee a b c` where any of a/b/c could be a protected file.
-          target_token="$tok"
-          detected_form="$found_cmd"
-          # Check this token immediately; if not protected, keep
-          # walking — there may be more positional args.
-          local _t
-          _t=$(_normalize_target "$target_token")
-          # 0.16.0 codex P2-3: outside-REA_ROOT sentinel handling (logical).
-          if [[ "$_t" == __rea_outside_root__:* ]]; then
-            local resolved="${_t#__rea_outside_root__:}"
-            {
-              printf 'PROTECTED PATH (bash): path traversal escapes project root\n'
-              printf '  Logical: %s\n  Resolved: %s\n' "$target_token" "$resolved"
-            } >&2
-            exit 2
-          fi
-          # 0.21.2 helix-022 #5: shell expansion in target — refuse.
-          if [[ "$_t" == __rea_unresolved_expansion__:* ]]; then
-            local raw="${_t#__rea_unresolved_expansion__:}"
-            {
-              printf 'PROTECTED PATH (bash): unresolved shell expansion in target\n'
-              printf '  Token: %s\n  Segment: %s\n' "$raw" "$segment"
-              printf '  Rule: $-substitution and `command-substitution` in redirect\n'
-              printf '        targets are refused at static-analysis time. Resolve\n'
-              printf '        the variable to a literal path before the redirect.\n'
-            } >&2
-            exit 2
-          fi
-          # 0.20.1 helix-021 #1: resolve intermediate symlinks via
-          # `cd -P / pwd -P` parent-canonicalization (Write-tier parity).
-          # `ln -s ../ .husky/pre-push.d/linkdir; printf x > .husky/pre-push.d/linkdir/pre-push`
-          # had a logical form of `.husky/pre-push.d/linkdir/pre-push`
-          # that didn't match any protected pattern; the resolved form
-          # is `.husky/pre-push` which DOES match. Refuse on either.
-          local _t_resolved
-          _t_resolved=$(rea_resolved_relative_form "$target_token")
-          if [[ "$_t_resolved" == __rea_outside_root__:* ]]; then
-            local resolved="${_t_resolved#__rea_outside_root__:}"
-            {
-              printf 'PROTECTED PATH (bash): symlink resolves outside project root\n'
-              printf '  Logical: %s\n  Resolved: %s\n' "$target_token" "$resolved"
-            } >&2
-            exit 2
-          fi
-          if rea_path_is_protected "$_t" \
-             || ([[ -n "$_t_resolved" ]] && rea_path_is_protected "$_t_resolved"); then
-            local matched=""
-            local pattern_lc
-            local hit_form="$_t"
-            if [[ -n "$_t_resolved" ]] && rea_path_is_protected "$_t_resolved" \
-               && ! rea_path_is_protected "$_t"; then
-              hit_form="$_t_resolved"
-            fi
-            for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
-              pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
-              if [[ "$hit_form" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
-              if [[ "$pattern_lc" == */ && "$hit_form" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
-            done
-            _refuse "$matched" "$hit_form" "$segment"
-          fi
-          # Reset target_token so the post-loop check doesn't double-check.
-          target_token=""
-          ;;
-      esac
-    done
-  fi
-
-  # 0.21.2 helix-022 #2: when no shell-redirect target was found,
-  # interpreter-scanner pass before returning. `node -e
-  # "fs.writeFileSync('.rea/HALT','x')"` has NO redirect or cp/mv
-  # token but still writes a protected path. Run the scanner on the
-  # raw segment; refuse if any extracted target is protected.
-  if [[ -z "$target_token" ]]; then
-    _interpreter_scan_and_refuse_protected "$segment"
-    return 0
-  fi
-
-  local target
-  target=$(_normalize_target "$target_token")
-  # 0.16.0 codex P2-3 fix: outside-REA_ROOT sentinel from _normalize_target.
-  if [[ "$target" == __rea_outside_root__:* ]]; then
-    local resolved="${target#__rea_outside_root__:}"
-    {
-      printf 'PROTECTED PATH (bash): path traversal escapes project root\n'
-      printf '\n'
-      printf '  Logical:  %s\n' "$target_token"
-      printf '  Resolved: %s\n' "$resolved"
-      printf '  Segment:  %s\n' "$segment"
-      printf '\n'
-      printf '  Rule: bash redirects whose target resolves outside REA_ROOT\n'
-      printf '        are refused. Use a project-relative path without `..`\n'
-      printf '        segments.\n'
-    } >&2
+    if [ "$verdict_check" != "ok:block" ]; then
+      printf 'rea: scan-bash exit 2 but verdict says %s. Refusing on uncertainty.\n' "$verdict_check" >&2
+      exit 2
+    fi
     exit 2
-  fi
-  # 0.21.2 helix-022 #5: shell expansion in target — refuse.
-  if [[ "$target" == __rea_unresolved_expansion__:* ]]; then
-    local raw="${target#__rea_unresolved_expansion__:}"
-    {
-      printf 'PROTECTED PATH (bash): unresolved shell expansion in target\n'
-      printf '\n'
-      printf '  Token:   %s\n' "$raw"
-      printf '  Segment: %s\n' "$segment"
-      printf '\n'
-      printf '  Rule: $-substitution and `command-substitution` in redirect\n'
-      printf '        targets are refused at static-analysis time. Resolve\n'
-      printf '        the variable to a literal path before the redirect.\n'
-    } >&2
+    ;;
+  *)
+    # Unexpected exit code — treat as block on uncertainty. The CLI
+    # writes its own diagnostic; we add an explicit refusal.
+    printf 'rea: scan-bash exited %d (expected 0/2). Refusing on uncertainty.\n' "$status" >&2
+    if [ -n "$verdict" ]; then
+      printf 'rea: scan-bash stdout was: %s\n' "$verdict" >&2
+    fi
     exit 2
-  fi
-  # 0.20.1 helix-021 #1: resolve intermediate symlinks. See parallel
-  # block in the multi-target loop above for the rationale.
-  local target_resolved
-  target_resolved=$(rea_resolved_relative_form "$target_token")
-  if [[ "$target_resolved" == __rea_outside_root__:* ]]; then
-    local resolved="${target_resolved#__rea_outside_root__:}"
-    {
-      printf 'PROTECTED PATH (bash): symlink resolves outside project root\n'
-      printf '\n'
-      printf '  Logical:  %s\n' "$target_token"
-      printf '  Resolved: %s\n' "$resolved"
-      printf '  Segment:  %s\n' "$segment"
-    } >&2
-    exit 2
-  fi
-  if rea_path_is_protected "$target" \
-     || ([[ -n "$target_resolved" ]] && rea_path_is_protected "$target_resolved"); then
-    # Find the matching pattern for the error message. Both `target`
-    # and `pattern` lowercased to match `_normalize_target`'s case-
-    # insensitive output (helix-015 P1 fix).
-    local matched="" pattern_lc
-    local hit_form="$target"
-    if [[ -n "$target_resolved" ]] && rea_path_is_protected "$target_resolved" \
-       && ! rea_path_is_protected "$target"; then
-      hit_form="$target_resolved"
-    fi
-    for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
-      pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
-      if [[ "$hit_form" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
-      if [[ "$pattern_lc" == */ && "$hit_form" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
-    done
-    _refuse "$matched" "$hit_form" "$segment"
-  fi
-
-  # 0.21.2 helix-022 #2: interpreter-scanner pass even when a
-  # shell-redirect target was already found. A single segment can
-  # have BOTH a shell redirect AND a node -e fs.write*; both must
-  # be checked.
-  _interpreter_scan_and_refuse_protected "$segment"
-
-  return 0
-}
-
-# 0.21.2 helix-022 #2: interpreter-scanner pass. Catches
-# `node -e "fs.writeFileSync('.rea/HALT','x')"` and equivalents in
-# python/ruby/perl. The blocked-paths sibling has had this since
-# 0.16.3 F3; this is parity. Each extracted target runs through
-# `_normalize_target` + `rea_path_is_protected` so the existing
-# logical-form + symlink-resolved-form checks both apply.
-_interpreter_scan_and_refuse_protected() {
-  local segment="$1"
-  local _interp_targets
-  _interp_targets=$(rea_interpreter_write_targets "$segment")
-  [[ -z "$_interp_targets" ]] && return 0
-  while IFS= read -r _interp_t; do
-    [[ -z "$_interp_t" ]] && continue
-    local _norm
-    _norm=$(_normalize_target "$_interp_t")
-    if [[ "$_norm" == __rea_outside_root__:* || "$_norm" == __rea_unresolved_expansion__:* ]]; then
-      continue
-    fi
-    local _norm_resolved
-    _norm_resolved=$(rea_resolved_relative_form "$_interp_t")
-    if rea_path_is_protected "$_norm" \
-       || ([[ -n "$_norm_resolved" && "$_norm_resolved" != __rea_outside_root__:* ]] \
-          && rea_path_is_protected "$_norm_resolved"); then
-      local matched_interp="" pattern_lc
-      local hit_form="$_norm"
-      if [[ -n "$_norm_resolved" ]] && rea_path_is_protected "$_norm_resolved" \
-         && ! rea_path_is_protected "$_norm"; then
-        hit_form="$_norm_resolved"
-      fi
-      for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
-        pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
-        if [[ "$hit_form" == "$pattern_lc" ]]; then matched_interp="$pattern"; break; fi
-        if [[ "$pattern_lc" == */ && "$hit_form" == "$pattern_lc"* ]]; then matched_interp="$pattern"; break; fi
-      done
-      _refuse "$matched_interp" "$hit_form" "$segment"
-    fi
-  done <<<"$_interp_targets"
-}
-
-for_each_segment "$CMD" _check_segment
-
-exit 0
+    ;;
+esac

--- a/.claude/hooks/protected-paths-bash-gate.sh
+++ b/.claude/hooks/protected-paths-bash-gate.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+# PreToolUse hook: protected-paths-bash-gate.sh
+# Fires BEFORE every Bash tool call.
+# Refuses Bash commands that write to PROTECTED_PATTERNS via shell
+# redirection or write-flag utilities — the kill-switch and policy
+# files MUST be unreachable via any tool surface, including Bash.
+#
+# Pre-0.15.0, settings-protection.sh §6 protected `.rea/HALT`,
+# `.rea/policy.yaml`, `.claude/settings.json`, `.husky/*` against
+# Write/Edit/MultiEdit tool calls. But shell redirects bypassed it
+# entirely:
+#
+#   printf '...' > .rea/HALT          # bypass — Bash matcher only
+#   tee .rea/policy.yaml < new.yaml   # bypass
+#   cp new-settings.json .claude/settings.json
+#   sed -i '' '/foo/d' .husky/pre-push
+#   dd of=.rea/HALT
+#
+# This hook closes that gap by detecting redirect/write patterns
+# whose target matches the same `_lib/protected-paths.sh` allowlist.
+#
+# Exit codes:
+#   0 = no protected-path write detected — allow
+#   2 = protected-path write via Bash detected — block
+
+set -uo pipefail
+
+# shellcheck source=_lib/protected-paths.sh
+source "$(dirname "$0")/_lib/protected-paths.sh"
+# shellcheck source=_lib/cmd-segments.sh
+source "$(dirname "$0")/_lib/cmd-segments.sh"
+
+INPUT=$(cat)
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'REA ERROR: jq is required but not installed.\n' >&2
+  exit 2
+fi
+
+REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# HALT check — uniform with other hooks.
+HALT_FILE="${REA_ROOT}/.rea/HALT"
+if [ -f "$HALT_FILE" ]; then
+  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
+    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
+  exit 2
+fi
+
+CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null)
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# Normalize a path token. 0.16.0 codex P1 fixes (helix Findings 015):
+#   - resolve `..` segments via realpath when the path exists, OR reject
+#     them outright when it doesn't (`.claude/hooks/../settings.json`
+#     writes to `.claude/settings.json` but the literal-string match
+#     missed it pre-fix)
+#   - lowercase the result so case-insensitive matchers (macOS APFS,
+#     `.ClAuDe/settings.json`) still match the canonical lowercase
+#     pattern (`.claude/settings.json`)
+#   - apply shared `_lib/path-normalize.sh::normalize_path` for backslash
+#     translation + URL decode + leading-`./` strip
+# shellcheck source=_lib/path-normalize.sh
+source "$(dirname "$0")/_lib/path-normalize.sh"
+
+_normalize_target() {
+  local t="$1"
+  # Strip matching surrounding quotes.
+  if [[ "$t" =~ ^\"(.*)\"$ ]]; then t="${BASH_REMATCH[1]}"; fi
+  if [[ "$t" =~ ^\'(.*)\'$ ]]; then t="${BASH_REMATCH[1]}"; fi
+  # If the path contains `..` segments, resolve them aggressively. We
+  # cannot rely on `realpath` being installed; do a manual resolution
+  # by walking segments. This is the helix-015 P1 fix: pre-fix, the
+  # literal `.claude/hooks/../settings.json` did not match the
+  # `.claude/settings.json` pattern even though the OS would resolve
+  # the write to that target.
+  case "/$t/" in
+    */../*)
+      # Build absolute then walk and normalize segments.
+      # 0.16.0 codex P1-1 fix: use `read -ra` with IFS=/ instead of an
+      # unquoted `for part in $abs` loop. The unquoted `for` was subject
+      # to pathname expansion — `.claude/*/../settings.json` would glob
+      # `*` against the agent's CWD, mangling the resolved path and
+      # bypassing the protected-paths matcher. `read -ra` with an
+      # explicit delimiter disables both word-splitting (via IFS) AND
+      # pathname expansion (read does not glob).
+      local abs="$t"
+      [[ "$abs" != /* ]] && abs="$REA_ROOT/$abs"
+      local -a raw_parts parts=()
+      IFS='/' read -ra raw_parts <<<"$abs"
+      for part in "${raw_parts[@]}"; do
+        case "$part" in
+          ''|.) continue ;;
+          ..) [[ "${#parts[@]}" -gt 0 ]] && unset 'parts[${#parts[@]}-1]' ;;
+          *) parts+=("$part") ;;
+        esac
+      done
+      t="/$(IFS=/; printf '%s' "${parts[*]}")"
+      # 0.16.0 codex P2-3 fix: if the resolved absolute path escapes
+      # REA_ROOT, emit a sentinel so the caller refuses outright.
+      # `exit 2` here would only exit the `$()` subshell, not the parent
+      # hook process — sentinel + caller-side handling is the only
+      # cross-shell-portable way.
+      if [[ "$t" != "$REA_ROOT" && "$t" != "$REA_ROOT"/* ]]; then
+        printf '__rea_outside_root__:%s' "$t"
+        return 0
+      fi
+      ;;
+  esac
+  # Hand off to shared normalize_path (strips $REA_ROOT, URL-decodes,
+  # translates `\` → `/`, strips leading `./`).
+  t=$(normalize_path "$t")
+  # Lowercase for case-insensitive matching (helix-015 P1 fix #2 —
+  # macOS APFS allows `.ClAuDe/settings.json` to land on the same
+  # file as `.claude/settings.json`, so the matcher must compare
+  # lowercased forms).
+  printf '%s' "$t" | tr '[:upper:]' '[:lower:]'
+}
+
+# Refuse and exit 2 with a uniform error message.
+_refuse() {
+  local pattern="$1" target="$2" segment="$3"
+  {
+    printf 'PROTECTED PATH (bash): write to a package-managed file blocked\n'
+    printf '\n'
+    printf '  Pattern matched: %s\n' "$pattern"
+    printf '  Resolved target: %s\n' "$target"
+    printf '  Segment:         %s\n' "$segment"
+    printf '\n'
+    printf '  Rule: protected paths (kill-switch, policy.yaml, settings.json,\n'
+    printf '        .husky/*) are unreachable via Bash redirects too — not just\n'
+    printf '        Write/Edit/MultiEdit. To modify, a human must edit directly.\n'
+  } >&2
+  exit 2
+}
+
+# Inspect one segment for redirect / write patterns and refuse if the
+# target matches any protected pattern.
+_check_segment() {
+  local _raw="$1" segment="$2"
+  [[ -z "$segment" ]] && return 0
+
+  local target_token=""
+  local detected_form=""
+
+  # bash `[[ =~ ]]` regex literals with `|` and `(...)` parsed inline
+  # confuse some bash versions on macOS. Use named variables for each
+  # pattern so the literal stays in a string context only.
+  # 0.16.0 codex P1 fix (helix-015 #3): widened redirect regex. Pre-fix
+  # only matched `>`, `>>`, `2>`, `2>>`, `&>`. Missed:
+  #   - `1>` / `1>>` (explicit stdout fd)
+  #   - `>|` (noclobber-override redirect)
+  #   - `[0-9]+>` / `[0-9]+>>` (any fd prefix — `9>file`, `42>>file`)
+  # All of these write to the target and bypassed the gate. The new
+  # pattern accepts: optional fd-prefix, then `>` or `>>` or `>|`, with
+  # optional `&` for stderr-merge variants.
+  local re_redirect='(^|[[:space:]])(&>>|&>|[0-9]+>>|[0-9]+>\||[0-9]+>|>>|>\||>)[[:space:]]*([^[:space:]&|;<>]+)'
+  local re_cpmv='(^|[[:space:]])(cp|mv)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
+  local re_sed='(^|[[:space:]])sed[[:space:]]+(-[a-zA-Z]*i[a-zA-Z]*[^[:space:]]*)[[:space:]]+[^&|;<>]+[[:space:]]([^[:space:]&|;<>]+)[[:space:]]*$'
+  local re_dd='(^|[[:space:]])dd[[:space:]]+[^&|;<>]*of=([^[:space:]&|;<>]+)'
+  # 0.15.0 codex P1 fix: replaced the bash-3.2-broken `(...)*` pattern
+  # for tee/truncate flag-skipping with a token-walk approach that
+  # works across BSD bash 3.2 and GNU bash 4+. Walks every token after
+  # the command, skips flags (single-dash short, double-dash long with
+  # optional =value), returns the first non-flag token as the target.
+
+  if [[ "$segment" =~ $re_redirect ]]; then
+    target_token="${BASH_REMATCH[3]}"
+    detected_form="redirect ${BASH_REMATCH[2]}"
+  elif [[ "$segment" =~ $re_cpmv ]]; then
+    target_token="${BASH_REMATCH[3]}"
+    detected_form="${BASH_REMATCH[2]}"
+  elif [[ "$segment" =~ $re_sed ]]; then
+    target_token="${BASH_REMATCH[3]}"
+    detected_form="sed -i"
+  elif [[ "$segment" =~ $re_dd ]]; then
+    target_token="${BASH_REMATCH[2]}"
+    detected_form="dd of="
+  else
+    # tee / truncate / install / ln — token-walk for cross-bash safety.
+    # Read tokens, find the command, then return the first non-flag arg.
+    local prev_word="" found_cmd=""
+    local _seg_for_walk="$segment"
+    # Strip leading whitespace.
+    _seg_for_walk="${_seg_for_walk#"${_seg_for_walk%%[![:space:]]*}"}"
+    # shellcheck disable=SC2086
+    set -- $_seg_for_walk
+    while [ "$#" -gt 0 ]; do
+      local tok="$1"
+      shift
+      if [[ -z "$found_cmd" ]]; then
+        case "$tok" in
+          tee|truncate|install|ln)
+            found_cmd="$tok"
+            ;;
+        esac
+        prev_word="$tok"
+        continue
+      fi
+      # We're inside the command's argv. Skip flags.
+      case "$tok" in
+        --) continue ;;
+        --*=*) continue ;;
+        --*)
+          # Long flag — may take a value as the NEXT token (we don't
+          # know which long options take values). For safety, skip
+          # only known no-value long flags; otherwise consume the
+          # next token too if it looks like a value.
+          case "$tok" in
+            --append|--ignore-interrupts|--no-clobber|--force|--no-target-directory|--symbolic|--no-dereference|--reference=*) continue ;;
+            *) shift 2>/dev/null || true; continue ;;
+          esac
+          ;;
+        -*)
+          # Short flag cluster. Skip. truncate -s SIZE — `-s` is a flag,
+          # SIZE is its arg. We're conservative: skip the next token if
+          # the flag cluster's last char is one of the size-bearing
+          # flags (truncate -s, install -m, ln -t).
+          case "$tok" in
+            -s*|-m*|-o*|-g*|-t*) shift 2>/dev/null || true ;;
+          esac
+          continue
+          ;;
+        *)
+          # First non-flag token — this is the target (or, for cp/mv-
+          # like commands, the first source; the cpmv detector above
+          # handles those separately). We treat ALL non-flag args as
+          # potential targets and check each — that catches
+          # `tee a b c` where any of a/b/c could be a protected file.
+          target_token="$tok"
+          detected_form="$found_cmd"
+          # Check this token immediately; if not protected, keep
+          # walking — there may be more positional args.
+          local _t
+          _t=$(_normalize_target "$target_token")
+          # 0.16.0 codex P2-3: outside-REA_ROOT sentinel handling.
+          if [[ "$_t" == __rea_outside_root__:* ]]; then
+            local resolved="${_t#__rea_outside_root__:}"
+            {
+              printf 'PROTECTED PATH (bash): path traversal escapes project root\n'
+              printf '  Logical: %s\n  Resolved: %s\n' "$target_token" "$resolved"
+            } >&2
+            exit 2
+          fi
+          if rea_path_is_protected "$_t"; then
+            local matched=""
+            local pattern_lc
+            for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
+              pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+              if [[ "$_t" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
+              if [[ "$pattern_lc" == */ && "$_t" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
+            done
+            _refuse "$matched" "$_t" "$segment"
+          fi
+          # Reset target_token so the post-loop check doesn't double-check.
+          target_token=""
+          ;;
+      esac
+    done
+  fi
+
+  if [[ -z "$target_token" ]]; then
+    return 0
+  fi
+
+  local target
+  target=$(_normalize_target "$target_token")
+  # 0.16.0 codex P2-3 fix: outside-REA_ROOT sentinel from _normalize_target.
+  if [[ "$target" == __rea_outside_root__:* ]]; then
+    local resolved="${target#__rea_outside_root__:}"
+    {
+      printf 'PROTECTED PATH (bash): path traversal escapes project root\n'
+      printf '\n'
+      printf '  Logical:  %s\n' "$target_token"
+      printf '  Resolved: %s\n' "$resolved"
+      printf '  Segment:  %s\n' "$segment"
+      printf '\n'
+      printf '  Rule: bash redirects whose target resolves outside REA_ROOT\n'
+      printf '        are refused. Use a project-relative path without `..`\n'
+      printf '        segments.\n'
+    } >&2
+    exit 2
+  fi
+  if rea_path_is_protected "$target"; then
+    # Find the matching pattern for the error message. Both `target`
+    # and `pattern` lowercased to match `_normalize_target`'s case-
+    # insensitive output (helix-015 P1 fix).
+    local matched="" pattern_lc
+    for pattern in "${REA_PROTECTED_PATTERNS[@]}"; do
+      pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+      if [[ "$target" == "$pattern_lc" ]]; then matched="$pattern"; break; fi
+      if [[ "$pattern_lc" == */ && "$target" == "$pattern_lc"* ]]; then matched="$pattern"; break; fi
+    done
+    _refuse "$matched" "$target" "$segment"
+  fi
+  return 0
+}
+
+for_each_segment "$CMD" _check_segment
+
+exit 0

--- a/.claude/hooks/secret-scanner.sh
+++ b/.claude/hooks/secret-scanner.sh
@@ -29,23 +29,24 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── HALT check ────────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
-FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
-CONTENT_WRITE=$(printf '%s' "$INPUT" | jq -r '.tool_input.content // empty' 2>/dev/null)
-CONTENT_EDIT=$(printf '%s' "$INPUT"  | jq -r '.tool_input.new_string // empty' 2>/dev/null)
+# 0.16.0: payload extraction moved to `_lib/payload-read.sh`. The shared
+# helpers handle Write content / Edit new_string / MultiEdit edits[] /
+# NotebookEdit new_source with the same defensive type-guards. Adding
+# the next write-tier tool is a one-line edit there, not a sweep
+# across N hooks.
+# shellcheck source=_lib/payload-read.sh
+source "$(dirname "$0")/_lib/payload-read.sh"
 
-if [[ -n "$CONTENT_WRITE" ]]; then
-  CONTENT="$CONTENT_WRITE"
-elif [[ -n "$CONTENT_EDIT" ]]; then
-  CONTENT="$CONTENT_EDIT"
-else
+FILE_PATH=$(extract_file_path "$INPUT")
+CONTENT=$(extract_write_content "$INPUT")
+
+if [[ -z "$CONTENT" ]]; then
   exit 0
 fi
 

--- a/.claude/hooks/security-disclosure-gate.sh
+++ b/.claude/hooks/security-disclosure-gate.sh
@@ -40,8 +40,23 @@ fi
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
 
 # Only intercept gh issue create
-if ! echo "$COMMAND" | grep -qE 'gh\s+issue\s+create'; then
-  exit 0
+# 0.16.3 F8: anchor at segment start so `gh pr create --body "context: gh issue create earlier"`
+# does not match. Same anchoring class as F5/F6 in this release. Source the
+# segment splitter and use any_segment_starts_with — when the cmd-segments
+# lib isn't reachable for any reason, fall back to the legacy unanchored
+# grep (defense-in-depth: better to over-block prose mentions than miss a
+# real `gh issue create`).
+# shellcheck source=_lib/cmd-segments.sh
+if [ -f "$(dirname "$0")/_lib/cmd-segments.sh" ]; then
+  # shellcheck source=_lib/cmd-segments.sh
+  source "$(dirname "$0")/_lib/cmd-segments.sh"
+  if ! any_segment_starts_with "$COMMAND" 'gh[[:space:]]+issue[[:space:]]+create'; then
+    exit 0
+  fi
+else
+  if ! echo "$COMMAND" | grep -qE 'gh\s+issue\s+create'; then
+    exit 0
+  fi
 fi
 
 require_jq
@@ -86,8 +101,107 @@ SECURITY_PATTERNS=(
   'jail.break'
 )
 
-# Scan the full command text (title + body + flags) for sensitive patterns
-FULL_TEXT=$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')
+# Scan the full command text (title + body + flags) for sensitive patterns.
+#
+# 0.16.3 discord-ops Round 9 #2 fix: pre-fix the scan only saw what was on
+# the command line, so `gh issue create --body-file leak.md` (or `-F`)
+# routed the body through a file the regex never read. We now resolve the
+# named flag's path argument(s), read up to 64 KiB of each (cap covers
+# realistic issue bodies; a multi-megabyte body is suspicious in itself),
+# and prepend the lowercased file contents to FULL_TEXT before the
+# pattern scan. Stdin form (`-F -` or `--body-file -`) is intentionally
+# skipped — the hook's stdin is the tool payload, not the issue body,
+# and re-reading is impossible. Files outside REA_ROOT (resolved via
+# `..` traversal) are refused as a defense-in-depth measure mirroring
+# protected-paths-bash-gate.sh's outside-root sentinel.
+REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+BODY_FILE_TEXT=""
+_extract_body_file_paths() {
+  # Emit each `--body-file PATH` and `-F PATH` argument on its own line.
+  # Skips the stdin form (`-`) and `-F=foo`/`--body-file=foo` (handled
+  # by a separate awk pass below).
+  printf '%s' "$COMMAND" \
+    | awk '
+        BEGIN { skip_next = 0; flag_was = "" }
+        {
+          n = split($0, toks, /[[:space:]]+/)
+          for (i = 1; i <= n; i++) {
+            t = toks[i]
+            if (skip_next) {
+              skip_next = 0
+              if (t == "-" || t == "") continue
+              # Strip surrounding quotes from the token if present.
+              gsub(/^["'"'"']/, "", t)
+              gsub(/["'"'"']$/, "", t)
+              print t
+              continue
+            }
+            if (t == "--body-file" || t == "-F") { skip_next = 1; continue }
+            # Equals form.
+            if (t ~ /^--body-file=/) {
+              v = substr(t, length("--body-file=") + 1)
+              gsub(/^["'"'"']/, "", v); gsub(/["'"'"']$/, "", v)
+              if (v != "" && v != "-") print v
+            }
+            if (t ~ /^-F=/) {
+              v = substr(t, length("-F=") + 1)
+              gsub(/^["'"'"']/, "", v); gsub(/["'"'"']$/, "", v)
+              if (v != "" && v != "-") print v
+            }
+          }
+        }'
+}
+while IFS= read -r body_path; do
+  [[ -z "$body_path" ]] && continue
+  raw_path="$body_path"
+  # Resolve relative to the hook's cwd (the agent's project dir). gh
+  # accepts both absolute paths (e.g. tmpfiles like /var/folders/…) and
+  # cwd-relative paths; we honor both. Absolute paths NOT containing
+  # `..` are taken at face value.
+  if [[ "$body_path" != /* ]]; then
+    body_path="$(pwd)/$body_path"
+  fi
+  # Walk `..` segments. The only outside-REA_ROOT shape we refuse is one
+  # where the canonical form contains `..` (i.e. an explicit traversal
+  # by the caller). Plain absolute tmp paths are NOT refused — gh issue
+  # body-files are very commonly written to /var/folders or /tmp and
+  # rejecting those would defeat the scan in routine use.
+  had_traversal=0
+  case "/$raw_path/" in */../*) had_traversal=1 ;; esac
+  resolved="$body_path"
+  if [[ "$had_traversal" -eq 1 ]]; then
+    IFS='/' read -ra _bf_parts_raw <<<"$body_path"
+    _bf_parts=()
+    for _seg in "${_bf_parts_raw[@]}"; do
+      case "$_seg" in
+        ''|.) continue ;;
+        ..) [[ "${#_bf_parts[@]}" -gt 0 ]] && unset '_bf_parts[${#_bf_parts[@]}-1]' ;;
+        *) _bf_parts+=("$_seg") ;;
+      esac
+    done
+    resolved="/$(IFS=/; printf '%s' "${_bf_parts[*]}")"
+    # If the raw path used `..` AND the resolved form escapes REA_ROOT,
+    # refuse — that's the obfuscation shape we care about. A file under
+    # /tmp or /var/folders without `..` segments is fine.
+    if [[ "$resolved" != "$REA_ROOT" && "$resolved" != "$REA_ROOT"/* ]]; then
+      printf 'security-disclosure-gate: --body-file path uses `..` traversal escaping project root; skipping body scan\n' >&2
+      continue
+    fi
+  fi
+  if [[ ! -r "$resolved" ]]; then
+    printf 'security-disclosure-gate: --body-file %s unreadable; skipping body scan\n' "$raw_path" >&2
+    continue
+  fi
+  # Cap at 64 KiB. Lowercase to match FULL_TEXT case folding.
+  body_chunk=$(head -c 65536 "$resolved" 2>/dev/null | tr '[:upper:]' '[:lower:]') || body_chunk=""
+  if [[ -n "$body_chunk" ]]; then
+    BODY_FILE_TEXT="${BODY_FILE_TEXT}
+${body_chunk}"
+  fi
+done < <(_extract_body_file_paths)
+
+FULL_TEXT="${BODY_FILE_TEXT}
+$(echo "$COMMAND" | tr '[:upper:]' '[:lower:]')"
 
 MATCHED_PATTERN=""
 for PATTERN in "${SECURITY_PATTERNS[@]}"; do

--- a/.claude/hooks/security-disclosure-gate.sh
+++ b/.claude/hooks/security-disclosure-gate.sh
@@ -118,37 +118,87 @@ REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 BODY_FILE_TEXT=""
 _extract_body_file_paths() {
   # Emit each `--body-file PATH` and `-F PATH` argument on its own line.
-  # Skips the stdin form (`-`) and `-F=foo`/`--body-file=foo` (handled
-  # by a separate awk pass below).
+  # Skips the stdin form (`-`) and emits the path verbatim from the
+  # equals-form (`--body-file=PATH` / `-F=PATH`).
+  #
+  # 0.17.0 helix-019 #2: quote-aware tokenization. The pre-fix awk split
+  # on whitespace, breaking `--body-file "security notes.md"` into three
+  # tokens — the hook then tried to read `"security` (with literal
+  # leading quote), failed, and silently skipped the body scan. Now we
+  # walk the string with quote-state awareness: whitespace inside
+  # matched `"..."` / `'...'` spans is part of the token, not a
+  # separator. Single-quote spans have no escape semantics; double-quote
+  # spans treat `\"` and `\\` as literal escapes (POSIX shell rules).
   printf '%s' "$COMMAND" \
     | awk '
-        BEGIN { skip_next = 0; flag_was = "" }
+        BEGIN { skip_next = 0 }
+        function strip_outer_quotes(s,    n, first, last) {
+          n = length(s)
+          if (n < 2) return s
+          first = substr(s, 1, 1)
+          last  = substr(s, n, 1)
+          if ((first == "\"" && last == "\"") || (first == "'\''" && last == "'\''")) {
+            return substr(s, 2, n - 2)
+          }
+          return s
+        }
+        function emit_token(t) {
+          if (skip_next) {
+            skip_next = 0
+            if (t == "-" || t == "") return
+            t = strip_outer_quotes(t)
+            print t
+            return
+          }
+          if (t == "--body-file" || t == "-F") { skip_next = 1; return }
+          if (t ~ /^--body-file=/) {
+            v = substr(t, length("--body-file=") + 1)
+            v = strip_outer_quotes(v)
+            if (v != "" && v != "-") print v
+          }
+          if (t ~ /^-F=/) {
+            v = substr(t, length("-F=") + 1)
+            v = strip_outer_quotes(v)
+            if (v != "" && v != "-") print v
+          }
+        }
         {
-          n = split($0, toks, /[[:space:]]+/)
-          for (i = 1; i <= n; i++) {
-            t = toks[i]
-            if (skip_next) {
-              skip_next = 0
-              if (t == "-" || t == "") continue
-              # Strip surrounding quotes from the token if present.
-              gsub(/^["'"'"']/, "", t)
-              gsub(/["'"'"']$/, "", t)
-              print t
+          line = $0
+          n = length(line)
+          i = 1
+          tok = ""
+          mode = 0  # 0=plain, 1=double-quoted, 2=single-quoted
+          while (i <= n) {
+            ch = substr(line, i, 1)
+            if (mode == 0) {
+              if (ch == " " || ch == "\t") {
+                if (tok != "") { emit_token(tok); tok = "" }
+                i++; continue
+              }
+              if (ch == "\"") { mode = 1; tok = tok ch; i++; continue }
+              if (ch == "'\''") { mode = 2; tok = tok ch; i++; continue }
+              tok = tok ch
+              i++
               continue
             }
-            if (t == "--body-file" || t == "-F") { skip_next = 1; continue }
-            # Equals form.
-            if (t ~ /^--body-file=/) {
-              v = substr(t, length("--body-file=") + 1)
-              gsub(/^["'"'"']/, "", v); gsub(/["'"'"']$/, "", v)
-              if (v != "" && v != "-") print v
+            if (mode == 1) {
+              if (ch == "\\" && i < n) {
+                nxt = substr(line, i + 1, 1)
+                tok = tok ch nxt
+                i += 2
+                continue
+              }
+              if (ch == "\"") { mode = 0; tok = tok ch; i++; continue }
+              tok = tok ch
+              i++
+              continue
             }
-            if (t ~ /^-F=/) {
-              v = substr(t, length("-F=") + 1)
-              gsub(/^["'"'"']/, "", v); gsub(/["'"'"']$/, "", v)
-              if (v != "" && v != "-") print v
-            }
+            # mode == 2
+            if (ch == "'\''") { mode = 0; tok = tok ch; i++; continue }
+            tok = tok ch
+            i++
           }
+          if (tok != "") emit_token(tok)
         }'
 }
 while IFS= read -r body_path; do
@@ -180,12 +230,24 @@ while IFS= read -r body_path; do
       esac
     done
     resolved="/$(IFS=/; printf '%s' "${_bf_parts[*]}")"
-    # If the raw path used `..` AND the resolved form escapes REA_ROOT,
-    # refuse — that's the obfuscation shape we care about. A file under
-    # /tmp or /var/folders without `..` segments is fine.
+    # 0.17.0 helix-019 #1: HARD REFUSAL on traversal escaping REA_ROOT.
+    # Pre-fix the gate logged "skipping body scan" and exited 0 — every
+    # sensitive payload at the resolved external path bypassed the
+    # disclosure check. The traversal-out-of-root shape exists ONLY to
+    # obfuscate; legitimate workflows pass absolute tmpfile paths
+    # (`/tmp/...`, `/var/folders/...`) without `..` segments.
     if [[ "$resolved" != "$REA_ROOT" && "$resolved" != "$REA_ROOT"/* ]]; then
-      printf 'security-disclosure-gate: --body-file path uses `..` traversal escaping project root; skipping body scan\n' >&2
-      continue
+      {
+        printf 'SECURITY DISCLOSURE GATE: --body-file path traversal escapes project root\n'
+        printf '\n'
+        printf '  Path:     %s\n' "$raw_path"
+        printf '  Resolved: %s\n' "$resolved"
+        printf '\n'
+        printf '  Rule: --body-file paths whose canonical form uses `..` segments to\n'
+        printf '        escape REA_ROOT are refused. Move the file inside the project\n'
+        printf '        tree, or paste the body inline via --body.\n'
+      } >&2
+      exit 2
     fi
   fi
   if [[ ! -r "$resolved" ]]; then

--- a/.claude/hooks/security-disclosure-gate.sh
+++ b/.claude/hooks/security-disclosure-gate.sh
@@ -171,6 +171,23 @@ _extract_body_file_paths() {
           while (i <= n) {
             ch = substr(line, i, 1)
             if (mode == 0) {
+              # 0.18.0 helix-020 G3.B fix: in plain (unquoted) mode,
+              # `\X` (any character X) is the POSIX shell escape for
+              # the literal character X — most commonly a space in
+              # paths like `path\ with\ spaces.md`. Pre-fix the
+              # tokenizer treated the `\` as an ordinary character and
+              # truncated at the following space, dropping the rest of
+              # the path. We now consume the backslash and emit the
+              # following byte as a literal part of the current token.
+              # `\<eol>` (line-continuation) is left intact — emit the
+              # `\` and let the splitter flow into the next record on
+              # the assumption that the caller already joined the line.
+              if (ch == "\\" && i < n) {
+                nxt = substr(line, i + 1, 1)
+                tok = tok nxt
+                i += 2
+                continue
+              }
               if (ch == " " || ch == "\t") {
                 if (tok != "") { emit_token(tok); tok = "" }
                 i++; continue

--- a/.claude/hooks/settings-protection.sh
+++ b/.claude/hooks/settings-protection.sh
@@ -199,8 +199,15 @@ case "$LOWER_NORM" in
     if [ -d "$parent_dir" ]; then
       resolved_parent=$(cd -P -- "$parent_dir" 2>/dev/null && pwd -P 2>/dev/null) || resolved_parent=""
       if [ -n "$resolved_parent" ]; then
+        # 0.20.1 helix-021 #3: directory-boundary on the case glob.
+        # Pre-fix `*"/.husky/commit-msg.d"*` matched `.husky/commit-msg.d.bak/`
+        # too (substring without trailing-slash anchor). A symlink
+        # `.husky/pre-push.d/linkdir -> ../pre-push.d.bak` then resolved
+        # to `.husky/pre-push.d.bak/...` and slipped through.
+        # The trailing `/` on each pattern (and the explicit
+        # exact-match arm) requires a real directory boundary.
         case "$resolved_parent" in
-          *"/.husky/commit-msg.d"*|*"/.husky/pre-push.d"*) : ;;
+          */.husky/commit-msg.d|*/.husky/commit-msg.d/*|*/.husky/pre-push.d|*/.husky/pre-push.d/*) : ;;
           *)
             {
               printf 'SETTINGS PROTECTION: extension path resolves outside surface\n'

--- a/.claude/hooks/settings-protection.sh
+++ b/.claude/hooks/settings-protection.sh
@@ -226,13 +226,16 @@ esac
 # §6 runs BEFORE the patch-session allowlist so hook-patch sessions cannot
 # reach .rea/policy.yaml, .rea/HALT, or .claude/settings.json via any glob
 # creativity.
-PROTECTED_PATTERNS=(
-  '.claude/settings.json'
-  '.claude/settings.local.json'
-  '.husky/'
-  '.rea/policy.yaml'
-  '.rea/HALT'
-)
+#
+# 0.16.3 F7: list is sourced from `_lib/protected-paths.sh`, which honors
+# the `protected_paths_relax` policy key (kill-switch invariants always
+# stay protected — see the lib for the always-protected subset).
+# shellcheck source=_lib/protected-paths.sh
+source "$(dirname "$0")/_lib/protected-paths.sh"
+# Trigger lazy load now so PROTECTED_PATTERNS reflects the relaxed list
+# from the start of this hook process.
+rea_path_is_protected "/__rea_force_load__" >/dev/null 2>&1 || true
+PROTECTED_PATTERNS=("${REA_PROTECTED_PATTERNS[@]}")
 
 # Patterns that are protected from general agent edits but can be unlocked by
 # REA_HOOK_PATCH_SESSION. Kept separate from the hard-protected list above so

--- a/.claude/hooks/settings-protection.sh
+++ b/.claude/hooks/settings-protection.sh
@@ -33,13 +33,11 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ── 3. HALT check ────────────────────────────────────────────────────────────
-REA_ROOT="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-HALT_FILE="${REA_ROOT}/.rea/HALT"
-if [ -f "$HALT_FILE" ]; then
-  printf 'REA HALT: %s\nAll agent operations suspended. Run: rea unfreeze\n' \
-    "$(head -c 1024 "$HALT_FILE" 2>/dev/null || echo 'Reason unknown')" >&2
-  exit 2
-fi
+# 0.16.0: HALT check sourced from shared _lib/halt-check.sh.
+# shellcheck source=_lib/halt-check.sh
+source "$(dirname "$0")/_lib/halt-check.sh"
+check_halt
+REA_ROOT=$(rea_root)
 
 # ── 4. Extract file path from payload ─────────────────────────────────────────
 FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null)
@@ -59,89 +57,473 @@ normalize_path() {
     p="${p#$root/}"
   fi
 
-  # URL decode common sequences
-  p=$(printf '%s' "$p" | sed 's/%2[Ff]/\//g; s/%2[Ee]/./g; s/%20/ /g')
+  # URL decode common sequences. Include %5C (`\`) so Windows-style or
+  # percent-encoded back-slash traversal (`..%5C`, `\..\`) normalizes to the
+  # forward-slash form the §5a detector sees.
+  p=$(printf '%s' "$p" \
+    | sed 's/%2[Ff]/\//g; s/%2[Ee]/./g; s/%20/ /g; s/%5[Cc]/\\/g')
 
-  # Collapse path traversals
-  # Remove ./ components
-  p=$(printf '%s' "$p" | sed 's|\./||g')
+  # Translate any backslash separators to forward slashes. Keeps the traversal
+  # check in §5a working for `.claude\hooks\..\settings.json`-style inputs.
+  p=$(printf '%s' "$p" | tr '\\\\' '/')
 
-  # Remove leading ./
-  p="${p#./}"
+  # Strip leading ./ components only. We intentionally do NOT strip interior
+  # ./ sequences — that transformation corrupts `..` traversals (e.g. `.../`
+  # collapsed to `../`, or `../` collapsed to `./`) and hides traversal from
+  # the §5a detector.
+  while [[ "$p" == ./* ]]; do
+    p="${p#./}"
+  done
 
   printf '%s' "$p"
 }
 
+# Strip C0/C1 control characters from a string to prevent terminal escape
+# injection when we echo protected paths back to the operator. Escape sequences
+# in file names could otherwise rewrite lines above the deny message.
+#
+# Byte ranges stripped:
+#   \000-\037  — C0 controls (BEL, BS, HT, LF, CR, ESC, …)
+#   \177       — DEL
+#   \200-\237  — C1 controls (CSI 0x9B, OSC 0x9D, …). Many terminals still
+#                interpret these as single-byte CSI introducers; without
+#                stripping, a UTF-8 file name whose bytes fall in this range
+#                could still drive the cursor on older emulators.
+sanitize_for_stderr() {
+  printf '%s' "$1" | LC_ALL=C tr -d '\000-\037\177\200-\237'
+}
+
 NORMALIZED=$(normalize_path "$FILE_PATH")
+SAFE_FILE_PATH=$(sanitize_for_stderr "$FILE_PATH")
+SAFE_NORMALIZED=$(sanitize_for_stderr "$NORMALIZED")
+
+# ── 5a. Reject path traversal segments (Codex HIGH: Defect I bypass) ─────────
+# A path containing `..` segments can be used to bypass the protected-path
+# globs in §6 — e.g. `.claude/hooks/../settings.json` would pass the
+# `.claude/hooks/*` case-glob in the patch-session allowlist but actually
+# refers to `.claude/settings.json`. We refuse any path that contains a `..`
+# segment in either the raw input OR the normalized form. The request must
+# be reissued with a canonical path.
+#
+# For the raw-input check, translate backslashes first so a Windows-style
+# `.claude\hooks\..\settings.json` is rejected at the raw stage too (the
+# normalized form also catches it — this is defense in depth).
+RAW_PATH_SLASHED=$(printf '%s' "$FILE_PATH" | tr '\\\\' '/')
+raw_has_traversal=0
+case "/$RAW_PATH_SLASHED/" in
+  */../*) raw_has_traversal=1 ;;
+esac
+norm_has_traversal=0
+case "/$NORMALIZED/" in
+  */../*) norm_has_traversal=1 ;;
+esac
+if [[ "$raw_has_traversal" -eq 1 ]] || [[ "$norm_has_traversal" -eq 1 ]]; then
+  {
+    printf 'SETTINGS PROTECTION: path traversal rejected\n'
+    printf '\n'
+    printf '  File: %s\n' "$SAFE_FILE_PATH"
+    printf "  Rule: path contains a '..' segment; rewrite to a canonical\n"
+    printf '        project-relative path without traversal.\n'
+  } >&2
+  exit 2
+fi
+
+# Compute lower-cased path early so the §5b allow-list (and §6/§6b matchers
+# below) all reference a single normalized variable.
+LOWER_NORM=$(printf '%s' "$NORMALIZED" | tr '[:upper:]' '[:lower:]')
+
+# ── 5b. Extension-surface allow-list ──────────────────────────────────────────
+# `.husky/commit-msg.d/*` and `.husky/pre-push.d/*` are the documented
+# consumer extension surface (Fix H / 0.13.0). Consumers — and the agents
+# that govern those consumers — are expected to write here freely so they
+# can layer commitlint, lint-staged, branch-policy, act-CI, etc. without
+# losing rea coverage on `rea upgrade`.
+#
+# The §6 PROTECTED_PATTERNS list below has `.husky/` as a prefix block,
+# which (correctly) keeps `.husky/pre-push`, `.husky/commit-msg`, and
+# the `.husky/_/*` runtime stubs out of agent reach. But the same prefix
+# also caught `.husky/pre-push.d/00-act-ci` and `.husky/commit-msg.d/*`
+# until 0.13.2 — the very directories advertised as the extension
+# surface. This early allow-list closes that contract gap.
+#
+# Anchored on the literal `.d/` segment (not `.d`) so `.husky/pre-push.d.bak/`
+# or `.husky/pre-push.dump` still hit the prefix block. Nested fragments
+# (e.g. `pre-push.d/sub/file`) are allowed so the surface composes naturally.
+#
+# SECURITY: runs AFTER §5a (path-traversal reject), so a clever
+# `.husky/pre-push.d/../pre-push` cannot bypass §6's protection of the
+# package-managed body — §5a kills it before this matcher runs.
+#
+# SECURITY (defense-in-depth): symlinks INSIDE the .d/ surface are
+# refused — both final-component AND intermediate-directory symlinks.
+# A fragment is a short shell script authored in place; consumers do
+# not need symlinks here. Without these checks the gate has two
+# bypass shapes:
+#
+#   (a) Final-component symlink:
+#       ln -s ../pre-push .husky/pre-push.d/00-evil; write 00-evil
+#       — caught by `[ -L "$FILE_PATH" ]`.
+#
+#   (b) Intermediate-directory symlink (helix Finding 2 / 0.15.0):
+#       mkdir .husky/pre-push.d; ln -s ../ .husky/pre-push.d/linkdir
+#       write .husky/pre-push.d/linkdir/pre-push
+#       — `[ -L $FILE_PATH ]` only inspects the FINAL component, so a
+#       not-yet-existing target whose parent contains a symlink resolves
+#       to outside the surface (here: `.husky/pre-push`), letting the
+#       attacker write through to the package-managed body.
+#
+# Resolve the realpath of the parent directory and require it to live
+# under the literal extension surface. Use a portable `cd ... && pwd -P`
+# subshell pattern (no Python or readlink -f dependency required).
+# Closes the path-string→symlink bypass completely.
+case "$LOWER_NORM" in
+  .husky/commit-msg.d/*|.husky/pre-push.d/*)
+    if [ -L "$FILE_PATH" ]; then
+      {
+        printf 'SETTINGS PROTECTION: symlink in extension surface refused\n'
+        printf '\n'
+        printf '  File: %s\n' "$SAFE_FILE_PATH"
+        printf '  Rule: .husky/commit-msg.d/* and .husky/pre-push.d/* must be\n'
+        printf '        regular files (a symlink could resolve to a protected\n'
+        printf '        package-managed body and bypass §6 protection).\n'
+      } >&2
+      exit 2
+    fi
+    # Resolve the parent directory's realpath. If any intermediate
+    # component is a symlink whose target leaves the surface, the
+    # resolved path no longer contains `/.husky/<surface>.d/` and we
+    # refuse. The parent dir must already exist for this check; if it
+    # doesn't, the write is creating the parent, in which case there
+    # is no intermediate symlink to follow yet.
+    parent_dir=$(dirname -- "$FILE_PATH")
+    if [ -d "$parent_dir" ]; then
+      resolved_parent=$(cd -P -- "$parent_dir" 2>/dev/null && pwd -P 2>/dev/null) || resolved_parent=""
+      if [ -n "$resolved_parent" ]; then
+        case "$resolved_parent" in
+          *"/.husky/commit-msg.d"*|*"/.husky/pre-push.d"*) : ;;
+          *)
+            {
+              printf 'SETTINGS PROTECTION: extension path resolves outside surface\n'
+              printf '\n'
+              printf '  Logical:  %s\n' "$SAFE_FILE_PATH"
+              printf '  Resolved: %s\n' "$resolved_parent"
+              printf '  Rule: an intermediate directory of the extension path is a\n'
+              printf '        symlink whose target leaves .husky/{commit-msg,pre-push}.d/.\n'
+              printf '        Refused to prevent symlinked-parent bypass of the\n'
+              printf '        package-managed body protection.\n'
+            } >&2
+            exit 2
+          ;;
+        esac
+      fi
+    fi
+    # Documented extension surface — agents can write here freely.
+    exit 0
+    ;;
+esac
 
 # ── 6. Protected path patterns ────────────────────────────────────────────────
+# §6 runs BEFORE the patch-session allowlist so hook-patch sessions cannot
+# reach .rea/policy.yaml, .rea/HALT, or .claude/settings.json via any glob
+# creativity.
 PROTECTED_PATTERNS=(
   '.claude/settings.json'
   '.claude/settings.local.json'
-  '.claude/hooks/'
   '.husky/'
   '.rea/policy.yaml'
   '.rea/HALT'
 )
 
-for pattern in "${PROTECTED_PATTERNS[@]}"; do
-  # Exact match
-  if [[ "$NORMALIZED" == "$pattern" ]]; then
-    {
-      printf 'SETTINGS PROTECTION: Modification blocked\n'
-      printf '\n'
-      printf '  File: %s\n' "$FILE_PATH"
-      printf '  Rule: This file is protected from agent modification.\n'
-      printf '\n'
-      printf '  Protected files include hook scripts, settings, policy,\n'
-      printf '  and kill switch files. These must be modified by humans\n'
-      printf '  via rea CLI or direct editing.\n'
-      printf '\n'
-      printf '  Use: rea init (to update hooks/settings)\n'
-      printf '       rea freeze/unfreeze (for HALT file)\n'
-      printf '       Edit .rea/policy.yaml manually\n'
-    } >&2
-    exit 2
-  fi
+# Patterns that are protected from general agent edits but can be unlocked by
+# REA_HOOK_PATCH_SESSION. Kept separate from the hard-protected list above so
+# the patch-session gate in §6b only applies to these directories.
+PATCH_SESSION_PATTERNS=(
+  '.claude/hooks/'
+)
 
-  # Directory prefix match (patterns ending in /)
-  if [[ "$pattern" == */ ]] && [[ "$NORMALIZED" == "$pattern"* ]]; then
-    {
-      printf 'SETTINGS PROTECTION: Modification blocked\n'
-      printf '\n'
-      printf '  File: %s\n' "$FILE_PATH"
-      printf '  Rule: Files under %s are protected from agent modification.\n' "$pattern"
-      printf '\n'
-      printf '  These files control the hook safety layer and must be\n'
-      printf '  modified by humans via rea CLI or direct editing.\n'
-    } >&2
-    exit 2
-  fi
-done
+# LOWER_NORM was computed in §5b above and is reused here.
 
-# ── 7. Case-insensitive fallback check ────────────────────────────────────────
-# Catch case-manipulation bypass attempts (e.g., .Claude/Settings.json)
-LOWER_NORM=$(printf '%s' "$NORMALIZED" | tr '[:upper:]' '[:lower:]')
-for pattern in "${PROTECTED_PATTERNS[@]}"; do
-  LOWER_PATTERN=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
-  if [[ "$LOWER_NORM" == "$LOWER_PATTERN" ]]; then
-    {
-      printf 'SETTINGS PROTECTION: Modification blocked (case-insensitive match)\n'
-      printf '\n'
-      printf '  File: %s\n' "$FILE_PATH"
-      printf '  Matched: %s\n' "$pattern"
-    } >&2
-    exit 2
+# Match $NORMALIZED against PROTECTED_PATTERNS (exact or prefix for patterns
+# ending in '/'). Sets $PROTECTED_MATCH to the matched pattern; exit 0 on hit.
+match_protected() {
+  local pattern
+  PROTECTED_MATCH=""
+  for pattern in "${PROTECTED_PATTERNS[@]}"; do
+    if [[ "$NORMALIZED" == "$pattern" ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+    if [[ "$pattern" == */ ]] && [[ "$NORMALIZED" == "$pattern"* ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+  done
+  return 1
+}
+
+match_protected_ci() {
+  local pattern lp
+  PROTECTED_MATCH=""
+  for pattern in "${PROTECTED_PATTERNS[@]}"; do
+    lp=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+    if [[ "$LOWER_NORM" == "$lp" ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+    if [[ "$lp" == */ ]] && [[ "$LOWER_NORM" == "$lp"* ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+  done
+  return 1
+}
+
+match_patch_session() {
+  local pattern
+  PROTECTED_MATCH=""
+  for pattern in "${PATCH_SESSION_PATTERNS[@]}"; do
+    if [[ "$NORMALIZED" == "$pattern" ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+    if [[ "$pattern" == */ ]] && [[ "$NORMALIZED" == "$pattern"* ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+  done
+  return 1
+}
+
+match_patch_session_ci() {
+  local pattern lp
+  PROTECTED_MATCH=""
+  for pattern in "${PATCH_SESSION_PATTERNS[@]}"; do
+    lp=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+    if [[ "$LOWER_NORM" == "$lp" ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+    if [[ "$lp" == */ ]] && [[ "$LOWER_NORM" == "$lp"* ]]; then
+      PROTECTED_MATCH="$pattern"
+      return 0
+    fi
+  done
+  return 1
+}
+
+if match_protected; then
+  {
+    printf 'SETTINGS PROTECTION: Modification blocked\n'
+    printf '\n'
+    printf '  File: %s\n' "$SAFE_FILE_PATH"
+    printf '  Matched: %s\n' "$PROTECTED_MATCH"
+    printf '  Rule: This file is protected from agent modification, including\n'
+    printf '        sessions with REA_HOOK_PATCH_SESSION set.\n'
+  } >&2
+  exit 2
+fi
+
+if match_protected_ci; then
+  {
+    printf 'SETTINGS PROTECTION: Modification blocked (case-insensitive match)\n'
+    printf '\n'
+    printf '  File: %s\n' "$SAFE_FILE_PATH"
+    printf '  Matched: %s\n' "$PROTECTED_MATCH"
+  } >&2
+  exit 2
+fi
+
+# ── 6c. Intermediate-symlink resolution (0.16.0 fix H.1) ──────────────────────
+# Helix Finding 2 reborn against the hard-protected list. The §5b
+# extension-surface fix (0.13.2) resolved parent realpath for the
+# `.husky/{commit-msg,pre-push}.d/*` allowlist; §6 was never given the
+# same protection. Attack:
+#
+#   mkdir innocuous_path
+#   ln -s ../.husky innocuous_path/maybe   # symlink resolves to .husky/
+#   write innocuous_path/maybe/pre-push    # writes through to .husky/pre-push
+#
+# §5a (`..` traversal) doesn't catch — the path string has no `..`.
+# §6 PROTECTED_PATTERNS sees `innocuous_path/maybe/pre-push` — doesn't
+# match `.husky/` prefix. The write succeeds and the package-managed
+# pre-push body is overwritten.
+#
+# Fix: when the parent directory of the target exists, resolve its
+# realpath via cd -P && pwd -P (same shape as §5b) and check whether
+# the resolved path falls inside any protected directory. Only resolve
+# when the parent already exists — a write that creates the parent has
+# nothing to follow.
+if [[ -e "$FILE_PATH" || -d "$(dirname -- "$FILE_PATH")" ]]; then
+  parent_dir=$(dirname -- "$FILE_PATH")
+  if [[ -d "$parent_dir" ]]; then
+    resolved_parent=$(cd -P -- "$parent_dir" 2>/dev/null && pwd -P 2>/dev/null) || resolved_parent=""
+    if [[ -n "$resolved_parent" ]]; then
+      # If the resolved parent is inside REA_ROOT, compute the project-
+      # relative path and test it against the protected patterns.
+      if [[ "$resolved_parent" == "$REA_ROOT"/* ]]; then
+        relative_resolved="${resolved_parent#"$REA_ROOT"/}"
+        # Walk every PROTECTED_PATTERN that's a directory prefix and
+        # check whether the resolved parent falls inside it. Direct
+        # filename matches against PROTECTED_PATTERNS for the resolved
+        # final path (parent + basename).
+        resolved_target="${relative_resolved}/$(basename -- "$FILE_PATH")"
+        resolved_target_lc=$(printf '%s' "$resolved_target" | tr '[:upper:]' '[:lower:]')
+        for pattern in "${PROTECTED_PATTERNS[@]}"; do
+          pattern_lc=$(printf '%s' "$pattern" | tr '[:upper:]' '[:lower:]')
+          if [[ "$resolved_target_lc" == "$pattern_lc" ]] || \
+             { [[ "$pattern_lc" == */ ]] && [[ "$resolved_target_lc" == "$pattern_lc"* ]]; }; then
+            {
+              printf 'SETTINGS PROTECTION: intermediate-symlink resolution blocked\n'
+              printf '\n'
+              printf '  Logical:  %s\n' "$SAFE_FILE_PATH"
+              printf '  Resolved: %s\n' "$resolved_target"
+              printf '  Matched:  %s\n' "$pattern"
+              printf '  Rule: an intermediate directory of the target path is a\n'
+              printf '        symlink whose target falls inside a hard-protected\n'
+              printf '        path. Refused to prevent symlinked-parent bypass.\n'
+            } >&2
+            exit 2
+          fi
+        done
+      fi
+    fi
   fi
-  if [[ "$LOWER_PATTERN" == */ ]] && [[ "$LOWER_NORM" == "$LOWER_PATTERN"* ]]; then
-    {
-      printf 'SETTINGS PROTECTION: Modification blocked (case-insensitive match)\n'
-      printf '\n'
-      printf '  File: %s\n' "$FILE_PATH"
-      printf '  Matched: %s*\n' "$pattern"
-    } >&2
-    exit 2
+fi
+
+# ── 6b. Hook-patch session (Defect I / rea#76) ───────────────────────────────
+# When REA_HOOK_PATCH_SESSION is set to a non-empty reason, allow edits under
+# .claude/hooks/ and hooks/ for this session. The session boundary IS the
+# expiry — a new shell requires a fresh opt-in. Every allowed edit is audited
+# as hooks.patch.session so the bypass is never silent.
+#
+# SECURITY: runs AFTER §5a (traversal reject) and §6 (hard-protected denies),
+# so no glob creativity can reach policy/HALT/settings files from here.
+if [[ -n "${REA_HOOK_PATCH_SESSION:-}" ]]; then
+  if match_patch_session; then
+    SAFE_REASON=$(sanitize_for_stderr "${REA_HOOK_PATCH_SESSION}")
+    # Audit record via the TypeScript chain so the hash chain stays intact.
+    # If the append fails, block the edit — silent failure would let an
+    # attacker disable audit logging and then patch hooks unobserved.
+    SHA_BEFORE=""
+    if [[ -f "$FILE_PATH" ]]; then
+      if command -v sha256sum >/dev/null 2>&1; then
+        SHA_BEFORE=$(sha256sum "$FILE_PATH" 2>/dev/null | awk '{print $1}')
+      elif command -v shasum >/dev/null 2>&1; then
+        SHA_BEFORE=$(shasum -a 256 "$FILE_PATH" 2>/dev/null | awk '{print $1}')
+      elif command -v openssl >/dev/null 2>&1; then
+        SHA_BEFORE=$(openssl dgst -sha256 "$FILE_PATH" 2>/dev/null | awk '{print $NF}')
+      fi
+    fi
+    ACTOR_NAME=$(git -C "$REA_ROOT" config user.name 2>/dev/null || printf 'unknown')
+    ACTOR_EMAIL=$(git -C "$REA_ROOT" config user.email 2>/dev/null || printf 'unknown')
+
+    AUDIT_PAYLOAD=$(
+      cd "$REA_ROOT" 2>/dev/null || true
+      REA_AUDIT_REASON="${REA_HOOK_PATCH_SESSION}" \
+      REA_AUDIT_FILE="$NORMALIZED" \
+      REA_AUDIT_SHA="$SHA_BEFORE" \
+      REA_AUDIT_ACTOR_NAME="$ACTOR_NAME" \
+      REA_AUDIT_ACTOR_EMAIL="$ACTOR_EMAIL" \
+      REA_AUDIT_PID="$$" \
+      REA_AUDIT_PPID="$PPID" \
+      REA_AUDIT_SESSION="${CLAUDE_SESSION_ID:-external}" \
+      REA_AUDIT_ROOT="$REA_ROOT" \
+      node --input-type=module -e '
+        const root = process.env.REA_AUDIT_ROOT;
+        async function loadMod() {
+          // Consumer path: `@bookedsolid/rea` resolvable via node_modules
+          // (how `rea init`-installed consumers reach the published package)
+          // or via package self-reference when the hook runs inside the rea
+          // source repo itself.
+          try {
+            return await import("@bookedsolid/rea/audit");
+          } catch (e1) {
+            // Dev path: direct file import from the source repos dist/.
+            try {
+              return await import(root + "/dist/audit/append.js");
+            } catch (e2) {
+              process.stderr.write(
+                "audit import failed: package=" + (e1 && e1.message ? e1.message : e1) +
+                "; dist=" + (e2 && e2.message ? e2.message : e2) + "\n");
+              process.exit(1);
+            }
+          }
+        }
+        (async () => {
+          const mod = await loadMod();
+          try {
+            await mod.appendAuditRecord(root, {
+              session_id: process.env.REA_AUDIT_SESSION,
+              tool_name: "hooks.patch.session",
+              server_name: "rea",
+              tier: "write",
+              status: "allowed",
+              autonomy_level: "unknown",
+              duration_ms: 0,
+              metadata: {
+                reason: process.env.REA_AUDIT_REASON,
+                file: process.env.REA_AUDIT_FILE,
+                sha_before: process.env.REA_AUDIT_SHA,
+                actor: {
+                  name: process.env.REA_AUDIT_ACTOR_NAME,
+                  email: process.env.REA_AUDIT_ACTOR_EMAIL,
+                },
+                pid: Number(process.env.REA_AUDIT_PID),
+                ppid: Number(process.env.REA_AUDIT_PPID),
+              },
+            });
+            process.exit(0);
+          } catch (e) {
+            process.stderr.write("audit append failed: " + (e && e.message ? e.message : e) + "\n");
+            process.exit(1);
+          }
+        })();
+      ' 2>&1
+    )
+    AUDIT_EXIT=$?
+    if [[ "$AUDIT_EXIT" -ne 0 ]]; then
+      # Fail closed. We deliberately do NOT fall back to a raw `jq … >> audit`
+      # write: that path skips prev_hash/hash computation and would silently
+      # degrade the hash-chain integrity the rest of REA (and `rea audit verify`)
+      # relies on. If the TypeScript chain is unavailable (no `dist/`, missing
+      # Node, broken import), refuse the hook-patch edit and surface why. The
+      # operator resolves by building the package (`pnpm build`) or running
+      # against a published install that ships `dist/`.
+      {
+        printf 'SETTINGS PROTECTION: audit-append failed; refusing hook-patch edit\n'
+        printf '  File: %s\n' "$SAFE_FILE_PATH"
+        printf '  Rule: hash-chained audit is required; no raw-jq fallback.\n'
+        printf '  Detail: %s\n' "$(sanitize_for_stderr "$AUDIT_PAYLOAD")"
+      } >&2
+      exit 2
+    fi
+    printf 'REA_HOOK_PATCH_SESSION: allowing edit to %s (reason: %s)\n' \
+      "$SAFE_NORMALIZED" "$SAFE_REASON" >&2
+    exit 0
   fi
-done
+fi
+
+# ── 6c. Patch-session patterns are still blocked when env var is NOT set ─────
+if match_patch_session; then
+  {
+    printf 'SETTINGS PROTECTION: Modification blocked\n'
+    printf '\n'
+    printf '  File: %s\n' "$SAFE_FILE_PATH"
+    printf '  Matched: %s\n' "$PROTECTED_MATCH"
+    printf '  Rule: Files under this path are protected. To apply an upstream\n'
+    printf '        hook finding, set REA_HOOK_PATCH_SESSION=<reason> and retry.\n'
+  } >&2
+  exit 2
+fi
+
+if match_patch_session_ci; then
+  {
+    printf 'SETTINGS PROTECTION: Modification blocked (case-insensitive match)\n'
+    printf '\n'
+    printf '  File: %s\n' "$SAFE_FILE_PATH"
+    printf '  Matched: %s\n' "$PROTECTED_MATCH"
+  } >&2
+  exit 2
+fi
 
 exit 0

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -99,9 +99,15 @@ if grep -qiE '^\s*(Generated|Created|Built|Powered|Authored|Written|Produced)\s+
 fi
 
 # Pattern 4: Markdown-linked attribution
-if grep -qiE '\[Claude Code\]|\[GitHub Copilot\]|\[ChatGPT\]|\[Gemini\]|\[Cursor\]' "$COMMIT_MSG_FILE" 2>/dev/null; then
+# 0.16.2 helix-017 P3 #4: anchor on the markdown link shape `[Text](url)`
+# rather than bare `[Text]`. Pre-fix the regex matched ANY bracketed
+# mention — `feat: support [Claude Code] hook output format` would block
+# a perfectly legitimate commit. The markdown-link form requires the `(`
+# immediately after the closing bracket, which is the actual structural
+# attribution we want to catch.
+if grep -qiE '\[Claude Code\]\(|\[GitHub Copilot\]\(|\[ChatGPT\]\(|\[Gemini\]\(|\[Cursor\]\(' "$COMMIT_MSG_FILE" 2>/dev/null; then
   BLOCKED=1
-  MATCHES="${MATCHES}$(grep -niE '\[Claude Code\]|\[GitHub Copilot\]|\[ChatGPT\]|\[Gemini\]|\[Cursor\]' "$COMMIT_MSG_FILE" 2>/dev/null)
+  MATCHES="${MATCHES}$(grep -niE '\[Claude Code\]\(|\[GitHub Copilot\]\(|\[ChatGPT\]\(|\[Gemini\]\(|\[Cursor\]\(' "$COMMIT_MSG_FILE" 2>/dev/null)
 "
 fi
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -78,9 +78,17 @@ BLOCKED=0
 MATCHES=""
 
 # Pattern 1: Co-Authored-By with noreply@ email
-if grep -qiE 'Co-Authored-By:.*noreply@' "$COMMIT_MSG_FILE" 2>/dev/null; then
+# 0.18.0 helix-020 / discord-ops Round 10 #3 fix (G4.B):
+# the pre-fix pattern `Co-Authored-By:.*noreply@` matched both AI-tool
+# noreply addresses AND legitimate `<user>@users.noreply.github.com`
+# collaborator credits — blocking honest co-author footers from human
+# contributors. Refined to enumerate AI-tool noreply domains explicitly;
+# Pattern 2 below catches Co-Authored-By with named tools regardless of
+# email, so dropping users.noreply.github.com from this branch only
+# relaxes the check for human collaborators — never for AI.
+if grep -qiE 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com)' "$COMMIT_MSG_FILE" 2>/dev/null; then
   BLOCKED=1
-  MATCHES="${MATCHES}$(grep -niE 'Co-Authored-By:.*noreply@' "$COMMIT_MSG_FILE" 2>/dev/null)
+  MATCHES="${MATCHES}$(grep -niE 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com)' "$COMMIT_MSG_FILE" 2>/dev/null)
 "
 fi
 

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,5 @@
 #!/bin/sh
+# rea:commit-msg v1
 # .husky/commit-msg — optionally BLOCKS commits that contain AI attribution
 #
 # OPT-IN: Only enforces when .rea/policy.yaml contains:
@@ -40,13 +41,34 @@ fi
 # Look for block_ai_attribution: true in .rea/policy.yaml
 # If not found or not true, exit 0 (normal commit behavior)
 
+# Helper: chain extension fragments under .husky/commit-msg.d/ in lex
+# order. Defined once and called from every exit path so consumers get
+# consistent behavior regardless of whether attribution blocking ran.
+chain_commit_msg_fragments() {
+  REA_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+  ext_dir="${REA_ROOT}/.husky/commit-msg.d"
+  if [ -d "$ext_dir" ]; then
+    for frag in "$ext_dir"/*; do
+      [ -e "$frag" ] || continue
+      [ -f "$frag" ] || continue
+      [ -x "$frag" ] || continue
+      "$frag" "$COMMIT_MSG_FILE"
+    done
+  fi
+}
+
 POLICY_FILE=".rea/policy.yaml"
 if [ ! -f "$POLICY_FILE" ]; then
+  chain_commit_msg_fragments
   exit 0
 fi
 
 # Simple grep — no YAML parser dependency needed for a boolean flag
 if ! grep -qE '^block_ai_attribution:[[:space:]]*true' "$POLICY_FILE" 2>/dev/null; then
+  # Attribution blocking is disabled — still chain extension fragments
+  # (consumers may want commitlint/conventional-commits checks regardless
+  # of rea's attribution stance).
+  chain_commit_msg_fragments
   exit 0
 fi
 
@@ -126,5 +148,15 @@ fi
 
 # Normalize trailing newlines (cosmetic, non-fatal)
 perl -i -0777 -pe 's/\n+$/\n/' "$COMMIT_MSG_FILE" 2>/dev/null || true
+
+# ── Extension-hook chaining ────────────────────────────────────────────────────
+# Source every executable file under `.husky/commit-msg.d/` in lexical order.
+# Missing directory = no-op (backward compatible). Each fragment receives the
+# commit-msg file path as $1. Non-zero exit fails the commit (set -e above).
+#
+# Fragments run AFTER rea's attribution check so HALT/governance enforcement
+# happens first; consumers can layer on commitlint, conventional-commits
+# linters, or branch-policy checks without losing rea coverage.
+chain_commit_msg_fragments
 
 exit 0

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -86,9 +86,9 @@ MATCHES=""
 # Pattern 2 below catches Co-Authored-By with named tools regardless of
 # email, so dropping users.noreply.github.com from this branch only
 # relaxes the check for human collaborators — never for AI.
-if grep -qiE 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com)' "$COMMIT_MSG_FILE" 2>/dev/null; then
+if grep -qiE 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com|mistral\.ai|xai-org|x\.ai|inflection\.ai|perplexity\.ai|replit\.com|jetbrains\.com|bito\.ai|pieces\.app|phind\.com|you\.com)' "$COMMIT_MSG_FILE" 2>/dev/null; then
   BLOCKED=1
-  MATCHES="${MATCHES}$(grep -niE 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com)' "$COMMIT_MSG_FILE" 2>/dev/null)
+  MATCHES="${MATCHES}$(grep -niE 'Co-Authored-By:.*noreply@(anthropic\.com|openai\.com|github-copilot|github\.com|claude\.ai|chatgpt\.com|googlemail\.com|google\.com|cursor\.com|codeium\.com|tabnine\.com|amazon\.com|amazonaws\.com|amazon-q\.amazonaws\.com|cody\.dev|sourcegraph\.com|mistral\.ai|xai-org|x\.ai|inflection\.ai|perplexity\.ai|replit\.com|jetbrains\.com|bito\.ai|pieces\.app|phind\.com|you\.com)' "$COMMIT_MSG_FILE" 2>/dev/null)
 "
 fi
 

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,160 +1,117 @@
-#!/bin/bash
-# .husky/pre-push — full quality gate before push
+#!/bin/sh
+# rea:husky-pre-push-gate v4
+# rea:gate-body-v4
 #
-# Enforces zero-bad-code policy: NOTHING reaches the remote without passing
-# all available quality gates. Every gate that exists in the project runs.
+# Husky pre-push hook installed by `rea init` / `rea upgrade`. Do NOT
+# edit by hand — the file is refreshed on every rea upgrade.
 #
-# Gates (skipped gracefully if script not present in package.json):
-#   1. Format check  (prettier --check .)
-#   2. Lint          (eslint .)
-#   3. Type check    (tsc --noEmit)
-#   4. Tests         (vitest run / jest / node --test)
-#   5. Build         (build script)
+# Governance contract: HALT kill-switch check, then delegate to
+# `rea hook push-gate`. See src/hooks/push-gate/index.ts.
+
+set -eu
+
+# REA push-gate (0.11.0+). The heavy lifting — git diff resolution, Codex
+# invocation, verdict inference, audit write — lives in
+# `src/hooks/push-gate/` and is invoked via `rea hook push-gate`.
+# This stub only short-circuits on the kill-switch and resolves the rea
+# binary (in priority: project node_modules/.bin/rea → dogfood dist →
+# PATH → npx).
 #
-# Exit codes:
-#   0 = all applicable gates passed
-#   1 = a gate failed — push blocked
+# The 0.10.x hooks assumed rea was on PATH. Consumers who bootstrap via
+# `npx @bookedsolid/rea init` have no persistent global rea install, so
+# the bare `exec rea` pattern fails with "rea: not found" on push. We
+# resolve against the project-local node_modules/.bin first, then PATH,
+# then fall back to npx so the gate runs in every documented setup.
 
-set -euo pipefail
-
-if [ ! -f "package.json" ]; then
-  echo "pre-push: no package.json found — quality gates skipped (non-npm project)"
-  echo "pre-push: consider adding project-specific gates to .husky/pre-push"
-  exit 0
-fi
-
-# Detect package manager
-PKG_MANAGER="npm"
-if [ -f "pnpm-lock.yaml" ]; then
-  PKG_MANAGER="pnpm"
-elif [ -f "yarn.lock" ]; then
-  PKG_MANAGER="yarn"
-fi
-
-FAILED=""
-OUT=$(mktemp)
-cleanup() { rm -f "$OUT"; }
-trap cleanup EXIT
-
-script_exists() {
-  local SCRIPT_NAME="$1"
-  node -e "const p=require('./package.json');if(!p.scripts||!p.scripts[process.argv[1]])process.exit(1);" "$SCRIPT_NAME" 2>/dev/null
-}
-
-run_gate() {
-  local SCRIPT_NAME="$1"
-  local LABEL="$2"
-
-  if script_exists "$SCRIPT_NAME"; then
-    echo "pre-push: running ${LABEL}..."
-    if ! $PKG_MANAGER run "$SCRIPT_NAME" > "$OUT" 2>&1; then
-      echo ""
-      echo "GATE FAILED: ${LABEL}"
-      cat "$OUT"
-      echo ""
-      FAILED="${FAILED} ${SCRIPT_NAME}"
-    fi
-  fi
-}
-
-# ── Gates ─────────────────────────────────────────────────────────────────────
-run_gate "format:check" "Prettier format check"
-run_gate "lint"         "ESLint"
-run_gate "type-check"   "TypeScript type check"
-run_gate "test:smart"   "Test suite (smart — changed components only)"
-# run_gate "build"        "Build"  # Enforced by CI — too heavy for local pre-push (includes storybook build)
-
-# Pack dry-run — enforced by CI, skipped locally (monorepo root packs 2000+ files)
-# if script_exists "build"; then
-#   npm pack --dry-run
-# fi
-
-# Shellcheck — lint all hook and husky shell scripts if shellcheck is installed
-if command -v shellcheck > /dev/null 2>&1; then
-  echo "pre-push: running Shellcheck on hook scripts..."
-  SHELL_SCRIPTS=$(find hooks/ husky/ -name "*.sh" 2>/dev/null | tr '\n' ' ' || true)
-  if [ -n "$SHELL_SCRIPTS" ]; then
-    # shellcheck disable=SC2086
-    if ! shellcheck --shell=bash --severity=warning --exclude=SC1091,SC2034 $SHELL_SCRIPTS > "$OUT" 2>&1; then
-      echo ""
-      echo "GATE FAILED: Shellcheck"
-      cat "$OUT"
-      echo ""
-      FAILED="${FAILED} shellcheck"
-    fi
-  fi
-else
-  echo "pre-push: shellcheck not installed — hook lint skipped (install: brew install shellcheck)"
-fi
-
-# ── Optional: coverage threshold gate ─────────────────────────────────────────
-# Enabled via .rea/policy.yaml:
-#   coverage:
-#     enabled: true
-#     threshold: 80   # line/function/statement coverage percentage (branches: threshold - 10)
-#
-# Only runs if coverage.enabled is true AND the project has a test script.
-POLICY_FILE=".rea/policy.yaml"
-COVERAGE_ENABLED="false"
-COVERAGE_THRESHOLD=80
-
-if [ -f "$POLICY_FILE" ]; then
-  # Extract coverage.enabled — look for "enabled: true" within the coverage block
-  if awk '/^coverage:/{in_block=1} in_block && /enabled: true/{found=1; exit} in_block && /^[^ ]/{in_block=0}' "$POLICY_FILE" | grep -q "enabled: true" 2>/dev/null || \
-     grep -A5 "^coverage:" "$POLICY_FILE" 2>/dev/null | grep -q "enabled: true"; then
-    COVERAGE_ENABLED="true"
-  fi
-
-  # Extract coverage.threshold (default 80)
-  # The || true prevents set -euo pipefail from exiting when coverage: block is absent
-  THRESHOLD_LINE=$(grep -A5 "^coverage:" "$POLICY_FILE" 2>/dev/null | grep "threshold:" | head -1) || true
-  if [ -n "$THRESHOLD_LINE" ]; then
-    EXTRACTED=$(echo "$THRESHOLD_LINE" | awk '{print $2}' | tr -d '"' | tr -d "'")
-    if [ -n "$EXTRACTED" ] && [ "$EXTRACTED" -eq "$EXTRACTED" ] 2>/dev/null; then
-      COVERAGE_THRESHOLD="$EXTRACTED"
-    fi
-  fi
-fi
-
-if [ "$COVERAGE_ENABLED" = "true" ] && script_exists "test"; then
-  echo "pre-push: running Coverage threshold (≥${COVERAGE_THRESHOLD}%)..."
-  if ! COVERAGE_THRESHOLD="$COVERAGE_THRESHOLD" $PKG_MANAGER run test -- --coverage > "$OUT" 2>&1; then
-    echo ""
-    echo "GATE FAILED: Coverage threshold (${COVERAGE_THRESHOLD}%)"
-    cat "$OUT"
-    echo ""
-    FAILED="${FAILED} coverage"
-  fi
-fi
-
-# ── Report ────────────────────────────────────────────────────────────────────
-HOOKS_LIB="$(git rev-parse --show-toplevel 2>/dev/null)/hooks/_lib/discord.sh"
-
-if [ -n "$FAILED" ]; then
-  echo "pre-push: FAILED gates:${FAILED}"
-  echo "All quality gates must pass before push. Fix failures and retry."
-  if [ -f "$HOOKS_LIB" ]; then
-    # shellcheck source=/dev/null
-    source "$HOOKS_LIB"
-    discord_notify "alert" "Push BLOCKED -- gate failures: \`${FAILED}\` on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null)\`" "red"
-  fi
+REA_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+if [ -f "${REA_ROOT}/.rea/HALT" ]; then
+  reason=$(awk 'NR==1 { print; exit }' "${REA_ROOT}/.rea/HALT" 2>/dev/null || printf 'unknown')
+  [ -z "${reason:-}" ] && reason='unknown'
+  printf 'REA HALT: %s\nAll push operations suspended. Run: rea unfreeze\n' "$reason" >&2
   exit 1
 fi
 
-echo "pre-push: all quality gates passed"
-if [ -f "$HOOKS_LIB" ]; then
-  # shellcheck source=/dev/null
-  source "$HOOKS_LIB"
-  discord_notify "dev" "Pre-push gates passed on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null)\`" "green"
+# Dispatch the rea CLI as a positional-args list rather than a string
+# (the 0.11.x `exec $REA_BIN ...` pattern broke when REA_ROOT contained
+# whitespace because the unquoted $REA_BIN expansion underwent word
+# splitting; `/Users/jane/My Projects/repo` produced four argv tokens
+# instead of two). The `set --` form below preserves spaces verbatim.
+#
+# 0.13.2 fix: the dispatch + invocation runs inside a SUBSHELL so the
+# `set --` rewrite does NOT bleed into the parent's $@. Before 0.13.2,
+# the parent's $@ ended up as the rea-CLI argv (`node /path/dist/cli/index.js
+# hook push-gate <remote-name> <remote-url>`) and the extension-fragment
+# loop below passed that mangled argv to fragments instead of git's
+# original `<remote-name> <remote-url>`. The subshell scopes the rewrite
+# so fragments see git's argv unchanged.
+#
+# The pre-push stdin carries one line per refspec; the subshell inherits
+# stdin unchanged. $@ on entry carries git's <remote-name> <remote-url>;
+# the subshell sees those as its initial $@, appends them inside each
+# `set --` arm, and the parent's $@ is preserved.
+
+if (
+  if [ -x "${REA_ROOT}/node_modules/.bin/rea" ]; then
+    set -- "${REA_ROOT}/node_modules/.bin/rea" hook push-gate "$@"
+  elif [ -f "${REA_ROOT}/dist/cli/index.js" ] && [ -f "${REA_ROOT}/package.json" ] && grep -q '"name": *"@bookedsolid/rea"' "${REA_ROOT}/package.json" 2>/dev/null; then
+    # rea's own repo (dogfood) — the package is not installed under
+    # node_modules here because we ARE the package. The built CLI
+    # entry point lives at dist/cli/index.js; node runs it directly.
+    # Gate this branch on `package.json` declaring `@bookedsolid/rea` so a
+    # consumer repo that happens to ship its own `dist/cli/index.js` does
+    # not get this hook executing the consumer's unrelated build.
+    set -- node "${REA_ROOT}/dist/cli/index.js" hook push-gate "$@"
+  elif command -v rea >/dev/null 2>&1; then
+    set -- rea hook push-gate "$@"
+  elif command -v npx >/dev/null 2>&1; then
+    # Last resort: npx will resolve the package from npm or the cache.
+    # Pass `--no-install` so a rare cache-cold machine surfaces a clear
+    # error instead of silently downloading at push time.
+    set -- npx --no-install @bookedsolid/rea hook push-gate "$@"
+  else
+    printf 'rea: cannot locate the rea CLI. Install locally (`pnpm add -D @bookedsolid/rea`) or globally (`npm i -g @bookedsolid/rea`).\n' >&2
+    exit 2
+  fi
+  exec "$@"
+); then
+  rea_status=0
+else
+  rea_status=$?
+fi
+if [ "$rea_status" -ne 0 ]; then
+  exit "$rea_status"
 fi
 
-# ── rea push-review-gate — REMOVED 2026-04-22 ────────────────────────────────
-# Removed per project owner directive. Two upstream rea bugs (schema mismatch
-# between codex-adversarial agent output and the gate's jq predicate; escape
-# hatch resolving `dist/audit/append.js` at repo root instead of node_modules)
-# made the gate unworkable across multiple releases. Codex adversarial review
-# is retained as a first-class step via the /codex-review slash command and
-# the codex-adversarial subagent, and is enforced in CI rather than at the
-# local push boundary. CodeRabbit + 3-tier agent review remain.
+# Extension-hook chaining: source every executable file under
+# `.husky/pre-push.d/` in lexical order. Missing directory = no-op
+# (backward compatible). Each fragment receives the original positional
+# args from git's `<remote-name> <remote-url>` invocation. Non-zero exit
+# from any fragment fails the push; this matches husky's normal hook
+# chaining semantics.
+#
+# The git pre-push contract delivers refspecs on stdin. Once rea's body has
+# consumed it (`exec rea hook push-gate "$@"` reads stdin during `runPushGate`),
+# subsequent fragments cannot replay it — that's by design: agents that need
+# refspec data should run before rea, not after. Fragments that need ambient
+# repo state can call `git rev-parse` themselves.
+ext_dir="${REA_ROOT}/.husky/pre-push.d"
+if [ -d "$ext_dir" ]; then
+  # Collect fragments deterministically. POSIX sort orders the same way on
+  # macOS (BSD sort) and Linux (GNU sort) for ASCII filenames; consumers who
+  # name their fragments `10-foo` / `20-bar` get predictable ordering.
+  for frag in "$ext_dir"/*; do
+    # Glob expands to itself when no matches — guard with -e.
+    [ -e "$frag" ] || continue
+    # Skip non-files (directories, sockets) and non-executables. The
+    # executable bit is the consumer's opt-in: dropping a non-executable
+    # README into the dir does not become a hook.
+    [ -f "$frag" ] || continue
+    [ -x "$frag" ] || continue
+    # Each fragment runs in its own subprocess with the original git args.
+    # Failures propagate via `set -eu` above (loop body inherits, so any
+    # non-zero exit blocks the push immediately).
+    "$frag" "$@"
+  done
+fi
 
 exit 0

--- a/.husky/pre-push.d/10-helix-quality-gates
+++ b/.husky/pre-push.d/10-helix-quality-gates
@@ -1,0 +1,160 @@
+#!/bin/bash
+# .husky/pre-push — full quality gate before push
+#
+# Enforces zero-bad-code policy: NOTHING reaches the remote without passing
+# all available quality gates. Every gate that exists in the project runs.
+#
+# Gates (skipped gracefully if script not present in package.json):
+#   1. Format check  (prettier --check .)
+#   2. Lint          (eslint .)
+#   3. Type check    (tsc --noEmit)
+#   4. Tests         (vitest run / jest / node --test)
+#   5. Build         (build script)
+#
+# Exit codes:
+#   0 = all applicable gates passed
+#   1 = a gate failed — push blocked
+
+set -euo pipefail
+
+if [ ! -f "package.json" ]; then
+  echo "pre-push: no package.json found — quality gates skipped (non-npm project)"
+  echo "pre-push: consider adding project-specific gates to .husky/pre-push"
+  exit 0
+fi
+
+# Detect package manager
+PKG_MANAGER="npm"
+if [ -f "pnpm-lock.yaml" ]; then
+  PKG_MANAGER="pnpm"
+elif [ -f "yarn.lock" ]; then
+  PKG_MANAGER="yarn"
+fi
+
+FAILED=""
+OUT=$(mktemp)
+cleanup() { rm -f "$OUT"; }
+trap cleanup EXIT
+
+script_exists() {
+  local SCRIPT_NAME="$1"
+  node -e "const p=require('./package.json');if(!p.scripts||!p.scripts[process.argv[1]])process.exit(1);" "$SCRIPT_NAME" 2>/dev/null
+}
+
+run_gate() {
+  local SCRIPT_NAME="$1"
+  local LABEL="$2"
+
+  if script_exists "$SCRIPT_NAME"; then
+    echo "pre-push: running ${LABEL}..."
+    if ! $PKG_MANAGER run "$SCRIPT_NAME" > "$OUT" 2>&1; then
+      echo ""
+      echo "GATE FAILED: ${LABEL}"
+      cat "$OUT"
+      echo ""
+      FAILED="${FAILED} ${SCRIPT_NAME}"
+    fi
+  fi
+}
+
+# ── Gates ─────────────────────────────────────────────────────────────────────
+run_gate "format:check" "Prettier format check"
+run_gate "lint"         "ESLint"
+run_gate "type-check"   "TypeScript type check"
+run_gate "test:smart"   "Test suite (smart — changed components only)"
+# run_gate "build"        "Build"  # Enforced by CI — too heavy for local pre-push (includes storybook build)
+
+# Pack dry-run — enforced by CI, skipped locally (monorepo root packs 2000+ files)
+# if script_exists "build"; then
+#   npm pack --dry-run
+# fi
+
+# Shellcheck — lint all hook and husky shell scripts if shellcheck is installed
+if command -v shellcheck > /dev/null 2>&1; then
+  echo "pre-push: running Shellcheck on hook scripts..."
+  SHELL_SCRIPTS=$(find hooks/ husky/ -name "*.sh" 2>/dev/null | tr '\n' ' ' || true)
+  if [ -n "$SHELL_SCRIPTS" ]; then
+    # shellcheck disable=SC2086
+    if ! shellcheck --shell=bash --severity=warning --exclude=SC1091,SC2034 $SHELL_SCRIPTS > "$OUT" 2>&1; then
+      echo ""
+      echo "GATE FAILED: Shellcheck"
+      cat "$OUT"
+      echo ""
+      FAILED="${FAILED} shellcheck"
+    fi
+  fi
+else
+  echo "pre-push: shellcheck not installed — hook lint skipped (install: brew install shellcheck)"
+fi
+
+# ── Optional: coverage threshold gate ─────────────────────────────────────────
+# Enabled via .rea/policy.yaml:
+#   coverage:
+#     enabled: true
+#     threshold: 80   # line/function/statement coverage percentage (branches: threshold - 10)
+#
+# Only runs if coverage.enabled is true AND the project has a test script.
+POLICY_FILE=".rea/policy.yaml"
+COVERAGE_ENABLED="false"
+COVERAGE_THRESHOLD=80
+
+if [ -f "$POLICY_FILE" ]; then
+  # Extract coverage.enabled — look for "enabled: true" within the coverage block
+  if awk '/^coverage:/{in_block=1} in_block && /enabled: true/{found=1; exit} in_block && /^[^ ]/{in_block=0}' "$POLICY_FILE" | grep -q "enabled: true" 2>/dev/null || \
+     grep -A5 "^coverage:" "$POLICY_FILE" 2>/dev/null | grep -q "enabled: true"; then
+    COVERAGE_ENABLED="true"
+  fi
+
+  # Extract coverage.threshold (default 80)
+  # The || true prevents set -euo pipefail from exiting when coverage: block is absent
+  THRESHOLD_LINE=$(grep -A5 "^coverage:" "$POLICY_FILE" 2>/dev/null | grep "threshold:" | head -1) || true
+  if [ -n "$THRESHOLD_LINE" ]; then
+    EXTRACTED=$(echo "$THRESHOLD_LINE" | awk '{print $2}' | tr -d '"' | tr -d "'")
+    if [ -n "$EXTRACTED" ] && [ "$EXTRACTED" -eq "$EXTRACTED" ] 2>/dev/null; then
+      COVERAGE_THRESHOLD="$EXTRACTED"
+    fi
+  fi
+fi
+
+if [ "$COVERAGE_ENABLED" = "true" ] && script_exists "test"; then
+  echo "pre-push: running Coverage threshold (≥${COVERAGE_THRESHOLD}%)..."
+  if ! COVERAGE_THRESHOLD="$COVERAGE_THRESHOLD" $PKG_MANAGER run test -- --coverage > "$OUT" 2>&1; then
+    echo ""
+    echo "GATE FAILED: Coverage threshold (${COVERAGE_THRESHOLD}%)"
+    cat "$OUT"
+    echo ""
+    FAILED="${FAILED} coverage"
+  fi
+fi
+
+# ── Report ────────────────────────────────────────────────────────────────────
+HOOKS_LIB="$(git rev-parse --show-toplevel 2>/dev/null)/hooks/_lib/discord.sh"
+
+if [ -n "$FAILED" ]; then
+  echo "pre-push: FAILED gates:${FAILED}"
+  echo "All quality gates must pass before push. Fix failures and retry."
+  if [ -f "$HOOKS_LIB" ]; then
+    # shellcheck source=/dev/null
+    source "$HOOKS_LIB"
+    discord_notify "alert" "Push BLOCKED -- gate failures: \`${FAILED}\` on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null)\`" "red"
+  fi
+  exit 1
+fi
+
+echo "pre-push: all quality gates passed"
+if [ -f "$HOOKS_LIB" ]; then
+  # shellcheck source=/dev/null
+  source "$HOOKS_LIB"
+  discord_notify "dev" "Pre-push gates passed on \`$(git rev-parse --abbrev-ref HEAD 2>/dev/null)\`" "green"
+fi
+
+# ── rea push-review-gate — REMOVED 2026-04-22 ────────────────────────────────
+# Removed per project owner directive. Two upstream rea bugs (schema mismatch
+# between codex-adversarial agent output and the gate's jq predicate; escape
+# hatch resolving `dist/audit/append.js` at repo root instead of node_modules)
+# made the gate unworkable across multiple releases. Codex adversarial review
+# is retained as a first-class step via the /codex-review slash command and
+# the codex-adversarial subagent, and is enforced in CI rather than at the
+# local push boundary. CodeRabbit + 3-tier agent review remain.
+
+exit 0

--- a/.husky/pre-push.d/10-helix-quality-gates
+++ b/.husky/pre-push.d/10-helix-quality-gates
@@ -72,7 +72,11 @@ run_gate "test:smart"   "Test suite (smart — changed components only)"
 # Shellcheck — lint all hook and husky shell scripts if shellcheck is installed
 if command -v shellcheck > /dev/null 2>&1; then
   echo "pre-push: running Shellcheck on hook scripts..."
-  SHELL_SCRIPTS=$(find hooks/ husky/ -name "*.sh" 2>/dev/null | tr '\n' ' ' || true)
+  SHELL_SCRIPTS=$(find .claude/hooks .husky \
+    \( -name "*.sh" \
+       -o -path ".husky/pre-push" -o -path ".husky/commit-msg" -o -path ".husky/pre-commit" \
+       -o -path ".husky/pre-push.d/*" -o -path ".husky/commit-msg.d/*" -o -path ".husky/pre-commit.d/*" \) \
+    -type f 2>/dev/null | tr '\n' ' ' || true)
   if [ -n "$SHELL_SCRIPTS" ]; then
     # shellcheck disable=SC2086
     if ! shellcheck --shell=bash --severity=warning --exclude=SC1091,SC2034 $SHELL_SCRIPTS > "$OUT" 2>&1; then

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.16.1",
+  "version": "0.16.2",
   "profile": "unknown",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-03T22:10:14.143Z",
+  "upgraded_at": "2026-05-03T22:21:59.243Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",
-      "sha256": "f1d562e1a61b0359650dd3408f0d8680fd81b3fb730069f8dbfe05387b6969d0",
+      "sha256": "5a963e79d26f2f9a4673951f093b38ee8084e4c35004844a31cb16efd0edfee6",
       "source": "hook"
     },
     {
@@ -46,7 +46,7 @@
     },
     {
       "path": ".claude/hooks/attribution-advisory.sh",
-      "sha256": "7179ce6880479706f14406743cc820c6033fc8a4a6a3d9953e719c6f48f02ba0",
+      "sha256": "109844439a45617c9f54f6d69ff16b77b5e55b39be26a193ab6d01085b80709b",
       "source": "hook"
     },
     {
@@ -71,7 +71,7 @@
     },
     {
       "path": ".claude/hooks/env-file-protection.sh",
-      "sha256": "ea079f4e7f94410ac18f854182d2c883739705f3a1601df3c9fdb5893ed77ccb",
+      "sha256": "52b9009b476eb9d133cf9f47c882e523f4e7091b5f3b00af0e4c4960a65f4dfe",
       "source": "hook"
     },
     {
@@ -176,7 +176,7 @@
     },
     {
       "path": ".husky/commit-msg",
-      "sha256": "e1f5f8a8a7536d13fa5f3fe168326c9caaf5cc14352064f13857a5fceb1eb23f",
+      "sha256": "53573ef6b8d73bc72dc5e77ca6be21169d6a2ff254bffb2fa43acf1ac070f4ae",
       "source": "husky"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.21.0",
+  "version": "0.22.0",
   "profile": "bst-internal",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-04T03:05:22.901Z",
+  "upgraded_at": "2026-05-04T03:55:51.897Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",
-      "sha256": "20ee41c06dd67f1ba19662eba57dfbc4fea3fe199b6a2f7f95d5b1c474ad31bc",
+      "sha256": "32879325d90fc0358049ac05c6fade47029a75cee827310a6b0452c075e21fc7",
       "source": "hook"
     },
     {
@@ -20,8 +20,13 @@
       "source": "hook"
     },
     {
+      "path": ".claude/hooks/_lib/interpreter-scanner.sh",
+      "sha256": "1564d8aa4e337f3914b0361497a7d2900b3ac656b29e3896fbce67cbe5b0e4f9",
+      "source": "hook"
+    },
+    {
       "path": ".claude/hooks/_lib/path-normalize.sh",
-      "sha256": "9fa2054bc519e9f0f3237a7f671740d3dec0f472f792cb1a0483402735f68d19",
+      "sha256": "eb773a1ed5fd49ea46ac1af41c1744af8e213e5942b763ea8a936aa0557abe5b",
       "source": "hook"
     },
     {
@@ -51,7 +56,7 @@
     },
     {
       "path": ".claude/hooks/blocked-paths-bash-gate.sh",
-      "sha256": "f21aa7ba60ad61ad1f7258a12ba9dfac5dfa18e4c2acf68aa1e9123bb625077b",
+      "sha256": "04bdedd0406d1caf1b2db83cff44ee010bf3a29736fdfd39bb05aba8b29ad2a9",
       "source": "hook"
     },
     {
@@ -86,7 +91,7 @@
     },
     {
       "path": ".claude/hooks/protected-paths-bash-gate.sh",
-      "sha256": "7cb38e0a6ad92d447bb3e42304e80e79e5287e2ae5c46d90c4d0b396acf0442b",
+      "sha256": "b584e78079a46a89e5fb1cb53490dab872be9a57755c811d9b118c8b38d5ab51",
       "source": "hook"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.17.0",
-  "profile": "unknown",
+  "version": "0.18.0",
+  "profile": "bst-internal",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-04T00:30:04.071Z",
+  "upgraded_at": "2026-05-04T01:52:07.734Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",
-      "sha256": "986b7452040c7ebf82e8e8c7162d9c56b7c1bbca1636859c9928d4589bcf7e84",
+      "sha256": "1813e590ab65f3eb270f040b21cff6348a6b2f3dea7a232781d04053d4de2b4b",
       "source": "hook"
     },
     {
@@ -31,12 +31,12 @@
     },
     {
       "path": ".claude/hooks/_lib/policy-read.sh",
-      "sha256": "480c5a0935f33f65d8bb3dfafc13e4f5819942ffe875953fe2e8607fd8222739",
+      "sha256": "07a06688f91d8fdde98785c586259d59769a6ed4a0e693ab66db66a24ae967bb",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/_lib/protected-paths.sh",
-      "sha256": "0f5ba2c71d55c9f51801bd52052bcc443312ff19cfd3973a1da8effc3c648822",
+      "sha256": "3e9366d817a2421a08e8f3b2ebf4a68bc48aef075fa8bd44864308e8c63b063f",
       "source": "hook"
     },
     {
@@ -46,7 +46,7 @@
     },
     {
       "path": ".claude/hooks/attribution-advisory.sh",
-      "sha256": "109844439a45617c9f54f6d69ff16b77b5e55b39be26a193ab6d01085b80709b",
+      "sha256": "ea01801c50fa6c2afd43b15deb570c7ae0ba6627d761a7167add7bb2b031b86b",
       "source": "hook"
     },
     {
@@ -96,7 +96,7 @@
     },
     {
       "path": ".claude/hooks/security-disclosure-gate.sh",
-      "sha256": "52255795e2a2b30d3c6b7953c0d12f2355827fb096f10beab2f7ab8224681040",
+      "sha256": "f05838f8e2ddb9f0f2d4fbfdee57a00978dcfd9e0fb862be02021714dc9c01e3",
       "source": "hook"
     },
     {
@@ -121,7 +121,7 @@
     },
     {
       "path": ".claude/agents/codex-adversarial.md",
-      "sha256": "c27f642fc2955c38a8175105d3e882ab03f7a47e2e340ad08a803884be0d4ae9",
+      "sha256": "7d30f0040d16eb765abddc73263c5674337e7ffec1a90a00a8448d93f28aded3",
       "source": "agent"
     },
     {
@@ -156,7 +156,7 @@
     },
     {
       "path": ".claude/commands/codex-review.md",
-      "sha256": "d4654cf14b2a850e76567c346d42335a423238ac2919eaf4c1482c846d1458c1",
+      "sha256": "3a9885edcb838d81d0e299d0e755136acf907eeb228e46f40965b0f085155adb",
       "source": "command"
     },
     {
@@ -181,7 +181,7 @@
     },
     {
       "path": ".husky/commit-msg",
-      "sha256": "53573ef6b8d73bc72dc5e77ca6be21169d6a2ff254bffb2fa43acf1ac070f4ae",
+      "sha256": "9c6f6e58ec3ee7fbaa6533abec5868cee6a3ebc3272969248dd736131df9174d",
       "source": "husky"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.16.4",
+  "version": "0.17.0",
   "profile": "unknown",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-03T23:22:10.199Z",
+  "upgraded_at": "2026-05-04T00:30:04.071Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",
-      "sha256": "5bd1b13737d76b7c06f217a926247b2346307e880dbea57d024f782f93f0b00b",
+      "sha256": "986b7452040c7ebf82e8e8c7162d9c56b7c1bbca1636859c9928d4589bcf7e84",
       "source": "hook"
     },
     {
@@ -36,7 +36,7 @@
     },
     {
       "path": ".claude/hooks/_lib/protected-paths.sh",
-      "sha256": "c0e85fa95569e056839783cfbb061c4369186e2c172a709c01ff7e99773d53ac",
+      "sha256": "0f5ba2c71d55c9f51801bd52052bcc443312ff19cfd3973a1da8effc3c648822",
       "source": "hook"
     },
     {
@@ -66,12 +66,12 @@
     },
     {
       "path": ".claude/hooks/dangerous-bash-interceptor.sh",
-      "sha256": "47f9c17101de93b6f3d2baac90081c04da9b3ccf3a6dd2c10518df2d5f84130f",
+      "sha256": "1d13c9684c233eaa3aa7e50d0b0496a2756a6e03d555423a97407c9996280776",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/dependency-audit-gate.sh",
-      "sha256": "3cb0f130e98f730a633ba8e6f4db106b02387a9771a48f1e1c3543494b9f4184",
+      "sha256": "dac01da3189704d52d677f4493b607771ac687b7ce5a16caabbcf1e94487e60d",
       "source": "hook"
     },
     {
@@ -96,7 +96,7 @@
     },
     {
       "path": ".claude/hooks/security-disclosure-gate.sh",
-      "sha256": "767a687407dea29b4d585c8c3893dc9f8e3a9ddbcbdaa7f92c38ab1702b583a1",
+      "sha256": "52255795e2a2b30d3c6b7953c0d12f2355827fb096f10beab2f7ab8224681040",
       "source": "hook"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,58 +1,77 @@
 {
-  "version": "0.11.0",
+  "version": "0.16.1",
   "profile": "unknown",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-04-23T15:09:02.547Z",
-  "bootstrap": true,
+  "upgraded_at": "2026-05-03T22:10:14.143Z",
   "files": [
     {
+      "path": ".claude/hooks/_lib/cmd-segments.sh",
+      "sha256": "f1d562e1a61b0359650dd3408f0d8680fd81b3fb730069f8dbfe05387b6969d0",
+      "source": "hook"
+    },
+    {
       "path": ".claude/hooks/_lib/common.sh",
-      "sha256": "c95da81ac71257b5feb426b6123d3eee1160ea225d204da0b4f22995d44d90c7",
+      "sha256": "5b3e4af7b2a464fcbebea3dffe32cf626dad604acf489cf8fcb9ce32f36d2e63",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/_lib/halt-check.sh",
-      "sha256": "4ee5e7b3b57172ca32d17f1746471000de33a4cee0a3f2ab1d3edea4c338c4e4",
+      "sha256": "c38b76f5af7b9b6b90451c689b1f98263a2c1a3d360d335f55e9bf5899486027",
+      "source": "hook"
+    },
+    {
+      "path": ".claude/hooks/_lib/path-normalize.sh",
+      "sha256": "2e5204a1eddbcfd868bdfac60411c03fb6cb59605ccdf206b974c8cbdcb53934",
+      "source": "hook"
+    },
+    {
+      "path": ".claude/hooks/_lib/payload-read.sh",
+      "sha256": "d367aabb22dc81426d7322f37d62606c718b01d6aa6df895953f35aadcd98202",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/_lib/policy-read.sh",
-      "sha256": "da8014b207641a2177b3b191472e7ac5937e085a9feab4ea04a02c57a23b34af",
+      "sha256": "480c5a0935f33f65d8bb3dfafc13e4f5819942ffe875953fe2e8607fd8222739",
+      "source": "hook"
+    },
+    {
+      "path": ".claude/hooks/_lib/protected-paths.sh",
+      "sha256": "5abed2eac22ed4cfa576f132c5cbc2241e82892e5dda2c1c59796c8b609c5b5c",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/architecture-review-gate.sh",
-      "sha256": "84c3e7acc245b4a90d53e17d6fc056998a0a75007854bf65d2b1a5f9f4fbd4a7",
+      "sha256": "80224c976a144ac57c2269a933eb5c92fb1a499d8122c888a04dcc60ff585cd9",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/attribution-advisory.sh",
-      "sha256": "71e64e6e6fcd23923a18ac345b3409cd7a1f4c0b8c3c595b4fa3d35990dc1ecf",
+      "sha256": "7179ce6880479706f14406743cc820c6033fc8a4a6a3d9953e719c6f48f02ba0",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/blocked-paths-enforcer.sh",
-      "sha256": "be98dd8ddad684ae72cf4b00a4643137c38c1aae7778a52061878a7cdf236f2a",
+      "sha256": "6b0fd5b23c086c180967ca0d78350c22f9977c9761b66dc97e8535342fb40cec",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/changeset-security-gate.sh",
-      "sha256": "c7cfc39135166cc7827f8cbd87df212401106edd3fd5b39206eaef3ffb3b21e1",
+      "sha256": "15c7ca4aff66148ee68bf6e79bf689f31b4066b7c0229c2e756838ece3e588c8",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/dangerous-bash-interceptor.sh",
-      "sha256": "60b29565301b86394175f6d2887e86246e562309a52bd3da492bc148f7970351",
+      "sha256": "18dad278d6bdddd0336d15347dd29c2a70edf3161cdc75e06207761c60fec8b5",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/dependency-audit-gate.sh",
-      "sha256": "6730fbae64edfa229e4095bfa68853236241a2e12f7c5f6ff68fc910dd1470a1",
+      "sha256": "3cb0f130e98f730a633ba8e6f4db106b02387a9771a48f1e1c3543494b9f4184",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/env-file-protection.sh",
-      "sha256": "1edc6f8698323dbdeb53f09b81531173f1b692c8c2c42afbab52d815ab57f6ce",
+      "sha256": "ea079f4e7f94410ac18f854182d2c883739705f3a1601df3c9fdb5893ed77ccb",
       "source": "hook"
     },
     {
@@ -61,8 +80,13 @@
       "source": "hook"
     },
     {
+      "path": ".claude/hooks/protected-paths-bash-gate.sh",
+      "sha256": "cb60c9bb12c150f808144a2a4457ded83ac52fb29f30bfe3894ef484eb3f95de",
+      "source": "hook"
+    },
+    {
       "path": ".claude/hooks/secret-scanner.sh",
-      "sha256": "8dc770ddddc75ca793294cca14d2856a3cded499f3e3c1ec93594dba8f80e279",
+      "sha256": "06c64c5c7675b2c0b2ec4ec21e742bce7ab987607516ab5426d0650ba523b439",
       "source": "hook"
     },
     {
@@ -72,7 +96,7 @@
     },
     {
       "path": ".claude/hooks/settings-protection.sh",
-      "sha256": "dc4918259da2d83d00097ec3a3d136c208d5112992ef63e6d211c114b0225820",
+      "sha256": "6ab80aed951e53c945bf3610d8920249ce57ca8306160cd495bd613f7daecec6",
       "source": "hook"
     },
     {
@@ -92,7 +116,7 @@
     },
     {
       "path": ".claude/agents/codex-adversarial.md",
-      "sha256": "6e72e40d5dab841401798b19158ec63caa88a2547f4b521a4577bb86f2bda174",
+      "sha256": "c27f642fc2955c38a8175105d3e882ab03f7a47e2e340ad08a803884be0d4ae9",
       "source": "agent"
     },
     {
@@ -127,12 +151,12 @@
     },
     {
       "path": ".claude/commands/codex-review.md",
-      "sha256": "56d815393e32d3f8342288dfb4701f0bbf0b34c1b65d6551999e880366d43221",
+      "sha256": "d4654cf14b2a850e76567c346d42335a423238ac2919eaf4c1482c846d1458c1",
       "source": "command"
     },
     {
       "path": ".claude/commands/freeze.md",
-      "sha256": "dfcad8b0352f82390f336ae62ccc06ccca711a05785c01b94c2cf76dcba5578b",
+      "sha256": "c5297513139fb9213ef1ad65e684484c6c2497ea963e43858f52e2d808ee9bfe",
       "source": "command"
     },
     {
@@ -147,22 +171,22 @@
     },
     {
       "path": ".claude/commands/review.md",
-      "sha256": "9c8a2e2d8bbab0fdff982df95aa0145216d0c958ed34271f9b18b6edc9364174",
+      "sha256": "97b00281a3b674b84d93e1951920f217087e7d9189efb55967863ccdc5a5c1a6",
       "source": "command"
     },
     {
       "path": ".husky/commit-msg",
-      "sha256": "ed152fb17c99606844d162e924bffb0563ad3aee800b1a087ac540cd96e82041",
+      "sha256": "e1f5f8a8a7536d13fa5f3fe168326c9caaf5cc14352064f13857a5fceb1eb23f",
       "source": "husky"
     },
     {
       "path": ".husky/pre-push",
-      "sha256": "b16897afaa747e2e661142272ffa1efaf1c094e0d381901103c263d6165d69fe",
+      "sha256": "d2d0a5a9fbc93a7d16dcb8039db96bca20bda507c28f670ff495a44ca5b746ff",
       "source": "husky"
     },
     {
       "path": ".claude/settings.json#rea:desired",
-      "sha256": "33887b8c4b01bef7e6473418b628bd1c71a2510f530aff04826dd2ba062ca760",
+      "sha256": "81ebb37f8d5dcaa133d7f0d744a0d73d374594e14cb8f123c866dfd286bb817f",
       "source": "settings"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.22.0",
+  "version": "0.23.0",
   "profile": "bst-internal",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-04T03:55:51.897Z",
+  "upgraded_at": "2026-05-04T23:17:20.364Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",
@@ -56,7 +56,7 @@
     },
     {
       "path": ".claude/hooks/blocked-paths-bash-gate.sh",
-      "sha256": "04bdedd0406d1caf1b2db83cff44ee010bf3a29736fdfd39bb05aba8b29ad2a9",
+      "sha256": "7c0f9b3304c7caf6b7f7b46801b49ff6b440a47d965814820807d331de8c531e",
       "source": "hook"
     },
     {
@@ -91,7 +91,7 @@
     },
     {
       "path": ".claude/hooks/protected-paths-bash-gate.sh",
-      "sha256": "b584e78079a46a89e5fb1cb53490dab872be9a57755c811d9b118c8b38d5ab51",
+      "sha256": "d82f05c827f8adec8e9428a1acd56c6a94723479e6e7f1821eb34668f48f5cbe",
       "source": "hook"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.19.0",
+  "version": "0.21.0",
   "profile": "bst-internal",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-04T02:35:25.722Z",
+  "upgraded_at": "2026-05-04T03:05:22.901Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",
-      "sha256": "1813e590ab65f3eb270f040b21cff6348a6b2f3dea7a232781d04053d4de2b4b",
+      "sha256": "20ee41c06dd67f1ba19662eba57dfbc4fea3fe199b6a2f7f95d5b1c474ad31bc",
       "source": "hook"
     },
     {
@@ -21,7 +21,7 @@
     },
     {
       "path": ".claude/hooks/_lib/path-normalize.sh",
-      "sha256": "2e5204a1eddbcfd868bdfac60411c03fb6cb59605ccdf206b974c8cbdcb53934",
+      "sha256": "9fa2054bc519e9f0f3237a7f671740d3dec0f472f792cb1a0483402735f68d19",
       "source": "hook"
     },
     {
@@ -36,22 +36,22 @@
     },
     {
       "path": ".claude/hooks/_lib/protected-paths.sh",
-      "sha256": "3e9366d817a2421a08e8f3b2ebf4a68bc48aef075fa8bd44864308e8c63b063f",
+      "sha256": "8a3c0bf922dee194295a8c1bd2dab7c32bb216007a4b0929ad129e70254421b6",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/architecture-review-gate.sh",
-      "sha256": "80224c976a144ac57c2269a933eb5c92fb1a499d8122c888a04dcc60ff585cd9",
+      "sha256": "658f28b11e563743239ee2ee716ebb687edcf8aa45e4b273d5fa4d276b6fcd9d",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/attribution-advisory.sh",
-      "sha256": "ea01801c50fa6c2afd43b15deb570c7ae0ba6627d761a7167add7bb2b031b86b",
+      "sha256": "5262575e6881d47673db7af5aa1acff770f16e623d401fe288dc22d6525d7932",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/blocked-paths-bash-gate.sh",
-      "sha256": "edd1636d60f7a9a2ba4374c7088dc6b7c172cb3cad684402def0138e5e357c2b",
+      "sha256": "f21aa7ba60ad61ad1f7258a12ba9dfac5dfa18e4c2acf68aa1e9123bb625077b",
       "source": "hook"
     },
     {
@@ -86,7 +86,7 @@
     },
     {
       "path": ".claude/hooks/protected-paths-bash-gate.sh",
-      "sha256": "cb60c9bb12c150f808144a2a4457ded83ac52fb29f30bfe3894ef484eb3f95de",
+      "sha256": "7cb38e0a6ad92d447bb3e42304e80e79e5287e2ae5c46d90c4d0b396acf0442b",
       "source": "hook"
     },
     {
@@ -101,7 +101,7 @@
     },
     {
       "path": ".claude/hooks/settings-protection.sh",
-      "sha256": "e5a232e591449083181cf7ccba0dcdcf39830c71aa9aac6bd6f10d5e11b3a9d8",
+      "sha256": "64b2b50a90bed0589551cb849016adffc9c0ab0313cbc71ca1ca154fdb3236dc",
       "source": "hook"
     },
     {
@@ -181,7 +181,7 @@
     },
     {
       "path": ".husky/commit-msg",
-      "sha256": "9c6f6e58ec3ee7fbaa6533abec5868cee6a3ebc3272969248dd736131df9174d",
+      "sha256": "70e9d3b52320f1eca888266de2fbf994de5d4617bb7a9ba814bfd6f9206c5809",
       "source": "husky"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,12 +1,12 @@
 {
-  "version": "0.16.2",
+  "version": "0.16.4",
   "profile": "unknown",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-03T22:21:59.243Z",
+  "upgraded_at": "2026-05-03T23:22:10.199Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",
-      "sha256": "5a963e79d26f2f9a4673951f093b38ee8084e4c35004844a31cb16efd0edfee6",
+      "sha256": "5bd1b13737d76b7c06f217a926247b2346307e880dbea57d024f782f93f0b00b",
       "source": "hook"
     },
     {
@@ -36,7 +36,7 @@
     },
     {
       "path": ".claude/hooks/_lib/protected-paths.sh",
-      "sha256": "5abed2eac22ed4cfa576f132c5cbc2241e82892e5dda2c1c59796c8b609c5b5c",
+      "sha256": "c0e85fa95569e056839783cfbb061c4369186e2c172a709c01ff7e99773d53ac",
       "source": "hook"
     },
     {
@@ -47,6 +47,11 @@
     {
       "path": ".claude/hooks/attribution-advisory.sh",
       "sha256": "109844439a45617c9f54f6d69ff16b77b5e55b39be26a193ab6d01085b80709b",
+      "source": "hook"
+    },
+    {
+      "path": ".claude/hooks/blocked-paths-bash-gate.sh",
+      "sha256": "edd1636d60f7a9a2ba4374c7088dc6b7c172cb3cad684402def0138e5e357c2b",
       "source": "hook"
     },
     {
@@ -61,7 +66,7 @@
     },
     {
       "path": ".claude/hooks/dangerous-bash-interceptor.sh",
-      "sha256": "18dad278d6bdddd0336d15347dd29c2a70edf3161cdc75e06207761c60fec8b5",
+      "sha256": "47f9c17101de93b6f3d2baac90081c04da9b3ccf3a6dd2c10518df2d5f84130f",
       "source": "hook"
     },
     {
@@ -71,7 +76,7 @@
     },
     {
       "path": ".claude/hooks/env-file-protection.sh",
-      "sha256": "52b9009b476eb9d133cf9f47c882e523f4e7091b5f3b00af0e4c4960a65f4dfe",
+      "sha256": "b311e888bf83ee4f6abc857eb886f5d392289341010ee4d4c62515adda1f7329",
       "source": "hook"
     },
     {
@@ -91,12 +96,12 @@
     },
     {
       "path": ".claude/hooks/security-disclosure-gate.sh",
-      "sha256": "3775cc14778266e862bb369a249332a8ae8a4fab511780cdca4e0531c3dce785",
+      "sha256": "767a687407dea29b4d585c8c3893dc9f8e3a9ddbcbdaa7f92c38ab1702b583a1",
       "source": "hook"
     },
     {
       "path": ".claude/hooks/settings-protection.sh",
-      "sha256": "6ab80aed951e53c945bf3610d8920249ce57ca8306160cd495bd613f7daecec6",
+      "sha256": "e5a232e591449083181cf7ccba0dcdcf39830c71aa9aac6bd6f10d5e11b3a9d8",
       "source": "hook"
     },
     {
@@ -186,7 +191,7 @@
     },
     {
       "path": ".claude/settings.json#rea:desired",
-      "sha256": "81ebb37f8d5dcaa133d7f0d744a0d73d374594e14cb8f123c866dfd286bb817f",
+      "sha256": "04939eb3652472695ab23d1fa836e27310b4b256364731a6a44564da8d254aac",
       "source": "settings"
     },
     {

--- a/.rea/install-manifest.json
+++ b/.rea/install-manifest.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.18.0",
+  "version": "0.19.0",
   "profile": "bst-internal",
   "installed_at": "2026-04-23T15:09:02.547Z",
-  "upgraded_at": "2026-05-04T01:52:07.734Z",
+  "upgraded_at": "2026-05-04T02:35:25.722Z",
   "files": [
     {
       "path": ".claude/hooks/_lib/cmd-segments.sh",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "0.9.2",
+    "@bookedsolid/rea": "^0.16.1",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.16.2",
+    "@bookedsolid/rea": "^0.16.4",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.17.0",
+    "@bookedsolid/rea": "^0.18.0",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.19.0",
+    "@bookedsolid/rea": "^0.21.0",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.16.4",
+    "@bookedsolid/rea": "^0.17.0",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.22.0",
+    "@bookedsolid/rea": "^0.23.0",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.18.0",
+    "@bookedsolid/rea": "^0.19.0",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.21.0",
+    "@bookedsolid/rea": "^0.22.0",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.10.1",
-    "@bookedsolid/rea": "^0.16.1",
+    "@bookedsolid/rea": "^0.16.2",
     "@changesets/cli": "^2.29.8",
     "@commitlint/cli": "^20.4.3",
     "@commitlint/config-conventional": "^20.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.19.0
-        version: 0.19.0
+        specifier: ^0.21.0
+        version: 0.21.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.19.0':
-    resolution: {integrity: sha512-3YoTLzGAbc9E76KSgNY8J2+ENGYLiW26XCOb4IzCGlYpFlc3wRic73BLJb2uFAiUaXR+sqH79bb1XCGd1LGaZg==}
+  '@bookedsolid/rea@0.21.0':
+    resolution: {integrity: sha512-69QYJap4+vrLQiPZjUvO0g8YcX5F7NAXntrjOPEGjeTk4mIDJkTzMlWck/C0Z60ApXAdIkHSIXL7M9k3PEXUSg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.19.0':
+  '@bookedsolid/rea@0.21.0':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.16.4
-        version: 0.16.4
+        specifier: ^0.17.0
+        version: 0.17.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.16.4':
-    resolution: {integrity: sha512-UU9AX8LZakaBQJILNAJR+aQmRcvmQPl5f0zj/H8eT2QldqH8xurswcqqXePja+X6WhVElxC/kiehjru4y2yqiA==}
+  '@bookedsolid/rea@0.17.0':
+    resolution: {integrity: sha512-6ab1nATExdvRC4P+b8K6EcXgKrXhB3mqdvXJfbee/siNKlLZGSpC104vVl5JSsqtcAFv4lsYH38uC4agsdKrEQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.16.4':
+  '@bookedsolid/rea@0.17.0':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.16.2
-        version: 0.16.2
+        specifier: ^0.16.4
+        version: 0.16.4
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.16.2':
-    resolution: {integrity: sha512-m8Bs0j1DFi65idmzWeyKK/F5bj30fT29xd0Iou4lV4sQ0Xim+fH3Yq03yoTuJZxTj29rC0W66XmVi9PNWTppOA==}
+  '@bookedsolid/rea@0.16.4':
+    resolution: {integrity: sha512-UU9AX8LZakaBQJILNAJR+aQmRcvmQPl5f0zj/H8eT2QldqH8xurswcqqXePja+X6WhVElxC/kiehjru4y2yqiA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.16.2':
+  '@bookedsolid/rea@0.16.4':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.17.0
-        version: 0.17.0
+        specifier: ^0.18.0
+        version: 0.18.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.17.0':
-    resolution: {integrity: sha512-6ab1nATExdvRC4P+b8K6EcXgKrXhB3mqdvXJfbee/siNKlLZGSpC104vVl5JSsqtcAFv4lsYH38uC4agsdKrEQ==}
+  '@bookedsolid/rea@0.18.0':
+    resolution: {integrity: sha512-CFbYDJeRkTO0B0pMaSx4ZN7K7aQeWle1yWZ34gUSXgnNltc3dzGPwueoD9LaBtTsP3lztVyaEdSvDYATBbXxaw==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.17.0':
+  '@bookedsolid/rea@0.18.0':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.16.1
-        version: 0.16.1
+        specifier: ^0.16.2
+        version: 0.16.2
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.16.1':
-    resolution: {integrity: sha512-IUFHBiGe40wIfx5HJaXWYW2Lcm+6CtuBZbg3mYGCRcV7bcfrdSbVF715DqfVumfqg7ZLa8UcJodcWp5s7M6NXA==}
+  '@bookedsolid/rea@0.16.2':
+    resolution: {integrity: sha512-m8Bs0j1DFi65idmzWeyKK/F5bj30fT29xd0Iou4lV4sQ0Xim+fH3Yq03yoTuJZxTj29rC0W66XmVi9PNWTppOA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.16.1':
+  '@bookedsolid/rea@0.16.2':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.22.0
-        version: 0.22.0
+        specifier: ^0.23.0
+        version: 0.23.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.22.0':
-    resolution: {integrity: sha512-OFpEK323Y7exTjHIaJm52tXpaOqJLk3ROsZGvqLoGcGiEm3tF+fZYD//zxXww+XjBgrngZJ+iiCc5lBXrg21GQ==}
+  '@bookedsolid/rea@0.23.0':
+    resolution: {integrity: sha512-CU5/9WOoCNFnBgjzdapKE6ar9ocTwkd5I4H1LyIboictcj+Ayj8ubo43kLsAd4aB+VsbaMDIcADzbe96VfbI/g==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -5070,6 +5070,10 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
+  mvdan-sh@0.10.1:
+    resolution: {integrity: sha512-kMbrH0EObaKmK3nVRKUIIya1dpASHIEusM13S4V1ViHFuxuNxCo+arxoa6j/dbV22YBGjl7UKJm9QQKJ2Crzhg==}
+    deprecated: See https://github.com/mvdan/sh/issues/1145
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -7052,12 +7056,13 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.22.0':
+  '@bookedsolid/rea@0.23.0':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0
       '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       commander: 14.0.3
+      mvdan-sh: 0.10.1
       proper-lockfile: 4.1.2
       safe-regex: 2.1.1
       yaml: 2.8.3
@@ -12117,6 +12122,8 @@ snapshots:
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
+
+  mvdan-sh@0.10.1: {}
 
   nanoid@3.3.11: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.18.0
-        version: 0.18.0
+        specifier: ^0.19.0
+        version: 0.19.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.18.0':
-    resolution: {integrity: sha512-CFbYDJeRkTO0B0pMaSx4ZN7K7aQeWle1yWZ34gUSXgnNltc3dzGPwueoD9LaBtTsP3lztVyaEdSvDYATBbXxaw==}
+  '@bookedsolid/rea@0.19.0':
+    resolution: {integrity: sha512-3YoTLzGAbc9E76KSgNY8J2+ENGYLiW26XCOb4IzCGlYpFlc3wRic73BLJb2uFAiUaXR+sqH79bb1XCGd1LGaZg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.18.0':
+  '@bookedsolid/rea@0.19.0':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: ^0.21.0
-        version: 0.21.0
+        specifier: ^0.22.0
+        version: 0.22.0
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.21.0':
-    resolution: {integrity: sha512-69QYJap4+vrLQiPZjUvO0g8YcX5F7NAXntrjOPEGjeTk4mIDJkTzMlWck/C0Z60ApXAdIkHSIXL7M9k3PEXUSg==}
+  '@bookedsolid/rea@0.22.0':
+    resolution: {integrity: sha512-OFpEK323Y7exTjHIaJm52tXpaOqJLk3ROsZGvqLoGcGiEm3tF+fZYD//zxXww+XjBgrngZJ+iiCc5lBXrg21GQ==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.21.0':
+  '@bookedsolid/rea@0.22.0':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^4.10.1
         version: 4.11.1(playwright-core@1.58.2)
       '@bookedsolid/rea':
-        specifier: 0.9.2
-        version: 0.9.2
+        specifier: ^0.16.1
+        version: 0.16.1
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.30.0(@types/node@24.12.0)
@@ -674,8 +674,8 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
-  '@bookedsolid/rea@0.9.2':
-    resolution: {integrity: sha512-SfXsLBYCo1OykrWjyXady/yIYFunWJ+l3bEfbELNhg69MtLMNIoeg05X2soyts9Z1UL2ZiSO6fSUxPlnB02BpQ==}
+  '@bookedsolid/rea@0.16.1':
+    resolution: {integrity: sha512-IUFHBiGe40wIfx5HJaXWYW2Lcm+6CtuBZbg3mYGCRcV7bcfrdSbVF715DqfVumfqg7ZLa8UcJodcWp5s7M6NXA==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -7052,7 +7052,7 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@bookedsolid/rea@0.9.2':
+  '@bookedsolid/rea@0.16.1':
     dependencies:
       '@anthropic-ai/sdk': 0.90.0(zod@3.25.76)
       '@clack/prompts': 1.2.0


### PR DESCRIPTION
## Summary

- closes helix-023 (8 bash-tier bypass classes from `.reports/codex/rea-bugs/023-…md` — all 8 PoCs verified refused)
- 0.23.0 collapses regex pipelines into thin shims forwarding stdin to a Node-based static AST scanner backed by `mvdan-sh@0.10.1`
- diff scope clean: 5 files only (`package.json`, `pnpm-lock.yaml`, `.rea/install-manifest.json`, the two bash-gate hook shims). manifest sha integrity verified byte-for-byte.

## Risk acceptance

3 new bypass classes deferred upstream as **helix-024** (`.reports/codex/rea-bugs/024-0.23.0-static-ast-scanner-bypass-classes.md`) — kill-switch defeat possible:

1. **CD-RELATIVE** — `cd .rea && echo > HALT` exits 0. Documented walker.js limitation: scanner does not model process-cwd.
2. **EVAL-DOUBLE-NESTED** — `eval "eval \"echo > .rea/HALT\""` exits 0. Recursion limit one level.
3. **SYMLINK-ALIAS-WRITE** — `ln -sf .rea/HALT /tmp/_x && echo > /tmp/_x` exits 0.

upstream defects, not patchable in helix. Surfaced for rea 0.24.0. Jake's call to ship anyway — net posture is 8 closed / 3 opened, parser failure fails closed, all 14 helix-022 regression cases still refuse.

## Test plan

- [x] all 8 helix-023 PoCs refuse (exit=2)
- [x] 14/14 helix-022 regression sample still refuse
- [x] 4/4 allow-path sanity still allow
- [x] manifest SHA256 byte-for-byte verified against on-disk
- [x] parser failure fails closed (`echo "unterminated > .rea/HALT` → exit=2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added modular pre-push quality gates framework with extensibility via hook directories.
  * Introduced structured AI agent specifications for accessibility, code review, frontend, and technical writing roles.

* **Chores**
  * Upgraded governance tool from 0.9.2 to 0.23.0, including enhanced security scanning, HALT enforcement, and audit logging.
  * Restructured pre-push validation workflow with improved hook composition and extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->