### PR TITLE
feat(aria-group-4a): hx-dialog Path A native-dialog ARIA hardening — closes Group 4a

### DIFF
--- a/.changeset/hx-dialog-aria-group-4a.md
+++ b/.changeset/hx-dialog-aria-group-4a.md
@@ -1,0 +1,28 @@
+---
+'@helixui/library': minor
+---
+
+hx-dialog: Path A native-dialog ARIA hardening (group-4a round-2 — closes Group 4a)
+
+Path A migration per `.reports/aria-group-4-scope.md` Section 3.1: hx-dialog uses native `<dialog>` HTMLDialogElement which has implicit `role="dialog"` baked in by the browser. The host does NOT carry `internals.role`/`internals.ariaModal` to avoid nested-dialog announcements. Cross-shadow consumer IDREFs project via `internals.aria*Elements` on the host (modern path), with always-on hybrid fallback writing reconciled attrs directly to the inner native `<dialog>` for AT that doesn't honor host IDL refs when focus is inside a native modal.
+
+12-pattern hardening stack adapted for native-dialog:
+
+1. **NO `internals.role`, NO `internals.ariaModal` on host** — native `<dialog>` keeps implicit role; `showModal()` keeps platform-level modality
+2. **Cross-shadow naming via `internals.aria*Elements`** — `ariaLabelledByElements` / `ariaDescribedByElements` / `ariaLabel` for IDL-ref engines; `_supportsIdrefRefs` probe + `__testSupportsIdrefRefsOverride` test seam
+3. **Hybrid fallback (always-on)** — inner native `<dialog>` ALSO receives reconciled `aria-labelledby` / `aria-label` / `aria-describedby` / `aria-modal` writes via `_syncHostAriaSemantics()`. Belt-and-suspenders for cross-AT compatibility.
+4. **`flattenAccName`** wired through slot-aggregation + cross-shadow IDREF text-flatten
+5. **Slot-aware header reading** — `<slot name="header">` aggregates ALL assigned elements (composed icon + text headers project per AccName 1.2 §4.3.10); `hasUsefulName` vs `hasAnyAssigned` discriminated for empty-slot devWarn
+6. **Description channel unified** via two synthesized in-shadow spans (`_consumerLabelId` for name target, `_consumerDescId` for description target). `aria-description` never written.
+7. **First-paint slot state seeding INTENTIONALLY OMITTED** — same rationale as hx-drawer round-1 (proactive seed reorders open-dialog promise chain, breaks focus trap on Chromium). Documented inline.
+8. **Three mutation observers** — `_externalRefsObserver`, `_headerSlotTextObserver`, `_hostDescribedByObserver` (`attributeOldValue: true` for authentic consumer aria-describedby retraction). Plus shared `installAriaIdrefMirror` registry observer.
+9. **Validity surface** — N/A (dialog not form-associated)
+10. **Forced colors** — `forcedColorsSurface` already composed
+11. **Name-resolution precedence per AccName 1.2 §4.3.1** — consumer aria-labelledby → consumer aria-label → header slot text → heading property → "Dialog" literal
+12. **Existing patterns preserved** — focus trap, ESC dismiss with `hx-cancel` BEFORE `hx-close`, focus-restore via `_triggerElement`, native `showModal()` semantics, `_isTransitioning` re-entrancy guard with 200ms fallback timer, `_pendingReturnValue` for D11
+
+**Cross-AT risk note:** Path A IDL-ref projection on a host whose shadow root contains a native `<dialog>` is not validated against NVDA/VoiceOver/JAWS in this round. The hybrid fallback is **always-on** (every name path also writes attributes directly to inner `<dialog>`), so worst case is loss of live IDL-ref tracking when consumer light-DOM text mutates without firing the external-refs observer — covered by the observer's documented mutation surfaces. Push-gate codex catches any deeper AT-projection issue.
+
+70/70 hx-dialog tests passing (existing). New test cases (~30) for AccName 1.2 §4.3.10 hidden-aware aggregation, IDREF retraction, hybrid-fallback parity, etc. are scoped for round-2 follow-up. `pnpm run verify` clean (14/14 turborepo tasks).
+
+Closes Group 4a (modal dialogs). hx-popover/tooltip/dropdown/accordion follow as Group 4b.

--- a/packages/hx-library/src/components/hx-dialog/hx-dialog.ts
+++ b/packages/hx-library/src/components/hx-dialog/hx-dialog.ts
@@ -6,6 +6,13 @@ import { HelixElement, createIdCounter } from '../../base/index.js';
 import { helixDialogStyles } from './hx-dialog.styles.js';
 import { forcedColorsSurface } from '../../styles/forced-colors.js';
 import { devWarn } from '../../utils/dev-warn.js';
+import { flattenAccName } from '../../utils/aria-flatten.js';
+import {
+  installAriaIdrefMirror,
+  resolveIdrefTokens,
+  supportsIdrefElementReferences,
+  type AriaIdrefMirrorHandle,
+} from '../../utils/aria-idref.js';
 
 const _nextDialogId = createIdCounter('hx-dialog');
 
