### PR TITLE
chore(budget): re-baseline CDN bundle ceilings for ARIA Group 3

### DIFF
--- a/.cdn-budget.json
+++ b/.cdn-budget.json
@@ -1,22 +1,22 @@
 {
   "comment": "CDN bundle size budgets for @helixui/library (gzipped bytes). Enforced in CI by scripts/check-cdn-size.mjs. Changes require code review and a justification in the PR description. The CDN build emits several artifacts with different size profiles — this file tracks per-artifact budgets rather than a single aggregate ceiling so drift in one strategy (A vs B) is surfaced precisely.",
-  "rationale": "Measured from packages/hx-library/dist/cdn/ on main at v2.1.2 (full JS=183.4 KB, full CSS=46.3 KB, core JS=8.4 KB, Strategy A=229.7 KB). Re-baselined 2026-04-25 after the 3.2.0 component-tier + palette expansion landed (full JS climbed to ~200.4 KB gz with the 3.2.1 token-cascade remediation). Re-baselined 2026-05-04 for ARIA Group 2 (selection controls): host-canonical ElementInternals refactor across hx-checkbox, hx-checkbox-group, hx-radio, hx-radio-group, hx-switch, hx-toggle-button added IDREF feature detection and branched render paths, taking full JS to ~210.3 KB gz and full CSS to ~53.3 KB gz (forced-colors blocks). Headroom is intentionally tight per artifact — fullBundleJs ~2.2%, fullBundleCss ~12.6%, coreBundleJs ~42.9%, strategyATotal ~2.4%. The fullBundleJs / strategyATotal envelope is sized to fail one Group 3-10 component shy of needing another bump: each remaining ARIA group is expected to add ~5-10 KB and will require its own re-baseline commit with attribution. Warn thresholds sit approximately halfway between current and ceiling (rounded for readability — fullBundleCss and coreBundleJs warns predate this convention and are left unchanged) so drift is surfaced before the hard fail.",
+  "rationale": "Measured from packages/hx-library/dist/cdn/ on main at v2.1.2 (full JS=183.4 KB, full CSS=46.3 KB, core JS=8.4 KB, Strategy A=229.7 KB). Re-baselined 2026-04-25 after the 3.2.0 component-tier + palette expansion landed (full JS climbed to ~200.4 KB gz with the 3.2.1 token-cascade remediation). Re-baselined 2026-05-04 for ARIA Group 2 (selection controls): host-canonical ElementInternals refactor across 6 components took full JS to ~210.3 KB gz and full CSS to ~53.3 KB gz. Re-baselined 2026-05-05 for ARIA Group 3 (selects/combos/pickers): hx-select host-canonical option-II combobox + hx-combobox option-I editable combobox + hx-time-picker + hx-date-picker + hx-color-picker — each adds ~1.5-3 KB for the AccName 1.2 §4.3.10 hardening pattern stack (12 patterns across 6 mutation observers, synthesized hidden description span, slot label aggregation, validity surface union, first-paint slot state seeding, etc.). hx-select + hx-combobox alone took fullBundleJs to ~216.7 KB gz; pickers (3 components) project to add ~6-10 KB more to fullBundleJs + ~1-2 KB CSS. New ceiling 230 KB / strategyATotal 290 KB sized to absorb the rest of Group 3 plus a small margin, with another re-baseline expected for Group 4 (overlays / disclosure — modal dialogs, popovers, tooltips, dropdowns, accordions). Headroom is intentionally tight per artifact so drift is surfaced. Warn thresholds sit approximately halfway between current and ceiling.",
   "budgets": {
     "fullBundleJs": {
       "file": "helix-{version}.min.js",
       "description": "Strategy A full self-contained JS bundle (all 81 components + Lit).",
-      "ceilingBytes": 220160,
-      "warnBytes": 217600,
-      "currentBytes": 215347,
-      "currentNote": "210.3 KB gz at ARIA Group 2 head (was 200.4 KB at 3.2.1; Group 2 host-canonical ElementInternals refactor added ~10 KB across 6 components — hx-checkbox, hx-checkbox-group, hx-radio, hx-radio-group, hx-switch, hx-toggle-button — IDREF feature detection + branched modern/fallback render paths)"
+      "ceilingBytes": 235520,
+      "warnBytes": 225280,
+      "currentBytes": 221952,
+      "currentNote": "216.7 KB gz at ARIA Group 3 partial-head (hx-select + hx-combobox merged; was 210.3 KB at Group 2 head — Group 3a adds ~6.4 KB so far across host-canonical option-II + option-I + AccName flatten + 6 mutation observers + synthesized hidden desc span. hx-time-picker + hx-date-picker + hx-color-picker are pending and will add ~6-10 KB more, hence the 230 KB ceiling)"
     },
     "fullBundleCss": {
       "file": "helix-{version}.min.css",
       "description": "Strategy A full CSS bundle (all component shadow-root-adoptable CSS).",
       "ceilingBytes": 61440,
       "warnBytes": 56320,
-      "currentBytes": 54579,
-      "currentNote": "53.3 KB gz at ARIA Group 2 head (was 51.0 KB at 3.2.1; Group 2 added forced-colors blocks across 6 components (hx-checkbox, hx-checkbox-group, hx-radio, hx-radio-group, hx-switch, hx-toggle-button) — ~2.3 KB)"
+      "currentBytes": 55296,
+      "currentNote": "54.0 KB gz at ARIA Group 3 partial-head (was 53.3 KB at Group 2 head; Group 3 adds ~0.7 KB so far for .field__sr-only visually-hidden style + minor CSS adjustments per component)"
     },
     "coreBundleJs": {
       "file": "helix-core-{version}.min.js",
@@ -28,10 +28,10 @@
     },
     "strategyATotal": {
       "description": "Aggregate Strategy A consumer payload (full JS + full CSS). This is what a page that loads the full bundle actually downloads.",
-      "ceilingBytes": 276480,
-      "warnBytes": 273203,
-      "currentBytes": 269926,
-      "currentNote": "263.6 KB gz at ARIA Group 2 head (was 251.4 KB at 3.2.1; tracks fullBundleJs + fullBundleCss growth — Group 2 added ~10 KB JS + ~2.3 KB CSS across 6 components — hx-checkbox, hx-checkbox-group, hx-radio, hx-radio-group, hx-switch, hx-toggle-button)"
+      "ceilingBytes": 296960,
+      "warnBytes": 286720,
+      "currentBytes": 277248,
+      "currentNote": "270.7 KB gz at ARIA Group 3 partial-head (was 263.6 KB at Group 2 head; tracks fullBundleJs + fullBundleCss growth — Group 3a added ~7 KB so far)"
     }
   }
 }

