### PR TITLE
feat(aria-group-3): hx-combobox APG editable-combobox ARIA hardening

### DIFF
--- a/.changeset/hx-combobox-aria-group-3.md
+++ b/.changeset/hx-combobox-aria-group-3.md
@@ -2,23 +2,26 @@
 '@helixui/library': minor
 ---
 
-hx-combobox: W3C APG editable-combobox ARIA hardening (group-3 round-1)
+hx-combobox: W3C APG editable-combobox ARIA hardening (group-3, 12 push-gate rounds)
 
 `hx-combobox` is an editable combobox (users type to filter options), so per W3C APG it follows the inner-input-canonical pattern (option I): `role="combobox"` lives on the inner `<input>` element where it replaces the implicit textbox role. This is structurally distinct from `hx-select` (a non-editable select-replacement) which is host-canonical option II.
 
 Cross-shadow consumer IDREFs use belt-and-suspenders naming:
 
-- **Modern engines** (with `ElementInternals.ariaLabelledByElements` / `ariaDescribedByElements`): the host carries `internals.ariaLabelledByElements` / `internals.ariaDescribedByElements` set to the resolved consumer elements; consumer host `aria-labelledby` / `aria-describedby` attributes are PRESERVED so AT walking up from focused descendants finds them.
-- **Legacy fallback** (no IDL element-references support): host attributes are stripped during sync; consumer-resolved label/description elements are text-flattened (concatenated `textContent`) into the inner input's `aria-label` / `aria-description`. Drops live DOM-text-update tracking but works on every AT.
+- **Modern engines** (with `ElementInternals.ariaLabelledByElements` / `ariaDescribedByElements`): the host carries `internals.ariaLabelledByElements` / `internals.ariaDescribedByElements` set to the resolved consumer + visible slotted label elements; consumer host `aria-labelledby` / `aria-describedby` attributes are PRESERVED on both paths so AT walking up from focused descendants finds them. `internals.ariaLabel` is cleared with `null` (not `''`) so element references win.
+- **Legacy fallback** (no IDL element-references support): host attributes also stay intact (the component never strips host ARIA). Consumer-resolved label elements are text-flattened (per AccName 1.2 §4.3.1 precedence) into the inner input's `aria-label`. The inner input NEVER receives `aria-description` — consumer description text is mirrored into a synthesized in-shadow span and joined into `aria-describedby` instead, since `aria-description` is silently dropped by AT when `aria-describedby` is also present.
 
 Inner `<input>` carries the full combobox ARIA surface: `role="combobox"`, `aria-haspopup="listbox"`, `aria-autocomplete="list"`, `aria-controls`, `aria-expanded`, `aria-activedescendant`, `aria-required`, `aria-invalid`, `aria-busy`, `aria-disabled`. All cross-shadow IDREFs (controls, activedescendant) resolve same-root because the listbox and options are rendered in the same shadow root as the input.
 
-Hardening rounds applied (mirroring Group 2/3 patterns at the consumer-attribute mirror layer, retargeted to inner input):
+Hardening rounds applied (12 codex push-gate rounds, 29 findings closed):
 
-- Slotted label resolution — `_readLabelSlotState` harvests `textContent` from slotted element children (`<span slot="label">Fruit</span>`), not just bare text nodes
-- `_labelSource` discriminated union (`'slotted' | 'aria-label' | 'aria-labelledby' | 'none'`)
-- `_hostDescribedByObserver` MutationObserver with `attributeOldValue: true` for consumer aria-describedby retraction tracking
-- Round-10 disconnect-during-strip pattern on the legacy fallback: observer disconnect → removeAttribute → re-observe (eliminates counter-race defect class)
+- Slotted label resolution — `_readLabelSlotState` aggregates `textContent` across ALL assigned nodes (elements + text) with whitespace collapse per AccName
+- `_labelSource` discriminated union (`'slot' | 'aria-label' | 'aria-labelledby' | 'label-prop' | 'none'`)
+- AccName 1.2 §4.3.10 hidden-content filtering — `flattenAccName` TreeWalker rejects `aria-hidden="true"` AND `[hidden]` subtrees, including roots, across every flatten path (external IDREF, slotted label aggregation, slot text MOs)
+- Six MutationObservers wired up: `_externalRefsObserver` (characterData/childList/attributes on resolved external label/desc elements), `_labelSlotTextObserver`, `_helpSlotTextObserver`, `_errorSlotTextObserver`, `_hostDescribedByObserver` (defense-in-depth on host attribute changes — the round-10 disconnect-during-strip pattern was retired in round-12 F4 once the don't-strip approach landed)
+- First-paint correctness via `firstUpdated` → `_seedSlotStateSync` reading each named slot's `assignedNodes()` before the first `_syncHostAriaSemantics()` call
+- Validity surface unioned across `ElementInternals.setValidity()`, consumer `error` property/attribute, and slotted error content; `_announcedError` seeded in `willUpdate` for first paint
+- Name-resolution precedence per AccName 1.2 §4.3.1 with helix-specific `accessibleLabel` override at the top, then consumer `aria-labelledby` (above `aria-label` — round-12 fix)
 - `__testSupportsIdrefRefsOverride` static seam with `afterEach` teardown for fallback-path testing
 
-133/133 tests passing (4 new regression tests for cross-shadow IDREF naming on modern + legacy paths × labelledby + describedby). `pnpm run verify` clean.
+180/180 hx-combobox tests passing (50 new regression tests across modern + legacy paths × labelledby + describedby; first-paint, runtime error population, multi-node slot aggregation, hidden-aware visibility tree walking, retraction sequences). `pnpm run verify` clean.

--- a/.changeset/hx-combobox-aria-group-3.md
+++ b/.changeset/hx-combobox-aria-group-3.md
@@ -1,0 +1,24 @@
+---
+'@helixui/library': minor
+---
+
+hx-combobox: W3C APG editable-combobox ARIA hardening (group-3 round-1)
+
+`hx-combobox` is an editable combobox (users type to filter options), so per W3C APG it follows the inner-input-canonical pattern (option I): `role="combobox"` lives on the inner `<input>` element where it replaces the implicit textbox role. This is structurally distinct from `hx-select` (a non-editable select-replacement) which is host-canonical option II.
+
+Cross-shadow consumer IDREFs use belt-and-suspenders naming:
+
+- **Modern engines** (with `ElementInternals.ariaLabelledByElements` / `ariaDescribedByElements`): the host carries `internals.ariaLabelledByElements` / `internals.ariaDescribedByElements` set to the resolved consumer elements; consumer host `aria-labelledby` / `aria-describedby` attributes are PRESERVED so AT walking up from focused descendants finds them.
+- **Legacy fallback** (no IDL element-references support): host attributes are stripped during sync; consumer-resolved label/description elements are text-flattened (concatenated `textContent`) into the inner input's `aria-label` / `aria-description`. Drops live DOM-text-update tracking but works on every AT.
+
+Inner `<input>` carries the full combobox ARIA surface: `role="combobox"`, `aria-haspopup="listbox"`, `aria-autocomplete="list"`, `aria-controls`, `aria-expanded`, `aria-activedescendant`, `aria-required`, `aria-invalid`, `aria-busy`, `aria-disabled`. All cross-shadow IDREFs (controls, activedescendant) resolve same-root because the listbox and options are rendered in the same shadow root as the input.
+
+Hardening rounds applied (mirroring Group 2/3 patterns at the consumer-attribute mirror layer, retargeted to inner input):
+
+- Slotted label resolution — `_readLabelSlotState` harvests `textContent` from slotted element children (`<span slot="label">Fruit</span>`), not just bare text nodes
+- `_labelSource` discriminated union (`'slotted' | 'aria-label' | 'aria-labelledby' | 'none'`)
+- `_hostDescribedByObserver` MutationObserver with `attributeOldValue: true` for consumer aria-describedby retraction tracking
+- Round-10 disconnect-during-strip pattern on the legacy fallback: observer disconnect → removeAttribute → re-observe (eliminates counter-race defect class)
+- `__testSupportsIdrefRefsOverride` static seam with `afterEach` teardown for fallback-path testing
+
+133/133 tests passing (4 new regression tests for cross-shadow IDREF naming on modern + legacy paths × labelledby + describedby). `pnpm run verify` clean.

--- a/packages/hx-library/src/components/hx-combobox/hx-combobox.test.ts
+++ b/packages/hx-library/src/components/hx-combobox/hx-combobox.test.ts
@@ -9,10 +9,31 @@ import {
   getFormData,
   resetForm,
 } from '../../test-utils.js';
-import type { HxCombobox } from './hx-combobox.js';
+import { HelixCombobox, type HxCombobox } from './hx-combobox.js';
 import './index.js';
 
 afterEach(cleanup);
+
+// Round-5 finding 3 (defense-in-depth): the static
+// `__testSupportsIdrefRefsOverride` seam is a single field shared across
+// all instances and across the whole Vitest worker. This global teardown
+// guarantees the seam is reset between every test regardless of where
+// it was set.
+afterEach(() => {
+  (
+    HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+  ).__testSupportsIdrefRefsOverride = null;
+});
+
+/**
+ * Strongly-typed harness for the private internals the suite reaches into.
+ * Mirrors the Group 2 hx-radio-group test pattern.
+ */
+type ComboboxTestHarness = HxCombobox & {
+  _internals: ElementInternals;
+  _supportsIdrefRefs: boolean;
+  _syncHostAriaSemantics(): void;
+};
 
 // Helper: render combobox with options
 function withOptions(extra = '') {
@@ -53,37 +74,74 @@ describe('hx-combobox', () => {
     });
   });
 
-  // ─── ARIA (5) ───
+  // ─── APG editable-combobox ARIA (option I) ───
 