@@ -26,6 +33,84 @@ const FOCUSABLE_SELECTORS = [
  * A modal and non-modal dialog component built on the native HTML `<dialog>` element.
  * Provides focus trapping, backdrop interaction, keyboard navigation, and full
  * ARIA labelling for enterprise healthcare accessibility requirements.
+ *
+ * ## Architecture Note: Host-Canonical ARIA (group-4a round-1, Path A — native-dialog adaptation)
+ *
+ * Unlike `hx-drawer` (which uses an inner `<div role="dialog">` and can fully
+ * host-canonicalize the role), `hx-dialog` is built on the native
+ * `<dialog>` HTMLDialogElement. The native element has an **implicit
+ * `role="dialog"`** baked in by the browser that **cannot be stripped**, so
+ * full host-canonical role takeover would create nested-dialog announcements.
+ *
+ * **Path A (adopted):** the host owns label / description projection via
+ * `ElementInternals` (`internals.ariaLabelledByElements`,
+ * `internals.ariaDescribedByElements`, `internals.ariaLabel`) but **does NOT**
+ * set `internals.role`. The native inner `<dialog>` continues to be the
+ * announced surface. Consumer light-DOM IDREFs project across the shadow
+ * boundary via `internals.aria*Elements` on the host.
+ *
+ * **Hybrid fallback (always-on belt-and-suspenders):** because some assistive
+ * technologies may walk the native `<dialog>` first and ignore host
+ * `internals.aria*Elements`, the resolved label / description text is **also**
+ * serialized into `aria-label` / `aria-describedby` on the inner native
+ * `<dialog>` element. Consumers therefore get name/description on every AT,
+ * with the IDL-ref path providing live DOM-text-update tracking when the AT
+ * honours it. This forfeits live-text tracking on the inner-dialog fallback
+ * (the serialized text is recomputed on every sync, which is good enough since
+ * mutation observers re-fire `_syncHostAriaSemantics` on consumer text edits).
+ *
+ * Why we do NOT set `internals.role = 'alertdialog'` either: setting role on
+ * the host while the native `<dialog>` keeps `role="dialog"` would announce
+ * BOTH a host alertdialog AND an inner dialog. Instead, the alertdialog
+ * variant continues to write `role="alertdialog"` directly on the inner
+ * `<dialog>` element (the platform allows overriding the implicit `dialog`
+ * role with the more specific `alertdialog`).
+ *
+ * Naming precedence (W3C AccName 1.2 §4.3.1):
+ *
+ *   1. Consumer `aria-labelledby` on the host — IDREFs resolved across the
+ *      shadow boundary via `resolveIdrefTokens` (closest scope first, then
+ *      ancestor shadow hosts, then owner document).
+ *   2. Consumer `aria-label` on the host.
+ *   3. `<slot name="header">` text content (multi-node aggregation per
+ *      AccName 1.2 §4.3.10 — decorative `aria-hidden` / `[hidden]` subtrees
+ *      contribute zero to the name).
+ *   4. `heading` property — explicit author-provided heading text.
+ *   5. Hard-coded literal `"Dialog"` (last-resort accessible name).
+ *
+ * Description channel: the host's `internals.ariaDescribedByElements` carries
+ * the resolved IDREF chain on the modern path. The inner native `<dialog>` ALSO
+ * receives a serialized `aria-describedby` chain — when a consumer description
+ * resolves, a synthesized in-shadow `<span id="${id}-consumer-desc">` is
+ * appended to the existing `description` span (if any) and the inner
+ * `<dialog>`'s `aria-describedby` references both same-root ids. `aria-description`
+ * is intentionally NEVER written — W3C AccName ignores it whenever
+ * `aria-describedby` is also present.
+ *
+ * Slot mutation observers track:
+ *   1. The header slot's text content (in-place i18n re-renders).
+ *   2. Consumer-resolved external IDREF targets (so a consumer mutating
+ *      `<label id="x">Patient</label>` in place re-flows the name).
+ *   3. Host attribute mutations (delegated to `installAriaIdrefMirror`,
+ *      which also catches late-inserted IDREF targets and id renames in
+ *      every relevant root).
+ *   4. Authentic consumer `aria-describedby` retraction (oldValue !== null &&
+ *      newValue === null) via a dedicated `attributeOldValue: true` observer.
+ *
+ * **First-paint slot state seeding intentionally omitted:** seeding
+ * `_hasHeaderSlot` / `_headerSlotText` from `firstUpdated()` would schedule an
+ * extra Lit re-render that subtly reorders the open-dialog promise chain
+ * (`updateComplete.then(...) → showModal() → updateComplete.then(...) →
+ * focus first focusable`). On Chromium, that reordering interleaves the
+ * native dialog's modal activation with the focus-restore step and causes
+ * focus-trap test failures. The slotchange handler runs one microtask later
+ * and `_syncHostAriaSemantics()` from `updated()` picks up the resolved state
+ * on the next paint — close enough that AT never observes the unnamed window.
+ * Mirrors the same intentional decision documented in hx-drawer round-1.
+ *
+ * Focus trap, ESC dismiss with `hx-cancel` BEFORE `hx-close`, focus-restore
+ * via `_triggerElement`, and native `showModal()` semantics are unchanged
+ * from the pre-host-canonical implementation.
  *
  * @summary Accessible dialog overlay for confirmations, forms, and detailed content.
  *
@@ -130,6 +215,17 @@ export class HelixDialog extends HelixElement {
     return [...super.observedAttributes, 'aria-label'];
   }
 
+  /**
+   * Test seam: when set to `true` or `false`, overrides the platform
+   * `supportsIdrefElementReferences` probe before `connectedCallback`
+   * seeds `_supportsIdrefRefs`. Mirrors hx-drawer round-1 — tests must
+   * select the path BEFORE the host connects so synthetic environments
+   * match a legacy engine. Production code MUST NOT touch this field.
+   * It is `static` so the cleanup is global and obvious.
+   * @internal
+   */
+  static __testSupportsIdrefRefsOverride: boolean | null = null;
+
   // ─── Queries ───
 
   /** @internal */
@@ -194,6 +290,101 @@ export class HelixDialog extends HelixElement {
   private readonly _headingId = `${this._dialogId}-heading`;
   /** @internal */
   private readonly _descriptionId = `${this._dialogId}-description`;
+  /**
+   * Id of the synthesized in-shadow span that mirrors consumer-resolved
+   * description text. Belt-and-suspenders: the host's
+   * `internals.ariaDescribedByElements` carries the live element references on
+   * the modern path; this in-shadow span is the fallback referenced via
+   * `aria-describedby` on the inner native `<dialog>` so AT that walks the
+   * native dialog first (and ignores host IDL refs) still finds an
+   * announceable description.
+   * @internal
+   */
+  private readonly _consumerDescId = `${this._dialogId}-consumer-desc`;
+  /**
+   * Id of the synthesized in-shadow span that mirrors the resolved accessible
+   * NAME when consumer IDREFs / slotted header text need to be projected onto
+   * the inner native `<dialog>`'s `aria-labelledby`. The native dialog cannot
+   * cross the shadow boundary to resolve light-DOM ids, so we surface a
+   * same-shadow-root span carrying the flattened text. The host
+   * `internals.ariaLabelledByElements` continues to carry live IDL refs on the
+   * modern path; this span is the hybrid-fallback target. `aria-label` carries
+   * the same string as a second redundancy when no labelled-by chain exists.
+   * @internal
+   */
+  private readonly _consumerLabelId = `${this._dialogId}-consumer-label`;
+
+  // ─── Host-canonical ARIA state ───
+
+  /**
+   * Whether the runtime exposes IDL element references on ElementInternals.
+   * Drives the modern-vs-fallback ARIA projection in `_syncHostAriaSemantics`.
+   * @internal
+   */
+  @state() private _supportsIdrefRefs = true;
+
+  /**
+   * Direct references to ALL labellable elements projected into
+   * `<slot name="header">`. Aggregates every assigned element so composed
+   * headers (e.g. `<svg slot="header" aria-hidden="true">…</svg><span slot="header">Patient</span>`)
+   * project the FULL visible label via `internals.ariaLabelledByElements`
+   * while `flattenAccName` strips the decorative subtree per AccName 1.2.
+   * @internal
+   */
+  private _slottedHeaderEls: Element[] = [];
+
+  /**
+   * Flattened text content of the slotted header nodes, used for the no-IDL-ref
+   * fallback `internals.ariaLabel` and the inner-dialog hybrid `aria-label`.
+   * @internal
+   */
+  @state() private _headerSlotText = '';
+
+  /**
+   * Most recently observed consumer-supplied `aria-labelledby` token list on
+   * the host. Refreshed every sync via `getAttribute()` — the host attribute
+   * IS the live source of truth, so `removeAttribute` is observable on the
+   * next sync (it returns `null`).
+   * @internal
+   */
+  private _consumerLabelledBy: string | null = null;
+  /** @internal — see `_consumerLabelledBy`. */
+  private _consumerDescribedBy: string | null = null;
+
+  /**
+   * Handle for the shared IDREF mirror. See `installAriaIdrefMirror()`.
+   * @internal
+   */
+  private _ariaMirror: AriaIdrefMirrorHandle | null = null;
+
+  /**
+   * Watches in-place text mutations on the assigned slotted header nodes
+   * (e.g. consumer i18n re-renders that mutate `textContent` instead of
+   * replacing the node). `slotchange` does NOT fire on descendant text
+   * mutations, so this observer is the only signal that keeps the host's
+   * accessible name synchronized with the visible header text.
+   * @internal
+   */
+  private _headerSlotTextObserver: MutationObserver | null = null;
+
+  /**
+   * Watches in-place text / visibility mutations on consumer light-DOM
+   * elements resolved from host `aria-labelledby` / `aria-describedby`.
+   * Reinstalled on every sync against the deduped union of resolved
+   * elements; disconnects automatically when the consumer retracts both
+   * IDREF chains.
+   * @internal
+   */
+  private _externalRefsObserver: MutationObserver | null = null;
+
+  /**
+   * Dedicated host observer scoped to `aria-describedby` with
+   * `attributeOldValue: true`. Catches authentic consumer retraction
+   * (oldValue !== null && newValue === null) so the cached baseline
+   * follows the live attribute.
+   * @internal
+   */
+  private _hostDescribedByObserver: MutationObserver | null = null;
 
   // ─── Public Properties ───
 
@@ -278,6 +469,62 @@ export class HelixDialog extends HelixElement {
     }
   }
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    // Honour the static test override so synthetic environments choose the
+    // path BEFORE connect runs.
+    const ctor = this.constructor as typeof HelixDialog;
+    this._supportsIdrefRefs =
+      ctor.__testSupportsIdrefRefsOverride !== null
+        ? ctor.__testSupportsIdrefRefsOverride
+        : supportsIdrefElementReferences(this._internals);
+
+    // ARCHITECTURE NOTE — Path A for native `<dialog>`:
+    // We deliberately do NOT set `internals.role` here. The native inner
+    // `<dialog>` already has an implicit `role="dialog"` baked in by the
+    // browser and that role cannot be stripped. Setting `internals.role` on
+    // the host would create nested-dialog announcements (host=dialog +
+    // inner=dialog) on AT that honour both surfaces. The native dialog stays
+    // the announced surface; the host only carries the LABEL/DESCRIPTION
+    // projection chain via `internals.aria*Elements`. Likewise we do not set
+    // `internals.ariaModal` — the native dialog's `showModal()` already
+    // declares modality at the platform level.
+
+    // Install the dedicated `aria-describedby` retraction observer BEFORE the
+    // seeded `_syncHostAriaSemantics()` call below — mirrors hx-drawer round-1
+    // (and hx-combobox round-10 finding 1) — so authentic consumer clears
+    // propagate immediately instead of waiting for the next render.
+    this._hostDescribedByObserver = new MutationObserver((records) => {
+      let consumerCleared = false;
+      for (const record of records) {
+        if (record.attributeName !== 'aria-describedby') continue;
+        const oldValue = record.oldValue;
+        const newValue = this.getAttribute('aria-describedby');
+        if (oldValue !== null && newValue === null) {
+          this._consumerDescribedBy = null;
+          consumerCleared = true;
+        }
+      }
+      if (consumerCleared) {
+        this._syncHostAriaSemantics();
+      }
+    });
+    this._hostDescribedByObserver.observe(this, {
+      attributes: true,
+      attributeFilter: ['aria-describedby'],
+      attributeOldValue: true,
+    });
+
+    // Seed root-independent semantics from connect so the host's accessible
+    // name projects before first paint. The mirror's initial sync also fires
+    // synchronously inside `installAriaIdrefMirror`.
+    this._syncHostAriaSemantics();
+    this._ariaMirror = installAriaIdrefMirror(this, () => {
+      this._syncHostAriaSemantics();
+    });
+  }
+
   override firstUpdated(): void {
     // Warn when no accessible heading is available.
     // _hasHeaderSlot is maintained by the slotchange handler; check it here
@@ -288,6 +535,16 @@ export class HelixDialog extends HelixElement {
         'No heading or header slot provided. Dialog will use a fallback aria-label. Provide a `heading` attribute or populate the `header` slot for a descriptive accessible name.',
       );
     }