--- a/.changeset/group-3-budget-rebaseline.md
+++ b/.changeset/group-3-budget-rebaseline.md
@@ -1,0 +1,12 @@
+---
+'@helixui/library': patch
+---
+
+Re-baseline CDN bundle ceilings for ARIA Group 3 (selects/combos/pickers)
+
+Config-only change to `.cdn-budget.json` per the documented per-Group bump pattern. No public API change. Bundle ceilings raised to accommodate Group 3 ARIA hardening pattern stack (~6.4 KB JS so far across hx-select + hx-combobox; pickers project to add ~6-10 KB more).
+
+- `fullBundleJs` ceiling: 215.0 KB → 230.0 KB
+- `strategyATotal` ceiling: 270.0 KB → 290.0 KB
+
+Unblocks PR #1631 (hx-combobox) and PR #1632 (hx-time-picker) bundle size CI checks.


### PR DESCRIPTION
## Summary

Re-baseline CDN bundle budgets for ARIA Group 3 (selects/combos/pickers) per the documented per-Group bump pattern. Unblocks PR #1631 (hx-combobox) and PR #1632 (hx-time-picker) which currently fail Build/Coverage on the Group 2 ceiling.

## Changes

- `fullBundleJs` ceiling: 215.0 KB → **230.0 KB** (220160 → 235520 bytes)
- `strategyATotal` ceiling: 270.0 KB → **290.0 KB** (276480 → 296960 bytes)
- `fullBundleCss` ceiling: unchanged (60.0 KB)
- `coreBundleJs` ceiling: unchanged (12.0 KB)

## Current sizes (post hx-select + hx-combobox land)

- fullBundleJs: 216.7 KB gz (was 210.3 KB at Group 2 head, +6.4 KB)
- fullBundleCss: 54.0 KB gz (was 53.3 KB, +0.7 KB)
- strategyATotal: 270.7 KB gz (+7.1 KB)

## Why Group 3 added ~6.4 KB JS

Each Group 3 component carries 12 hardening patterns from the canonical hx-combobox stack:
- 6 MutationObservers (external IDREFs + 4 slots + host attrs)
- AccName 1.2 §4.3.10 `flattenAccName` TreeWalker (rejects aria-hidden/[hidden] subtrees)
- Synthesized hidden consumer-desc span in shadow root
- `_supportsIdrefRefs` + `__testSupportsIdrefRefsOverride` seam
- Modern + legacy branch resolution in `_syncHostAriaSemantics`
- Validity surface union (setValidity ∪ error prop ∪ slotted error)
- First-paint slot state seeding (`_seedSlotStateSync`)
- Forced-colors mixin composition
- Cross-shadow IDREF + assignedSlot owner walk in aria-idref util

## Headroom rationale

Pickers (hx-time-picker + hx-date-picker + hx-color-picker) project to add ~6-10 KB more to fullBundleJs as they land. New ceiling absorbs that plus a small margin (~8 KB headroom). Group 4 (overlays/disclosure — modal dialogs, popovers, tooltips, dropdowns, accordions) will need its own re-baseline once those land.

## Test plan

- [x] Local verify clean (`pnpm run verify`)
- [ ] CI Bundle Size Check passes (this PR)
- [ ] CI Bundle Size Check passes on PR #1631 + PR #1632 after this lands

🚦 No version bump (config-only change to `.cdn-budget.json`).