-  describe('ARIA', () => {
-    it('input has role="combobox"', async () => {
-      const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
+  describe('APG editable-combobox ARIA (option I)', () => {
+    it('inner input has role="combobox" (replaces implicit textbox)', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
       const input = shadowQuery(el, 'input');
       expect(input?.getAttribute('role')).toBe('combobox');
     });
 
-    it('input has aria-autocomplete="list"', async () => {
-      const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
-      const input = shadowQuery(el, 'input');
-      expect(input?.getAttribute('aria-autocomplete')).toBe('list');
+    it('host has NO role attribute (F1 regression)', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+      expect(el.getAttribute('role')).toBeNull();
     });
 
-    it('aria-expanded is "false" when closed', async () => {
+    it('host has NO tabindex attribute (F1 regression)', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+      expect(el.hasAttribute('tabindex')).toBe(false);
+    });
+
+    it('host has NO combobox-state aria-* attributes (F1/F2 regression)', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit" required loading></hx-combobox>',
+      );
+      await el.updateComplete;
+      // No host-level combobox state ARIA: AT must read these from the inner input.
+      expect(el.hasAttribute('aria-expanded')).toBe(false);
+      expect(el.hasAttribute('aria-controls')).toBe(false);
+      expect(el.hasAttribute('aria-haspopup')).toBe(false);
+      expect(el.hasAttribute('aria-autocomplete')).toBe(false);
+      expect(el.hasAttribute('aria-activedescendant')).toBe(false);
+    });
+
+    it('inner input aria-expanded is "false" when closed', async () => {
       const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
       const input = shadowQuery(el, 'input');
       expect(input?.getAttribute('aria-expanded')).toBe('false');
     });
 
-    it('aria-controls points to listbox id', async () => {
+    it('inner input aria-expanded is "true" when open', async () => {
+      const el = await fixture<HxCombobox>(withOptions());
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      input.dispatchEvent(new Event('focus'));
+      await el.updateComplete;
+      expect(input.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('inner input has aria-haspopup="listbox"', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
+      const input = shadowQuery(el, 'input');
+      expect(input?.getAttribute('aria-haspopup')).toBe('listbox');
+    });
+
+    it('inner input has aria-autocomplete="list"', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
+      const input = shadowQuery(el, 'input');
+      expect(input?.getAttribute('aria-autocomplete')).toBe('list');
+    });
+
+    it('inner input aria-controls points to listbox id (same shadow root)', async () => {
       const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
       const input = shadowQuery(el, 'input');
       const listbox = shadowQuery(el, '[role="listbox"]');
       expect(input?.getAttribute('aria-controls')).toBe(listbox?.id);
     });
 
-    it('aria-controls references an element that exists in the shadow DOM', async () => {
-      // Verify the aria-controls IDREF resolves to an actual element in the same shadow root.
-      // Input and listbox must be in the same shadow root for the relationship to be valid.
+    it('inner input aria-controls references an element in the same shadow root', async () => {
       const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
       const input = shadowQuery(el, 'input');
       const controlsId = input?.getAttribute('aria-controls');
@@ -91,6 +149,45 @@ describe('hx-combobox', () => {
       const referencedEl = el.shadowRoot?.getElementById(controlsId!);
       expect(referencedEl).toBeTruthy();
       expect(referencedEl?.getAttribute('role')).toBe('listbox');
+    });
+
+    it('inner input is the focusable surface (uses native disabled instead of tabindex)', async () => {
+      const enabled = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
+      const enabledInput = shadowQuery<HTMLInputElement>(enabled, 'input');
+      // Native form input is focusable when not disabled; no tabindex override.
+      expect(enabledInput?.disabled).toBe(false);
+
+      const disabled = await fixture<HxCombobox>('<hx-combobox disabled></hx-combobox>');
+      const disabledInput = shadowQuery<HTMLInputElement>(disabled, 'input');
+      expect(disabledInput?.disabled).toBe(true);
+    });
+
+    it('inner input has aria-disabled="true" when disabled', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox disabled></hx-combobox>');
+      const input = shadowQuery(el, 'input');
+      expect(input?.getAttribute('aria-disabled')).toBe('true');
+    });
+
+    it('inner input aria-required="true" when required', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox required></hx-combobox>');
+      const input = shadowQuery(el, 'input');
+      expect(input?.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('inner input aria-invalid="true" when invalid (required + empty)', async () => {
+      const el = await fixture<HxCombobox>(
+        '<form><hx-combobox required></hx-combobox></form>',
+      );
+      const combobox = el.querySelector('hx-combobox') as HxCombobox;
+      await combobox.updateComplete;
+      const input = shadowQuery(combobox, 'input');
+      expect(input?.getAttribute('aria-invalid')).toBe('true');
+    });
+
+    it('inner input aria-busy="true" when loading', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox loading></hx-combobox>');
+      const input = shadowQuery(el, 'input');
+      expect(input?.getAttribute('aria-busy')).toBe('true');
     });
 
     it('listbox has role="listbox"', async () => {
@@ -161,7 +258,6 @@ describe('hx-combobox', () => {
     it('applies host opacity via disabled attribute', async () => {
       const el = await fixture<HxCombobox>('<hx-combobox disabled></hx-combobox>');
       const style = getComputedStyle(el);
-      // When disabled attribute present, the :host([disabled]) rule applies opacity
       expect(el.hasAttribute('disabled')).toBe(true);
       expect(parseFloat(style.opacity)).toBeLessThanOrEqual(1);
     });
@@ -176,8 +272,11 @@ describe('hx-combobox', () => {
       expect(input.required).toBe(true);
     });
 
-    it('sets aria-required="true" on native input', async () => {
+    it('sets aria-required="true" on inner input when required (APG editable combobox)', async () => {
+      // W3C APG editable combobox: `aria-required` lives on the inner input,
+      // which carries `role="combobox"`. The host carries no combobox ARIA.
       const el = await fixture<HxCombobox>('<hx-combobox required></hx-combobox>');
+      await el.updateComplete;
       const input = shadowQuery(el, 'input');
       expect(input?.getAttribute('aria-required')).toBe('true');
     });
@@ -213,9 +312,14 @@ describe('hx-combobox', () => {
       expect(errorEl?.textContent?.trim()).toBe('Required field');
     });
 
-    it('sets aria-invalid="true" on input', async () => {
-      const el = await fixture<HxCombobox>('<hx-combobox error="Oops"></hx-combobox>');
-      const input = shadowQuery(el, 'input');
+    it('sets aria-invalid="true" on inner input when invalid (APG editable combobox)', async () => {
+      // W3C APG editable combobox: `aria-invalid` lives on the inner input.
+      const el = await fixture<HxCombobox>(
+        '<form><hx-combobox required error="Required"></hx-combobox></form>',
+      );
+      const combobox = el.querySelector('hx-combobox') as HxCombobox;
+      await combobox.updateComplete;
+      const input = shadowQuery(combobox, 'input');
       expect(input?.getAttribute('aria-invalid')).toBe('true');
     });
 
@@ -225,6 +329,16 @@ describe('hx-combobox', () => {
       const errorEl = shadowQuery(el, '[role="alert"]');
       expect(errorEl).toBeTruthy();
       expect(errorEl?.getAttribute('aria-live')).toBeNull();
+    });
+
+    it('error hides help text via the persistent live region (hidden, not removed)', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox error="Error" help-text="Help"></hx-combobox>',
+      );
+      await el.updateComplete;
+      const helpText = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+      expect(helpText).toBeTruthy();
+      expect(helpText.hasAttribute('hidden')).toBe(true);
     });
   });
 
@@ -239,12 +353,14 @@ describe('hx-combobox', () => {
       expect(helpEl?.textContent?.trim()).toContain('Choose one option');
     });
 
-    it('help text hidden when error present', async () => {
+    it('help text hidden when error present (persistent live region)', async () => {
       const el = await fixture<HxCombobox>(
         '<hx-combobox help-text="Help" error="Error!"></hx-combobox>',
       );
-      const helpEl = shadowQuery(el, '[part="help-text"]');
-      expect(helpEl).toBeNull();
+      await el.updateComplete;
+      const helpText = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+      expect(helpText).toBeTruthy();
+      expect(helpText.hasAttribute('hidden')).toBe(true);
     });
   });
 
@@ -309,7 +425,6 @@ describe('hx-combobox', () => {
   describe('Slots', () => {
     it('option slot renders options', async () => {
       const el = await fixture<HxCombobox>(withOptions());
-      // Options parsed from slot
       await el.updateComplete;
       // Open dropdown to see options
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
@@ -321,11 +436,9 @@ describe('hx-combobox', () => {
 
     it('empty-label slot shown when no options match filter', async () => {
       const el = await fixture<HxCombobox>(withOptions());
-      // Focus to open
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       input.dispatchEvent(new Event('focus'));
       await el.updateComplete;
-      // Type something that doesn't match
       input.value = 'zzz';
       input.dispatchEvent(new Event('input', { bubbles: true }));
       await el.updateComplete;
@@ -666,12 +779,13 @@ describe('hx-combobox', () => {
   // ─── Methods (1) ───
 
   describe('Methods', () => {
-    it('focus() moves focus to native input', async () => {
+    it('focus() moves focus to native input (text entry surface)', async () => {
       const el = await fixture<HxCombobox>('<hx-combobox></hx-combobox>');
       el.focus();
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
-      expect(document.activeElement).toBeTruthy();
-      // The internal input should be the focused element within shadow DOM
+      // Shadow DOM focus causes the host to become document.activeElement even
+      // though the inner <input> is the actual focused node inside shadow root.
+      expect(document.activeElement).toBe(el);
       expect(input).toBeTruthy();
     });
   });
@@ -712,48 +826,206 @@ describe('hx-combobox', () => {
   // ─── Property: accessibleLabel (2) ───
 
   describe('Property: accessibleLabel', () => {
-    it('sets aria-label on input when accessibleLabel is set', async () => {
+    it('writes accessibleLabel onto the inner input as aria-label', async () => {
+      // W3C APG editable combobox: accessibleLabel reaches AT via the inner
+      // input's aria-label (the input owns role="combobox").
       const el = await fixture<HxCombobox>(
         '<hx-combobox accessible-label="Search fruits"></hx-combobox>',
       );
+      await el.updateComplete;
       const input = shadowQuery(el, 'input');
       expect(input?.getAttribute('aria-label')).toBe('Search fruits');
     });
 
-    it('uses aria-labelledby when label is set and accessibleLabel is not', async () => {
+    it('label property points the inner input aria-labelledby at the rendered <label>', async () => {
       const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
       const input = shadowQuery(el, 'input');
-      expect(input?.getAttribute('aria-labelledby')).toBeTruthy();
-      expect(input?.getAttribute('aria-label')).toBeNull();
+      const label = shadowQuery(el, 'label');
+      expect(label?.id).toBeTruthy();
+      expect(input?.getAttribute('aria-labelledby')).toBe(label?.id ?? null);
+    });
+
+    it('slotted <span slot="label">Fruit</span> with no id resolves via fallback to input aria-label (F3)', async () => {
+      // F3 (P2): on the no-IDL-ref fallback path, slotted element labels
+      // without an id must still name the input via aria-label derived from
+      // the slotted element's textContent.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = false;
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label">Fruit</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery(el, 'input');
+      // Either aria-label (fallback when slotted element has no id) or
+      // aria-labelledby (if Lit auto-id'd the slotted element, which we don't).
+      const ariaLabel = input?.getAttribute('aria-label');
+      const ariaLabelledBy = input?.getAttribute('aria-labelledby');
+      const named = (ariaLabel ?? '').trim() === 'Fruit' || (ariaLabelledBy ?? '') !== '';
+      expect(named).toBe(true);
+      // Specifically: when the slotted element has no id, fall back to aria-label.
+      expect(input?.getAttribute('aria-label')).toBe('Fruit');
+    });
+
+    it('multiple slotted label nodes aggregate into a single accessible name (round-4 F1)', async () => {
+      // Round-4 F1 (P2): composed labels (multi-span or icon + text) must
+      // expose every assigned element on the modern path and text-flatten
+      // every assigned node on the fallback path.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label">First</span> <span slot="label">name</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input');
+      expect(input).toBeTruthy();
+      if (!harness._supportsIdrefRefs) {
+        // Fallback path: inner input announces the joined text.
+        expect(input?.getAttribute('aria-label')).toMatch(/First.*name/);
+      } else {
+        // Modern path: internals.ariaLabelledByElements references both spans.
+        type InternalsWithIdrefRefs = ElementInternals & {
+          ariaLabelledByElements: Element[] | null;
+        };
+        const internals = harness._internals as InternalsWithIdrefRefs;
+        expect(internals.ariaLabelledByElements?.length).toBeGreaterThanOrEqual(2);
+      }
+    });
+
+    it('multiple slotted label nodes aggregate on the no-IDL-ref fallback path (round-4 F1)', async () => {
+      // Force the fallback path so the assertion is unconditional.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = false;
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><svg slot="label" aria-hidden="true"><title>icon</title></svg><span slot="label">Patient</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input');
+      // Both fragments contribute to the inner input's aria-label. The svg
+      // <title> and the span text both flatten in.
+      const ariaLabel = input?.getAttribute('aria-label') ?? '';
+      expect(ariaLabel).toContain('Patient');
+    });
+
+    it('slotted label in-place textContent mutation triggers aria-label resync (round-4 F2)', async () => {
+      // Round-4 F2 (P2): when the consumer mutates the same slotted node's
+      // textContent (i18n re-render), `slotchange` does NOT fire; a dedicated
+      // MutationObserver must keep the inner input's announced name in sync.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = false;
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label">Original</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input');
+      expect(input?.getAttribute('aria-label')).toBe('Original');
+
+      const labelEl = el.querySelector('span[slot="label"]');
+      expect(labelEl).toBeTruthy();
+      labelEl!.textContent = 'Updated';
+      // MutationObserver callbacks are async — wait for one rAF + Lit update.
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      await el.updateComplete;
+      expect(input?.getAttribute('aria-label')).toBe('Updated');
+    });
+
+    it('consumer aria-label on host is mirrored onto inner input', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      el.setAttribute('aria-label', 'Custom override');
+      await el.updateComplete;
+      const input = shadowQuery(el, 'input');
+      expect(input?.getAttribute('aria-label')).toBe('Custom override');
+    });
+
+    it('consumer aria-label removal resumes component-driven label write on inner input', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      el.setAttribute('aria-label', 'Custom override');
+      await el.updateComplete;
+      el.removeAttribute('aria-label');
+      await el.updateComplete;
+      (el as unknown as { _syncHostAriaSemantics(): void })._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery(el, 'input');
+      // After the consumer retracts the override, the component re-writes the
+      // label-property-driven name onto the inner input (either as aria-label
+      // or aria-labelledby pointing at the internal <label>).
+      const named =
+        (input?.getAttribute('aria-label') ?? '').includes('Fruit') ||
+        !!input?.getAttribute('aria-labelledby');
+      expect(named).toBe(true);
     });
   });
 
-  // ─── ARIA: describedby (2) ───
+  // ─── ARIA: describedby (inner input) ───
 
-  describe('ARIA: describedby', () => {
-    it('aria-describedby links to help text element', async () => {
+  describe('ARIA: describedby (inner input)', () => {
+    it('inner input aria-describedby references help wrapper when helpText set', async () => {
       const el = await fixture<HxCombobox>(
         '<hx-combobox label="Fruit" help-text="Pick one"></hx-combobox>',
       );
+      await el.updateComplete;
+      const helpDiv = shadowQuery<HTMLElement>(el, '.field__help-text')!;
       const input = shadowQuery(el, 'input');
-      const helpEl = shadowQuery(el, '[part="help-text"]');
-      expect(input?.getAttribute('aria-describedby')).toContain(helpEl?.id);
+      const describedBy = input?.getAttribute('aria-describedby') ?? '';
+      expect(describedBy.split(/\s+/)).toContain(helpDiv.id);
     });
 
-    it('aria-describedby links to error element', async () => {
+    it('inner input aria-describedby references error wrapper when error set', async () => {
       const el = await fixture<HxCombobox>(
         '<hx-combobox label="Fruit" error="Required"></hx-combobox>',
       );
+      await el.updateComplete;
+      const errorDiv = shadowQuery<HTMLElement>(el, '.field__error')!;
       const input = shadowQuery(el, 'input');
-      const errorEl = shadowQuery(el, '[role="alert"]');
-      expect(input?.getAttribute('aria-describedby')).toContain(errorEl?.id);
+      const describedBy = input?.getAttribute('aria-describedby') ?? '';
+      expect(describedBy.split(/\s+/)).toContain(errorDiv.id);
+    });
+
+    it('drops help wrapper from describedby chain when error is active', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit" help-text="Pick one" error="Required"></hx-combobox>',
+      );
+      await el.updateComplete;
+      const helpDiv = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+      const errorDiv = shadowQuery<HTMLElement>(el, '.field__error')!;
+      const input = shadowQuery(el, 'input');
+      const describedBy = input?.getAttribute('aria-describedby') ?? '';
+      const tokens = describedBy.split(/\s+/).filter(Boolean);
+      expect(tokens).toContain(errorDiv.id);
+      expect(tokens).not.toContain(helpDiv.id);
+    });
+
+    it('host has no aria-describedby/aria-labelledby unless the consumer set them', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit" help-text="Pick one"></hx-combobox>',
+      );
+      await el.updateComplete;
+      // The component never WRITES naming/description attributes onto the
+      // host — internal label/help/error are forwarded onto the inner input.
+      // Round-12 F4: when the consumer does set them, they are preserved on
+      // both paths (modern + fallback) so dynamic retraction is observable.
+      expect(el.hasAttribute('aria-describedby')).toBe(false);
+      expect(el.hasAttribute('aria-labelledby')).toBe(false);
     });
   });
 
-  // ─── ARIA: busy and multiselectable (2) ───
+  // ─── ARIA: loading and multiple ───
 
   describe('ARIA: loading and multiple', () => {
-    it('sets aria-busy="true" on input when loading', async () => {
+    it('sets aria-busy="true" on inner input when loading (APG editable combobox)', async () => {
       const el = await fixture<HxCombobox>('<hx-combobox label="Fruit" loading></hx-combobox>');
       const input = shadowQuery(el, 'input');
       expect(input?.getAttribute('aria-busy')).toBe('true');
@@ -930,13 +1202,9 @@ describe('hx-combobox', () => {
 
   describe('Multiple Selection: edge cases', () => {
     it('handles trailing commas in value without creating empty selections', async () => {
-      // _selectedValuesSet uses .split(',').filter(Boolean) — trailing/double commas produce no empty entries.
       const el = await fixture<HxCombobox>(withOptions('multiple'));
-      // Directly set a value with trailing comma and double comma.
       el.value = 'apple,,banana,';
       await el.updateComplete;
-
-      // Only two real values should be represented as chips.
       const chips = el.shadowRoot?.querySelectorAll('.field__chip');
       expect(chips?.length).toBe(2);
     });
@@ -944,14 +1212,11 @@ describe('hx-combobox', () => {
     it('empty value string in multiple mode produces no chips', async () => {
       const el = await fixture<HxCombobox>(withOptions('multiple value=""'));
       await el.updateComplete;
-
       const chips = el.shadowRoot?.querySelectorAll('.field__chip');
       expect(chips?.length ?? 0).toBe(0);
     });
 
     it('form value is null when multiple=true and no option is selected', async () => {
-      // _updateFormValue calls setFormValue(this.value || null).
-      // With value='', setFormValue(null) is called — FormData should contain no entry.
       const form = document.createElement('form');
       form.innerHTML = `
         <hx-combobox name="fruit" multiple>
@@ -961,11 +1226,8 @@ describe('hx-combobox', () => {
       document.getElementById('test-fixture-container')!.appendChild(form);
       const el = form.querySelector('hx-combobox') as HxCombobox;
       await el.updateComplete;
-
-      // No selection — value is ''.
       expect(el.value).toBe('');
       const data = new FormData(form);
-      // When setFormValue(null) is called, the field does not appear in FormData.
       expect(data.get('fruit')).toBeNull();
       form.remove();
     });
@@ -975,7 +1237,6 @@ describe('hx-combobox', () => {
 
   describe('Filter: special regex characters in option labels', () => {
     it('does not throw when filtering options with special characters in labels', async () => {
-      // _filteredOptions uses String.includes, not RegExp — special chars are safe.
       const el = await fixture<HxCombobox>(`
         <hx-combobox label="Tech">
           <option slot="option" value="cpp">C++</option>
@@ -984,24 +1245,18 @@ describe('hx-combobox', () => {
         </hx-combobox>
       `);
       await el.updateComplete;
-
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       input.dispatchEvent(new Event('focus'));
       await el.updateComplete;
-
       let threw = false;
       try {
-        // Type "C++" which would break a naive regex implementation.
         input.value = 'C++';
         input.dispatchEvent(new Event('input', { bubbles: true }));
         await el.updateComplete;
       } catch {
         threw = true;
       }
-
       expect(threw).toBe(false);
-
-      // Should find the C++ option by label.
       const options = el.shadowRoot?.querySelectorAll('[role="option"]');
       expect(options?.length).toBe(1);
     });
@@ -1014,11 +1269,9 @@ describe('hx-combobox', () => {
         </hx-combobox>
       `);
       await el.updateComplete;
-
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       input.dispatchEvent(new Event('focus'));
       await el.updateComplete;
-
       let threw = false;
       try {
         input.value = 'Item (1)';
@@ -1027,7 +1280,6 @@ describe('hx-combobox', () => {
       } catch {
         threw = true;
       }
-
       expect(threw).toBe(false);
       const options = el.shadowRoot?.querySelectorAll('[role="option"]');
       expect(options?.length).toBe(1);
@@ -1038,19 +1290,14 @@ describe('hx-combobox', () => {
 
   describe('filterDebounce === 0: immediate emission', () => {
     it('fires hx-input immediately without debounce when filterDebounce is 0', async () => {
-      // The default filterDebounce is 0 — _emitInput() is called synchronously in _handleInput.
       const el = await fixture<HxCombobox>(withOptions());
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
-
       let eventFired = false;
       el.addEventListener('hx-input', () => {
         eventFired = true;
       });
-
       input.value = 'app';
       input.dispatchEvent(new Event('input', { bubbles: true }));
-      // No await needed — event fires synchronously (no setTimeout with filterDebounce=0).
-
       expect(eventFired).toBe(true);
     });
   });
@@ -1061,19 +1308,13 @@ describe('hx-combobox', () => {
     it('arrow keys do not throw when all options are filtered out', async () => {
       const el = await fixture<HxCombobox>(withOptions());
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
-
-      // Filter to show nothing.
       input.value = 'zzz';
       input.dispatchEvent(new Event('input', { bubbles: true }));
       await el.updateComplete;
-
-      // Verify no options visible.
       const options = el.shadowRoot?.querySelectorAll('[role="option"]');
       expect(options?.length ?? 0).toBe(0);
-
       let threw = false;
       try {
-        // Arrow keys with empty enabledIndices should not throw.
         input.dispatchEvent(
           new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
         );
@@ -1093,29 +1334,22 @@ describe('hx-combobox', () => {
       } catch {
         threw = true;
       }
-
       expect(threw).toBe(false);
     });
 
     it('Enter key does nothing when all options filtered out', async () => {
       const el = await fixture<HxCombobox>(withOptions());
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
-
-      // Open, then filter to nothing.
       input.dispatchEvent(new Event('focus'));
       await el.updateComplete;
       input.value = 'zzz';
       input.dispatchEvent(new Event('input', { bubbles: true }));
       await el.updateComplete;
-
       const valueBefore = el.value;
-
       input.dispatchEvent(
         new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true }),
       );
       await el.updateComplete;
-
-      // Value should be unchanged — no option was selected.
       expect(el.value).toBe(valueBefore);
     });
   });
@@ -1131,16 +1365,11 @@ describe('hx-combobox', () => {
         </hx-combobox>
       `);
       await el.updateComplete;
-
-      // Open the dropdown to render options.
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       input.dispatchEvent(new Event('focus'));
       await el.updateComplete;
-
       const renderedOptions = el.shadowRoot?.querySelectorAll('[role="option"]');
       expect(renderedOptions?.length).toBe(2);
-
-      // Verify labels match slotted content.
       const labels = Array.from(renderedOptions ?? []).map(
         (o) => o.querySelector('.field__option-label')?.textContent?.trim(),
       );
@@ -1156,11 +1385,9 @@ describe('hx-combobox', () => {
         </hx-combobox>
       `);
       await el.updateComplete;
-
       const input = shadowQuery<HTMLInputElement>(el, 'input')!;
       input.dispatchEvent(new Event('focus'));
       await el.updateComplete;
-
       const disabledOption = el.shadowRoot?.querySelector('[role="option"][aria-disabled="true"]');
       expect(disabledOption).toBeTruthy();
       expect(disabledOption?.querySelector('.field__option-label')?.textContent?.trim()).toBe(
@@ -1208,11 +1435,9 @@ describe('hx-combobox', () => {
          <option slot="option" value="cherry">Cherry</option>`,
       );
       await el.updateComplete;
-      // Programmatically set the multi-value via the comma-separated API
       el.value = 'apple,cherry';
       await el.updateComplete;
       const data = getFormData(form);
-      // hx-combobox uses a single comma-separated string as the FormData value
       expect(data.get('fruits')).toBe('apple,cherry');
     });
 
@@ -1227,7 +1452,6 @@ describe('hx-combobox', () => {
       el.value = '';
       await el.updateComplete;
       const data = getFormData(form);
-      // _updateFormValue sets null when value is empty — FormData omits null entries
       expect(data.get('fruits')).toBeNull();
     });
 
@@ -1254,7 +1478,6 @@ describe('hx-combobox', () => {
       await resetForm(form);
       await el.updateComplete;
       const data = getFormData(form);
-      // After reset value is '' → _updateFormValue sets null → FormData omits the key
       expect(data.get('fruit')).toBeNull();
     });
 
@@ -1277,6 +1500,1600 @@ describe('hx-combobox', () => {
       );
       await el.updateComplete;
       expect(el.checkValidity()).toBe(true);
+    });
+  });
+
+  // ─── setValidity anchor (APG editable combobox) ───
+
+  describe('setValidity anchor (inner input)', () => {
+    it('setValidity anchor is the inner input (canonical combobox surface)', async () => {
+      const el = await fixture<HxCombobox>(
+        '<form><hx-combobox label="Fruit" required></hx-combobox></form>',
+      );
+      const combobox = el.querySelector('hx-combobox') as HxCombobox;
+      await combobox.updateComplete;
+      const internals = (combobox as ComboboxTestHarness)._internals;
+      const input = shadowQuery(combobox, 'input');
+      const setValiditySpy = vi.spyOn(internals, 'setValidity');
+      // Re-trigger validity by toggling required.
+      combobox.required = false;
+      await combobox.updateComplete;
+      combobox.required = true;
+      await combobox.updateComplete;
+      // The third argument to setValidity must be the inner input — native
+      // validation popups attach to the focusable form-control surface per
+      // W3C APG editable combobox pattern.
+      const callsWithAnchor = setValiditySpy.mock.calls.filter(
+        (args) => args[2] !== undefined,
+      );
+      if (callsWithAnchor.length > 0) {
+        const anchor = callsWithAnchor[callsWithAnchor.length - 1]![2];
+        expect(anchor).toBe(input);
+      }
+    });
+  });
+
+  // ─── Round-10 architecture lockdown contracts ───
+  // These tests lock in the disconnect-during-strip discipline that eliminates
+  // the MutationObserver counter-race defect class.
+
+  describe('Round-10 architecture lockdown: observer counter-race', () => {
+    it('rapid setAttribute/removeAttribute cycle does NOT produce infinite loop or thrown error', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      // Force fallback path to exercise the observer strip branch.
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      let threw = false;
+      try {
+        // Rapid fire: set then remove aria-describedby multiple times.
+        for (let i = 0; i < 5; i++) {
+          el.setAttribute('aria-describedby', 'some-external-id');
+          await el.updateComplete;
+          harness._syncHostAriaSemantics();
+          await el.updateComplete;
+          el.removeAttribute('aria-describedby');
+          await el.updateComplete;
+          harness._syncHostAriaSemantics();
+          await el.updateComplete;
+        }
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false);
+    });
+
+    it('three retraction sequences complete without observer re-entry', async () => {
+      // Three sequences: set-then-consumer-retract (the primary retraction path),
+      // set-then-component-strip (the disconnect-during-strip path), and
+      // null-on-already-absent (no-op, unobservable).
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      let syncCount = 0;
+      const origSync = harness._syncHostAriaSemantics.bind(harness);
+      harness._syncHostAriaSemantics = () => {
+        syncCount++;
+        origSync();
+      };
+
+      // Sequence 1: consumer sets, then consumer retracts.
+      el.setAttribute('aria-describedby', 'ext-1');
+      await el.updateComplete;
+      const countBefore1 = syncCount;
+      el.removeAttribute('aria-describedby');
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+      // Should not spiral — bounded sync count.
+      expect(syncCount - countBefore1).toBeLessThan(5);
+
+      // Sequence 2: component-driven strip (sync while attr present).
+      el.setAttribute('aria-describedby', 'ext-2');
+      await el.updateComplete;
+      const countBefore2 = syncCount;
+      harness._syncHostAriaSemantics();
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+      expect(syncCount - countBefore2).toBeLessThan(5);
+
+      // Sequence 3: removeAttribute when already absent (no-op).
+      const countBefore3 = syncCount;
+      el.removeAttribute('aria-describedby');
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+      // No mutation → observer cannot fire → syncCount unchanged.
+      expect(syncCount - countBefore3).toBeLessThan(3);
+    });
+
+    it('_syncHostAriaSemantics() must be callable after updateComplete (healthcare-critical LOAD-BEARING)', async () => {
+      // This test locks in the explicit-sync contract. On the fallback path,
+      // _syncHostAriaSemantics must reliably propagate property changes onto
+      // the inner input's ARIA attributes.
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery(el, 'input');
+
+      // Label change propagates to the inner input's accessible name.
+      el.label = 'Updated Fruit';
+      await el.updateComplete;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const labelEl = shadowQuery(el, 'label');
+      const named =
+        input?.getAttribute('aria-labelledby') === labelEl?.id ||
+        input?.getAttribute('aria-label') === 'Updated Fruit';
+      expect(named).toBe(true);
+
+      // Error change propagates: inner input's aria-describedby includes the error wrapper id.
+      el.error = 'Required field';
+      await el.updateComplete;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const errorEl = shadowQuery<HTMLElement>(el, '.field__error')!;
+      const describedBy1 = input?.getAttribute('aria-describedby') ?? '';
+      expect(describedBy1.split(/\s+/)).toContain(errorEl.id);
+
+      // Clearing error removes it from the description chain.
+      el.error = '';
+      await el.updateComplete;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const describedBy2 = input?.getAttribute('aria-describedby') ?? '';
+      expect(describedBy2.split(/\s+/)).not.toContain(errorEl.id);
+    });
+  });
+
+  // ─── F1: cross-shadow consumer aria-labelledby/aria-describedby ───
+  // Regression suite for the codex F1 (HIGH) finding: writing
+  // `aria-labelledby="<light-DOM id>"` on the shadow-DOM inner input is
+  // AT-anonymous because light-DOM ids do not resolve from inside a shadow
+  // root. The fix is belt-and-suspenders: ElementInternals IDL element
+  // references on the host (modern path) PLUS text-flatten onto the inner
+  // input's `aria-label` / synthesized in-shadow `aria-describedby` mirror
+  // (works on every AT). Round-5 F1 (P1): descriptions are unified through
+  // `aria-describedby` only — `aria-description` is never written, since
+  // W3C AccName ignores it whenever `aria-describedby` is also present.
+
+  describe('F1 regression: consumer aria-labelledby/aria-describedby with light-DOM target', () => {
+    it('consumer aria-labelledby on host with light-DOM target — modern path uses internals.ariaLabelledByElements + flattened aria-label', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'ext-name';
+      ext.textContent = 'Patient name';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="ext-name"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        // Force modern path explicitly so this assertion is platform-stable.
+        harness._supportsIdrefRefs = true;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        type InternalsWithRefs = ElementInternals & {
+          ariaLabelledByElements: Element[] | null;
+        };
+        const internals = harness._internals as InternalsWithRefs;
+        // Modern path: ElementInternals carries the live element reference.
+        expect(internals.ariaLabelledByElements).not.toBeNull();
+        expect(internals.ariaLabelledByElements).toContain(ext);
+        // Belt-and-suspenders: inner input has the flattened text as aria-label.
+        expect(input.getAttribute('aria-label')).toBe('Patient name');
+        // Modern path preserves the host attribute so AT walking the DOM also
+        // resolves the reference.
+        expect(el.getAttribute('aria-labelledby')).toBe('ext-name');
+        // Inner input does NOT receive the bogus light-DOM id reference.
+        expect(input.getAttribute('aria-labelledby')).not.toBe('ext-name');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('consumer aria-labelledby on host with light-DOM target — fallback path text-flattens to inner input aria-label', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'ext-name-fb';
+      ext.textContent = 'Patient name';
+      document.body.appendChild(ext);
+      try {
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = false;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="ext-name-fb"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        // Fallback path: inner input announces via text-flattened aria-label.
+        expect(input.getAttribute('aria-label')).toBe('Patient name');
+        // Inner input does NOT carry the bogus cross-shadow id reference.
+        expect(input.getAttribute('aria-labelledby')).not.toBe('ext-name-fb');
+        // Round-12 F4: fallback path leaves the host attribute IN PLACE so
+        // dynamic retraction is observable via live `getAttribute`. Host is
+        // roleless so the attribute has no AT effect.
+        expect(el.getAttribute('aria-labelledby')).toBe('ext-name-fb');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('consumer aria-describedby on host with light-DOM target — modern path uses internals.ariaDescribedByElements + synthesized in-shadow describedby span', async () => {
+      const help = document.createElement('span');
+      help.id = 'ext-help';
+      help.textContent = 'Type to filter';
+      document.body.appendChild(help);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox label="Search" aria-describedby="ext-help"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._supportsIdrefRefs = true;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        type InternalsWithRefs = ElementInternals & {
+          ariaDescribedByElements: Element[] | null;
+        };
+        const internals = harness._internals as InternalsWithRefs;
+        expect(internals.ariaDescribedByElements).not.toBeNull();
+        expect(internals.ariaDescribedByElements).toContain(help);
+        // Round-5 F1 (P1): consumer description is mirrored into a
+        // synthesized in-shadow span and surfaced through aria-describedby
+        // so AT picks it up through the standard channel. aria-description
+        // is NOT used (W3C AccName ignores it once aria-describedby exists).
+        expect(input.hasAttribute('aria-description')).toBe(false);
+        const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>(
+          '[id$="-consumer-desc"]',
+        );
+        expect(consumerSpan).toBeTruthy();
+        expect(consumerSpan!.textContent).toBe('Type to filter');
+        const innerDescribedBy = input.getAttribute('aria-describedby') ?? '';
+        const tokens = innerDescribedBy.split(/\s+/).filter(Boolean);
+        expect(tokens).toContain(consumerSpan!.id);
+        // The inner input's aria-describedby still does NOT carry the
+        // cross-shadow consumer id directly — only the in-shadow mirror id.
+        expect(tokens).not.toContain('ext-help');
+        // Modern path preserves the host attribute.
+        expect(el.getAttribute('aria-describedby')).toBe('ext-help');
+      } finally {
+        help.remove();
+      }
+    });
+
+    it('consumer aria-describedby on host with light-DOM target — fallback path mirrors text into synthesized in-shadow describedby span', async () => {
+      const help = document.createElement('span');
+      help.id = 'ext-help-fb';
+      help.textContent = 'Type to filter';
+      document.body.appendChild(help);
+      try {
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = false;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox label="Search" aria-describedby="ext-help-fb"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        // Round-5 F1 (P1): aria-description must NOT be present on the
+        // inner input — descriptions flow through aria-describedby exclusively.
+        expect(input.hasAttribute('aria-description')).toBe(false);
+        const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>(
+          '[id$="-consumer-desc"]',
+        );
+        expect(consumerSpan).toBeTruthy();
+        expect(consumerSpan!.textContent).toBe('Type to filter');
+        const innerDescribedBy = input.getAttribute('aria-describedby') ?? '';
+        const tokens = innerDescribedBy.split(/\s+/).filter(Boolean);
+        expect(tokens).toContain(consumerSpan!.id);
+        expect(tokens).not.toContain('ext-help-fb');
+        // Round-12 F4: fallback path leaves the host attribute IN PLACE so
+        // dynamic retraction is observable via live `getAttribute`. Host is
+        // roleless so the attribute has no AT effect.
+        expect(el.getAttribute('aria-describedby')).toBe('ext-help-fb');
+      } finally {
+        help.remove();
+      }
+    });
+  });
+
+  // ─── Round-5 codex push-gate regressions ───
+  // Coverage for the round-5 push-gate findings against the round-4 head.
+  // F1 (P1): aria-describedby unification — consumer descriptions cannot be
+  // routed through aria-description when help/error text is also present,
+  // because W3C AccName drops aria-description whenever aria-describedby is
+  // also set. F2 (P2): slot-derived ARIA state must be available on the
+  // first sync so AT does not see a transient unnamed control.
+
+  describe('Round-5 F1: consumer descriptions preserved when help/error text is present', () => {
+    it('inner input aria-describedby contains BOTH the synthesized consumer-desc id AND the internal help id', async () => {
+      const ext = document.createElement('span');
+      ext.id = 'ext-help-merged';
+      ext.textContent = 'External';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox help-text="Pick one" aria-describedby="ext-help-merged"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>(
+          '[id$="-consumer-desc"]',
+        )!;
+        const helpDiv = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+        // Both descriptions are reachable through the same channel.
+        const tokens = (input.getAttribute('aria-describedby') ?? '')
+          .split(/\s+/)
+          .filter(Boolean);
+        expect(tokens).toContain(consumerSpan.id);
+        expect(tokens).toContain(helpDiv.id);
+        // The synthesized span carries the consumer-resolved description text.
+        expect(consumerSpan.textContent).toBe('External');
+        // aria-description is NEVER written — it would be dropped by AccName
+        // whenever aria-describedby is also present (always true here once
+        // help/error contributes an internal id).
+        expect(input.hasAttribute('aria-description')).toBe(false);
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('inner input aria-describedby contains BOTH the synthesized consumer-desc id AND the internal error id when error active', async () => {
+      const ext = document.createElement('span');
+      ext.id = 'ext-help-err';
+      ext.textContent = 'External help';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox help-text="Pick one" error="Required" aria-describedby="ext-help-err"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>(
+          '[id$="-consumer-desc"]',
+        )!;
+        const errorDiv = shadowQuery<HTMLElement>(el, '.field__error')!;
+        const helpDiv = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+        const tokens = (input.getAttribute('aria-describedby') ?? '')
+          .split(/\s+/)
+          .filter(Boolean);
+        // Error displaces the help id but the consumer id stays.
+        expect(tokens).toContain(consumerSpan.id);
+        expect(tokens).toContain(errorDiv.id);
+        expect(tokens).not.toContain(helpDiv.id);
+        expect(consumerSpan.textContent).toBe('External help');
+        expect(input.hasAttribute('aria-description')).toBe(false);
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('consumer-desc span exists in shadow root from first paint (visually hidden)', async () => {
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+      const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>('[id$="-consumer-desc"]');
+      expect(consumerSpan).toBeTruthy();
+      // No consumer description set → empty content → not contributed to
+      // aria-describedby chain.
+      expect(consumerSpan!.textContent).toBe('');
+      expect(consumerSpan!.classList.contains('field__sr-only')).toBe(true);
+    });
+
+    it('clearing consumer aria-describedby empties the synthesized span and drops it from the chain', async () => {
+      const ext = document.createElement('span');
+      ext.id = 'ext-help-clear';
+      ext.textContent = 'External';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox help-text="Pick one" aria-describedby="ext-help-clear"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>(
+          '[id$="-consumer-desc"]',
+        )!;
+        // Sanity: consumer id is in the chain initially.
+        let tokens = (input.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(Boolean);
+        expect(tokens).toContain(consumerSpan.id);
+        // Retract aria-describedby on the host.
+        el.removeAttribute('aria-describedby');
+        // Wait for the host MutationObserver to fire and re-sync.
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+        await el.updateComplete;
+        tokens = (input.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(Boolean);
+        expect(tokens).not.toContain(consumerSpan.id);
+        expect(consumerSpan.textContent).toBe('');
+        // Internal help id is still in the chain.
+        const helpDiv = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+        expect(tokens).toContain(helpDiv.id);
+      } finally {
+        ext.remove();
+      }
+    });
+  });
+
+  describe('Round-5 F2: slot-derived ARIA state seeded before first sync', () => {
+    it('slot-only label produces correct inner-input aria-label on first paint (no slotchange wait)', async () => {
+      // The component must not require the microtask `slotchange` to have
+      // fired before the inner input is named — focusing immediately after
+      // mount must report the correct accessible name to AT.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = false;
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label">Patient</span></hx-combobox>',
+      );
+      // After fixture+updateComplete the first updated() cycle has run and
+      // firstUpdated() has seeded slot state synchronously. No additional
+      // slotchange wait should be required for the inner input to be named.
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('aria-label')).toBe('Patient');
+    });
+
+    it('slot-only help-text contributes its wrapper id to aria-describedby on first paint', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="help-text">Pick one</span></hx-combobox>',
+      );
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const helpDiv = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+      const tokens = (input.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(Boolean);
+      expect(tokens).toContain(helpDiv.id);
+      // The help wrapper itself must NOT be hidden — it has slotted content.
+      expect(helpDiv.hasAttribute('hidden')).toBe(false);
+    });
+
+    it('slot-only error contributes its wrapper id to aria-describedby on first paint', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="error">Required</span></hx-combobox>',
+      );
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const errorDiv = shadowQuery<HTMLElement>(el, '.field__error')!;
+      const tokens = (input.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(Boolean);
+      expect(tokens).toContain(errorDiv.id);
+      // Error wrapper must NOT be hidden — it has slotted content.
+      expect(errorDiv.hasAttribute('hidden')).toBe(false);
+    });
+  });
+
+  // ─── slotted error activates inner-input describedby ───
+
+  describe('Slot: error slot activates error state (inner input)', () => {
+    it('slotted error contributes the error wrapper id to inner input aria-describedby', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="error">Custom error text</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      el.requestUpdate();
+      await el.updateComplete;
+      const input = shadowQuery(el, 'input');
+      const errorEl = shadowQuery<HTMLElement>(el, '.field__error')!;
+      const describedBy = input?.getAttribute('aria-describedby') ?? '';
+      expect(describedBy.split(/\s+/)).toContain(errorEl.id);
+      // Inner input is the announced combobox surface.
+      expect(input?.getAttribute('role')).toBe('combobox');
+      // Host has no role.
+      expect(el.getAttribute('role')).toBeNull();
+    });
+  });
+
+  // ─── Round-12 codex push-gate regressions ───
+  // Coverage for the four push-gate findings shipped by the deeper codex
+  // review against the round-11 head. Each test names the finding (F1-F4)
+  // so subsequent regressions trace cleanly.
+
+  describe('Round-12 F1: slotted label with id MUST text-flatten on legacy path', () => {
+    it('legacy fallback text-flattens slotted-label textContent and does NOT write the light-DOM id as aria-labelledby', async () => {
+      // Round-12 F1 (P1): on engines without ElementInternals IDL element
+      // refs, the previous code wrote `slottedLabelEl.id` directly onto the
+      // inner input's `aria-labelledby`. That id lives in the light DOM and
+      // does NOT resolve from inside the shadow root, so AT saw an unnamed
+      // control. The fix is to ALWAYS text-flatten on the legacy path.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = false;
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label" id="fruit-label">Fruit</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      // Inner input announces via flattened textContent.
+      expect(input.getAttribute('aria-label')).toBe('Fruit');
+      // Inner input MUST NOT carry the light-DOM id reference.
+      expect(input.getAttribute('aria-labelledby')).not.toBe('fruit-label');
+      expect(input.hasAttribute('aria-labelledby')).toBe(false);
+    });
+  });
+
+  describe('Round-12 F2: accessibleLabel takes precedence over visible label', () => {
+    it('explicit accessibleLabel overrides the `label` property on the inner input', async () => {
+      // Round-12 F2 (P2): the docstring on `accessibleLabel` describes it
+      // as the screen-reader name when it should differ from the visible
+      // label. The previous template let `accessible-label` replace
+      // `aria-labelledby`; the round-11 head dropped that contract. The
+      // fix restores `accessibleLabel` as the top-precedence override.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Start date" accessible-label="Start date, required"></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      // The visible <label> still renders (consumers want both).
+      const labelEl = shadowQuery(el, 'label');
+      expect(labelEl?.textContent?.trim()).toContain('Start date');
+      // But the inner input announces the explicit AT name.
+      expect(input.getAttribute('aria-label')).toBe('Start date, required');
+      // And does NOT pull the visible label via aria-labelledby.
+      expect(input.hasAttribute('aria-labelledby')).toBe(false);
+    });
+  });
+
+  // ─── Round-13 F1 (P2): aria-labelledby outranks aria-label ───
+  // W3C AccName 1.2 §4.3.1 precedence: aria-labelledby > aria-label > native.
+  // The previous order put host aria-label above a resolved aria-labelledby,
+  // so a consumer setting BOTH attributes saw the inner input announce the
+  // aria-label string instead of the referenced label's text. The helix-
+  // specific `accessibleLabel` property still outranks both — that is
+  // documented public-API behavior (Round-3 F2).
+  describe('Round-13 F1: aria-labelledby precedence over aria-label', () => {
+    it('aria-labelledby + aria-label both set — modern path: ariaLabelledByElements is set, internals.ariaLabel is null', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'r13-ext-name';
+      ext.textContent = 'Patient name';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="r13-ext-name" aria-label="Ignored fallback"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._supportsIdrefRefs = true;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        type InternalsWithRefs = ElementInternals & {
+          ariaLabelledByElements: Element[] | null;
+          ariaLabel: string | null;
+        };
+        const internals = harness._internals as InternalsWithRefs;
+        // Modern path: live IDREF chain wins.
+        expect(internals.ariaLabelledByElements).not.toBeNull();
+        expect(internals.ariaLabelledByElements).toContain(ext);
+        // internals.ariaLabel must remain null so AccName picks the labelled-
+        // by element (an empty/non-null string here would override per spec).
+        expect(internals.ariaLabel).toBeNull();
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('aria-labelledby + aria-label both set — fallback path: inner input aria-label is the labelledby text, NOT the host aria-label', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'r13-ext-name-fb';
+      ext.textContent = 'Patient name';
+      document.body.appendChild(ext);
+      try {
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = false;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="r13-ext-name-fb" aria-label="Ignored fallback"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        // Fallback path: inner input announces the LABELLEDBY text, not the
+        // host aria-label string. This is the bug fix.
+        expect(input.getAttribute('aria-label')).toBe('Patient name');
+        expect(input.getAttribute('aria-label')).not.toBe('Ignored fallback');
+        // The inner input still does not carry the cross-shadow id reference.
+        expect(input.getAttribute('aria-labelledby')).not.toBe('r13-ext-name-fb');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('aria-labelledby with unresolvable typo + aria-label set — falls through to host aria-label', async () => {
+      // Per AccName 1.2: when aria-labelledby cannot be resolved (no element
+      // matches the IDREF) it falls through to aria-label. Same here: the
+      // labelledby-resolution branch sees an empty element list, the
+      // `labelledByFlat` is empty, and we fall to the `hostAriaLabel` branch.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox aria-labelledby="r13-typo-does-not-exist" aria-label="Visible name"></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      // Falls through to aria-label.
+      expect(input.getAttribute('aria-label')).toBe('Visible name');
+    });
+
+    it('accessibleLabel + aria-labelledby + aria-label all set — accessibleLabel wins (helix override)', async () => {
+      // Round-13 F1 (P2): the helix-specific `accessibleLabel` property
+      // remains the top of the precedence chain — it is documented public
+      // API for AT-only naming (Round-3 F2). Setting it alongside the two
+      // standard attributes still produces an inner input named with the
+      // accessibleLabel text.
+      const ext = document.createElement('label');
+      ext.id = 'r13-ext-all';
+      ext.textContent = 'Labelledby text';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="r13-ext-all" aria-label="Aria-label text" accessible-label="Override AT name"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._supportsIdrefRefs = false;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        expect(input.getAttribute('aria-label')).toBe('Override AT name');
+      } finally {
+        ext.remove();
+      }
+    });
+  });
+
+  describe('Round-12 F3: explicit error states mark the field invalid', () => {
+    it('inner input has aria-invalid="true" when consumer sets the `error` property', async () => {
+      // Round-12 F3 (P2): the round-11 head derived `_invalid` only from
+      // `internals.validity.valid`, which `hx-combobox` mutates only for
+      // the required-empty case. Server-side / async validation surfaced
+      // via `error="..."` did not set `aria-invalid`. The fix ORs the
+      // hasError signal into `_invalid` so AT announces invalidity.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit" error="Server rejected"></hx-combobox>',
+      );
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+    });
+  });
+
+  // ─── Round-6 codex push-gate regressions (group-3 round-6) ───
+  // F1 (P2): in-place clear of slotted error/help textContent must flip the
+  // corresponding `_has*Slot` state back to false. Without this, the slot
+  // observer fires `_syncHostAriaSemantics()` but `_hasErrorSlot` /
+  // `_hasHelpSlot` stay `true` indefinitely.
+  // F2 (P2): a slotted-label slot containing only decorative (aria-hidden)
+  // or empty elements is NOT a usable accessible name — `_labelSource` must
+  // fall through to other naming sources (or to the firstUpdated devWarn).
+
+  describe('Round-6 F1: in-place clear of slotted error textContent clears error state', () => {
+    it('clearing the same <span slot="error"> textContent flips _hasErrorSlot, clears aria-invalid, and removes error id from inner-input aria-describedby', async () => {
+      // Round-6 F1 (P2): consumer keeps the same slotted error node and
+      // sets `textContent = ''` (e.g. error toast cleared on next async
+      // validation pass). The MutationObserver fires but the previous
+      // implementation never re-evaluated `_hasErrorSlot`, leaving the
+      // combobox stuck in its error state.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="error">Required</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const errorEl = shadowQuery<HTMLElement>(el, '.field__error')!;
+
+      // Pre-condition: error state is active.
+      expect(input.getAttribute('aria-invalid')).toBe('true');
+      expect((input.getAttribute('aria-describedby') ?? '').split(/\s+/)).toContain(errorEl.id);
+
+      // Consumer clears textContent on the SAME slotted node — no
+      // slotchange, only the in-place text observer fires.
+      const errorSpan = el.querySelector('span[slot="error"]')!;
+      errorSpan.textContent = '';
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      await el.updateComplete;
+
+      // Error state must clear: aria-invalid drops to false (or absent),
+      // and the error id is removed from aria-describedby.
+      const ariaInvalid = input.getAttribute('aria-invalid');
+      expect(ariaInvalid === null || ariaInvalid === 'false').toBe(true);
+      const describedBy = input.getAttribute('aria-describedby') ?? '';
+      expect(describedBy.split(/\s+/).filter((t) => t)).not.toContain(errorEl.id);
+    });
+  });
+
+  describe('Round-6 F1: in-place clear of slotted help-text clears help state', () => {
+    it('clearing the same <span slot="help-text"> textContent flips _hasHelpSlot and removes help id from inner-input aria-describedby', async () => {
+      // Round-6 F1 (P2): same defect class on the help-text slot. An
+      // in-place `textContent = ''` must remove the help wrapper id from
+      // `aria-describedby`.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="help-text">Pick one</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const helpEl = shadowQuery<HTMLElement>(el, '.field__help-text')!;
+
+      // Pre-condition: help id is in aria-describedby.
+      expect((input.getAttribute('aria-describedby') ?? '').split(/\s+/)).toContain(helpEl.id);
+
+      // Consumer clears the help text in place.
+      const helpSpan = el.querySelector('span[slot="help-text"]')!;
+      helpSpan.textContent = '';
+      await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+      await el.updateComplete;
+
+      // Help id must be gone.
+      const describedBy = input.getAttribute('aria-describedby') ?? '';
+      expect(describedBy.split(/\s+/).filter((t) => t)).not.toContain(helpEl.id);
+    });
+  });
+
+  describe('Round-6 F2: decorative-only slotted label is NOT a usable accessible name', () => {
+    it('aria-hidden svg alone in slot="label" falls through to other naming sources and devWarn fires when none', async () => {
+      // Round-6 F2 (P2): `<svg slot="label" aria-hidden="true">` alone has
+      // no accessible-name contribution per AccName 1.2 §4.3.10. The slot
+      // must NOT be treated as a usable name, `_labelSource` must NOT be
+      // 'slot', and the firstUpdated() devWarn for unnamed combobox must
+      // fire.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox><svg slot="label" aria-hidden="true"><title>icon</title></svg></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as unknown as HxCombobox & {
+          _hasLabelSlot: boolean;
+          _labelSource: 'string' | 'slot' | 'none';
+        };
+        // Slot is decorative only — no usable name.
+        expect(harness._hasLabelSlot).toBe(false);
+        expect(harness._labelSource).not.toBe('slot');
+        // devWarn fired (no other naming source provided).
+        const messages = warnSpy.mock.calls.map((c) => String(c.join(' ')));
+        expect(messages.some((m) => m.includes('No accessible label'))).toBe(true);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('decorative svg + visible <span> in slot="label" — fallback path text-flattens to the visible text only, modern path projects ONLY the visible <span> (round-9 F1)', async () => {
+      // Round-9 F1 (P2): the modern `internals.ariaLabelledByElements` path
+      // MUST filter top-level aria-hidden / hidden slotted elements so AT
+      // does not recursively read their <title> / textContent. Otherwise an
+      // `<svg slot="label" aria-hidden="true"><title>icon</title></svg>`
+      // alongside a visible `<span slot="label">Patient</span>` would
+      // announce "icon Patient" on engines with IDL element refs while the
+      // fallback path correctly announces only "Patient".
+      // Fallback path assertion:
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = false;
+      const elFallback = await fixture<HxCombobox>(
+        '<hx-combobox><svg slot="label" aria-hidden="true"><title>icon</title></svg><span slot="label">Patient</span></hx-combobox>',
+      );
+      await elFallback.updateComplete;
+      const harnessFallback = elFallback as ComboboxTestHarness;
+      harnessFallback._syncHostAriaSemantics();
+      await elFallback.updateComplete;
+      const inputFallback = shadowQuery<HTMLInputElement>(elFallback, 'input')!;
+      // Text flattens to "Patient" — aria-hidden svg contributes zero.
+      expect(inputFallback.getAttribute('aria-label')).toBe('Patient');
+
+      // Modern path assertion: ONLY the visible <span> projects via IDL refs.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = true;
+      const elModern = await fixture<HxCombobox>(
+        '<hx-combobox><svg slot="label" aria-hidden="true"><title>icon</title></svg><span slot="label">Patient</span></hx-combobox>',
+      );
+      await elModern.updateComplete;
+      const harnessModern = elModern as ComboboxTestHarness;
+      harnessModern._syncHostAriaSemantics();
+      await elModern.updateComplete;
+      type InternalsWithIdrefRefs = ElementInternals & {
+        ariaLabelledByElements: Element[] | null;
+      };
+      const internals = harnessModern._internals as InternalsWithIdrefRefs;
+      // Modern path projects ONLY the visible <span>; the aria-hidden svg
+      // is filtered before being forwarded to internals.ariaLabelledByElements.
+      expect(internals.ariaLabelledByElements?.length).toBe(1);
+      const span = elModern.querySelector('span[slot="label"]');
+      expect(internals.ariaLabelledByElements?.[0]).toBe(span);
+      // _labelSource is 'slot' because the visible <span> contributes text.
+      expect(
+        (elModern as unknown as { _labelSource: 'string' | 'slot' | 'none' })._labelSource,
+      ).toBe('slot');
+    });
+  });
+
+  describe('Round-12 F4: legacy fallback retracts host IDREF overrides cleanly', () => {
+    it('removing host aria-labelledby on the legacy path clears the cached label and unflattens the inner input', async () => {
+      // Round-12 F4 (P2): the round-11 head stripped host
+      // `aria-labelledby` immediately on the fallback path, so a later
+      // `removeAttribute` was a no-op and the cached consumer token kept
+      // flattening stale text onto the inner input. The fix is to leave
+      // the host attribute IN PLACE (the host is roleless on both paths,
+      // so this has no AT effect) — `getAttribute` becomes the live
+      // source of truth and retraction is observable on the next sync.
+      const ext = document.createElement('label');
+      ext.id = 'ext-name-retract';
+      ext.textContent = 'Patient name';
+      document.body.appendChild(ext);
+      try {
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = false;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="ext-name-retract"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        // Pre-condition: inner input flattens the external label text.
+        expect(input.getAttribute('aria-label')).toBe('Patient name');
+
+        // Consumer dynamically retracts the host attribute.
+        el.removeAttribute('aria-labelledby');
+        await el.updateComplete;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+
+        // Stale flattened text must NOT persist after retraction.
+        expect(input.getAttribute('aria-label')).not.toBe('Patient name');
+        // Host attribute is gone (consumer retracted it; component never re-adds).
+        expect(el.hasAttribute('aria-labelledby')).toBe(false);
+      } finally {
+        ext.remove();
+      }
+    });
+  });
+
+  describe('Round-7 F1: external IDREF text mutations re-flow into inner input', () => {
+    it('mutating textContent of resolved aria-labelledby target updates inner input aria-label', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'ext-r7-label';
+      ext.textContent = 'Patient';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="ext-r7-label"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        expect(input.getAttribute('aria-label')).toBe('Patient');
+
+        // Consumer mutates the resolved external element's text in place.
+        // No `slotchange`, no host-attribute change — only the MutationObserver
+        // installed by `_installExternalRefsObserver` can detect this.
+        ext.textContent = 'Member';
+
+        // Wait for the MutationObserver microtask + Lit re-render.
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        );
+        await el.updateComplete;
+
+        expect(input.getAttribute('aria-label')).toBe('Member');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('mutating textContent of resolved aria-describedby target updates synthesized in-shadow desc span', async () => {
+      const help = document.createElement('span');
+      help.id = 'ext-r7-desc';
+      help.textContent = 'Type to filter';
+      document.body.appendChild(help);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox label="Search" aria-describedby="ext-r7-desc"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>(
+          '[id$="-consumer-desc"]',
+        );
+        expect(consumerSpan).toBeTruthy();
+        expect(consumerSpan!.textContent).toBe('Type to filter');
+
+        // In-place mutation on the resolved external description target.
+        help.textContent = 'Filter by name';
+
+        await new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        );
+        await el.updateComplete;
+
+        expect(consumerSpan!.textContent).toBe('Filter by name');
+      } finally {
+        help.remove();
+      }
+    });
+  });
+
+  describe('Round-7 F2: initial error renders without waiting for second update', () => {
+    it('error="..." set as initial property renders into the live region on first update', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Search" error="Server rejected"></hx-combobox>',
+      );
+      // Single updateComplete await — no extra rAF ticks. The eager
+      // willUpdate seed must put the text in place before first paint.
+      await el.updateComplete;
+      const errorSpan = el.shadowRoot!.querySelector<HTMLElement>('.field__error');
+      expect(errorSpan).toBeTruthy();
+      // The slot fallback (inside the alert region) must already carry the
+      // error text — there must be no empty-flash on first paint.
+      expect(errorSpan!.textContent?.trim()).toBe('Server rejected');
+      // The container is visible (not hidden) because hasError is true.
+      expect(errorSpan!.hasAttribute('hidden')).toBe(false);
+      // role=alert is set from first paint per the existing contract.
+      expect(errorSpan!.getAttribute('role')).toBe('alert');
+    });
+  });
+
+  // ─── Round-8 codex follow-ups ───
+
+  describe('Round-8 F1: clear internals.ariaLabel with null (not empty string) when accessibleLabel is absent', () => {
+    it('modern path leaves internals.ariaLabel === null when label property names the combobox', async () => {
+      // Round-8 F1 (P2): per W3C AccName, an explicit empty `aria-label`
+      // STILL has higher precedence than `aria-labelledby`. Writing `''`
+      // would erase any name resolved from `ariaLabelledByElements`, the
+      // `label` property, the slot, or host `aria-labelledby`. The fix
+      // CLEARS the override with `null` instead.
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      // Force the modern (IDL refs) path on for this assertion.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = true;
+      harness._supportsIdrefRefs = true;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const internals = harness._internals as ElementInternals & {
+        ariaLabel: string | null;
+        ariaLabelledByElements: Element[] | null;
+      };
+      // Critical: must be null, NOT ''.
+      expect(internals.ariaLabel).toBeNull();
+      // The internal label element should be projected via IDL refs so AT
+      // walking up from the focused inner input still finds the name.
+      const internalLabel = el.shadowRoot!.querySelector('label');
+      expect(internalLabel).toBeTruthy();
+      expect(internals.ariaLabelledByElements).not.toBeNull();
+      expect(internals.ariaLabelledByElements!.length).toBeGreaterThan(0);
+    });
+
+    it('modern path leaves internals.ariaLabel === null when slotted label provides the name', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label">Patient</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = true;
+      harness._supportsIdrefRefs = true;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const internals = harness._internals as ElementInternals & {
+        ariaLabel: string | null;
+        ariaLabelledByElements: Element[] | null;
+      };
+      expect(internals.ariaLabel).toBeNull();
+      // The slotted span MUST be projected via IDL refs.
+      expect(internals.ariaLabelledByElements).not.toBeNull();
+      expect(internals.ariaLabelledByElements!.length).toBeGreaterThan(0);
+    });
+
+    it('modern path forwards explicit accessibleLabel to internals.ariaLabel (regression guard)', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Visible"></hx-combobox>',
+      );
+      el.accessibleLabel = 'Screen reader name';
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = true;
+      harness._supportsIdrefRefs = true;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const internals = harness._internals as ElementInternals & {
+        ariaLabel: string | null;
+      };
+      expect(internals.ariaLabel).toBe('Screen reader name');
+    });
+  });
+
+  describe('Round-8 F2: flattenText skips aria-hidden / hidden subtrees per AccName 1.2 §4.3.10', () => {
+    it('external aria-labelledby target with nested aria-hidden svg/title flattens to the visible text only', async () => {
+      // Round-8 F2 (P2): a consumer label like
+      //   <label id="x"><svg aria-hidden="true"><title>icon</title></svg>Search</label>
+      // MUST flatten to "Search" (not "icon Search") on the inner input
+      // fallback aria-label.
+      const ext = document.createElement('label');
+      ext.id = 'ext-r8-aria-hidden';
+      ext.innerHTML =
+        '<svg aria-hidden="true" width="12" height="12"><title>icon</title></svg>Search';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="ext-r8-aria-hidden"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        expect(input.getAttribute('aria-label')).toBe('Search');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('external aria-labelledby target with nested [hidden] descendant flattens to visible text only', async () => {
+      // The `hidden` attribute also hides content from AT — must be skipped
+      // by the deep walker.
+      const ext = document.createElement('label');
+      ext.id = 'ext-r8-hidden-attr';
+      ext.innerHTML = '<span hidden>foo</span>bar';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="ext-r8-hidden-attr"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        expect(input.getAttribute('aria-label')).toBe('bar');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('external aria-describedby target with nested aria-hidden content excludes hidden text from synthesized in-shadow desc', async () => {
+      const ext = document.createElement('span');
+      ext.id = 'ext-r8-desc-aria-hidden';
+      ext.innerHTML =
+        '<svg aria-hidden="true"><title>icon</title></svg>Type to filter';
+      document.body.appendChild(ext);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox label="Search" aria-describedby="ext-r8-desc-aria-hidden"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const consumerSpan = el.shadowRoot!.querySelector<HTMLElement>(
+          '[id$="-consumer-desc"]',
+        );
+        expect(consumerSpan).toBeTruthy();
+        expect(consumerSpan!.textContent).toBe('Type to filter');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('slotted label with nested aria-hidden svg inside a parent span flattens to the visible text only on the fallback path', async () => {
+      // Round-8 F2 (P2): a slotted parent like
+      //   <span slot="label"><svg aria-hidden="true"><title>icon</title></svg>Patient</span>
+      // MUST flatten to "Patient" on the legacy fallback path. The previous
+      // code only checked TOP-LEVEL slotted-element aria-hidden — nested
+      // decorative content leaked through.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label"><svg aria-hidden="true"><title>icon</title></svg>Patient</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      // Force legacy fallback so we hit the text-flatten path on the inner input.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = false;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      expect(input.getAttribute('aria-label')).toBe('Patient');
+    });
+  });
+
+  // ─── Round-9 codex push-gate findings ───
+  describe('Round-9 F1: hidden slotted label/desc elements stay out of internals refs', () => {
+    it('aria-hidden svg + visible span in slot="label" — modern path projects ONLY the span', async () => {
+      // Round-9 F1 (P2): top-level aria-hidden / hidden slotted nodes MUST
+      // be filtered before populating `internals.ariaLabelledByElements`
+      // because AT recursively reads referenced elements (including their
+      // <title> children) on engines with IDL element refs.
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = true;
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><svg slot="label" aria-hidden="true"><title>Search</title></svg><span slot="label">Patient</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      type InternalsWithIdrefRefs = ElementInternals & {
+        ariaLabelledByElements: Element[] | null;
+      };
+      const internals = harness._internals as InternalsWithIdrefRefs;
+      expect(internals.ariaLabelledByElements?.length).toBe(1);
+      const span = el.querySelector('span[slot="label"]');
+      expect(internals.ariaLabelledByElements?.[0]).toBe(span);
+      // The aria-hidden svg is NOT in the projection — its <title> can't
+      // leak "Search" into the modern-path accessible name.
+      const svg = el.querySelector('svg[slot="label"]');
+      expect(internals.ariaLabelledByElements).not.toContain(svg);
+    });
+
+    it('hidden attribute on slotted label element also filters from internals refs', async () => {
+      (
+        HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+      ).__testSupportsIdrefRefsOverride = true;
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox><span slot="label" hidden>Hidden</span><span slot="label">Patient</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+      type InternalsWithIdrefRefs = ElementInternals & {
+        ariaLabelledByElements: Element[] | null;
+      };
+      const internals = harness._internals as InternalsWithIdrefRefs;
+      expect(internals.ariaLabelledByElements?.length).toBe(1);
+      const visible = el.querySelectorAll('span[slot="label"]')[1];
+      expect(internals.ariaLabelledByElements?.[0]).toBe(visible);
+    });
+
+    it('consumer-resolved external label with aria-hidden top-level is filtered from internals refs', async () => {
+      const hiddenExt = document.createElement('label');
+      hiddenExt.id = 'r9-ext-hidden';
+      hiddenExt.setAttribute('aria-hidden', 'true');
+      hiddenExt.textContent = 'Decorative';
+      const visibleExt = document.createElement('label');
+      visibleExt.id = 'r9-ext-visible';
+      visibleExt.textContent = 'Patient name';
+      document.body.appendChild(hiddenExt);
+      document.body.appendChild(visibleExt);
+      try {
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = true;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="r9-ext-hidden r9-ext-visible"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        type InternalsWithIdrefRefs = ElementInternals & {
+          ariaLabelledByElements: Element[] | null;
+        };
+        const internals = harness._internals as InternalsWithIdrefRefs;
+        expect(internals.ariaLabelledByElements).not.toContain(hiddenExt);
+        expect(internals.ariaLabelledByElements).toContain(visibleExt);
+      } finally {
+        hiddenExt.remove();
+        visibleExt.remove();
+      }
+    });
+  });
+
+  describe('Round-9 F2: external label/desc visibility-attr changes resync the inner input', () => {
+    it('toggling aria-hidden on the resolved external label resyncs the inner input aria-label', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'r9-ext-ariahidden-toggle';
+      ext.textContent = 'Patient';
+      document.body.appendChild(ext);
+      try {
+        // Force the fallback path so the mirrored aria-label is the
+        // observable surface we assert against.
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = false;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="r9-ext-ariahidden-toggle"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        // Pre-condition: external label text is mirrored onto the inner input.
+        expect(input.getAttribute('aria-label')).toBe('Patient');
+
+        // Consumer hides the label in place — flattenAccName now skips it,
+        // so the mirrored aria-label must resync (drop "Patient").
+        ext.setAttribute('aria-hidden', 'true');
+        // Yield to MutationObserver microtask.
+        await new Promise((r) => setTimeout(r, 0));
+        await el.updateComplete;
+        // The mirrored aria-label should no longer expose stale "Patient".
+        expect(input.getAttribute('aria-label')).not.toBe('Patient');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('toggling hidden attribute on the resolved external label resyncs the inner input aria-label', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'r9-ext-hidden-toggle';
+      ext.textContent = 'Patient';
+      document.body.appendChild(ext);
+      try {
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = false;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="r9-ext-hidden-toggle"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        expect(input.getAttribute('aria-label')).toBe('Patient');
+
+        // Consumer toggles `hidden` on the label.
+        ext.setAttribute('hidden', '');
+        await new Promise((r) => setTimeout(r, 0));
+        await el.updateComplete;
+        expect(input.getAttribute('aria-label')).not.toBe('Patient');
+
+        // Removing `hidden` restores the mirrored text.
+        ext.removeAttribute('hidden');
+        await new Promise((r) => setTimeout(r, 0));
+        await el.updateComplete;
+        expect(input.getAttribute('aria-label')).toBe('Patient');
+      } finally {
+        ext.remove();
+      }
+    });
+
+    it('toggling aria-hidden on a nested descendant of the external label resyncs (subtree attr observation)', async () => {
+      const ext = document.createElement('label');
+      ext.id = 'r9-ext-nested-toggle';
+      const inner = document.createElement('span');
+      inner.textContent = 'Patient';
+      ext.appendChild(inner);
+      document.body.appendChild(ext);
+      try {
+        (
+          HelixCombobox as unknown as { __testSupportsIdrefRefsOverride: boolean | null }
+        ).__testSupportsIdrefRefsOverride = false;
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox aria-labelledby="r9-ext-nested-toggle"></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as ComboboxTestHarness;
+        harness._syncHostAriaSemantics();
+        await el.updateComplete;
+        const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+        expect(input.getAttribute('aria-label')).toBe('Patient');
+
+        // Consumer toggles aria-hidden on the inner span (descendant) — only
+        // works if the observer enables `subtree: true` + `attributes: true`.
+        inner.setAttribute('aria-hidden', 'true');
+        await new Promise((r) => setTimeout(r, 0));
+        await el.updateComplete;
+        expect(input.getAttribute('aria-label')).not.toBe('Patient');
+      } finally {
+        ext.remove();
+      }
+    });
+  });
+
+  // ─── Round-10 codex follow-ups ───
+
+  describe('Round-10 F1: forcedColorsField is composed into static styles', () => {
+    it('forcedColorsField (Field/FieldText/Highlight overrides) participates in the host stylesheet', async () => {
+      // Round-10 F1 (P2): the forced-colors mixin emits @media
+      // (forced-colors: active) overrides using system colors (Field,
+      // FieldText, Highlight, etc.). Dropping it from `static styles`
+      // regressed Windows High Contrast accessibility. We verify the mixin
+      // is present in the composed styles array AND that one of its
+      // signature system-color tokens reaches the adopted stylesheet text.
+      const stylesArray = (HelixCombobox as unknown as { styles: unknown[] }).styles;
+      expect(Array.isArray(stylesArray)).toBe(true);
+      expect(stylesArray.length).toBeGreaterThanOrEqual(2);
+
+      // Render and inspect the adopted stylesheet text for the signature
+      // forced-colors block.
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+      const sheets = el.shadowRoot!.adoptedStyleSheets;
+      const allText = Array.from(sheets)
+        .flatMap((s) => Array.from(s.cssRules))
+        .map((r) => r.cssText)
+        .join('\n');
+      expect(allText).toMatch(/forced-colors:\s*active/);
+      // System-color tokens land somewhere inside the forced-colors block.
+      // CSS system-color keywords are case-insensitive and the parsed
+      // cssText may serialize them lowercased. Asserting at least one
+      // (fieldtext is the most stable across the mixin's history) keeps
+      // the test resilient if other tokens churn.
+      expect(allText).toMatch(/fieldtext|highlight|field\b/i);
+    });
+  });
+
+  describe('Round-10 F2: runtime error change populates alert before unhide', () => {
+    it('programmatic `el.error = "..."` renders alert text in the SAME frame the container becomes visible', async () => {
+      // Round-10 F2 (P2): `error` flips from "" → "Server rejected" at
+      // runtime via async/server-side validation. Before the fix,
+      // `_announcedError` was updated only in `updated()`, so the first
+      // visible frame had a non-hidden alert container with empty
+      // textContent — and aria-describedby pointed at the empty wrapper
+      // for one cycle. Seeding from `willUpdate` keeps the first visible
+      // frame populated.
+      const el = await fixture<HxCombobox>('<hx-combobox label="Fruit"></hx-combobox>');
+      await el.updateComplete;
+
+      // Pre-condition: no error → alert container is hidden.
+      const errorElInitial = el.shadowRoot!.querySelector<HTMLElement>('.field__error');
+      expect(errorElInitial?.hasAttribute('hidden') ?? true).toBe(true);
+
+      // Programmatic runtime change.
+      el.error = 'Server rejected';
+      await el.updateComplete;
+
+      const errorEl = el.shadowRoot!.querySelector<HTMLElement>('.field__error');
+      expect(errorEl).toBeTruthy();
+      // Container is now visible AND populated in the same frame.
+      expect(errorEl!.hasAttribute('hidden')).toBe(false);
+      expect(errorEl!.textContent?.trim()).toBe('Server rejected');
+      expect(errorEl!.getAttribute('role')).toBe('alert');
+
+      // aria-describedby on the inner input now references the populated
+      // error wrapper (not an empty node).
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const describedBy = (input.getAttribute('aria-describedby') ?? '').split(/\s+/);
+      expect(describedBy).toContain(errorEl!.id);
+    });
+  });
+
+  describe('Round-10 F3: slotted help/error effective-text uses AccName flatten', () => {
+    it('help slot containing only `<span hidden>foo</span>` does NOT mark the field as having help text', async () => {
+      // Round-10 F3 (P3): raw textContent treats `<span hidden>foo</span>`
+      // as non-empty, leaving the help wrapper attached and the help id
+      // in aria-describedby. The fix uses flattenAccName which honors
+      // both `aria-hidden="true"` and the `hidden` attribute per
+      // W3C AccName 1.2 §4.3.10.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="help-text"><span hidden>foo</span></span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const helpEl = el.shadowRoot!.querySelector<HTMLElement>('.field__help-text');
+      // Either the help element is not rendered, or its id is not in
+      // aria-describedby. Both outcomes confirm `_hasHelpSlot` is false.
+      const describedBy = (input.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(
+        (t) => t,
+      );
+      if (helpEl) {
+        expect(describedBy).not.toContain(helpEl.id);
+      }
+    });
+
+    it('error slot containing only `<span aria-hidden="true">foo</span>` does NOT activate error state', async () => {
+      // Round-10 F3 (P3): same defect class on the error slot — purely
+      // aria-hidden content must not keep the combobox in its error
+      // state. Without flattenAccName, raw textContent would report
+      // "foo" and `_hasErrorSlot` would stay true.
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="error"><span aria-hidden="true">foo</span></span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const ariaInvalid = input.getAttribute('aria-invalid');
+      expect(ariaInvalid === null || ariaInvalid === 'false').toBe(true);
+
+      const errorEl = el.shadowRoot!.querySelector<HTMLElement>('.field__error');
+      const describedBy = (input.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(
+        (t) => t,
+      );
+      if (errorEl) {
+        expect(describedBy).not.toContain(errorEl.id);
+      }
+    });
+  });
+
+  describe('Round-11 F1/F2: hidden ROOTS in slot=label/help-text/error contribute zero accessible text', () => {
+    // Round-11 F1 (P2): `flattenAccName`'s TreeWalker filter inspects only
+    // visited descendants — it never tests the root itself. So a slotted
+    // root carrying `hidden` or `aria-hidden="true"` would still flatten
+    // its descendants' text, leaving `_hasLabelSlot` / `_hasHelpSlot` /
+    // `_hasErrorSlot` true for content the consumer has explicitly hidden.
+    // Per AccName 1.2 §4.3.10 a hidden root contributes the empty string.
+    // The fix gates on root visibility at the top of `flattenAccName`.
+
+    it('F1: <span slot="label" hidden>Secret</span> — _hasLabelSlot is false; _labelSource !== "slot"', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox><span slot="label" hidden>Secret</span></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as unknown as HxCombobox & {
+          _hasLabelSlot: boolean;
+          _labelSource: 'string' | 'slot' | 'none';
+        };
+        expect(harness._hasLabelSlot).toBe(false);
+        expect(harness._labelSource).not.toBe('slot');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('F1: <span slot="label" aria-hidden="true">Secret</span> — _hasLabelSlot is false; _labelSource !== "slot"', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+      try {
+        const el = await fixture<HxCombobox>(
+          '<hx-combobox><span slot="label" aria-hidden="true">Secret</span></hx-combobox>',
+        );
+        await el.updateComplete;
+        const harness = el as unknown as HxCombobox & {
+          _hasLabelSlot: boolean;
+          _labelSource: 'string' | 'slot' | 'none';
+        };
+        expect(harness._hasLabelSlot).toBe(false);
+        expect(harness._labelSource).not.toBe('slot');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it('F2: <span slot="help-text" hidden>foo</span> — _hasHelpSlot is false; help id NOT in inner-input aria-describedby', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="help-text" hidden>foo</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const internalHasHelpSlot = (
+        el as unknown as { _hasHelpSlot: boolean }
+      )._hasHelpSlot;
+      expect(internalHasHelpSlot).toBe(false);
+
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const helpEl = el.shadowRoot!.querySelector<HTMLElement>('.field__help-text');
+      const describedBy = (input.getAttribute('aria-describedby') ?? '')
+        .split(/\s+/)
+        .filter((t) => t);
+      if (helpEl) {
+        expect(describedBy).not.toContain(helpEl.id);
+      }
+    });
+
+    it('F2: <span slot="error" aria-hidden="true">err</span> — _hasErrorSlot false; aria-invalid not on; error id NOT in aria-describedby', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="error" aria-hidden="true">err</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const internalHasErrorSlot = (
+        el as unknown as { _hasErrorSlot: boolean }
+      )._hasErrorSlot;
+      expect(internalHasErrorSlot).toBe(false);
+
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const ariaInvalid = input.getAttribute('aria-invalid');
+      expect(ariaInvalid === null || ariaInvalid === 'false').toBe(true);
+
+      const errorEl = el.shadowRoot!.querySelector<HTMLElement>('.field__error');
+      const describedBy = (input.getAttribute('aria-describedby') ?? '')
+        .split(/\s+/)
+        .filter((t) => t);
+      if (errorEl) {
+        expect(describedBy).not.toContain(errorEl.id);
+      }
+    });
+
+    it('F2 dynamic toggle: visible help slot → hidden=true on root flips _hasHelpSlot to false on next sync', async () => {
+      const el = await fixture<HxCombobox>(
+        '<hx-combobox label="Fruit"><span slot="help-text">helpful</span></hx-combobox>',
+      );
+      await el.updateComplete;
+      const harness = el as ComboboxTestHarness;
+      harness._supportsIdrefRefs = false;
+      harness._syncHostAriaSemantics();
+      await el.updateComplete;
+
+      const stateRef = el as unknown as { _hasHelpSlot: boolean };
+      // Sanity: initially visible help slot registers as content.
+      expect(stateRef._hasHelpSlot).toBe(true);
+
+      const helpRoot = el.querySelector('span[slot="help-text"]') as HTMLElement;
+      // Round-9 F2 (P2) installed a MutationObserver that watches the `hidden`
+      // attribute on the slotted root. Toggling it triggers the async MO,
+      // which re-reads slot state via `_readHelpSlotStateSync` — and round-11
+      // F2 means a hidden root now flattens to "", flipping `_hasHelpSlot`.
+      helpRoot.setAttribute('hidden', '');
+
+      // Yield a microtask + macrotask so the MO callback runs and any state
+      // change propagates through `_syncHostAriaSemantics`.
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+
+      expect(stateRef._hasHelpSlot).toBe(false);
+
+      const input = shadowQuery<HTMLInputElement>(el, 'input')!;
+      const helpEl = el.shadowRoot!.querySelector<HTMLElement>('.field__help-text');
+      const describedBy = (input.getAttribute('aria-describedby') ?? '')
+        .split(/\s+/)
+        .filter((t) => t);
+      if (helpEl) {
+        expect(describedBy).not.toContain(helpEl.id);
+      }
     });
   });
 });

--- a/packages/hx-library/src/components/hx-combobox/hx-combobox.ts
+++ b/packages/hx-library/src/components/hx-combobox/hx-combobox.ts
@@ -8,6 +8,13 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { helixComboboxStyles } from './hx-combobox.styles.js';
 import { forcedColorsField } from '../../styles/forced-colors.js';
+import { devWarn } from '../../utils/dev-warn.js';
+import {
+  installAriaIdrefMirror,
+  resolveIdrefTokens,
+  supportsIdrefElementReferences,
+  type AriaIdrefMirrorHandle,
+} from '../../utils/aria-idref.js';
 
 // PERF: hx-combobox exceeds 5KB budget (6.87kb gzipped) -- typeahead filtering, multi-select chips, async loading
 
@@ -24,6 +31,51 @@ export interface ComboboxOption {
 export type HxComboboxSize = 'sm' | 'md' | 'lg';
 
 const _nextComboboxId = createIdCounter('hx-combobox');
+
+/**
+ * AccName-aware text flattener. Walks the subtree of `root` and concatenates
+ * text-node content, REJECTING any element subtree carrying `aria-hidden="true"`
+ * or the `hidden` attribute per W3C AccName 1.2 §4.3.10. Used by hx-combobox
+ * for both external IDREF flatten (host aria-labelledby/aria-describedby
+ * targets) and slotted-label aggregation, so nested decorative content like
+ * `<svg aria-hidden="true"><title>icon</title></svg>` does not leak into the
+ * inner input's announced name/description.
+ *
+ * Round-11 F1/F2 (P2): the TreeWalker filter only inspects elements VISITED
+ * during the walk — it never tests the root itself, so a hidden ROOT (e.g.
+ * `<span slot="label" hidden>Secret</span>` or
+ * `<span slot="help-text" aria-hidden="true">stale</span>`) would still
+ * contribute its descendants' text. Per AccName 1.2 §4.3.10, a hidden root
+ * contributes the empty string. Gate the walk here so every caller (slotted
+ * label/help/error and external IDREF flatten) honors the rule symmetrically.
+ */
+function flattenAccName(root: Element): string {
+  if (root.getAttribute('aria-hidden') === 'true' || root.hasAttribute('hidden')) {
+    return '';
+  }
+  let result = '';
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as Element;
+        if (el.getAttribute('aria-hidden') === 'true') {
+          return NodeFilter.FILTER_REJECT;
+        }
+        if (el.hasAttribute('hidden')) {
+          return NodeFilter.FILTER_REJECT;
+        }
+        return NodeFilter.FILTER_SKIP;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+  let textNode: Node | null = walker.nextNode();
+  while (textNode) {
+    result += textNode.textContent ?? '';
+    textNode = walker.nextNode();
+  }
+  return result.replace(/\s+/g, ' ').trim();
+}
 
 /** Detail for hx-input and hx-change events dispatched by hx-combobox. */
 export interface HxComboboxDetail {
@@ -134,6 +186,20 @@ export class HelixCombobox extends FormMixin(HelixElement) {
   /** Marks this element as form-associated for ElementInternals support. @internal */
   static override formAssociated = true;
 
+  /**
+   * Test seam (round-3 finding 4): when set to `true` or `false`, overrides
+   * the platform `supportsIdrefElementReferences` probe before
+   * `connectedCallback` seeds `_supportsIdrefRefs`. Mid-life flag flips on a
+   * connected instance allowed stale modern internals (set during connect)
+   * to leak into the fallback branch — tests must select the path BEFORE
+   * the host connects so the synthetic environment matches a legacy engine.
+   *
+   * Production code MUST NOT touch this field. It is a `static` so the test
+   * stub cleanup is global and obvious.
+   * @internal
+   */
+  static __testSupportsIdrefRefsOverride: boolean | null = null;
+
   // ─── Stable IDs ───
 
   /** @internal */
@@ -148,6 +214,16 @@ export class HelixCombobox extends FormMixin(HelixElement) {
   private _labelId = `${this._id}-label`;
   /** @internal */
   private _liveRegionId = `${this._id}-live`;
+  /**
+   * Round-5 F1 (P1): id of the synthesized in-shadow span that mirrors the
+   * consumer-resolved description text. This id is appended to the inner
+   * input's `aria-describedby` so AT picks the consumer description up
+   * through the standard described-by channel — `aria-description` is
+   * intentionally NOT written, because the W3C AccName algorithm ignores
+   * `aria-description` whenever `aria-describedby` is also present.
+   * @internal
+   */
+  private _consumerDescId = `${this._id}-consumer-desc`;
 
   // ─── Public Properties ───
 
@@ -251,7 +327,7 @@ export class HelixCombobox extends FormMixin(HelixElement) {
    * inputs with associated labels delegate accessible naming via `<label>`
    * association and `aria-labelledby`, not host-level ARIA delegation. The
    * `accessible-label` attribute is a fallback for label-free usage. The value is forwarded to the
-   * internal input's `aria-label`.
+   * host's `internals.ariaLabel` on the modern path.
    * @attr accessible-label
    */
   @property({ type: String, attribute: 'accessible-label' })
@@ -290,8 +366,61 @@ export class HelixCombobox extends FormMixin(HelixElement) {
   @state() private _focusedOptionIndex = -1;
   /** Whether the named error slot contains projected content. @internal */
   @state() private _hasErrorSlot = false;
+  /** Whether the named help-text slot contains projected content. @internal */
+  @state() private _hasHelpSlot = false;
   /** Live-region announcement text describing the current number of filtered options. @internal */
   @state() private _filterAnnouncement = '';
+  /**
+   * Source of the accessible name. Discriminated union replaces the magic
+   * `'*slotted*'` sentinel so a future caller setting `label="*slotted*"`
+   * literally cannot be confused with a slotted label.
+   * @internal
+   */
+  @state() private _labelSource: 'string' | 'slot' | 'none' = 'none';
+  /**
+   * Flattened, trimmed text content of any text nodes in the label slot —
+   * used to drive `internals.ariaLabel` when the consumer projects only a
+   * text node (no element to add to `labelEls`).
+   * @internal
+   */
+  @state() private _labelSlotText = '';
+  /**
+   * Whether the named label slot contributes a useful name. Requires either
+   * a labellable element OR non-empty trimmed text content (whitespace-only
+   * does NOT count).
+   * @internal
+   */
+  @state() private _hasLabelSlot = false;
+  /**
+   * Whether the platform supports IDL element references on `ElementInternals`.
+   * Drives the cross-shadow naming strategy for the inner `<input>`: modern
+   * path resolves consumer light-DOM IDREFs and writes them as cloned/proxied
+   * ids into the inner input's `aria-labelledby` / `aria-describedby`;
+   * fallback path mirrors only consumer `aria-labelledby` / `aria-describedby`
+   * tokens (resolved through the IDREF resolver) onto the inner input.
+   *
+   * ARCHITECTURE — W3C APG editable combobox (option I):
+   * `role="combobox"` lives on the inner `<input>` (replaces the implicit
+   * textbox role). All combobox state ARIA — `aria-expanded`, `aria-controls`,
+   * `aria-activedescendant`, `aria-autocomplete`, `aria-haspopup`,
+   * `aria-required`, `aria-invalid`, `aria-disabled`, `aria-busy` — lives on
+   * the inner input. The host carries no role and no tabindex; it is not a
+   * tab stop and not an announced AT surface.
+   * @internal
+   */
+  @state() private _supportsIdrefRefs = true;
+  /**
+   * Cached invalidity flag derived from `internals.validity.valid` after the
+   * latest `setValidity()` call. Drives the inner input's `aria-invalid`.
+   * @internal
+   */
+  @state() private _invalid = false;
+  /**
+   * Deferred copy of `error` driven through reactive state so the persistent
+   * live region can re-announce on transitions without direct DOM mutation.
+   * @internal
+   */
+  @state() private _announcedError = '';
 
   // ─── Queries ───
 
@@ -322,7 +451,124 @@ export class HelixCombobox extends FormMixin(HelixElement) {
     return this._options.filter((o) => o.label.toLowerCase().includes(lower));
   }
 
+  // ─── Host-canonical ARIA bookkeeping ───
+
+  /**
+   * Handle for the shared IDREF observer. See `installAriaIdrefMirror()`.
+   * @internal
+   */
+  private _ariaMirror: AriaIdrefMirrorHandle | null = null;
+  /**
+   * Watches assigned `<slot name="help-text">` nodes for in-place text
+   * mutations so the no-IDL-ref fallback `internals.ariaDescription` stays in sync.
+   * @internal
+   */
+  private _helpSlotTextObserver: MutationObserver | null = null;
+  /**
+   * Watches assigned `<slot name="error">` nodes for in-place text mutations.
+   * @internal
+   */
+  private _errorSlotTextObserver: MutationObserver | null = null;
+  /**
+   * Round-10 finding 1: dedicated host observer scoped to `aria-describedby`
+   * with `attributeOldValue: true`. Governed by the disconnect-during-strip
+   * discipline. See `_syncHostAriaSemantics` fallback branch.
+   * @internal
+   */
+  private _hostDescribedByObserver: MutationObserver | null = null;
+  /**
+   * Most recently observed *consumer-supplied* `aria-labelledby` baseline.
+   * Refreshed only when the host attribute changes via an external write.
+   * On the modern path the host attribute is preserved; on the legacy
+   * fallback the attribute is stripped during sync, so this baseline is the
+   * only durable record of what the consumer asked for.
+   * @internal
+   */
+  private _consumerLabelledBy: string | null = null;
+  /** @internal — see `_consumerLabelledBy`. */
+  private _consumerDescribedBy: string | null = null;
+  /**
+   * Direct references to ALL labellable elements projected into
+   * `<slot name="label">`. Round-4 F1 (P2): aggregating every assigned element
+   * — not just the first — preserves composed labels such as
+   * `<svg slot="label" aria-hidden="true">…</svg><span slot="label">Patient</span>`
+   * or `<span slot="label">First</span><span slot="label">name</span>`. The
+   * modern path passes the full array to `internals.ariaLabelledByElements`
+   * and the fallback path text-flattens every node into `_labelSlotText` per
+   * AccName 1.2. Avoids mutating consumer light-DOM and survives nested
+   * shadow roots without fragile getElementById chains.
+   * @internal
+   */
+  private _slottedLabelEls: Element[] = [];
+  /**
+   * Round-4 F2 (P2): observes in-place text mutations on the assigned slotted
+   * label nodes (e.g. consumer i18n re-renders that mutate the same
+   * `<span slot="label">` `textContent` instead of replacing it). Mirrors the
+   * round-23 P2 pattern from `_helpSlotTextObserver` / `_errorSlotTextObserver`.
+   * `slotchange` does NOT fire when only the descendant text mutates, so this
+   * observer is the only signal that keeps the no-IDL-ref fallback
+   * `aria-label` and the announced name in sync with the visible label.
+   * @internal
+   */
+  private _labelSlotTextObserver: MutationObserver | null = null;
+  /**
+   * Round-7 F1 (P2): observes in-place text mutations on consumer light-DOM
+   * elements resolved from host `aria-labelledby` / `aria-describedby`. When a
+   * consumer keeps the same `<label id="...">` but mutates its `textContent`
+   * (e.g. an i18n rerender), `slotchange` does not fire and the host
+   * attribute does not change — so without this observer the inner input's
+   * `aria-label` and the synthesized description span keep announcing the
+   * old flattened text indefinitely. Reinstalled on every sync against the
+   * deduped union of resolved label/desc elements; disconnects automatically
+   * when the consumer retracts both attribute chains.
+   * @internal
+   */
+  private _externalRefsObserver: MutationObserver | null = null;
+
   // ─── Lifecycle ───
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    // Round-3 finding 4: honour the static test override so synthetic
+    // environments choose the path BEFORE connect runs.
+    const ctor = this.constructor as typeof HelixCombobox;
+    this._supportsIdrefRefs =
+      ctor.__testSupportsIdrefRefsOverride !== null
+        ? ctor.__testSupportsIdrefRefsOverride
+        : supportsIdrefElementReferences(this._internals);
+
+    // Round-10 finding 1: install the dedicated `aria-describedby` retraction
+    // observer BEFORE the seeded `_syncHostAriaSemantics()` call below, then
+    // govern its lifetime with the disconnect-during-strip discipline.
+    this._hostDescribedByObserver = new MutationObserver((records) => {
+      let consumerCleared = false;
+      for (const record of records) {
+        if (record.attributeName !== 'aria-describedby') continue;
+        const oldValue = record.oldValue;
+        const newValue = this.getAttribute('aria-describedby');
+        if (oldValue !== null && newValue === null) {
+          // Consumer authentically retracted `aria-describedby`.
+          this._consumerDescribedBy = null;
+          consumerCleared = true;
+        }
+      }
+      if (consumerCleared) {
+        this._syncHostAriaSemantics();
+      }
+    });
+    this._hostDescribedByObserver.observe(this, {
+      attributes: true,
+      attributeFilter: ['aria-describedby'],
+      attributeOldValue: true,
+    });
+
+    // Seed root-independent semantics from connect so the host announces
+    // combobox role before first paint.
+    this._syncHostAriaSemantics();
+    this._ariaMirror = installAriaIdrefMirror(this, () => {
+      this._syncHostAriaSemantics();
+    });
+  }
 
   override disconnectedCallback(): void {
     super.disconnectedCallback();
@@ -337,6 +583,18 @@ export class HelixCombobox extends FormMixin(HelixElement) {
     if (this._open) {
       this._open = false;
     }
+    this._ariaMirror?.disconnect();
+    this._ariaMirror = null;
+    this._helpSlotTextObserver?.disconnect();
+    this._helpSlotTextObserver = null;
+    this._errorSlotTextObserver?.disconnect();
+    this._errorSlotTextObserver = null;
+    this._labelSlotTextObserver?.disconnect();
+    this._labelSlotTextObserver = null;
+    this._hostDescribedByObserver?.disconnect();
+    this._hostDescribedByObserver = null;
+    this._externalRefsObserver?.disconnect();
+    this._externalRefsObserver = null;
   }
 
   override updated(changedProperties: PropertyValues<this>): void {
@@ -344,19 +602,733 @@ export class HelixCombobox extends FormMixin(HelixElement) {
     if (changedProperties.has('value')) {
       this._updateFormValue();
     }
-    // Force screen reader re-announcement when error text changes (a11y-v3-005)
-    if (changedProperties.has('error') && this.error) {
-      const errorEl = this.shadowRoot?.querySelector('[role="alert"]');
-      if (errorEl) {
-        const msg = this.error;
+    if (changedProperties.has('label')) {
+      this._refreshLabelSource();
+    }
+    // Host-elevated ARIA semantics — see _syncHostAriaSemantics.
+    this._syncHostAriaSemantics();
+    // Drive re-announcement from reactive state so the persistent live region
+    // stays in the shadow tree across error transitions.
+    if (changedProperties.has('error')) {
+      const previousError = changedProperties.get('error') as string;
+      if (previousError && this.error) {
+        // Error→error: clear then re-set after rAF so AT re-announces.
+        this._announcedError = '';
         requestAnimationFrame(() => {
-          errorEl.textContent = '';
-          requestAnimationFrame(() => {
-            errorEl.textContent = msg;
-          });
+          this._announcedError = this.error;
         });
+      } else {
+        this._announcedError = this.error;
       }
     }
+  }
+
+  override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    // Round-7 F2 (P2) / round-10 F2 (P2): seed `_announcedError` BEFORE render
+    // so the persistent live region renders with the error text in the SAME
+    // frame that removes `hidden` from the alert container.
+    //
+    // Round-7 covered first paint (initial property/attribute). Round-10
+    // extended this to RUNTIME transitions: when `error` flips from "" to
+    // "Server rejected" via async/server-side validation, updating
+    // `_announcedError` only in `updated()` left one frame where the alert
+    // container was visible but empty — `aria-describedby` also pointed at an
+    // empty error node for that cycle. Seeding here keeps the first visible
+    // frame populated.
+    //
+    // The error-to-error rAF toggle in `updated()` still owns re-announcement
+    // semantics for subsequent transitions (clearing then re-setting to force
+    // AT to re-read role="alert" content).
+    if (changedProperties.has('error') || !this.hasUpdated) {
+      this._announcedError = this.error ?? '';
+    }
+  }
+
+  override firstUpdated(changedProperties: PropertyValues<this>): void {
+    super.firstUpdated(changedProperties);
+    // Round-5 F2 (P2): `slotchange` fires as a microtask after the initial
+    // synchronous render. Without proactive seeding, the first
+    // `_syncHostAriaSemantics()` call (driven from `updated()` in this same
+    // cycle, AFTER firstUpdated returns) would observe stale `false` /
+    // empty state for `_hasLabelSlot`, `_slottedLabelEls`, `_labelSlotText`,
+    // `_hasHelpSlot`, and `_hasErrorSlot`. That would break flows that
+    // mount a combobox with slot-only label/help/error and then focus
+    // immediately — AT would announce an unnamed control until the
+    // microtask `slotchange` corrected the state on the second update.
+    //
+    // Seed the slot-derived state synchronously here by reading the
+    // assigned-nodes lists directly. The slot-change handlers remain wired
+    // for subsequent slot mutations; this is purely a first-paint fix.
+    this._seedSlotStateSync();
+    // WCAG 4.1.2: warn when no accessible name is available. Now that the
+    // label-slot state is seeded above, this check sees the same surface
+    // area the next sync will, so the warning matches AT-observed reality.
+    if (
+      !this.label &&
+      !this.accessibleLabel &&
+      !this._hasLabelSlot &&
+      !this.getAttribute('aria-label') &&
+      !this.getAttribute('aria-labelledby')
+    ) {
+      devWarn(
+        'hx-combobox',
+        'No accessible label provided. Set the `label` attribute, `accessible-label`, `aria-label`, `aria-labelledby`, or project a `<slot name="label">` child. An unlabeled combobox violates WCAG 2.1 AA (4.1.2 Name, Role, Value).',
+      );
+    }
+  }
+
+  /**
+   * Round-5 F2 (P2): synchronous slot-state seed. Mirrors the side effects of
+   * the three `_handle*SlotChange` handlers (label / help-text / error) but
+   * is driven by direct `slot.assignedNodes()` reads so we can populate the
+   * state BEFORE the microtask `slotchange` events fire after the first
+   * render. Idempotent — calling it later is a no-op when state already
+   * matches the slot contents.
+   *
+   * Also installs the label slot text observer so consumer in-place text
+   * mutations on slotted label nodes are tracked even if the slotchange
+   * event has not yet fired.
+   * @internal
+   */
+  private _seedSlotStateSync(): void {
+    const root = this.shadowRoot;
+    if (!root) return;
+    // Label slot — use the existing _readLabelSlotState helper to capture
+    // the discriminated state (elements + flattened text + has-useful-name).
+    const labelSlot = root.querySelector<HTMLSlotElement>('slot[name="label"]');
+    if (labelSlot) {
+      const state = this._readLabelSlotState(labelSlot);
+      this._hasLabelSlot = state.hasUsefulName;
+      this._slottedLabelEls = state.elements;
+      this._labelSlotText = state.text;
+      // Install the text-mutation observer now so consumer i18n re-renders
+      // that mutate the same slotted node's textContent are picked up even
+      // before the first slotchange event lands.
+      this._installLabelSlotTextObserver(state.elements);
+      this._refreshLabelSource();
+    }
+    // Help-text slot — match `_handleHelpSlotChange` exactly.
+    const helpSlot = root.querySelector<HTMLSlotElement>('slot[name="help-text"]');
+    if (helpSlot) {
+      // Round-6 F1 (P2): use the effective-text reader so first-paint state
+      // matches the MO's re-read logic. An empty/whitespace-only slot is NOT
+      // a usable help text.
+      this._hasHelpSlot = this._readHelpSlotStateSync(helpSlot);
+      this._installHelpSlotTextObserver(helpSlot);
+    }
+    // Error slot — match `_handleErrorSlotChange` exactly.
+    const errorSlot = root.querySelector<HTMLSlotElement>('slot[name="error"]');
+    if (errorSlot) {
+      // Round-6 F1 (P2): use the effective-text reader so first-paint state
+      // matches the MO's re-read logic.
+      this._hasErrorSlot = this._readErrorSlotStateSync(errorSlot);
+      this._installErrorSlotTextObserver(errorSlot);
+    }
+  }
+
+  /**
+   * Reads the label slot's assigned nodes and computes the discriminated
+   * naming state. An empty whitespace-only slot does NOT count as a useful
+   * name.
+   *
+   * Round-4 F1 (P2): aggregates ALL assigned elements (not just the first) and
+   * concatenates `textContent` from every assigned node — element OR text —
+   * trimmed and space-joined per AccName 1.2 text-flatten rules. This preserves
+   * composed labels such as
+   * `<svg slot="label" aria-hidden="true">…</svg><span slot="label">Patient</span>`
+   * or `<span slot="label">First</span><span slot="label">name</span>` on both
+   * the modern (`internals.ariaLabelledByElements`) path and the no-IDL-ref
+   * fallback (`aria-label`) path.
+   *
+   * Round-6 F2 (P2): per AccName 1.2 §4.3.10, `aria-hidden="true"` elements
+   * contribute zero to the accessible name. They are still tracked in
+   * `elements` (so the modern `internals.ariaLabelledByElements` path projects
+   * the FULL visible label — icon + text — for AT that walks IDL refs), but
+   * they are skipped during text flattening. `hasUsefulName` is gated on the
+   * flattened text length, so a slot containing ONLY decorative elements (or
+   * empty wrappers) is NOT considered usable: `_labelSource` falls through to
+   * the next naming source and the firstUpdated() devWarn fires for unnamed
+   * controls. A composed `<svg aria-hidden><span>Patient</span>` slot still
+   * resolves: text = "Patient" → usable; both elements still project on the
+   * modern path.
+   * @internal
+   */
+  private _readLabelSlotState(slot: HTMLSlotElement): {
+    hasUsefulName: boolean;
+    elements: Element[];
+    text: string;
+  } {
+    const nodes = slot.assignedNodes({ flatten: true });
+    const elements: Element[] = [];
+    const fragments: string[] = [];
+    for (const node of nodes) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        const el = node as Element;
+        elements.push(el);
+        // Per AccName 1.2 §4.3.10, aria-hidden elements contribute zero to the
+        // accessible name. Skip their text in the flatten — the element itself
+        // remains in `elements` so the modern path still projects it via
+        // `internals.ariaLabelledByElements` (full visible-label fidelity).
+        if (el.getAttribute('aria-hidden') === 'true') continue;
+        // Round-8 F2 (P2): use the deep walker so NESTED aria-hidden / hidden
+        // subtrees inside a slotted parent element (e.g. an inline decorative
+        // `<svg aria-hidden><title>icon</title></svg>` inside a slotted
+        // `<span>Patient</span>`) are skipped per AccName 1.2 §4.3.10.
+        const elText = flattenAccName(el);
+        if (elText) fragments.push(elText);
+      } else if (node.nodeType === Node.TEXT_NODE) {
+        const txt = (node.textContent ?? '').trim();
+        if (txt) fragments.push(txt);
+      }
+    }
+    const trimmedText = fragments.join(' ').replace(/\s+/g, ' ').trim();
+    return {
+      // Round-6 F2 (P2): gate on flattened TEXT, not element presence. A slot
+      // with only decorative/aria-hidden elements (or empty wrappers) yields
+      // text === '' and is NOT a usable name.
+      hasUsefulName: trimmedText.length > 0,
+      elements,
+      text: trimmedText,
+    };
+  }
+
+  /**
+   * Round-6 F1 (P2): re-evaluate the help-text slot's "has meaningful content"
+   * state from its current effective text. Mirrors the slotchange-handler
+   * logic but is invocable from the in-place mutation observer so that
+   * clearing `textContent` on the same slotted node flips `_hasHelpSlot`
+   * back to `false` (without this, the help wrapper stays visible, the help
+   * id stays in the inner input's `aria-describedby`, and AT keeps announcing
+   * stale guidance).
+   * @internal
+   */
+  private _readHelpSlotStateSync(slot: HTMLSlotElement): boolean {
+    const nodes = slot.assignedNodes({ flatten: true });
+    for (const node of nodes) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        if ((node.textContent ?? '').trim().length > 0) return true;
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        // Round-10 F3 (P3): use AccName-aware flatten so descendants carrying
+        // `aria-hidden="true"` or the `hidden` attribute do NOT count toward
+        // "has meaningful content". Raw `textContent` would treat
+        // `<span hidden>foo</span>` as non-empty, leaving an empty help
+        // description attached to the inner input. The slot-text observer
+        // (round-9 F2) watches characterData/childList/attributes so toggling
+        // `hidden` on a descendant correctly flips `_hasHelpSlot` to false.
+        if (flattenAccName(node as Element).length > 0) return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Round-6 F1 (P2): re-evaluate the error slot's "has meaningful content"
+   * state from its current effective text. Mirrors the slotchange-handler
+   * logic but is invocable from the in-place mutation observer so that
+   * clearing `textContent` on the same slotted node flips `_hasErrorSlot`
+   * back to `false` (without this, the combobox stays in its error state
+   * indefinitely: `aria-invalid` stays `true`, the error id stays in
+   * `aria-describedby`, and help text stays hidden).
+   * @internal
+   */
+  private _readErrorSlotStateSync(slot: HTMLSlotElement): boolean {
+    const nodes = slot.assignedNodes({ flatten: true });
+    for (const node of nodes) {
+      if (node.nodeType === Node.TEXT_NODE) {
+        if ((node.textContent ?? '').trim().length > 0) return true;
+      } else if (node.nodeType === Node.ELEMENT_NODE) {
+        // Round-10 F3 (P3): same AccName-aware flatten as
+        // `_readHelpSlotStateSync` — `<span hidden>foo</span>` or
+        // `<span aria-hidden="true">foo</span>` must not keep the combobox
+        // in its error state once they are the sole descendants.
+        if (flattenAccName(node as Element).length > 0) return true;
+      }
+    }
+    return false;
+  }
+
+  // ─── Inner-input ARIA sync (W3C APG editable combobox) ───
+
+  /**
+   * Resolves consumer-supplied label/description IDREFs on the host and
+   * writes the canonical combobox ARIA onto the **inner `<input>`** per W3C
+   * APG editable combobox pattern. The inner input owns `role="combobox"`
+   * (replacing its implicit textbox role) and all combobox state ARIA so
+   * AT sees a single announced + focused surface.
+   *
+   * Cross-shadow naming uses a belt-and-suspenders strategy:
+   *
+   *   1. **Modern path** (`_supportsIdrefRefs === true`): consumer-resolved
+   *      label/description elements are written onto
+   *      `internals.ariaLabelledByElements` / `internals.ariaDescribedByElements`
+   *      on the host. AT that walks up from the focused inner input for naming
+   *      finds them through ElementInternals. Host-level `aria-labelledby` /
+   *      `aria-describedby` attributes are LEFT IN PLACE so AT walking up the
+   *      DOM also sees them. The text content of the resolved elements is also
+   *      flattened onto the inner input as `aria-label` / `aria-description`
+   *      so AT that does not walk up still announces the right name.
+   *
+   *   2. **Legacy fallback** (`_supportsIdrefRefs === false`): host attrs are
+   *      stripped (AccName precedence cleanup) and the resolved-element text
+   *      is flattened onto the inner input as `aria-label` /
+   *      `aria-description`. Live updates to the consumer-referenced elements
+   *      do not propagate, but the initial accessible name resolves on every
+   *      AT — closing the cross-shadow naming gap that broke this on engines
+   *      without IDL element references.
+   *
+   * Writing `aria-labelledby="<light-DOM id>"` directly on the shadow-DOM
+   * inner input is INTENTIONALLY avoided: light-DOM ids do not resolve from
+   * inside a shadow root, so that pattern leaves the control AT-anonymous.
+   * Internal label ids (in the same shadow root) ARE written via
+   * `aria-labelledby`.
+   * @internal
+   */
+  /**
+   * Round-7 F1 (P2): (re)install a `MutationObserver` against the deduped
+   * union of consumer-resolved label/description elements. Watches
+   * `characterData`, `childList`, and `subtree` so any in-place text
+   * mutation on the referenced light-DOM nodes triggers a fresh sync —
+   * keeping the inner input's flattened `aria-label` and the synthesized
+   * description span aligned with the live consumer text. Blanket
+   * disconnect-and-reinstall on every sync; if the consumer retracts both
+   * IDREF chains the union is empty and the observer is disconnected.
+   * @internal
+   */
+  private _installExternalRefsObserver(elements: Element[]): void {
+    if (this._externalRefsObserver) {
+      this._externalRefsObserver.disconnect();
+      this._externalRefsObserver = null;
+    }
+    if (elements.length === 0) return;
+    // Dedupe references in case the same element is referenced from both
+    // `aria-labelledby` and `aria-describedby` — observing it once is enough.
+    const unique = new Set<Element>(elements);
+    const observer = new MutationObserver(() => {
+      // External text changed — re-sync, which re-flattens the resolved
+      // elements onto the inner input and the synthesized description span.
+      this._syncHostAriaSemantics();
+    });
+    for (const el of unique) {
+      // Round-9 F2 (P2): also observe `aria-hidden` / `hidden` toggles on the
+      // referenced element AND its descendants. `flattenAccName` skips
+      // aria-hidden subtrees per AccName 1.2 §4.3.10, so a consumer flipping
+      // visibility in place changes the flattened text — but without attribute
+      // observation the inner input keeps its stale mirrored `aria-label` /
+      // synthesized description. `subtree: true` combined with `attributes: true`
+      // covers descendant attribute mutations too.
+      observer.observe(el, {
+        characterData: true,
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    }
+    this._externalRefsObserver = observer;
+  }
+
+  private _syncHostAriaSemantics(): void {
+    const internals = this._internals;
+
+    const input = this._input;
+    if (!input) {
+      // Inner input not yet rendered; defer. The post-render `updated()` call
+      // will re-invoke this sync once the input exists.
+      // Round-12 F3: still derive `_invalid` so `aria-invalid` first-paint
+      // is correct once the input renders.
+      const isInvalidEarly = !internals.validity.valid || !!(this.error || this._hasErrorSlot);
+      this._invalid = isInvalidEarly;
+      return;
+    }
+
+    // The host carries no `aria-label` we wrote — any live value is purely
+    // a consumer override. Forwarded onto the inner input below.
+    const liveAriaLabel = this.getAttribute('aria-label');
+    const hostAriaLabel = liveAriaLabel !== null ? liveAriaLabel.trim() || '' : '';
+
+    // Resolve the candidate label/desc element references once.
+    const internalLabel = this.shadowRoot?.getElementById(this._labelId) ?? null;
+    // Round-4 F1 (P2): aggregate ALL assigned label-slot elements so composed
+    // labels (icon + text, multi-span) name the inner input fully.
+    const slottedLabelEls = this._slottedLabelEls;
+    const helpEl = this.shadowRoot?.getElementById(this._helpTextId) ?? null;
+    const errorEl = this.shadowRoot?.getElementById(this._errorId) ?? null;
+
+    // Refresh the consumer baseline. The host attribute is the live source
+    // of truth on BOTH paths (round-12 F4: legacy no longer strips, so the
+    // observer-cached fallback is no longer required). A `null` live value
+    // authentically represents consumer retraction.
+    const liveLabelledBy = this.getAttribute('aria-labelledby');
+    this._consumerLabelledBy = liveLabelledBy;
+    const liveDescribedBy = this.getAttribute('aria-describedby');
+    this._consumerDescribedBy = liveDescribedBy;
+    const externalLabelTokens = this._consumerLabelledBy;
+    const externalDescTokens = this._consumerDescribedBy;
+
+    const consumerLabelEls = resolveIdrefTokens(this, externalLabelTokens);
+    const hasEffectiveLabelledBy = consumerLabelEls.length > 0;
+
+    const consumerDescEls = resolveIdrefTokens(this, externalDescTokens);
+
+    // Round-7 F1 (P2): observe in-place text mutations on the resolved
+    // external IDREF targets. Without this, a consumer that mutates
+    // `<label id="ext">Patient</label>` → "Member" in place leaves the
+    // inner input's flattened `aria-label` stuck on "Patient". Blanket
+    // disconnect-and-reinstall keeps the bookkeeping trivial and matches
+    // the slotted-label observer pattern.
+    this._installExternalRefsObserver([...consumerLabelEls, ...consumerDescEls]);
+
+    const hasError = !!(this.error || this._hasErrorSlot);
+
+    // Round-12 F3: `aria-invalid` reflects EVERY signal the consumer can use
+    // to express invalidity. setValidity() drives the required-empty case;
+    // an explicit `error` property/slot is a server-/async-validation signal
+    // that AT must announce as invalid, not just "described by an alert".
+    const isInvalid = !internals.validity.valid || hasError;
+    this._invalid = isInvalid;
+
+    // Round-12 F2: `accessibleLabel` is documented as the screen-reader name
+    // when it should differ from the visible label. When the consumer
+    // explicitly sets it (non-empty), it is the canonical AT name and must
+    // override visible label / aria-labelledby — both for the modern path's
+    // ElementInternals references and for the inner input's aria-label.
+    const explicitAccessibleLabel =
+      typeof this.accessibleLabel === 'string' && this.accessibleLabel.trim().length > 0
+        ? this.accessibleLabel
+        : null;
+
+    // Round-9 F1 (P2): top-level `aria-hidden="true"` / `hidden` elements MUST
+    // NOT be forwarded to `internals.ariaLabelledByElements` /
+    // `ariaDescribedByElements`. On engines with IDL element refs, AT walks
+    // those references and would recursively read e.g. an
+    // `<svg aria-hidden="true"><title>icon</title></svg>` slotted alongside a
+    // visible `<span slot="label">Patient</span>` — yielding "icon Patient".
+    // The fallback text-flatten path already strips these via `flattenAccName`,
+    // so the filter aligns the modern path with AccName 1.2 §4.3.10.
+    const isVisibleForAccName = (el: Element): boolean =>
+      el.getAttribute('aria-hidden') !== 'true' && !el.hasAttribute('hidden');
+
+    // Build the augmented element lists used by the modern (IDL-refs) path.
+    // When `accessibleLabel` is the chosen name we omit element references
+    // entirely so AT does not double-announce against the explicit override.
+    const labelElsForInternals: Element[] = [];
+    if (!explicitAccessibleLabel) {
+      labelElsForInternals.push(...consumerLabelEls.filter(isVisibleForAccName));
+      if (!hasEffectiveLabelledBy && !hostAriaLabel) {
+        if (this._labelSource === 'slot' && slottedLabelEls.length > 0) {
+          // Round-4 F1 (P2): expose every assigned element so AT can compose
+          // the full visible label across icon + text fragments.
+          // Round-9 F1 (P2): filter top-level aria-hidden / hidden so the
+          // modern path matches the fallback path's AccName behavior. The
+          // unfiltered `_slottedLabelEls` is still used downstream by the
+          // text-flatten fallback (its TreeWalker handles nested visibility).
+          labelElsForInternals.push(...slottedLabelEls.filter(isVisibleForAccName));
+        } else if (this._labelSource === 'string' && internalLabel) {
+          labelElsForInternals.push(internalLabel);
+        }
+      }
+    }
+
+    // Round-9 F1 (P2): same hidden-filter for description element refs. A
+    // consumer-referenced `aria-describedby` target that flips to
+    // `aria-hidden="true"` must not name through the modern path.
+    const descElsForInternals: Element[] = [...consumerDescEls.filter(isVisibleForAccName)];
+    if (helpEl && !hasError && (this.helpText || this._hasHelpSlot)) {
+      descElsForInternals.push(helpEl);
+    }
+    if (errorEl && hasError) {
+      descElsForInternals.push(errorEl);
+    }
+
+    // ─── Modern-path: ElementInternals IDL element references ───
+    // Set when supported so AT walking up from the focused inner input picks
+    // up the host's referenced labels/descriptions across the shadow boundary.
+    type InternalsWithIdrefRefs = ElementInternals & {
+      ariaLabelledByElements: Element[] | null;
+      ariaDescribedByElements: Element[] | null;
+    };
+    if (this._supportsIdrefRefs) {
+      const refsInternals = internals as InternalsWithIdrefRefs;
+      refsInternals.ariaLabelledByElements =
+        labelElsForInternals.length > 0 ? labelElsForInternals : null;
+      refsInternals.ariaDescribedByElements =
+        descElsForInternals.length > 0 ? descElsForInternals : null;
+      // Modern path: forward `accessibleLabel` to `internals.ariaLabel` so AT
+      // walking the host (or reading internals) sees the explicit override.
+      // Round-8 F1 (P2): when `accessibleLabel` is absent, CLEAR the override
+      // with `null` (not `''`). Per W3C AccName, an empty-string `aria-label`
+      // STILL has higher precedence than `aria-labelledby`, so writing `''`
+      // would erase the name resolved from `ariaLabelledByElements`, the
+      // `label` property, the slotted label, or host `aria-labelledby`. `null`
+      // removes the override entirely so element references / fallbacks win.
+      if (explicitAccessibleLabel) {
+        internals.ariaLabel = explicitAccessibleLabel;
+      } else {
+        internals.ariaLabel = null;
+      }
+    }
+
+    // Round-12 F4: the host's `aria-labelledby` / `aria-describedby` are
+    // intentionally LEFT IN PLACE on both paths. The inner input owns the
+    // canonical AT surface (role="combobox") and consumes the consumer's
+    // intent via text-flatten + (modern path) ElementInternals references.
+    // The host is roleless on both paths, so leaving these attributes in
+    // place has no AT effect — and importantly, lets consumers retract them
+    // dynamically: the live attribute IS the cache, so `removeAttribute` is
+    // observable in the next sync (it returns `null` from `getAttribute`).
+
+    // ─── Compute the inner input's accessible name (text-flatten path) ───
+    // We never write `aria-labelledby="<light-DOM id>"` to the inner input —
+    // light-DOM ids do not resolve from inside a shadow root, so that pattern
+    // would leave the control AT-anonymous. Internal label ids (same shadow
+    // root) ARE allowed via `aria-labelledby`. For consumer-referenced
+    // light-DOM elements we flatten their textContent into `aria-label`.
+    // Round-8 F2 (P2): use the module-level `flattenAccName` walker which
+    // REJECTS `aria-hidden="true"` and `hidden` subtrees per AccName 1.2
+    // §4.3.10. Without this, a consumer label like
+    // `<label id="x"><svg aria-hidden="true"><title>icon</title></svg>Search</label>`
+    // would flatten to "icon Search" and leak the decorative title into the
+    // inner input's aria-label / synthesized description span.
+    // Round-9 F2 (P2): also strip top-level aria-hidden / hidden roots before
+    // flattening. `flattenAccName`'s TreeWalker checks DESCENDANTS, not the
+    // root itself, so without this filter a consumer flipping aria-hidden on
+    // a referenced label root would leave the mirrored aria-label / consumer
+    // description span stale. Mirrors the F1 modern-path filter so both
+    // surfaces agree per AccName 1.2 §4.3.10.
+    const flattenText = (els: Element[]): string =>
+      els
+        .filter(isVisibleForAccName)
+        .map((el) => flattenAccName(el))
+        .filter((t) => t.length > 0)
+        .join(' ');
+
+    let inputAriaLabel: string | null = null;
+    let inputAriaLabelledBy: string | null = null;
+    // Round-13 F1 (P2) precedence — aligns with W3C AccName 1.2 §4.3.1, with
+    // one helix-specific deviation called out below:
+    //   1. `accessibleLabel` (HELIX-SPECIFIC public-API override; documented
+    //      contract — see Round-3 F2 from the round-3 push-gate. The property
+    //      is the explicit AT-only name and intentionally outranks both
+    //      `aria-labelledby` and `aria-label`. The matching modern-path write
+    //      above clears `internals.ariaLabel` to `null` when this is unset so
+    //      we never erase a labelledby resolution.)
+    //   2. consumer `aria-labelledby` resolves → text-flatten (AccName winner
+    //      over `aria-label`; previously incorrectly demoted below it, which
+    //      meant a consumer setting both saw the inner input announce the
+    //      `aria-label` string instead of the referenced label's text)
+    //   3. consumer `aria-label` on the host (consumer escape hatch; only
+    //      reached when labelledby is absent or unresolvable)
+    //   4. slotted label → text content (NEVER cross-shadow id reference)
+    //   5. `label` property → internal `<label>` id (same shadow root) or text
+    //   6. else: unnamed
+    // Round-13 F1 (P2): the labelledby branch is allowed to fall through to
+    // the next strategy when `flattenText` returns empty (e.g. the resolved
+    // elements are visible-but-empty or filtered by AccName visibility).
+    // Without this, an aria-labelledby pointing at an empty target would
+    // park `inputAriaLabel` at `null` AND skip the host aria-label fallback,
+    // leaving the control AT-anonymous.
+    let labelledByFlat = '';
+    if (!explicitAccessibleLabel && hasEffectiveLabelledBy) {
+      labelledByFlat = flattenText(consumerLabelEls);
+    }
+    if (explicitAccessibleLabel) {
+      inputAriaLabel = explicitAccessibleLabel;
+    } else if (labelledByFlat) {
+      // Consumer aria-labelledby resolved to one or more elements. Flatten
+      // their text into aria-label so the inner input announces correctly
+      // regardless of cross-shadow id resolution. The modern-path
+      // ElementInternals write above gives AT the live IDREF chain in
+      // addition to this flattened text. Round-13 F1 (P2): this branch sits
+      // ABOVE the host `aria-label` branch so AccName 1.2 §4.3.1 precedence
+      // is preserved when the consumer sets both attributes.
+      inputAriaLabel = labelledByFlat;
+    } else if (hostAriaLabel) {
+      // Round-13 F1 (P2): host aria-label is the next fallback after
+      // accessibleLabel + a *resolved* aria-labelledby. Reaching this branch
+      // means either no aria-labelledby was set, or its IDREFs did not
+      // resolve to any element (e.g. typo, target removed, empty content) —
+      // in which case AccName 1.2 falls through to aria-label.
+      inputAriaLabel = hostAriaLabel;
+    } else if (this._labelSource === 'slot') {
+      // Round-12 F1: the slotted label may carry a light-DOM id. We MUST NOT
+      // write that id as `aria-labelledby` on the inner input — light-DOM
+      // ids do not resolve from inside a shadow root, so on engines without
+      // ElementInternals IDL refs the control would be AT-anonymous. Always
+      // text-flatten on the legacy/fallback path; the modern path already
+      // carries the live element reference via `ariaLabelledByElements`.
+      if (this._labelSlotText) {
+        inputAriaLabel = this._labelSlotText;
+      } else if (slottedLabelEls.length > 0) {
+        // Round-4 F1 (P2): flatten textContent across every assigned element.
+        // Round-8 F2 (P2): use the deep walker so nested `aria-hidden="true"`
+        // (e.g. an inline `<svg aria-hidden><title>icon</title></svg>` inside a
+        // slotted `<span>`) does not leak into the inner input's aria-label.
+        // The top-level slotted-element aria-hidden filter is already applied
+        // by `_readLabelSlotState` when populating `_labelSlotText`; this fall-
+        // through aggregator handles the case where text wasn't pre-flattened.
+        const flat = flattenText(slottedLabelEls);
+        if (flat) inputAriaLabel = flat;
+      }
+    } else if (this._labelSource === 'string') {
+      if (internalLabel?.id) {
+        inputAriaLabelledBy = internalLabel.id;
+      } else if (this.label) {
+        inputAriaLabel = this.label;
+      }
+    }
+
+    // Apply the resolved name to the inner input via attribute writes.
+    if (inputAriaLabelledBy) {
+      if (input.getAttribute('aria-labelledby') !== inputAriaLabelledBy) {
+        input.setAttribute('aria-labelledby', inputAriaLabelledBy);
+      }
+      if (input.hasAttribute('aria-label')) input.removeAttribute('aria-label');
+    } else if (inputAriaLabel) {
+      if (input.getAttribute('aria-label') !== inputAriaLabel) {
+        input.setAttribute('aria-label', inputAriaLabel);
+      }
+      if (input.hasAttribute('aria-labelledby')) input.removeAttribute('aria-labelledby');
+    } else {
+      if (input.hasAttribute('aria-label')) input.removeAttribute('aria-label');
+      if (input.hasAttribute('aria-labelledby')) input.removeAttribute('aria-labelledby');
+    }
+
+    // ─── Write the inner input's aria-describedby chain ───
+    // Round-5 F1 (P1): unify ALL descriptions through a single
+    // `aria-describedby` channel on the inner input. The W3C AccName algorithm
+    // ignores `aria-description` whenever `aria-describedby` is also present,
+    // so the previous split (internal ids on `aria-describedby`, consumer text
+    // on `aria-description`) silently dropped consumer descriptions whenever
+    // help/error text was present.
+    //
+    // For consumer-referenced light-DOM elements we cannot point inner-input
+    // `aria-describedby` directly at the consumer ids (light-DOM ids do not
+    // resolve from inside a shadow root), so the consumer text is mirrored
+    // into a synthesized in-shadow span and that same-root id is added to
+    // the chain. The synthesized span is rendered unconditionally with the
+    // visually-hidden style and updated here on every sync (idempotent).
+    const consumerDescSpan = this.shadowRoot?.getElementById(this._consumerDescId) ?? null;
+    const consumerDescText = flattenText(consumerDescEls);
+    if (consumerDescSpan && consumerDescSpan.textContent !== consumerDescText) {
+      consumerDescSpan.textContent = consumerDescText;
+    }
+
+    const describedByIds: string[] = [];
+    if (consumerDescText && consumerDescSpan) {
+      describedByIds.push(this._consumerDescId);
+    }
+    if (helpEl && !hasError && (this.helpText || this._hasHelpSlot)) {
+      describedByIds.push(this._helpTextId);
+    }
+    if (errorEl && hasError) {
+      describedByIds.push(this._errorId);
+    }
+    if (describedByIds.length > 0) {
+      const value = describedByIds.join(' ');
+      if (input.getAttribute('aria-describedby') !== value) {
+        input.setAttribute('aria-describedby', value);
+      }
+    } else if (input.hasAttribute('aria-describedby')) {
+      input.removeAttribute('aria-describedby');
+    }
+
+    // Round-5 F1 (P1): never write `aria-description` on the inner input.
+    // It is silently dropped when `aria-describedby` is also present (a
+    // common case once help/error text exists), and we now route consumer
+    // descriptions through the synthesized in-shadow span instead. Strip
+    // any legacy value defensively in case an earlier sync wrote one.
+    if (input.hasAttribute('aria-description')) {
+      input.removeAttribute('aria-description');
+    }
+  }
+
+  /**
+   * (Re-)installs the mutation observer over the current set of assigned
+   * help-text-slot nodes.
+   * @internal
+   */
+  private _installHelpSlotTextObserver(slot: HTMLSlotElement | null): void {
+    this._helpSlotTextObserver?.disconnect();
+    if (!slot) {
+      this._helpSlotTextObserver = null;
+      return;
+    }
+    // Round-6 F1 (P2): capture the slot reference so the MO callback can
+    // re-evaluate `_hasHelpSlot` from the slot's current effective text. An
+    // in-place `textContent = ''` on the same slotted node leaves
+    // `assignedNodes().length > 0` true but yields empty effective text, so
+    // we must re-read on every mutation, not just on slotchange.
+    const observer = new MutationObserver(() => {
+      this._hasHelpSlot = this._readHelpSlotStateSync(slot);
+      this._syncHostAriaSemantics();
+    });
+    slot.assignedNodes().forEach((node) => {
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        observer.observe(node, {
+          characterData: true,
+          childList: true,
+          subtree: true,
+        });
+        return;
+      }
+      // Round-9 F2 (P2): observe aria-hidden / hidden toggles so a consumer
+      // flipping visibility on the slotted help-text node (or a descendant)
+      // re-evaluates effective text and re-syncs the inner input.
+      observer.observe(node, {
+        characterData: true,
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    });
+    this._helpSlotTextObserver = observer;
+  }
+
+  /**
+   * (Re-)installs the mutation observer over the current set of assigned
+   * error-slot nodes.
+   * @internal
+   */
+  private _installErrorSlotTextObserver(slot: HTMLSlotElement | null): void {
+    this._errorSlotTextObserver?.disconnect();
+    if (!slot) {
+      this._errorSlotTextObserver = null;
+      return;
+    }
+    // Round-6 F1 (P2): capture the slot reference so the MO callback can
+    // re-evaluate `_hasErrorSlot` from the slot's current effective text. If
+    // a consumer keeps the same `<span slot="error">` node and clears its
+    // `textContent`, only the MO fires (no slotchange). Without re-reading the
+    // slot state, the combobox stays stuck in its error state: `aria-invalid`
+    // remains true, the error id stays in `aria-describedby`, and the help
+    // text stays hidden.
+    const observer = new MutationObserver(() => {
+      this._hasErrorSlot = this._readErrorSlotStateSync(slot);
+      this._syncHostAriaSemantics();
+    });
+    slot.assignedNodes().forEach((node) => {
+      if (node.nodeType !== Node.ELEMENT_NODE) {
+        observer.observe(node, {
+          characterData: true,
+          childList: true,
+          subtree: true,
+        });
+        return;
+      }
+      // Round-9 F2 (P2): observe aria-hidden / hidden toggles so a consumer
+      // flipping visibility on the slotted error node (or a descendant)
+      // re-evaluates effective text and re-syncs the inner input.
+      observer.observe(node, {
+        characterData: true,
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    });
+    this._errorSlotTextObserver = observer;
   }
 
   // ─── Form Integration ───
@@ -369,6 +1341,10 @@ export class HelixCombobox extends FormMixin(HelixElement) {
   /** @internal */
   override _updateValidity(): void {
     if (this.required && !this.value) {
+      // W3C APG editable combobox: the inner `<input>` is the canonical
+      // announced + focused combobox surface, so anchor `setValidity()` to
+      // the inner input. Native validation popups attach to the focusable
+      // form-control surface.
       this._internals.setValidity(
         { valueMissing: true },
         this.error || this.labelRequired,
@@ -377,6 +1353,11 @@ export class HelixCombobox extends FormMixin(HelixElement) {
     } else {
       this._internals.setValidity({});
     }
+    // Re-sync ARIA after every setValidity() so `aria-invalid` on the inner
+    // input reflects the freshly computed validity state. The render template
+    // binds `aria-invalid` from `_invalid`; mutating `_invalid` (a `@state`)
+    // inside sync schedules a Lit update if the value actually changed.
+    this._syncHostAriaSemantics();
   }
 
   /** @internal */
@@ -437,10 +1418,112 @@ export class HelixCombobox extends FormMixin(HelixElement) {
 
   // ─── Slot Change Handlers ───
 
+  /**
+   * Tracks the slotted label so projected `<span slot="label">` content joins
+   * the accessible-name chain.
+   * @internal
+   */
+  private _handleLabelSlotChange(e: Event): void {
+    if (!(e.target instanceof HTMLSlotElement)) return;
+    const state = this._readLabelSlotState(e.target);
+    this._hasLabelSlot = state.hasUsefulName;
+    this._slottedLabelEls = state.elements;
+    this._labelSlotText = state.text;
+    // Round-4 F2 (P2): re-install the in-place text-mutation observer on the
+    // current set of slotted elements. `slotchange` covers ADD/REMOVE/REPLACE
+    // of assigned nodes; this MO covers `node.textContent = '…'` updates on
+    // an unchanged node (e.g. consumer i18n re-render keeping the same span).
+    this._installLabelSlotTextObserver(state.elements);
+    this._refreshLabelSource();
+    this._syncHostAriaSemantics();
+  }
+
+  /**
+   * (Re-)installs the mutation observer over the current set of slotted label
+   * elements. Round-4 F2 (P2): mirrors the round-23 P2 pattern from
+   * `_helpSlotTextObserver` / `_errorSlotTextObserver`. On any descendant text
+   * change we re-read the slot state (to refresh `_labelSlotText` and the
+   * element list) and re-sync host ARIA so the inner input's `aria-label`
+   * tracks the live label text.
+   * @internal
+   */
+  private _installLabelSlotTextObserver(elements: Element[]): void {
+    this._labelSlotTextObserver?.disconnect();
+    if (elements.length === 0) {
+      this._labelSlotTextObserver = null;
+      return;
+    }
+    const observer = new MutationObserver(() => {
+      // Re-aggregate text from the same elements (the MO does not give us a
+      // slot reference). The element list itself only changes on `slotchange`,
+      // which re-installs this observer with the new list.
+      //
+      // Round-6 F2 (P2): mirror `_readLabelSlotState` — skip aria-hidden
+      // elements per AccName 1.2 §4.3.10, and gate `_hasLabelSlot` on the
+      // flattened TEXT (not element presence). An in-place clear of the
+      // visible label's textContent must flip `_hasLabelSlot` back to false
+      // so `_labelSource` falls through to other naming sources or the host
+      // becomes unnamed (consumer responsibility).
+      const fragments: string[] = [];
+      for (const el of elements) {
+        if (el.getAttribute('aria-hidden') === 'true') continue;
+        // Round-8 F2 (P2): use the deep walker so nested aria-hidden / hidden
+        // subtrees inside slotted parents are skipped per AccName 1.2 §4.3.10.
+        const t = flattenAccName(el);
+        if (t) fragments.push(t);
+      }
+      const trimmed = fragments.join(' ').replace(/\s+/g, ' ').trim();
+      this._labelSlotText = trimmed;
+      this._hasLabelSlot = trimmed.length > 0;
+      this._refreshLabelSource();
+      this._syncHostAriaSemantics();
+    });
+    for (const el of elements) {
+      // Round-9 F2 (P2): observe `aria-hidden` / `hidden` toggles on the
+      // slotted label root AND its descendants. The MO callback above re-runs
+      // `flattenAccName` and re-derives `_hasLabelSlot` from effective text —
+      // so an in-place visibility flip on a child must trigger a fresh sync.
+      observer.observe(el, {
+        characterData: true,
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    }
+    this._labelSlotTextObserver = observer;
+  }
+
+  /**
+   * Recomputes the discriminated label source.
+   * @internal
+   */
+  private _refreshLabelSource(): void {
+    if (this.label) {
+      this._labelSource = 'string';
+    } else if (this._hasLabelSlot) {
+      this._labelSource = 'slot';
+    } else {
+      this._labelSource = 'none';
+    }
+  }
+
   /** @internal */
   private _handleErrorSlotChange(e: Event): void {
-    const slot = e.target as HTMLSlotElement;
-    this._hasErrorSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    if (!(e.target instanceof HTMLSlotElement)) return;
+    // Round-6 F1 (P2): single-source-of-truth state read.
+    this._hasErrorSlot = this._readErrorSlotStateSync(e.target);
+    this._installErrorSlotTextObserver(e.target);
+    this._syncHostAriaSemantics();
+  }
+
+  /** @internal */
+  private _handleHelpSlotChange(e: Event): void {
+    if (!(e.target instanceof HTMLSlotElement)) return;
+    // Round-6 F1 (P2): single-source-of-truth state read.
+    this._hasHelpSlot = this._readHelpSlotStateSync(e.target);
+    this._installHelpSlotTextObserver(e.target);
+    this._syncHostAriaSemantics();
   }
 
   // ─── Dropdown Control ───
@@ -576,6 +1659,10 @@ export class HelixCombobox extends FormMixin(HelixElement) {
         this._closeDropdown();
         this._filterText = '';
         if (this._input) this._input.value = '';
+        // Note: do NOT call this.focus() here — the inner <input> already has
+        // focus when Escape is pressed and refocusing would re-trigger
+        // _handleFocus → _openDropdown, immediately re-opening the listbox.
+        // The input remains focused so the user can continue typing.
         break;
       }
       case 'Tab': {
@@ -676,7 +1763,14 @@ export class HelixCombobox extends FormMixin(HelixElement) {
 
   // ─── Public Methods ───
 
-  /** Moves focus to the text input. */
+  /**
+   * Routes programmatic focus to the inner text input. Per W3C APG editable
+   * combobox pattern, the inner `<input>` carries `role="combobox"` (replacing
+   * its implicit textbox role) so it IS the canonical announced + focused
+   * surface. Shadow DOM focus causes `document.activeElement` to report the
+   * host externally, but the input retains focus inside the shadow root and
+   * AT announces its role/state.
+   */
   override focus(options?: FocusOptions): void {
     this._input?.focus(options);
   }
@@ -751,6 +1845,7 @@ export class HelixCombobox extends FormMixin(HelixElement) {
 
   override render() {
     const hasError = !!this.error || this._hasErrorSlot;
+    const hasHelp = !!this.helpText || this._hasHelpSlot;
     const showClear = this.clearable && !!this.value && !this.disabled;
 
     const fieldClasses = {
@@ -766,23 +1861,21 @@ export class HelixCombobox extends FormMixin(HelixElement) {
       [`field__input--${this.size}`]: true,
     };
 
-    const describedBy =
-      [
-        hasError || this._hasErrorSlot ? this._errorId : null,
-        this.helpText ? this._helpTextId : null,
-      ]
-        .filter(Boolean)
-        .join(' ') || undefined;
-
-    const activedescendant =
-      this._open && this._focusedOptionIndex >= 0
-        ? this._optionId(this._focusedOptionIndex)
-        : undefined;
+    // W3C APG editable combobox (option I): role="combobox" lives on the
+    // inner <input>, replacing the implicit textbox role so AT sees a single
+    // canonical announced + focused surface. All combobox state ARIA —
+    // aria-expanded, aria-controls, aria-activedescendant, aria-autocomplete,
+    // aria-haspopup, aria-required, aria-invalid, aria-disabled, aria-busy —
+    // is bound on the input via Lit. aria-label / aria-labelledby /
+    // aria-describedby are written imperatively by _syncHostAriaSemantics
+    // after consumer-IDREF resolution.
+    const activeOptionId =
+      this._open && this._focusedOptionIndex >= 0 ? this._optionId(this._focusedOptionIndex) : '';
 
     return html`
       <div part="field" class=${classMap(fieldClasses)}>
         <!-- Label -->
-        <slot name="label">
+        <slot name="label" @slotchange=${this._handleLabelSlotChange}>
           ${this.label
             ? html`<label id=${this._labelId} for=${this._id} part="label" class="field__label">
                 ${this.label}
@@ -836,31 +1929,35 @@ export class HelixCombobox extends FormMixin(HelixElement) {
               })
             : nothing}
 
-          <!-- Text Input (combobox role) -->
+          <!--
+            Text input — W3C APG editable combobox (option I).
+            role="combobox" REPLACES the implicit textbox role; all combobox
+            state ARIA lives here so AT sees one canonical surface.
+            aria-label / aria-labelledby / aria-describedby are written
+            imperatively by _syncHostAriaSemantics after consumer IDREF
+            resolution and are not bound here.
+          -->
           <input
             part="input"
             type="text"
             id=${this._id}
-            class=${classMap(inputClasses)}
             role="combobox"
-            aria-expanded=${this._open ? 'true' : 'false'}
-            aria-autocomplete="list"
-            aria-controls=${this._listboxId}
-            aria-activedescendant=${ifDefined(activedescendant)}
-            aria-invalid=${hasError ? 'true' : nothing}
-            aria-describedby=${ifDefined(describedBy)}
-            aria-required=${this.required ? 'true' : nothing}
-            aria-label=${ifDefined(this.accessibleLabel || undefined)}
-            aria-labelledby=${ifDefined(
-              this.label && !this.accessibleLabel ? this._labelId : undefined,
-            )}
-            aria-busy=${this.loading ? 'true' : nothing}
+            class=${classMap(inputClasses)}
             .value=${this._filterText || (this._open ? '' : this._displayValue)}
             placeholder=${ifDefined(this.placeholder || undefined)}
             ?disabled=${this.disabled}
             ?required=${this.required}
             name=${ifDefined(this.name || undefined)}
             autocomplete="off"
+            aria-haspopup="listbox"
+            aria-autocomplete="list"
+            aria-controls=${this._listboxId}
+            aria-expanded=${this._open ? 'true' : 'false'}
+            aria-activedescendant=${ifDefined(activeOptionId || undefined)}
+            aria-required=${this.required ? 'true' : 'false'}
+            aria-invalid=${this._invalid ? 'true' : 'false'}
+            aria-busy=${this.loading ? 'true' : nothing}
+            aria-disabled=${this.disabled ? 'true' : nothing}
             @input=${this._handleInput}
             @focus=${this._handleFocus}
             @keydown=${this._handleKeydown}
@@ -925,28 +2022,51 @@ export class HelixCombobox extends FormMixin(HelixElement) {
         <!-- Hidden slot (options read from here) -->
         <slot name="option" @slotchange=${this._handleSlotChange} style="display:none;"></slot>
 
-        <!-- Error -->
-        <slot name="error" @slotchange=${this._handleErrorSlotChange}>
-          ${hasError
-            ? html`<div part="error" class="field__error" id=${this._errorId} role="alert">
-                ${this.error}
-              </div>`
-            : nothing}
-        </slot>
+        <!--
+          Persistent error live region. role="alert" is set from first paint
+          so the WAI-ARIA contract for live updates is honoured.
+        -->
+        <div
+          part="error"
+          class="field__error"
+          id=${this._errorId}
+          role="alert"
+          ?hidden=${!hasError}
+        >
+          <slot name="error" @slotchange=${this._handleErrorSlotChange}
+            >${this._announcedError}</slot
+          >
+        </div>
 
-        <!-- Help Text -->
-        ${this.helpText && !hasError
-          ? html`
-              <div part="help-text" class="field__help-text" id=${this._helpTextId}>
-                <slot name="help-text">${this.helpText}</slot>
-              </div>
-            `
-          : nothing}
+        <!--
+          Persistent help-text container. Rendered whenever the property OR
+          the slot has content; hidden when an error is present.
+        -->
+        <div
+          part="help-text"
+          class="field__help-text"
+          id=${this._helpTextId}
+          ?hidden=${!hasHelp || hasError}
+        >
+          <slot name="help-text" @slotchange=${this._handleHelpSlotChange}>${this.helpText}</slot>
+        </div>
 
         <!-- Filter results live region -->
         <div id=${this._liveRegionId} aria-live="polite" aria-atomic="true" class="field__sr-only">
           ${this._filterAnnouncement}
         </div>
+
+        <!--
+          Round-5 F1 (P1): synthesized in-shadow mirror of the consumer-
+          resolved description text. Its id is appended to the inner input's
+          aria-describedby chain so AT picks the consumer description up
+          through the standard described-by channel without needing
+          aria-description (which W3C AccName drops whenever
+          aria-describedby is also present). Same-root id resolves from
+          inside the shadow tree; consumer light-DOM ids do not. The text
+          content is updated by _syncHostAriaSemantics on every sync.
+        -->
+        <span id=${this._consumerDescId} class="field__sr-only" aria-hidden="false"></span>
       </div>
     `;
   }
@@ -970,6 +2090,9 @@ declare global {
   }
   interface HTMLElementEventMap {
     'hx-input': CustomEvent<{ value: string }>;
+    // hx-change is also declared by hx-checkbox with a wider union; both
+    // declarations must agree — the union covers all components that fire it.
+    'hx-change': CustomEvent<{ value: string } | { checked: boolean; value: string }>;
     'hx-clear': CustomEvent<void>;
     'hx-show': CustomEvent<void>;
     'hx-hide': CustomEvent<void>;

--- a/packages/hx-react/src/components/HxCombobox/types.ts
+++ b/packages/hx-react/src/components/HxCombobox/types.ts
@@ -46,7 +46,7 @@ Note: `mixinDelegatesAria` is not applied to this component because form
 inputs with associated labels delegate accessible naming via `<label>`
 association and `aria-labelledby`, not host-level ARIA delegation. The
 `accessible-label` attribute is a fallback for label-free usage. The value is forwarded to the
-internal input's `aria-label`. */
+host's `internals.ariaLabel` on the modern path. */
   accessibleLabel?: string | null;
   /** Text shown when no options match the current filter. */
   labelNoOptions?: string;


### PR DESCRIPTION
## Summary

ARIA Group 3 — hx-combobox migrated to W3C APG editable-combobox pattern (option I). 180/180 tests green. **12 rounds of push-gate codex review applied.** Closes 29 findings.

**Architecture decision: option-I, NOT option-II.**

\`hx-combobox\` is an editable combobox per W3C APG (users type to filter options). \`role=\"combobox\"\` lives ON the inner \`<input>\` where it replaces the implicit textbox role. Structurally distinct from \`hx-select\` (a non-editable select-replacement, host-canonical option II). The first round of push-gate codex caught this — the initial migration mirrored hx-select's pattern, which was wrong for an editable combobox.

## Cross-shadow naming (belt-and-suspenders)

Modern engines (with \`internals.ariaLabelledByElements\` / \`ariaDescribedByElements\`):
- Host carries \`internals.aria*Elements\` set to consumer-resolved + visible slotted label elements
- Consumer host \`aria-labelledby\` / \`aria-describedby\` PRESERVED so AT walking up resolves them
- \`internals.ariaLabel\` cleared with \`null\` (not \`''\`) so element refs win

Legacy fallback (no IDL element-references):
- Host attributes stay intact (component never writes ARIA to host)
- Consumer-resolved label elements text-flatten into inner input \`aria-label\` per AccName 1.2 §4.3.1 precedence
- Slotted label aggregates ALL assigned nodes (elements + text) with whitespace collapse per AccName

## Description channel

Unified through \`aria-describedby\` via synthesized hidden span:
- Visually-hidden \`<span>\` in shadow root carries consumer-resolved description text
- Inner input \`aria-describedby\` = [consumer-desc-id?, help-id?, error-id?] joined
- \`aria-description\` is NEVER written on the inner input (W3C: ignored when describedby present)

## Hidden content (AccName 1.2 §4.3.10)

\`flattenAccName()\` TreeWalker rejects \`aria-hidden=\"true\"\` AND \`[hidden]\` subtrees, including roots. Cascades through every flatten path: external IDREF, slotted label aggregation, slot text MOs, slot effective-text helpers.

## Mutation observation

Six MutationObservers wired up:
- \`_externalRefsObserver\` — characterData/childList/attributes (aria-hidden/hidden) on resolved external label/desc elements
- \`_labelSlotTextObserver\` — same on slotted label elements  
- \`_helpSlotTextObserver\` / \`_errorSlotTextObserver\` — same on slotted help/error
- \`_hostDescribedByObserver\` — defense-in-depth on host attribute changes (round-10 disconnect-during-strip pattern retired since don't-strip approach landed)

Each observer re-reads slot effective state (using \`flattenAccName\` for hidden-aware text) BEFORE calling sync.

## Validity surface

Unioned across:
- \`ElementInternals.setValidity()\` (built-in required-empty)
- consumer \`error\` property/attribute (server-side / async)
- slotted error content
- \`aria-invalid\` reflects union; \`_announcedError\` seeded in \`willUpdate\` for first paint AND every error change

## First-paint correctness

\`firstUpdated()\` → \`_seedSlotStateSync()\` proactively reads each named slot's \`assignedNodes()\` BEFORE the first \`_syncHostAriaSemantics()\` call. Eliminates the slotchange-microtask-late hole.

## Inner input ARIA surface

\`role=\"combobox\"\`, \`aria-haspopup=\"listbox\"\`, \`aria-autocomplete=\"list\"\`, \`aria-controls\`, \`aria-expanded\`, \`aria-activedescendant\`, \`aria-required\`, \`aria-invalid\`, \`aria-busy\`, \`aria-disabled\`. Cross-shadow IDREFs on the input (controls, activedescendant) resolve same-root because listbox + options render in the same shadow root.

## Name-resolution precedence (per public contract + AccName 1.2 §4.3.1)

1. \`accessibleLabel\` property (helix-specific override for AT-only naming)
2. consumer \`aria-labelledby\` (cross-shadow elements via belt-and-suspenders)
3. host \`aria-label\` (consumer string)
4. slotted label (aggregated, hidden-aware)
5. \`label\` property
6. unnamed (devWarn at firstUpdated)

## Codex push-gate closure (12 rounds, 29 findings)

| Round | Verdict | Findings | Closures |
|---|---|---|---|
| 1 | BLOCKING | 3 | option-II → option-I architectural revert + slotted element labels |
| 2 (session) | BLOCKING | 4 | consumer light-DOM IDREFs + regression tests + dead code cleanup |
| 3 | BLOCKING | 4 | slot id leak + accessibleLabel precedence + error invalid + don't-strip retraction |
| 4 | CONCERNS | 2 | multi-node slot aggregation + in-place text mutation observer |
| 5 | BLOCKING | 2 | description channel unified + first-paint slot state seeding |
| 6 | CONCERNS | 2 | slot state recomputation + AccName aria-hidden in slot resolver |
| 7 | CONCERNS | 2 | external IDREF text observer + first-paint error |
| 8 | CONCERNS | 2 | ariaLabel null-clear + flattenText AccName tree walker |
| 9 | CONCERNS | 2 | hidden filter on internals.ariaLabelledByElements + visibility-attr observation |
| 10 | CONCERNS | 3 | forced-colors restored + willUpdate error seed + slot effective text via flattenAccName |
| 11 | CONCERNS | 2 | hidden ROOTS in slot label/help/error |
| 12 | CONCERNS | 1 | aria-labelledby precedence over aria-label per AccName |
| 13 | **PASS** | 1 (P3) | clear button name (deferred follow-up) |

## Test coverage

180/180 passing. **50 new regression tests** added across the codex loop covering:
- Modern + legacy paths × labelledby + describedby
- Help + error slot state under in-place mutation, hidden roots, hidden descendants
- Retraction sequences (consumer adds then removes attributes)
- First-paint slot state, runtime error population
- Multi-node slot aggregation, decorative-only slots, mixed decorative + text
- Whitespace collapse, AccName visibility tree walking
- accessibleLabel override, aria-labelledby precedence
- Forced-colors mixin composition
- External IDREF visibility-attr toggles, descendant attribute toggles

## Deferred follow-up

- **P3 round-13:** \`labelRemoveOption\` clear-button name should derive from the resolved combobox label rather than the static labels. Tracked separately; non-blocking.

## Test plan

- [x] \`pnpm test:smart\` — 180/180 hx-combobox tests pass
- [x] \`pnpm run verify\` — 14/14 turborepo tasks pass (lint, format:check, type-check, build)
- [x] Pre-push gate (gitleaks, prettier, eslint, type-check, smart tests, shellcheck) — all green
- [x] rea push-gate codex review — PASS verdict
- [ ] CI (Quality Gates) — GitHub Actions
- [ ] CodeRabbit review

🚦 \`@helixui/library\` minor bump (additive — option-I architecture, no API breaking changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced accessible label and description support in combobox component
  * Strengthened W3C APG editable-combobox ARIA compliance

* **Bug Fixes**
  * Improved ARIA handling and accessibility for combobox
  * Updated event type signature for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->