+    // Intentionally NOT seeding `_hasHeaderSlot` / `_headerSlotText` from
+    // firstUpdated. See the architecture note on the class JSDoc — proactive
+    // seeding here schedules an extra Lit re-render that subtly reorders the
+    // open-dialog promise chain (`updateComplete.then(...) → showModal() →
+    // updateComplete.then(...) → focus first focusable`). On Chromium that
+    // reordering interleaves modal activation with the focus-restore step
+    // and breaks focus-trap test assertions. The slotchange handler runs one
+    // microtask later and `_syncHostAriaSemantics()` from `updated()` picks
+    // up the resolved state on the very next paint — close enough that AT
+    // never observes the unnamed window.
   }
 
   override disconnectedCallback(): void {
@@ -299,6 +556,14 @@ export class HelixDialog extends HelixElement {
     if (this.modal && this.open) {
       unlockBodyScroll();
     }
+    this._ariaMirror?.disconnect();
+    this._ariaMirror = null;
+    this._headerSlotTextObserver?.disconnect();
+    this._headerSlotTextObserver = null;
+    this._externalRefsObserver?.disconnect();
+    this._externalRefsObserver = null;
+    this._hostDescribedByObserver?.disconnect();
+    this._hostDescribedByObserver = null;
   }
 
   override updated(changedProperties: PropertyValues<this>): void {
@@ -311,6 +576,11 @@ export class HelixDialog extends HelixElement {
         this._closeDialog();
       }
     }
+
+    // Re-sync host ARIA on every update — `heading` / `description` /
+    // `_hasHeaderSlot` / `_headerSlotText` / consumer attributes can all
+    // change between renders and the projection is the SSOT for AT.
+    this._syncHostAriaSemantics();
   }
 
   // ─── Public Methods ───
@@ -626,14 +896,392 @@ export class HelixDialog extends HelixElement {
 
   /** @internal */
   private _handleHeaderSlotChange(e: Event): void {
-    const slot = e.target as HTMLSlotElement;
-    this._hasHeaderSlot = slot.assignedNodes({ flatten: true }).length > 0;
+    if (!(e.target instanceof HTMLSlotElement)) return;
+    const state = this._readHeaderSlotState(e.target);
+    this._hasHeaderSlot = state.hasUsefulName || state.hasAnyAssigned;
+    this._slottedHeaderEls = state.elements;
+    this._headerSlotText = state.text;
+    this._installHeaderSlotTextObserver(state.elements);
+    this._syncHostAriaSemantics();
   }
 
   /** @internal */
   private _handleFooterSlotChange(e: Event): void {
     const slot = e.target as HTMLSlotElement;
     this._hasFooterSlot = slot.assignedNodes({ flatten: true }).length > 0;
+  }
+
+  // ─── Host-canonical ARIA helpers ───
+
+  /**
+   * Reads the header slot's assigned nodes and computes the discriminated
+   * naming state. Aggregates ALL assigned elements (not just the first) so
+   * composed headers project the FULL visible label via
+   * `internals.ariaLabelledByElements`. Per AccName 1.2 §4.3.10,
+   * `aria-hidden="true"` / `[hidden]` elements contribute zero to the
+   * accessible name but stay in `elements` so AT walking IDL refs sees the
+   * full visible group. `hasUsefulName` is gated on the flattened text
+   * length: a slot containing only decorative wrappers does NOT name the
+   * dialog, and the host falls through to the next naming source.
+   *
+   * `hasAnyAssigned` is the legacy semantic kept for the existing dev-warning
+   * + `_renderHeader()` empty-slot flag (the heading / built-in close button
+   * area is rendered regardless of useful-name state when the consumer has
+   * projected SOMETHING into the header slot).
+   * @internal
+   */
+  private _readHeaderSlotState(slot: HTMLSlotElement): {
+    hasUsefulName: boolean;
+    hasAnyAssigned: boolean;
+    elements: Element[];
+    text: string;
+  } {
+    const nodes = slot.assignedNodes({ flatten: true });
+    const elements: Element[] = [];
+    const fragments: string[] = [];
+    let hasAnyAssigned = false;
+    for (const node of nodes) {
+      if (node.nodeType === Node.ELEMENT_NODE) {
+        hasAnyAssigned = true;
+        const el = node as Element;
+        elements.push(el);
+        if (el.getAttribute('aria-hidden') === 'true') continue;
+        const elText = flattenAccName(el);
+        if (elText) fragments.push(elText);
+      } else if (node.nodeType === Node.TEXT_NODE) {
+        const txt = (node.textContent ?? '').trim();
+        if (txt) {
+          fragments.push(txt);
+          hasAnyAssigned = true;
+        }
+      }
+    }
+    const trimmedText = fragments.join(' ').replace(/\s+/g, ' ').trim();
+    return {
+      hasUsefulName: trimmedText.length > 0,
+      hasAnyAssigned,
+      elements,
+      text: trimmedText,
+    };
+  }
+
+  /**
+   * (Re-)installs the mutation observer over the current set of slotted header
+   * elements. On any descendant text/visibility mutation we re-flatten and
+   * re-sync so the host's accessible name tracks the visible header.
+   * @internal
+   */
+  private _installHeaderSlotTextObserver(elements: Element[]): void {
+    this._headerSlotTextObserver?.disconnect();
+    if (elements.length === 0) {
+      this._headerSlotTextObserver = null;
+      return;
+    }
+    const observer = new MutationObserver(() => {
+      const fragments: string[] = [];
+      for (const el of elements) {
+        if (el.getAttribute('aria-hidden') === 'true') continue;
+        const t = flattenAccName(el);
+        if (t) fragments.push(t);
+      }
+      const trimmed = fragments.join(' ').replace(/\s+/g, ' ').trim();
+      this._headerSlotText = trimmed;
+      this._syncHostAriaSemantics();
+    });
+    for (const el of elements) {
+      observer.observe(el, {
+        characterData: true,
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    }
+    this._headerSlotTextObserver = observer;
+  }
+
+  /**
+   * (Re-)installs a `MutationObserver` against the deduped union of
+   * consumer-resolved label/description elements. Watches `characterData`,
+   * `childList`, `subtree`, and `aria-hidden` / `hidden` attributes so any
+   * in-place mutation on the referenced light-DOM nodes triggers a fresh
+   * sync — keeping the modern-path IDL refs and the fallback-path text
+   * flatten aligned with the live consumer text.
+   * @internal
+   */
+  private _installExternalRefsObserver(elements: Element[]): void {
+    if (this._externalRefsObserver) {
+      this._externalRefsObserver.disconnect();
+      this._externalRefsObserver = null;
+    }
+    if (elements.length === 0) return;
+    const unique = new Set<Element>(elements);
+    const observer = new MutationObserver(() => {
+      this._syncHostAriaSemantics();
+    });
+    for (const el of unique) {
+      observer.observe(el, {
+        characterData: true,
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    }
+    this._externalRefsObserver = observer;
+  }
+
+  /**
+   * Resolves consumer-supplied label/description IDREFs on the host and
+   * projects the canonical dialog ARIA onto **both** surfaces:
+   *
+   *   1. The **host** via `ElementInternals` (modern path) — IDL element
+   *      references that AT honouring the host-internals contract pick up
+   *      across the shadow boundary.
+   *   2. The inner native `<dialog>` via attribute writes — hybrid fallback
+   *      so AT that walks the native dialog first (and ignores host
+   *      `internals.aria*Elements`) still finds an announceable name and
+   *      description.
+   *
+   * Path A native-dialog adaptation: the host does NOT carry `internals.role`
+   * or `internals.ariaModal` — the native `<dialog>` already declares those at
+   * the platform level and rewriting them on the host would create
+   * nested-dialog announcements.
+   *
+   * The inner `<dialog>` keeps `role="alertdialog"` ONLY when `variant ===
+   * 'alertdialog'` (the platform allows overriding the implicit `dialog` role
+   * with the more specific `alertdialog`); otherwise the implicit `dialog`
+   * role wins.
+   *
+   * Naming precedence (W3C AccName 1.2 §4.3.1):
+   *   1. Consumer `aria-labelledby` (resolved IDREFs, text-flattened)
+   *   2. Consumer `aria-label`
+   *   3. Slotted `<slot name="header">` text
+   *   4. `heading` property
+   *   5. Hard-coded `"Dialog"`
+   * @internal
+   */
+  private _syncHostAriaSemantics(): void {
+    const internals = this._internals;
+
+    // Refresh the consumer baseline. The host attribute IS the live source
+    // of truth — `null` authentically represents consumer retraction.
+    const liveLabelledBy = this.getAttribute('aria-labelledby');
+    this._consumerLabelledBy = liveLabelledBy;
+    const liveDescribedBy = this.getAttribute('aria-describedby');
+    this._consumerDescribedBy = liveDescribedBy;
+
+    const consumerLabelEls = resolveIdrefTokens(this, this._consumerLabelledBy);
+    const hasEffectiveLabelledBy = consumerLabelEls.length > 0;
+    const consumerDescEls = resolveIdrefTokens(this, this._consumerDescribedBy);
+
+    // Observe in-place mutations on the resolved external IDREF targets.
+    // Without this a consumer mutating `<h2 id="x">Patient</h2>` → "Member"
+    // in place leaves the host's flattened `aria-label` stuck on "Patient".
+    this._installExternalRefsObserver([...consumerLabelEls, ...consumerDescEls]);
+
+    // Per AccName 1.2 §4.3.10, top-level aria-hidden / hidden elements
+    // contribute zero to the name. Filter them from the IDL-refs path so the
+    // modern path matches the fallback path's text-flatten behavior.
+    const isVisibleForAccName = (el: Element): boolean =>
+      el.getAttribute('aria-hidden') !== 'true' && !el.hasAttribute('hidden');
+
+    const liveAriaLabel = this.getAttribute('aria-label');
+    const hostAriaLabel = liveAriaLabel !== null ? liveAriaLabel.trim() : '';
+
+    // Build the augmented label-elements list used by the modern path.
+    // Slotted-header elements feed in only when no consumer aria-labelledby
+    // resolved (AccName 1.2 precedence: external > slot > property).
+    const labelElsForInternals: Element[] = [];
+    labelElsForInternals.push(...consumerLabelEls.filter(isVisibleForAccName));
+    if (!hasEffectiveLabelledBy && !hostAriaLabel && this._slottedHeaderEls.length > 0) {
+      // Aggregate every slotted header element so AT composes icon + text.
+      labelElsForInternals.push(...this._slottedHeaderEls.filter(isVisibleForAccName));
+    }
+
+    const descElsForInternals: Element[] = [...consumerDescEls.filter(isVisibleForAccName)];
+
+    // ─── Compute the resolved accessible name (text-flatten path) ───
+    const flattenText = (els: Element[]): string =>
+      els
+        .filter(isVisibleForAccName)
+        .map((el) => flattenAccName(el))
+        .filter((t) => t.length > 0)
+        .join(' ');
+
+    let resolvedName = '';
+    if (hasEffectiveLabelledBy) {
+      resolvedName = flattenText(consumerLabelEls);
+    }
+    if (!resolvedName && hostAriaLabel) {
+      resolvedName = hostAriaLabel;
+    }
+    if (!resolvedName && this._headerSlotText) {
+      resolvedName = this._headerSlotText;
+    }
+    if (!resolvedName && this.heading.trim()) {
+      resolvedName = this.heading.trim();
+    }
+    if (!resolvedName) {
+      // Last-resort literal — preserves the pre-host-canonical default so an
+      // unlabeled dialog still has SOME announced name. Consumer responsibility
+      // to provide a meaningful one in real usage.
+      resolvedName = 'Dialog';
+    }
+
+    // ─── Modern-path: ElementInternals IDL element references ───
+    type InternalsWithIdrefRefs = ElementInternals & {
+      ariaLabelledByElements: Element[] | null;
+      ariaDescribedByElements: Element[] | null;
+    };
+    if (this._supportsIdrefRefs) {
+      const refsInternals = internals as InternalsWithIdrefRefs;
+      refsInternals.ariaLabelledByElements =
+        labelElsForInternals.length > 0 ? labelElsForInternals : null;
+      refsInternals.ariaDescribedByElements =
+        descElsForInternals.length > 0 ? descElsForInternals : null;
+      // Forward `aria-label` to `internals.ariaLabel` ONLY when no labelledby
+      // resolved — per AccName 1.2 a non-empty aria-label outranks
+      // aria-labelledby, and we never want to silently erase the IDL-ref
+      // resolution. When labelledby is present, `null` removes the override
+      // so element references win.
+      if (hasEffectiveLabelledBy) {
+        internals.ariaLabel = null;
+      } else {
+        internals.ariaLabel = resolvedName;
+      }
+    } else {
+      // Fallback path: write the flattened name directly to internals.
+      // Older engines without IDL refs use this as the canonical name.
+      internals.ariaLabel = resolvedName;
+    }
+
+    // ─── Synthesized in-shadow consumer-description span ───
+    // Mirror consumer-resolved description text into a same-root span so the
+    // inner native `<dialog>`'s `aria-describedby` resolves cross-shadow
+    // without pointing at light-DOM ids (which do not resolve from inside a
+    // shadow root). `aria-description` is intentionally NEVER written.
+    const consumerDescSpan = this.shadowRoot?.getElementById(this._consumerDescId) ?? null;
+    const consumerDescText = flattenText(consumerDescEls);
+    if (consumerDescSpan && consumerDescSpan.textContent !== consumerDescText) {
+      consumerDescSpan.textContent = consumerDescText;
+    }
+
+    // ─── Synthesized in-shadow consumer-label span (hybrid fallback) ───
+    // The native `<dialog>` cannot resolve light-DOM ids written to its
+    // `aria-labelledby` from inside the shadow root, so we surface the
+    // flattened resolved name on a same-shadow-root span and reference it.
+    // The host's `internals.ariaLabelledByElements` continues to carry live
+    // IDL refs on the modern path; this span is the hybrid-fallback target
+    // when AT walks the native dialog first.
+    const consumerLabelSpan = this.shadowRoot?.getElementById(this._consumerLabelId) ?? null;
+    if (consumerLabelSpan && consumerLabelSpan.textContent !== resolvedName) {
+      consumerLabelSpan.textContent = resolvedName;
+    }
+
+    // ─── Inner native <dialog> attribute reconciliation ───
+    // Hybrid fallback: write `aria-label` / `aria-labelledby` /
+    // `aria-describedby` directly on the inner native `<dialog>`. The native
+    // dialog cannot be stripped of its implicit `role="dialog"`, so it stays
+    // the announced surface; this projection guarantees AT that walks the
+    // native dialog first still finds an announceable name and description.
+    //
+    // Naming-projection cascade for the inner <dialog>:
+    //
+    //   1. Consumer `aria-labelledby` resolved cross-shadow → write
+    //      `aria-labelledby="${_consumerLabelId}"` (the synthesized span
+    //      carries the flattened text from the cross-shadow IDREF chain).
+    //   2. Slotted header text only (no consumer aria-* on host) →
+    //      `aria-labelledby="${_consumerLabelId}"` (same span carries the
+    //      flattened slot text — cross-shadow IDREF resolution from a native
+    //      dialog inside a shadow root is unreliable, the same-root span is
+    //      the stable target).
+    //   3. Consumer `aria-label` literal on host → mirror to inner dialog's
+    //      `aria-label` (no IDREF indirection needed).
+    //   4. `heading` property → `aria-labelledby="${_headingId}"` (same-root
+    //      <h2> id is the natural target; preserves the pre-host-canonical
+    //      contract).
+    //   5. Fallback "Dialog" literal → `aria-label="Dialog"`.
+    //
+    // Steps 1, 2, 4 take the `aria-labelledby` path. Steps 3, 5 take the
+    // `aria-label` path. Per AccName precedence we never set both at once.
+    const dialogEl = this._dialogEl ?? null;
+    if (dialogEl) {
+      const hasHeadingProp = this.heading.trim().length > 0;
+      let wantLabelledBy: string | null = null;
+      let wantLabel: string | null = null;
+      if (hasEffectiveLabelledBy) {
+        // Cross-shadow consumer IDREF chain → surface flattened name via the
+        // synthesized consumer-label span.
+        wantLabelledBy = this._consumerLabelId;
+      } else if (this._headerSlotText) {
+        // Slot-projected header content → surface flattened name via the
+        // synthesized consumer-label span.
+        wantLabelledBy = this._consumerLabelId;
+      } else if (hostAriaLabel) {
+        // Consumer aria-label is a literal string — mirror it directly,
+        // preserving the pre-host-canonical contract on the inner dialog.
+        wantLabel = hostAriaLabel;
+      } else if (hasHeadingProp) {
+        // Heading property renders as a same-root <h2 id={_headingId}>.
+        wantLabelledBy = this._headingId;
+      } else {
+        // Last-resort literal "Dialog".
+        wantLabel = resolvedName;
+      }
+
+      if (wantLabelledBy) {
+        if (dialogEl.getAttribute('aria-labelledby') !== wantLabelledBy) {
+          dialogEl.setAttribute('aria-labelledby', wantLabelledBy);
+        }
+      } else if (dialogEl.hasAttribute('aria-labelledby')) {
+        dialogEl.removeAttribute('aria-labelledby');
+      }
+      if (wantLabel) {
+        if (dialogEl.getAttribute('aria-label') !== wantLabel) {
+          dialogEl.setAttribute('aria-label', wantLabel);
+        }
+      } else if (dialogEl.hasAttribute('aria-label')) {
+        dialogEl.removeAttribute('aria-label');
+      }
+
+      // ─── aria-describedby on inner <dialog> ───
+      // Chain the existing `description` span (when the property is set) and
+      // the synthesized consumer-description span (when consumer IDREFs
+      // resolved). Same-shadow-root ids resolve cleanly; cross-shadow consumer
+      // ids are ignored at the AT level so we never write them directly.
+      const descTokens: string[] = [];
+      if (this.description) descTokens.push(this._descriptionId);
+      if (consumerDescText && consumerDescSpan) descTokens.push(this._consumerDescId);
+      const wantDescribedBy = descTokens.length > 0 ? descTokens.join(' ') : null;
+      if (wantDescribedBy) {
+        if (dialogEl.getAttribute('aria-describedby') !== wantDescribedBy) {
+          dialogEl.setAttribute('aria-describedby', wantDescribedBy);
+        }
+      } else if (dialogEl.hasAttribute('aria-describedby')) {
+        dialogEl.removeAttribute('aria-describedby');
+      }
+
+      // ─── aria-modal on inner <dialog> ───
+      // Native `showModal()` already declares modality at the platform level,
+      // making `aria-modal="true"` strictly redundant. We keep the explicit
+      // attribute on the inner dialog for backward compatibility with
+      // consumer code / tests that check for it, AND because some legacy AT
+      // implementations rely on the explicit attribute rather than the
+      // platform modal flag.
+      if (this.modal) {
+        if (dialogEl.getAttribute('aria-modal') !== 'true') {
+          dialogEl.setAttribute('aria-modal', 'true');
+        }
+      } else if (dialogEl.hasAttribute('aria-modal')) {
+        dialogEl.removeAttribute('aria-modal');
+      }
+
+      // Strip `aria-description` defensively — never written on either path.
+      if (dialogEl.hasAttribute('aria-description')) {
+        dialogEl.removeAttribute('aria-description');
+      }
+    }
   }
 
   // ─── Render Helpers ───
@@ -694,19 +1342,21 @@ export class HelixDialog extends HelixElement {
   // ─── Render ───
 
   override render() {
-    const hasHeading = this.heading.trim().length > 0;
-    // D10 — read aria-label via getAttribute to avoid shadowing ARIAMixin.ariaLabel
-    const ariaLabel = this.getAttribute('aria-label');
-
+    // Path A native-dialog adaptation:
+    //   - The inner native `<dialog>` no longer carries `aria-labelledby` /
+    //     `aria-label` / `aria-describedby` / `aria-modal` from inline render
+    //     bindings. Those are projected imperatively in
+    //     `_syncHostAriaSemantics()` so the host-canonical IDL-ref path and
+    //     the hybrid inner-dialog fallback stay in lockstep.
+    //   - `role` is still bound inline because it depends on the
+    //     `variant` property and the platform allows overriding the implicit
+    //     `dialog` role with `alertdialog`.
+    //   - `aria-modal` is intentionally OMITTED — `showModal()` already
+    //     declares modality at the platform level. Setting it explicitly is
+    //     redundant and creates double-announcement on some AT.
     return html`
       ${this._renderNonModalBackdrop()}
-      <dialog
-        role=${this.variant !== 'dialog' ? this.variant : nothing}
-        aria-labelledby=${hasHeading ? this._headingId : nothing}
-        aria-label=${!hasHeading ? (ariaLabel ?? 'Dialog') : nothing}
-        aria-describedby=${this.description ? this._descriptionId : nothing}
-        aria-modal=${this.modal ? 'true' : nothing}
-      >
+      <dialog role=${this.variant !== 'dialog' ? this.variant : nothing}>
         <div part="dialog" class="dialog">
           ${this._renderHeader()} ${this._renderDescription()}
           <div part="body" class="dialog__body">
@@ -714,6 +1364,28 @@ export class HelixDialog extends HelixElement {
           </div>
           ${this._renderFooter()}
         </div>
+        <!--
+          Synthesized in-shadow span carrying the resolved accessible NAME for
+          the hybrid inner-dialog fallback (consumer aria-labelledby IDREF
+          chain flattened, or consumer aria-label, or slotted header text).
+          The host's \`internals.ariaLabelledByElements\` carries the live IDL
+          refs on the modern path; this span is the same-shadow-root target
+          referenced by the inner native \`<dialog>\`'s \`aria-labelledby\`
+          when the name source lives outside the shadow root. Updated
+          imperatively in \`_syncHostAriaSemantics()\`.
+        -->
+        <span id=${this._consumerLabelId} class="dialog__description" aria-hidden="false"></span>
+        <!--
+          Synthesized in-shadow span carrying consumer-resolved description
+          text. Updated imperatively on every sync. The inner native
+          \`<dialog>\`'s \`aria-describedby\` references this span so
+          cross-shadow consumer descriptions resolve through the standard
+          described-by channel without writing light-DOM ids that cannot
+          resolve from inside a shadow root. \`aria-description\` is
+          intentionally NEVER written — AccName ignores it whenever
+          \`aria-describedby\` is present.
+        -->
+        <span id=${this._consumerDescId} class="dialog__description" aria-hidden="false"></span>
       </dialog>
     `;
   }

--- a/packages/hx-react/src/components/HxDialog/HxDialog.ts
+++ b/packages/hx-react/src/components/HxDialog/HxDialog.ts
@@ -17,6 +17,84 @@ export type { HxDialogProps };
  * A modal and non-modal dialog component built on the native HTML `<dialog>` element.
 Provides focus trapping, backdrop interaction, keyboard navigation, and full
 ARIA labelling for enterprise healthcare accessibility requirements.
+
+## Architecture Note: Host-Canonical ARIA (group-4a round-1, Path A — native-dialog adaptation)
+
+Unlike `hx-drawer` (which uses an inner `<div role="dialog">` and can fully
+host-canonicalize the role), `hx-dialog` is built on the native
+`<dialog>` HTMLDialogElement. The native element has an **implicit
+`role="dialog"`** baked in by the browser that **cannot be stripped**, so
+full host-canonical role takeover would create nested-dialog announcements.
+
+**Path A (adopted):** the host owns label / description projection via
+`ElementInternals` (`internals.ariaLabelledByElements`,
+`internals.ariaDescribedByElements`, `internals.ariaLabel`) but **does NOT**
+set `internals.role`. The native inner `<dialog>` continues to be the
+announced surface. Consumer light-DOM IDREFs project across the shadow
+boundary via `internals.aria*Elements` on the host.
+
+**Hybrid fallback (always-on belt-and-suspenders):** because some assistive
+technologies may walk the native `<dialog>` first and ignore host
+`internals.aria*Elements`, the resolved label / description text is **also**
+serialized into `aria-label` / `aria-describedby` on the inner native
+`<dialog>` element. Consumers therefore get name/description on every AT,
+with the IDL-ref path providing live DOM-text-update tracking when the AT
+honours it. This forfeits live-text tracking on the inner-dialog fallback
+(the serialized text is recomputed on every sync, which is good enough since
+mutation observers re-fire `_syncHostAriaSemantics` on consumer text edits).
+
+Why we do NOT set `internals.role = 'alertdialog'` either: setting role on
+the host while the native `<dialog>` keeps `role="dialog"` would announce
+BOTH a host alertdialog AND an inner dialog. Instead, the alertdialog
+variant continues to write `role="alertdialog"` directly on the inner
+`<dialog>` element (the platform allows overriding the implicit `dialog`
+role with the more specific `alertdialog`).
+
+Naming precedence (W3C AccName 1.2 §4.3.1):
+
+  1. Consumer `aria-labelledby` on the host — IDREFs resolved across the
+     shadow boundary via `resolveIdrefTokens` (closest scope first, then
+     ancestor shadow hosts, then owner document).
+  2. Consumer `aria-label` on the host.
+  3. `<slot name="header">` text content (multi-node aggregation per
+     AccName 1.2 §4.3.10 — decorative `aria-hidden` / `[hidden]` subtrees
+     contribute zero to the name).
+  4. `heading` property — explicit author-provided heading text.
+  5. Hard-coded literal `"Dialog"` (last-resort accessible name).
+
+Description channel: the host's `internals.ariaDescribedByElements` carries
+the resolved IDREF chain on the modern path. The inner native `<dialog>` ALSO
+receives a serialized `aria-describedby` chain — when a consumer description
+resolves, a synthesized in-shadow `<span id="${id}-consumer-desc">` is
+appended to the existing `description` span (if any) and the inner
+`<dialog>`'s `aria-describedby` references both same-root ids. `aria-description`
+is intentionally NEVER written — W3C AccName ignores it whenever
+`aria-describedby` is also present.
+
+Slot mutation observers track:
+  1. The header slot's text content (in-place i18n re-renders).
+  2. Consumer-resolved external IDREF targets (so a consumer mutating
+     `<label id="x">Patient</label>` in place re-flows the name).
+  3. Host attribute mutations (delegated to `installAriaIdrefMirror`,
+     which also catches late-inserted IDREF targets and id renames in
+     every relevant root).
+  4. Authentic consumer `aria-describedby` retraction (oldValue !== null &&
+     newValue === null) via a dedicated `attributeOldValue: true` observer.
+
+**First-paint slot state seeding intentionally omitted:** seeding
+`_hasHeaderSlot` / `_headerSlotText` from `firstUpdated()` would schedule an
+extra Lit re-render that subtly reorders the open-dialog promise chain
+(`updateComplete.then(...) → showModal() → updateComplete.then(...) →
+focus first focusable`). On Chromium, that reordering interleaves the
+native dialog's modal activation with the focus-restore step and causes
+focus-trap test failures. The slotchange handler runs one microtask later
+and `_syncHostAriaSemantics()` from `updated()` picks up the resolved state
+on the next paint — close enough that AT never observes the unnamed window.
+Mirrors the same intentional decision documented in hx-drawer round-1.
+
+Focus trap, ESC dismiss with `hx-cancel` BEFORE `hx-close`, focus-restore
+via `_triggerElement`, and native `showModal()` semantics are unchanged
+from the pre-host-canonical implementation.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
## Summary

Closes **Group 4a (Modal dialogs)**. Migrates `hx-dialog` to host-canonical Path A per `.reports/aria-group-4-scope.md` Section 3.1. hx-dialog uses native `<dialog>` HTMLDialogElement with implicit `role="dialog"` baked in by the browser. Host does **NOT** carry `internals.role` / `internals.ariaModal` to avoid nested-dialog announcements. Cross-shadow consumer IDREFs project via `internals.aria*Elements` on host (modern path), with **always-on hybrid fallback** writing reconciled attributes directly to the inner native `<dialog>` for AT that doesn't honor host IDL refs when focus is inside a native modal.

## Path A vs hx-drawer round-1

hx-drawer (PR #1641) validated Path A on a plain inner `<div>` (no native role conflict). hx-dialog faces the harder native-`<dialog>` coexistence question. Solution: keep host's  cleared, project naming via  IDL refs, AND **always** mirror reconciled attrs to the inner `<dialog>` as belt-and-suspenders.

## 12-pattern hardening stack adapted

1. **NO `internals.role` / NO `internals.ariaModal` on host** — native dialog keeps implicit role; `showModal()` keeps platform modality
2. **Cross-shadow naming via `internals.aria*Elements`** with `_supportsIdrefRefs` probe + test seam
3. **Hybrid fallback (always-on)** — inner `<dialog>` ALSO receives reconciled attrs
4. **`flattenAccName`** wired through slot + IDREF text-flatten
5. **Slot-aware header reading** on `<slot name="header">` aggregates ALL assigned elements per AccName 1.2 §4.3.10
6. **Description channel unified** via two synthesized in-shadow spans (`_consumerLabelId`, `_consumerDescId`); `aria-description` never written
7. **First-paint slot state seeding INTENTIONALLY OMITTED** per hx-drawer round-1's focus-trap timing discovery (documented inline)
8. **Three mutation observers** — external IDREFs + header slot text + dedicated aria-describedby retraction (`attributeOldValue: true`) + shared `installAriaIdrefMirror`
9. (validity surface — N/A)
10. `forcedColorsSurface` preserved
11. **Name precedence per AccName 1.2 §4.3.1** — consumer aria-labelledby → consumer aria-label → header slot text → heading property → "Dialog" literal
12. **Focus trap, ESC dismiss with `hx-cancel` BEFORE `hx-close`, focus-restore, native showModal() semantics, transitioning re-entrancy guard, pendingReturnValue** — preserved

## Cross-AT risk note

Path A IDL-ref projection on a host wrapping a native `<dialog>` is **not validated** against NVDA / VoiceOver / JAWS in this round. The hybrid fallback is **always-on** (every name path also writes attributes directly to the inner `<dialog>`), so worst case is loss of live IDL-ref tracking when consumer light-DOM text mutates without firing the external-refs observer — and that observer covers the documented mutation surfaces. Push-gate codex catches any deeper AT-projection issue.

## Tests

- 70/70 hx-dialog tests passing (existing)
- New test cases (~30) for AccName 1.2 §4.3.10 hidden-aware aggregation, IDREF retraction, hybrid-fallback parity, etc. scoped for round-2 follow-up
- `pnpm run verify` clean (14/14 turborepo tasks)

## Push-gate disposition

helix-028 (rea-managed cmd-segments multiline awk) standing risk-accept. Filter wrapper at `scripts/helix-push-gate-filter.mjs` confirms only rea-managed P1s remain in cumulative diff vs main.

🚦 `@helixui/library` minor (additive — host-canonical migration; no breaking changes).

## Sequencing — closes Group 4a, opens Group 4b

With this PR + #1641 (hx-drawer) on dev:
- Modal dialogs (Group 4a) ✅
- Anchored overlays + disclosure (Group 4b): hx-popover, hx-tooltip, hx-dropdown panel refactor, hx-accordion — separate PR(s)