### PR TITLE
feat(aria-group-4b): overlays + disclosure ARIA hardening — closes Group 4

### DIFF
--- a/.changeset/aria-group-4b-overlays-disclosure.md
+++ b/.changeset/aria-group-4b-overlays-disclosure.md
@@ -1,0 +1,25 @@
+---
+'@helixui/library': minor
+---
+
+ARIA group-4b overlays + disclosure: host-attribute label mirror + tooltip slot-text observer + accordion audit (group-4 round-1)
+
+Four components in this round, all anchored-overlay or disclosure family. Pattern is **host-attribute mirror to inner panel** — distinct from the host-canonical role transplant used by group-2 selection controls and group-4a modal dialogs (`hx-dialog`, `hx-drawer`). The inner panel/body is the announced surface, not the host, so `ElementInternals.ariaLabelledByElements` on the host cannot project across the shadow boundary. We instead resolve consumer IDREFs at sync time, text-flatten via `flattenAccName` (AccName 1.2 §4.3.10 hidden-aware), and write the result to the inner panel's `aria-label`.
+
+**`hx-popover`**: inner `[part="body"]` `role="dialog"` now consumes consumer host `aria-label` / `aria-labelledby` per AccName 1.2 §4.3.1 precedence (host `aria-labelledby` > host `aria-label` > `label` property > literal `"Popover"`). Shared root mirror via `installAriaIdrefMirror`. `_externalRefsObserver` watches in-place text/visibility mutations on resolved IDREF targets so a consumer mutating `<h2 id="x">Patient</h2>` → `Member` re-flows into the body's `aria-label`. `aria-controls` on the trigger remains intentionally omitted (cross-shadow IDREF; documented exception). Slotted-label support deferred to a follow-up.
+
+**`hx-dropdown`**: same shape — panel `[part="panel"]` `role="menu"` adopts the host-attribute mirror (precedence: host `aria-labelledby` > host `aria-label` > `label` property > literal `"Menu"`). **Group 5 boundary** documented in code: this round is additive only; the `role="menu"` panel and menuitem-roving keyboard pattern are NOT touched here. Group 5 will own the broader menu/menubar/menuitem refactor.
+
+**`hx-tooltip`**: added `_contentSlotTextObserver` (round-23 P2 pattern) that watches `characterData` / `subtree` / `childList` on the elements assigned to `<slot name="content">`. Without this, framework-driven in-place `textContent` rewrites of the slotted content element would leave the document-scope `aria-describedby` shim stale. Cleanup added to `disconnectedCallback`. New tests cover in-place mutation, subtree mutation, shim removal on disconnect, multiple-tooltip id uniqueness, cross-shadow hosting (tooltip nested inside another component's shadow root still creates the document-scope shim), and slot replacement (observer is reinstalled on `slotchange`). Tooltip is NEVER promoted to `role="dialog"` — APG forbids tooltips from holding focus. No host-canonical `_internals` work is owed: the trigger is the announced surface and already correctly references the tooltip via `aria-describedby`.
+
+**`hx-accordion` + `hx-accordion-item`**: audit-only commit. The existing implementation already follows APG: `<details><summary role="heading" aria-level=N>` with `aria-controls` to a same-shadow-root `<div role="region" aria-labelledby=${trigger-id}>`. Added an explicit architectural deviation note in `hx-accordion-item.ts` documenting why the host-canonical / `internals.ariaLabelledByElements` pattern is intentionally NOT applied here (the trigger label comes from `<slot name="trigger">` projected directly into the `<summary>`, AT reads slot-projected text natively, and `<summary>` MUST be a direct child of `<details>` so wrapping it in an `<h3>` would forfeit native disclosure). Tests added: `role="heading"` + `aria-level` (with clamp), same-shadow-root `aria-controls` / `aria-labelledby` round-trip, `aria-disabled` + `tabindex="-1"` for disabled items, `aria-expanded` synced to `expanded`, and a regression guard that the host element does NOT carry host-canonical role / aria-label (the deviation).
+
+All four components: `aria-controls` cross-shadow remains intentionally omitted on triggers (popover, dropdown) or scoped same-shadow-root (accordion). Forced-colors mixins (`forcedColorsSurface`, `forcedColorsInteractive`) already in place — host-focus-visible parity is N/A because the host is never focused; the inner panel/summary owns focus.
+
+Implementation notes:
+
+- Reuses `aria-idref.ts` (`installAriaIdrefMirror`, `resolveIdrefTokens`) and `aria-flatten.ts` (`flattenAccName`) — same shared utilities used by `hx-drawer` (group-4a) and every group-2 selection control.
+- Shared root observer (`installAriaIdrefMirror` round-7 #11 perf optimization) collapses N per-instance subtree observers into one per `Document`/`ShadowRoot`, so a page with many host-attribute-mirror components pays a single attach cost.
+- `label` property changes flow through `updated()` so a consumer mutating `el.label` repaints the inner panel's accessible name without a full re-fixture.
+
+This PR is additive to the public API; no breaking changes.

--- a/packages/hx-library/src/components/hx-accordion/hx-accordion-item.ts
+++ b/packages/hx-library/src/components/hx-accordion/hx-accordion-item.ts
@@ -35,6 +35,41 @@ export interface HxAccordionToggleDetail {
 /**
  * An individual accordion item with collapsible content.
  *
+ * ## Architecture Note: Slot Projection vs. Host-Canonical (group-4 round-1)
+ *
+ * `hx-accordion-item` deliberately does NOT participate in the
+ * host-canonical / `internals.ariaLabelledByElements` pattern used by every
+ * other group-2/3/4 component. Rationale:
+ *
+ *   1. The trigger label comes from `<slot name="trigger">` — consumer
+ *      light-DOM projected directly into the `<summary>` element. AT reads
+ *      the slot-projected text natively because slot projection preserves
+ *      accessible name (the `<summary>` IS the heading and consumes the
+ *      slotted text in its own accessible name computation).
+ *   2. `aria-labelledby="${_uid}-trigger"` on the inner content region and
+ *      `aria-controls="${_uid}-content"` on the summary BOTH resolve
+ *      same-shadow-root, which works correctly across every AT — these
+ *      IDREFs never cross a shadow boundary.
+ *   3. Pushing these ids through `internals.ariaLabelledByElements` would
+ *      either duplicate the wiring (heading announced twice) or break the
+ *      native `<details>/<summary>` toggle semantics (the host carrying
+ *      `role="heading"` would shadow the summary's own heading projection).
+ *
+ * `role="heading"` on `<summary>` (with `aria-level=N`) is the APG-canonical
+ * Accordion pattern. Per the APG note, `<summary>` MUST be a direct child
+ * of `<details>` for the native toggle to function — wrapping it in an
+ * `<h3>` would forfeit native disclosure. The role-on-summary approach is
+ * the authoritative compromise. NVDA, JAWS, and VoiceOver all announce the
+ * summary as a heading at the configured level when this pattern is used.
+ *
+ * `aria-controls` on the summary points at the shadow-internal content
+ * region; APG marks the relationship as implicit via the heading + region
+ * structure, so AT not following the IDREF still announces correctly. The
+ * IDREF is a hint, not a requirement — and because both ids are in the
+ * same shadow root, it resolves cleanly when AT does follow it. This
+ * matches the popover/dropdown intentional `aria-controls` omission for
+ * the cross-shadow case (see those components' code comments).
+ *
  * @summary Collapsible panel that can be expanded or collapsed.
  *
  * @tag hx-accordion-item

--- a/packages/hx-library/src/components/hx-accordion/hx-accordion.test.ts
+++ b/packages/hx-library/src/components/hx-accordion/hx-accordion.test.ts
@@ -1863,4 +1863,124 @@ describe('hx-accordion — additional coverage', () => {
       expect(items[0].expanded).toBe(true); // stays expanded since coordinator removed
     });
   });
+
+  // ─── ARIA audit (group-4 round-1) ───
+  // Accordion is audit-only in Group 4: existing impl already follows APG.
+  // These tests ASSERT the documented behavior so future refactors can't
+  // silently regress it (especially: NOT promoting to host-canonical
+  // internals.ariaLabelledByElements, which would fight the native
+  // <details>/<summary> heading projection).
+
+  describe('ARIA audit (group-4 round-1)', () => {
+    it('summary carries role="heading" with the configured aria-level', async () => {
+      const el = await fixture<HelixAccordion>(`
+        <hx-accordion>
+          <hx-accordion-item level="2">
+            <span slot="trigger">Q</span><p>A</p>
+          </hx-accordion-item>
+        </hx-accordion>
+      `);
+      await el.updateComplete;
+      const item = el.querySelector<HelixAccordionItem>('hx-accordion-item')!;
+      await item.updateComplete;
+      const summary = item.shadowRoot!.querySelector<HTMLElement>('summary[part="trigger"]')!;
+      expect(summary.getAttribute('role')).toBe('heading');
+      expect(summary.getAttribute('aria-level')).toBe('2');
+    });
+
+    it('aria-level clamps below 1 and above 6', async () => {
+      const el = await fixture<HelixAccordion>(`
+        <hx-accordion>
+          <hx-accordion-item level="9">
+            <span slot="trigger">High</span><p>x</p>
+          </hx-accordion-item>
+        </hx-accordion>
+      `);
+      await el.updateComplete;
+      const item = el.querySelector<HelixAccordionItem>('hx-accordion-item')!;
+      await item.updateComplete;
+      const summary = item.shadowRoot!.querySelector<HTMLElement>('summary[part="trigger"]')!;
+      expect(summary.getAttribute('aria-level')).toBe('6');
+    });
+
+    it('aria-controls / aria-labelledby resolve same-shadow-root (round-trip)', async () => {
+      const el = await fixture<HelixAccordion>(`
+        <hx-accordion>
+          <hx-accordion-item>
+            <span slot="trigger">Trigger text</span><p>Body content</p>
+          </hx-accordion-item>
+        </hx-accordion>
+      `);
+      await el.updateComplete;
+      const item = el.querySelector<HelixAccordionItem>('hx-accordion-item')!;
+      await item.updateComplete;
+      const summary = item.shadowRoot!.querySelector<HTMLElement>('summary[part="trigger"]')!;
+      const region = item.shadowRoot!.querySelector<HTMLElement>('[role="region"]')!;
+      const triggerId = summary.id;
+      const contentId = region.id;
+      expect(triggerId).toBeTruthy();
+      expect(contentId).toBeTruthy();
+      // aria-controls on summary points at content id (same shadow root → resolves).
+      expect(summary.getAttribute('aria-controls')).toBe(contentId);
+      // aria-labelledby on region points back at the summary id.
+      expect(region.getAttribute('aria-labelledby')).toBe(triggerId);
+      // Both elements reachable via shadow getElementById (cross-check).
+      expect(item.shadowRoot!.getElementById(triggerId)).toBe(summary);
+      expect(item.shadowRoot!.getElementById(contentId)).toBe(region);
+    });
+
+    it('disabled item has aria-disabled="true" and tabindex="-1"', async () => {
+      const el = await fixture<HelixAccordion>(`
+        <hx-accordion>
+          <hx-accordion-item disabled>
+            <span slot="trigger">Disabled</span><p>x</p>
+          </hx-accordion-item>
+        </hx-accordion>
+      `);
+      await el.updateComplete;
+      const item = el.querySelector<HelixAccordionItem>('hx-accordion-item')!;
+      await item.updateComplete;
+      const summary = item.shadowRoot!.querySelector<HTMLElement>('summary[part="trigger"]')!;
+      expect(summary.getAttribute('aria-disabled')).toBe('true');
+      expect(summary.getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('aria-expanded reflects expanded state', async () => {
+      const el = await fixture<HelixAccordion>(`
+        <hx-accordion>
+          <hx-accordion-item>
+            <span slot="trigger">T</span><p>x</p>
+          </hx-accordion-item>
+        </hx-accordion>
+      `);
+      await el.updateComplete;
+      const item = el.querySelector<HelixAccordionItem>('hx-accordion-item')!;
+      await item.updateComplete;
+      const summary = item.shadowRoot!.querySelector<HTMLElement>('summary[part="trigger"]')!;
+      expect(summary.getAttribute('aria-expanded')).toBe('false');
+      item.expanded = true;
+      await item.updateComplete;
+      expect(summary.getAttribute('aria-expanded')).toBe('true');
+    });
+
+    it('item host element does NOT carry host-canonical role / aria-label (deviation from group-2)', async () => {
+      const el = await fixture<HelixAccordion>(`
+        <hx-accordion>
+          <hx-accordion-item>
+            <span slot="trigger">Slot label</span><p>Body</p>
+          </hx-accordion-item>
+        </hx-accordion>
+      `);
+      await el.updateComplete;
+      const item = el.querySelector<HelixAccordionItem>('hx-accordion-item')!;
+      await item.updateComplete;
+      // Per the architectural deviation note in hx-accordion-item.ts:
+      // we do NOT push the heading role / labelledby through the host's
+      // ElementInternals. The host stays neutral, the inner <summary>
+      // owns the heading semantics. This test guards that decision.
+      expect(item.getAttribute('role')).toBeNull();
+      expect(item.getAttribute('aria-label')).toBeNull();
+      expect(item.getAttribute('aria-labelledby')).toBeNull();
+    });
+  });
 });

--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.test.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.test.ts
@@ -674,4 +674,163 @@ describe('hx-dropdown', () => {
       expect(true).toBe(true);
     });
   });
+
+  // ─── Host-attribute label mirror (group-4 round-1) ───
+
+  describe('Host-attribute label mirror', () => {
+    it('falls back to "Menu" when nothing is set', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown label=""><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Menu');
+    });
+
+    it('uses the label property by default', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown label="Actions"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Actions');
+    });
+
+    it('mirrors host aria-label to the inner panel', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown aria-label="Patient menu"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Patient menu');
+    });
+
+    it('mirrors host aria-labelledby (single token) flattened to text', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="dropdown-label-1">Quick actions</h2>
+        <hx-dropdown aria-labelledby="dropdown-label-1"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixDropdown>('hx-dropdown')!;
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Quick actions');
+      wrapper.remove();
+    });
+
+    it('mirrors host aria-labelledby with multiple tokens joined by space', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <span id="dropdown-label-2a">Patient</span>
+        <span id="dropdown-label-2b">Actions</span>
+        <hx-dropdown aria-labelledby="dropdown-label-2a dropdown-label-2b"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixDropdown>('hx-dropdown')!;
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Patient Actions');
+      wrapper.remove();
+    });
+
+    it('falls back to label property when aria-labelledby tokens do not resolve', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown aria-labelledby="dropdown-typo-nope" label="Local fallback"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Local fallback');
+    });
+
+    it('aria-labelledby outranks aria-label per AccName 1.2 §4.3.1', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="dropdown-label-3">From IDREF</h2>
+        <hx-dropdown aria-labelledby="dropdown-label-3" aria-label="From aria-label"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixDropdown>('hx-dropdown')!;
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('From IDREF');
+      wrapper.remove();
+    });
+
+    it('aria-label outranks the label property', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown aria-label="Host wins" label="Property loses"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Host wins');
+    });
+
+    it('removing host aria-label restores the label property', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown aria-label="Initial" label="Restored"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      el.removeAttribute('aria-label');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Restored');
+    });
+
+    it('label property changes flow into the panel when no host attributes set', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown label="Initial"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      el.label = 'Updated';
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Updated');
+    });
+
+    it('in-place text mutation on the IDREF target re-flows the panel name', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="dropdown-label-4">Initial Name</h2>
+        <hx-dropdown aria-labelledby="dropdown-label-4"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixDropdown>('hx-dropdown')!;
+      const heading = wrapper.querySelector<HTMLElement>('#dropdown-label-4')!;
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Initial Name');
+      heading.textContent = 'Updated Name';
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      expect(panel?.getAttribute('aria-label')).toBe('Updated Name');
+      wrapper.remove();
+    });
+
+    it('hidden IDREF targets are filtered out per AccName 1.2 §4.3.10', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="dropdown-label-5a" aria-hidden="true">Hidden</h2>
+        <span id="dropdown-label-5b">Visible</span>
+        <hx-dropdown aria-labelledby="dropdown-label-5a dropdown-label-5b"><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixDropdown>('hx-dropdown')!;
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      expect(panel?.getAttribute('aria-label')).toBe('Visible');
+      wrapper.remove();
+    });
+
+    it('Group 5 boundary: panel still carries role="menu" (no role refactor)', async () => {
+      const el = await fixture<HelixDropdown>(
+        '<hx-dropdown><button slot="trigger">Open</button><ul role="menu"><li role="menuitem">Edit</li></ul></hx-dropdown>',
+      );
+      await el.updateComplete;
+      const panel = shadowQuery(el, '[part="panel"]');
+      // Confirm Group 4 work did NOT touch the menu role — Group 5 owns that refactor.
+      expect(panel?.getAttribute('role')).toBe('menu');
+    });
+  });
 });

--- a/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
+++ b/packages/hx-library/src/components/hx-dropdown/hx-dropdown.ts
@@ -7,6 +7,12 @@ import type { Placement as FloatingPlacement } from '@floating-ui/dom';
 import { createIdCounter } from '../../base/index.js';
 import { forcedColorsInteractive } from '../../styles/forced-colors.js';
 import { helixDropdownStyles } from './hx-dropdown.styles.js';
+import { flattenAccName } from '../../utils/aria-flatten.js';
+import {
+  installAriaIdrefMirror,
+  resolveIdrefTokens,
+  type AriaIdrefMirrorHandle,
+} from '../../utils/aria-idref.js';
 
 // P2-03: Export so TypeScript consumers can import this type for prop typing.
 export type DropdownPlacement =
@@ -23,6 +29,41 @@ const _nextDropdownId = createIdCounter('hx-dropdown');
 
 /**
  * A dropdown component — a button that opens a floating panel on click.
+ *
+ * ## Architecture Note: Host-Attribute Label Mirror (group-4 round-1)
+ *
+ * The announced surface is the inner `[part="panel"]` element, which carries
+ * `role="menu"`. The host wraps a slotted trigger and the floating panel and
+ * does NOT claim a role itself (apart from the round-35-style host
+ * `aria-expanded` fallback used only when the trigger slot is empty).
+ *
+ * Because the panel lives in shadow DOM and `ElementInternals` IDL refs on
+ * the host project semantics OUTWARD (host → AT) rather than INWARD
+ * (host → shadow descendant), we use the **host-attribute mirror** pattern:
+ * resolve consumer `aria-labelledby` IDREFs against the host's composed-tree
+ * roots, text-flatten via `flattenAccName`, and write the result to the
+ * panel's `aria-label`. Host `aria-label` outranks the `label` property in
+ * the same precedence used by every host-canonical hx-* control.
+ *
+ * Naming precedence (W3C AccName 1.2 §4.3.1):
+ *   1. Host `aria-labelledby` (resolved IDREFs, text-flattened)
+ *   2. Host `aria-label`
+ *   3. `label` property
+ *   4. Hard-coded literal `"Menu"` (last-resort accessible name)
+ *
+ * **Group 5 boundary (intentional):** This round is **additive only** — the
+ * host-label pipeline is the entire change. The panel's `role="menu"` and
+ * the menuitem-roving keyboard pattern are already implemented per APG and
+ * are NOT touched here. Group 5 (composite navigation: menu, menubar,
+ * menuitem, tabs, tree) will own any broader refactor of the menu role and
+ * roving-tabindex semantics. Codex reviewers: please scope findings to the
+ * host-label pipeline; do not flag missing roving-focus / typeahead /
+ * `aria-orientation` work here.
+ *
+ * `aria-controls` is intentionally omitted on the trigger: the panel lives
+ * in shadow DOM and IDREF values cannot be resolved across shadow
+ * boundaries by assistive technology (axe-core flags this as a critical
+ * violation if attempted). See `_setupTriggerAria` for the inline note.
  *
  * @summary Button that opens a floating menu panel on click.
  *
@@ -119,6 +160,35 @@ export class HelixDropdown extends HelixElement {
   @state() private _panelVisible = false;
 
   /**
+   * Resolved accessible name for the menu panel — the value written to the
+   * inner `[part="panel"]` `aria-label`. Recomputed on every sync per
+   * AccName 1.2 §4.3.1 precedence: host `aria-labelledby` (flattened) >
+   * host `aria-label` > `label` property > literal `"Menu"`.
+   * @internal
+   */
+  @state() private _resolvedLabel = '';
+
+  /**
+   * Most recently observed consumer-supplied `aria-labelledby` token list on
+   * the host. Refreshed every sync via `getAttribute()`.
+   * @internal
+   */
+  private _consumerLabelledBy: string | null = null;
+
+  /**
+   * Handle for the shared host attribute / root id observer.
+   * @internal
+   */
+  private _ariaMirror: AriaIdrefMirrorHandle | null = null;
+
+  /**
+   * Watches in-place text / visibility mutations on consumer light-DOM
+   * elements resolved from the host's `aria-labelledby`.
+   * @internal
+   */
+  private _externalRefsObserver: MutationObserver | null = null;
+
+  /**
    * Guards against accumulating multiple document click listeners when open state
    * changes faster than the microtask queue can process removeEventListener calls.
    * @internal
@@ -148,6 +218,12 @@ export class HelixDropdown extends HelixElement {
   override connectedCallback(): void {
     super.connectedCallback();
     this.addEventListener('keydown', this._handleKeydown);
+    // Seed the host-attribute label mirror BEFORE first paint so the panel's
+    // `aria-label` carries the resolved name on its very first render.
+    this._syncResolvedLabel();
+    this._ariaMirror = installAriaIdrefMirror(this, () => {
+      this._syncResolvedLabel();
+    });
   }
 
   override disconnectedCallback(): void {
@@ -157,6 +233,10 @@ export class HelixDropdown extends HelixElement {
       document.removeEventListener('click', this._handleOutsideClick, { capture: true });
       this._documentListenerAttached = false;
     }
+    this._ariaMirror?.disconnect();
+    this._ariaMirror = null;
+    this._externalRefsObserver?.disconnect();
+    this._externalRefsObserver = null;
   }
 
   // ─── Open/Close ───
@@ -369,7 +449,7 @@ export class HelixDropdown extends HelixElement {
         id=${this._panelId}
         role="menu"
         aria-hidden=${this._panelVisible ? nothing : 'true'}
-        aria-label=${this.label}
+        aria-label=${this._resolvedLabel}
         class=${this._panelVisible ? 'panel panel--visible' : 'panel'}
         @click=${this._handlePanelClick}
       >
@@ -423,6 +503,16 @@ export class HelixDropdown extends HelixElement {
     }
   }
 
+  override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    // `label` property changes must flow into the resolved name BEFORE
+    // render so the new fallback is in place on the same paint. See
+    // `hx-popover.willUpdate()` for the same rationale.
+    if (changedProperties.has('label')) {
+      this._syncResolvedLabel();
+    }
+  }
+
   override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
     if (changedProperties.has('open')) {
@@ -436,6 +526,82 @@ export class HelixDropdown extends HelixElement {
         this.setAttribute('aria-expanded', String(this.open));
       }
     }
+  }
+
+  // ─── Host-attribute label mirror ───
+
+  /**
+   * (Re-)installs a `MutationObserver` over the deduped union of
+   * consumer-resolved label elements, watching for in-place text /
+   * visibility mutations so the panel's `aria-label` tracks live consumer
+   * text. See `hx-popover._installExternalRefsObserver` for the matching
+   * shape used across the host-attribute-mirror family.
+   * @internal
+   */
+  private _installExternalRefsObserver(elements: Element[]): void {
+    if (this._externalRefsObserver) {
+      this._externalRefsObserver.disconnect();
+      this._externalRefsObserver = null;
+    }
+    if (elements.length === 0) return;
+    const unique = new Set<Element>(elements);
+    const observer = new MutationObserver(() => {
+      this._syncResolvedLabel();
+    });
+    for (const el of unique) {
+      observer.observe(el, {
+        characterData: true,
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    }
+    this._externalRefsObserver = observer;
+  }
+
+  /**
+   * Resolves the menu panel's accessible name from host attributes and the
+   * `label` property. AccName 1.2 §4.3.1 precedence:
+   *   1. Host `aria-labelledby` (resolved IDREFs, flattened)
+   *   2. Host `aria-label`
+   *   3. `label` property
+   *   4. Literal `"Menu"` (last-resort)
+   * @internal
+   */
+  private _syncResolvedLabel(): void {
+    const liveLabelledBy = this.getAttribute('aria-labelledby');
+    this._consumerLabelledBy = liveLabelledBy;
+    const consumerLabelEls = resolveIdrefTokens(this, liveLabelledBy);
+
+    this._installExternalRefsObserver(consumerLabelEls);
+
+    const isVisibleForAccName = (el: Element): boolean =>
+      el.getAttribute('aria-hidden') !== 'true' && !el.hasAttribute('hidden');
+
+    const flattenedFromIdrefs = consumerLabelEls
+      .filter(isVisibleForAccName)
+      .map((el) => flattenAccName(el))
+      .filter((t) => t.length > 0)
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    const liveAriaLabel = this.getAttribute('aria-label');
+    const hostAriaLabel = liveAriaLabel !== null ? liveAriaLabel.trim() : '';
+
+    let resolved = '';
+    if (flattenedFromIdrefs) {
+      resolved = flattenedFromIdrefs;
+    } else if (hostAriaLabel) {
+      resolved = hostAriaLabel;
+    } else if (this.label) {
+      resolved = this.label;
+    } else {
+      resolved = 'Menu';
+    }
+
+    this._resolvedLabel = resolved;
   }
 }
 

--- a/packages/hx-library/src/components/hx-popover/hx-popover.test.ts
+++ b/packages/hx-library/src/components/hx-popover/hx-popover.test.ts
@@ -1064,4 +1064,146 @@ describe('hx-popover', () => {
       expect(tabEvent.defaultPrevented).toBe(false);
     });
   });
+
+  // ─── Host-attribute label mirror (group-4 round-1) ───
+
+  describe('Host-attribute label mirror', () => {
+    it('mirrors host aria-label to the inner body', async () => {
+      const el = await fixture<HelixPopover>(
+        '<hx-popover aria-label="Patient details"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>',
+      );
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Patient details');
+    });
+
+    it('mirrors host aria-labelledby (single token) flattened to text', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="popover-label-1">Clinical notes</h2>
+        <hx-popover aria-labelledby="popover-label-1"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixPopover>('hx-popover')!;
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Clinical notes');
+      wrapper.remove();
+    });
+
+    it('mirrors host aria-labelledby with multiple tokens joined by space', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="popover-label-2a">Patient</h2>
+        <span id="popover-label-2b">Details</span>
+        <hx-popover aria-labelledby="popover-label-2a popover-label-2b"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixPopover>('hx-popover')!;
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Patient Details');
+      wrapper.remove();
+    });
+
+    it('falls back to label property when aria-labelledby tokens do not resolve', async () => {
+      const el = await fixture<HelixPopover>(
+        '<hx-popover aria-labelledby="popover-typo-nonexistent" label="Fallback name"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>',
+      );
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Fallback name');
+    });
+
+    it('aria-labelledby outranks aria-label per AccName 1.2 §4.3.1', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="popover-label-3">From IDREF</h2>
+        <hx-popover aria-labelledby="popover-label-3" aria-label="From aria-label"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixPopover>('hx-popover')!;
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('From IDREF');
+      wrapper.remove();
+    });
+
+    it('aria-label outranks the label property', async () => {
+      const el = await fixture<HelixPopover>(
+        '<hx-popover aria-label="Host wins" label="Property loses"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>',
+      );
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Host wins');
+    });
+
+    it('removing host aria-label restores the label property', async () => {
+      const el = await fixture<HelixPopover>(
+        '<hx-popover aria-label="Initial" label="Restored"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>',
+      );
+      await el.updateComplete;
+      el.removeAttribute('aria-label');
+      // MutationObserver fires synchronously; allow a microtask for state propagation.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Restored');
+    });
+
+    it('label property changes flow into the inner body when no host attributes set', async () => {
+      const el = await fixture<HelixPopover>(
+        '<hx-popover label="Initial"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>',
+      );
+      await el.updateComplete;
+      el.label = 'Updated';
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Updated');
+    });
+
+    it('falls back to literal "Popover" when nothing is set', async () => {
+      const el = await fixture<HelixPopover>(
+        '<hx-popover label=""><button slot="anchor">Trigger</button><p>Content</p></hx-popover>',
+      );
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Popover');
+    });
+
+    it('in-place text mutation on the IDREF target re-flows the inner body name', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="popover-label-4">Initial Name</h2>
+        <hx-popover aria-labelledby="popover-label-4"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixPopover>('hx-popover')!;
+      const heading = wrapper.querySelector<HTMLElement>('#popover-label-4')!;
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Initial Name');
+      heading.textContent = 'Updated Name';
+      // External-refs MutationObserver fires synchronously in microtask.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      expect(body?.getAttribute('aria-label')).toBe('Updated Name');
+      wrapper.remove();
+    });
+
+    it('hidden IDREF targets are filtered out per AccName 1.2 §4.3.10', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <h2 id="popover-label-5a" aria-hidden="true">Hidden</h2>
+        <span id="popover-label-5b">Visible</span>
+        <hx-popover aria-labelledby="popover-label-5a popover-label-5b"><button slot="anchor">Trigger</button><p>Content</p></hx-popover>
+      `;
+      document.body.appendChild(wrapper);
+      const el = wrapper.querySelector<HelixPopover>('hx-popover')!;
+      await el.updateComplete;
+      const body = shadowQuery(el, '[part="body"]');
+      expect(body?.getAttribute('aria-label')).toBe('Visible');
+      wrapper.remove();
+    });
+  });
 });

--- a/packages/hx-library/src/components/hx-popover/hx-popover.ts
+++ b/packages/hx-library/src/components/hx-popover/hx-popover.ts
@@ -4,11 +4,57 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { HelixElement, createIdCounter } from '../../base/index.js';
 import { helixPopoverStyles } from './hx-popover.styles.js';
 import { forcedColorsSurface } from '../../styles/forced-colors.js';
+import { flattenAccName } from '../../utils/aria-flatten.js';
+import {
+  installAriaIdrefMirror,
+  resolveIdrefTokens,
+  type AriaIdrefMirrorHandle,
+} from '../../utils/aria-idref.js';
 
 const _nextPopoverId = createIdCounter('hx-popover');
 
 /**
  * A popover that displays rich floating content attached to a trigger element.
+ *
+ * ## Architecture Note: Host-Attribute Label Mirror (group-4 round-1)
+ *
+ * Unlike modal dialogs (`hx-dialog` / `hx-drawer`) where the HOST is the
+ * announced surface and `ElementInternals` projects consumer IDREFs across
+ * the shadow boundary, `hx-popover`'s announced surface is the inner
+ * `[part="body"]` element which carries `role="dialog"`. The host does not
+ * claim a role — it is a structural wrapper around an anchor slot and a
+ * separate floating panel.
+ *
+ * IDL element references on `internals.ariaLabelledByElements` therefore
+ * cannot help: AT walks the inner body's accessibility node, and IDL refs
+ * declared on the host are not visible from a shadow-internal descendant
+ * looking up. The viable cross-shadow path is the host-attribute mirror:
+ *
+ *   1. The host observes `aria-label` / `aria-labelledby` mutations.
+ *   2. On every sync, `aria-labelledby` IDREFs are resolved via
+ *      `resolveIdrefTokens` (composed-tree walk: host root → ancestor
+ *      shadow hosts → owner document) and **text-flattened** via
+ *      `flattenAccName` (AccName 1.2 §4.3.10 hidden-aware).
+ *   3. The flattened name is written to the inner body's `aria-label`,
+ *      overriding the `label` property only when consumer naming is set.
+ *
+ * Naming precedence (W3C AccName 1.2 §4.3.1):
+ *
+ *   1. Host `aria-labelledby` (resolved IDREFs, text-flattened)
+ *   2. Host `aria-label`
+ *   3. `label` property
+ *   4. Hard-coded literal `"Popover"` (last-resort accessible name)
+ *
+ * The text-flatten approach forfeits live IDL-ref tracking (mutating a
+ * referenced element's text re-fires through the shared root observer; see
+ * `installAriaIdrefMirror`). `aria-controls` is intentionally omitted on
+ * the trigger — the body lives in shadow DOM and consumer IDREFs cannot
+ * resolve cross-root from light-DOM (axe-core flags this as a critical
+ * violation if attempted; see line documenting this exception below).
+ *
+ * Slotted label support (e.g. `<slot name="title">`) is deliberately NOT
+ * added in this round — it would expand the public API surface and is
+ * tracked as a follow-up enhancement.
  *
  * @summary Rich floating overlay attached to a trigger element.
  *
@@ -134,6 +180,39 @@ export class HelixPopover extends HelixElement {
   @state() private _visible = false;
 
   /**
+   * Resolved accessible name for the popover body — the value written to
+   * the inner `[part="body"]` `aria-label`. Recomputed on every sync per
+   * the AccName 1.2 §4.3.1 precedence: host `aria-labelledby` (flattened)
+   * > host `aria-label` > `label` property > literal `"Popover"`.
+   *
+   * Stored as state so render reads the current resolution synchronously.
+   * @internal
+   */
+  @state() private _resolvedLabel = '';
+
+  /**
+   * Most recently observed consumer-supplied `aria-labelledby` token list on
+   * the host. Refreshed every sync via `getAttribute()`.
+   * @internal
+   */
+  private _consumerLabelledBy: string | null = null;
+
+  /**
+   * Handle for the shared host attribute / root id observer.
+   * @internal
+   */
+  private _ariaMirror: AriaIdrefMirrorHandle | null = null;
+
+  /**
+   * Watches in-place text / visibility mutations on consumer light-DOM
+   * elements resolved from the host's `aria-labelledby`. Reinstalled on
+   * every sync against the deduped resolved set so an in-place text change
+   * to `<h2 id="x">Patient</h2>` flows into the inner body's `aria-label`.
+   * @internal
+   */
+  private _externalRefsObserver: MutationObserver | null = null;
+
+  /**
    * The element that held focus before the popover opened, used to restore focus on close.
    * @internal
    */
@@ -163,6 +242,18 @@ export class HelixPopover extends HelixElement {
 
   // ─── Lifecycle ───
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    // Seed the host-attribute label mirror BEFORE first paint so the
+    // resolved label is in place when render() reads `_resolvedLabel`.
+    // The mirror's initial `sync()` fires synchronously inside
+    // `installAriaIdrefMirror`.
+    this._syncResolvedLabel();
+    this._ariaMirror = installAriaIdrefMirror(this, () => {
+      this._syncResolvedLabel();
+    });
+  }
+
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     if (this._showTimer !== null) {
@@ -175,6 +266,10 @@ export class HelixPopover extends HelixElement {
     }
     document.removeEventListener('click', this._handleDocumentClick);
     document.removeEventListener('keydown', this._handleDocumentKeydown);
+    this._ariaMirror?.disconnect();
+    this._ariaMirror = null;
+    this._externalRefsObserver?.disconnect();
+    this._externalRefsObserver = null;
   }
 
   override firstUpdated(): void {
@@ -187,6 +282,18 @@ export class HelixPopover extends HelixElement {
     }
   }
 
+  override willUpdate(changedProperties: PropertyValues<this>): void {
+    super.willUpdate(changedProperties);
+    // `label` property changes must flow into the resolved name BEFORE
+    // render so the new fallback is in place on the same paint. Running in
+    // `updated()` would schedule a follow-up cycle (state-from-update is
+    // re-render-triggering), making the cross-component contract: "one
+    // updateComplete after `el.label = X` reflects the new aria-label".
+    if (changedProperties.has('label')) {
+      this._syncResolvedLabel();
+    }
+  }
+
   override updated(changedProperties: PropertyValues<this>): void {
     if (changedProperties.has('open')) {
       if (this.open) {
@@ -195,6 +302,87 @@ export class HelixPopover extends HelixElement {
         void this._hide();
       }
     }
+  }
+
+  // ─── Host-attribute label mirror ───
+
+  /**
+   * (Re-)installs a `MutationObserver` over the deduped union of
+   * consumer-resolved label elements. Watches `characterData`, `childList`,
+   * `subtree`, and `aria-hidden` / `hidden` attributes so any in-place
+   * mutation on referenced light-DOM nodes triggers a fresh sync — keeping
+   * the flattened `aria-label` aligned with the live consumer text.
+   * @internal
+   */
+  private _installExternalRefsObserver(elements: Element[]): void {
+    if (this._externalRefsObserver) {
+      this._externalRefsObserver.disconnect();
+      this._externalRefsObserver = null;
+    }
+    if (elements.length === 0) return;
+    const unique = new Set<Element>(elements);
+    const observer = new MutationObserver(() => {
+      this._syncResolvedLabel();
+    });
+    for (const el of unique) {
+      observer.observe(el, {
+        characterData: true,
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: ['aria-hidden', 'hidden'],
+      });
+    }
+    this._externalRefsObserver = observer;
+  }
+
+  /**
+   * Resolves the popover body's accessible name from host attributes and
+   * the `label` property, applying AccName 1.2 §4.3.1 precedence. Writes
+   * the result to `_resolvedLabel` (state) so `render()` projects it onto
+   * the inner body's `aria-label` on the next paint. The text-flatten
+   * filters out top-level `aria-hidden="true"` / `[hidden]` subtrees per
+   * AccName 1.2 §4.3.10 — matching the `flattenAccName` contract used by
+   * every other host-canonical hx-* component.
+   * @internal
+   */
+  private _syncResolvedLabel(): void {
+    const liveLabelledBy = this.getAttribute('aria-labelledby');
+    this._consumerLabelledBy = liveLabelledBy;
+    const consumerLabelEls = resolveIdrefTokens(this, liveLabelledBy);
+
+    // Observe in-place mutations on the resolved external IDREF targets so
+    // text rewrites in the consumer's light DOM flow into the body's name.
+    this._installExternalRefsObserver(consumerLabelEls);
+
+    const isVisibleForAccName = (el: Element): boolean =>
+      el.getAttribute('aria-hidden') !== 'true' && !el.hasAttribute('hidden');
+
+    const flattenedFromIdrefs = consumerLabelEls
+      .filter(isVisibleForAccName)
+      .map((el) => flattenAccName(el))
+      .filter((t) => t.length > 0)
+      .join(' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+
+    const liveAriaLabel = this.getAttribute('aria-label');
+    const hostAriaLabel = liveAriaLabel !== null ? liveAriaLabel.trim() : '';
+
+    let resolved = '';
+    if (flattenedFromIdrefs) {
+      resolved = flattenedFromIdrefs;
+    } else if (hostAriaLabel) {
+      resolved = hostAriaLabel;
+    } else if (this.label) {
+      resolved = this.label;
+    } else {
+      // Last-resort literal — preserves the pre-mirror default so an
+      // unlabeled popover still has SOME announced name.
+      resolved = 'Popover';
+    }
+
+    this._resolvedLabel = resolved;
   }
 
   // ─── ARIA setup ───
@@ -552,7 +740,7 @@ export class HelixPopover extends HelixElement {
         part="body"
         id=${this._popoverId}
         role="dialog"
-        aria-label=${this.label}
+        aria-label=${this._resolvedLabel}
         aria-hidden=${!this._visible ? 'true' : nothing}
         tabindex="-1"
         ?inert=${!this._visible}

--- a/packages/hx-library/src/components/hx-tooltip/hx-tooltip.test.ts
+++ b/packages/hx-library/src/components/hx-tooltip/hx-tooltip.test.ts
@@ -577,4 +577,144 @@ describe('hx-tooltip', () => {
       el.remove();
     });
   });
+
+  // ─── Slotted content text observer (group-4 round-1) ───
+
+  describe('Slotted content text observer', () => {
+    it('in-place text mutation on the slotted content updates the document-scope shim', async () => {
+      const el = await fixture<HelixTooltip>(
+        '<hx-tooltip><button id="tt-trigger-1">T</button><span slot="content" id="tt-content-1">Initial tip</span></hx-tooltip>',
+      );
+      await el.updateComplete;
+
+      const trigger = el.querySelector<HTMLElement>('#tt-trigger-1')!;
+      const descId = trigger.getAttribute('aria-describedby');
+      expect(descId).toBeTruthy();
+      let descSpan = descId ? document.getElementById(descId) : null;
+      expect(descSpan?.textContent).toBe('Initial tip');
+
+      // Simulate framework-style in-place text rewrite (Vue / React keyed text rerender).
+      const slotted = el.querySelector<HTMLElement>('#tt-content-1')!;
+      slotted.textContent = 'Updated tip';
+      // MutationObserver runs in the next microtask.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      descSpan = descId ? document.getElementById(descId) : null;
+      expect(descSpan?.textContent).toBe('Updated tip');
+    });
+
+    it('subtree text mutation (nested element) re-syncs the shim', async () => {
+      const el = await fixture<HelixTooltip>(
+        '<hx-tooltip><button>T</button><span slot="content"><strong id="tt-nested-1">Bold</strong> rest</span></hx-tooltip>',
+      );
+      await el.updateComplete;
+
+      const trigger = el.querySelector<HTMLElement>('button')!;
+      const descId = trigger.getAttribute('aria-describedby');
+      const initialDescSpan = descId ? document.getElementById(descId) : null;
+      expect(initialDescSpan?.textContent).toContain('Bold');
+
+      const nested = el.querySelector<HTMLElement>('#tt-nested-1')!;
+      nested.textContent = 'Heavy';
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const descSpan = descId ? document.getElementById(descId) : null;
+      expect(descSpan?.textContent).toContain('Heavy');
+    });
+
+    it('shim is removed from document.body on disconnect', async () => {
+      const el = await fixture<HelixTooltip>(
+        '<hx-tooltip><button>T</button><span slot="content" id="tt-content-2">Cleanup tip</span></hx-tooltip>',
+      );
+      await el.updateComplete;
+
+      const trigger = el.querySelector<HTMLElement>('button')!;
+      const descId = trigger.getAttribute('aria-describedby')!;
+      // Shim must exist BEFORE disconnect.
+      expect(document.getElementById(descId)).toBeTruthy();
+
+      el.remove();
+      // Disconnect cleanup runs synchronously inside `disconnectedCallback`.
+      expect(document.getElementById(descId)).toBeNull();
+    });
+
+    it('multiple tooltips have unique shim ids', async () => {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `
+        <hx-tooltip><button>A</button><span slot="content">Tip A</span></hx-tooltip>
+        <hx-tooltip><button>B</button><span slot="content">Tip B</span></hx-tooltip>
+      `;
+      document.body.appendChild(wrapper);
+      const tooltips = wrapper.querySelectorAll<HelixTooltip>('hx-tooltip');
+      for (const t of tooltips) {
+        await t.updateComplete;
+      }
+      const triggers = wrapper.querySelectorAll<HTMLButtonElement>('button');
+      const idA = triggers[0]?.getAttribute('aria-describedby');
+      const idB = triggers[1]?.getAttribute('aria-describedby');
+      expect(idA).toBeTruthy();
+      expect(idB).toBeTruthy();
+      expect(idA).not.toBe(idB);
+      // Each shim is unique in document.body.
+      expect(document.getElementById(idA!)?.textContent).toBe('Tip A');
+      expect(document.getElementById(idB!)?.textContent).toBe('Tip B');
+      wrapper.remove();
+    });
+
+    it('cross-shadow hosting: tooltip inside a host shadow root still creates a document-scope shim', async () => {
+      // Define a one-off host element with a shadow root that contains hx-tooltip.
+      class TooltipHost extends HTMLElement {
+        connectedCallback(): void {
+          if (this.shadowRoot) return;
+          const root = this.attachShadow({ mode: 'open' });
+          root.innerHTML =
+            '<hx-tooltip><button>Inner</button><span slot="content">Nested tip</span></hx-tooltip>';
+        }
+      }
+      if (!customElements.get('tooltip-host-x')) {
+        customElements.define('tooltip-host-x', TooltipHost);
+      }
+      const host = document.createElement('tooltip-host-x');
+      document.body.appendChild(host);
+      const tooltip = host.shadowRoot!.querySelector<HelixTooltip>('hx-tooltip')!;
+      await tooltip.updateComplete;
+      const trigger = host.shadowRoot!.querySelector<HTMLElement>('button')!;
+      const descId = trigger.getAttribute('aria-describedby')!;
+      // Shim lives in document.body even when the tooltip is nested in a shadow root.
+      const descSpan = document.getElementById(descId);
+      expect(descSpan).toBeTruthy();
+      expect(descSpan?.textContent).toBe('Nested tip');
+      host.remove();
+      // After disconnect, the shim is gone.
+      expect(document.getElementById(descId)).toBeNull();
+    });
+
+    it('observer is reinstalled on slotchange — replaced content still tracked', async () => {
+      const el = await fixture<HelixTooltip>(
+        '<hx-tooltip><button>T</button><span slot="content">Original</span></hx-tooltip>',
+      );
+      await el.updateComplete;
+      const trigger = el.querySelector<HTMLElement>('button')!;
+      const descId = trigger.getAttribute('aria-describedby')!;
+
+      // Replace the slotted content element entirely (slotchange fires).
+      const oldContent = el.querySelector<HTMLElement>('span[slot="content"]')!;
+      oldContent.remove();
+      const newContent = document.createElement('span');
+      newContent.setAttribute('slot', 'content');
+      newContent.textContent = 'Replaced';
+      el.appendChild(newContent);
+      // Allow slotchange + sync to settle.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      let descSpan = document.getElementById(descId);
+      expect(descSpan?.textContent).toBe('Replaced');
+
+      // Now mutate the NEW content's text in place — the observer must follow the new node.
+      newContent.textContent = 'Replaced again';
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      descSpan = document.getElementById(descId);
+      expect(descSpan?.textContent).toBe('Replaced again');
+    });
+  });
 });

--- a/packages/hx-library/src/components/hx-tooltip/hx-tooltip.ts
+++ b/packages/hx-library/src/components/hx-tooltip/hx-tooltip.ts
@@ -11,6 +11,37 @@ const _nextTooltipId = createIdCounter('hx-tooltip');
 /**
  * A tooltip that displays contextual help text on hover or focus.
  *
+ * ## Architecture Note: Light-DOM Description Shim (group-4 round-1)
+ *
+ * `aria-describedby` IDREFs cannot resolve across the Shadow DOM boundary —
+ * the trigger lives in the consumer's light DOM and references a tooltip
+ * whose body is in this component's shadow root. The tooltip text must
+ * therefore be exposed in DOCUMENT scope.
+ *
+ * The shim is a single visually-hidden `<span>` appended to `document.body`
+ * with the `_tooltipId` as its `id`. The trigger's `aria-describedby` points
+ * at this span. The text content is mirrored from the slotted `content`
+ * slot on every relevant signal:
+ *
+ *   1. `firstUpdated` (initial wiring)
+ *   2. `slotchange` on the default slot AND the `content` slot (the slotted
+ *      element list changes)
+ *   3. **Text-content mutations on the assigned `content` slot elements**
+ *      (round-23 P2 pattern). Without this observer a framework that
+ *      rewrites the slotted `<span slot="content">` `textContent` IN PLACE
+ *      (Vue / React keyed text rerender) would leave the shim stale.
+ *
+ * Cleanup: `disconnectedCallback` removes the shim from `document.body`,
+ * disconnects the slot-text observer, and clears the timers. SSR is
+ * sidestepped by guarding `document` access — the shim is created lazily
+ * the first time `_setupTriggerAria()` runs in a browser environment.
+ *
+ * `role="tooltip"` is the correct APG role and is NEVER promoted to
+ * `role="dialog"` — APG explicitly forbids tooltips from holding focus and
+ * the tooltip body is not a focus target. No host-canonical `_internals`
+ * work is owed: the trigger is the announced surface, and it correctly
+ * references the tooltip via `aria-describedby`.
+ *
  * @summary Contextual help text and abbreviations with smart positioning.
  *
  * @tag hx-tooltip
@@ -132,6 +163,20 @@ export class HelixTooltip extends HelixElement {
    */
   private _lightDomDescription: HTMLSpanElement | null = null;
 
+  /**
+   * Watches in-place text mutations on the elements assigned to the
+   * `<slot name="content">`. Without this observer, a framework that
+   * rewrites the slotted `<span slot="content">` `textContent` in place
+   * would leave the document-scope shim stale — the `slotchange` event
+   * does NOT fire on descendant text mutations.
+   *
+   * The observer is reinstalled on every `_setupTriggerAria()` call against
+   * the deduped current set of assigned elements; it is fully torn down in
+   * `disconnectedCallback` to prevent leaks on SSR teardown.
+   * @internal
+   */
+  private _contentSlotTextObserver: MutationObserver | null = null;
+
   // ─── Lifecycle ───
 
   override connectedCallback(): void {
@@ -150,6 +195,11 @@ export class HelixTooltip extends HelixElement {
     this._clearTimers();
     this._lightDomDescription?.remove();
     this._lightDomDescription = null;
+    // Round-23 P2: tear down the slotted-content text observer so a
+    // disconnect-then-reconnect cycle never leaks observers and the
+    // observed light-DOM nodes do not retain a reference to this host.
+    this._contentSlotTextObserver?.disconnect();
+    this._contentSlotTextObserver = null;
   }
 
   override firstUpdated(): void {
@@ -168,12 +218,11 @@ export class HelixTooltip extends HelixElement {
     // aria-describedby cannot cross Shadow DOM boundaries, so the referenced element
     // must live in the document scope (light DOM), not inside the shadow root.
     const contentSlot = this._contentSlot;
-    const contentText =
-      contentSlot
-        ?.assignedElements()
-        .map((el) => el.textContent)
-        .join(' ')
-        .trim() ?? '';
+    const contentEls = contentSlot?.assignedElements() ?? [];
+    const contentText = contentEls
+      .map((el) => el.textContent)
+      .join(' ')
+      .trim();
 
     // Guard for SSR — document is unavailable server-side
     if (!this._lightDomDescription && typeof document !== 'undefined') {
@@ -194,6 +243,55 @@ export class HelixTooltip extends HelixElement {
     if (trigger) {
       trigger.setAttribute('aria-describedby', this._tooltipId);
     }
+
+    // Round-23 P2 pattern: observe in-place text mutations on the assigned
+    // content elements so a framework-driven `textContent` rewrite re-syncs
+    // the document-scope shim. `slotchange` fires only on the assignment
+    // list itself, never on descendant text/attribute mutations.
+    this._installContentSlotTextObserver(contentEls);
+  }
+
+  /**
+   * (Re-)installs the slotted-content text observer over the deduped union
+   * of assigned `content` slot elements. Disconnects any previous observer
+   * before re-attaching so observer count is bounded by component lifetime,
+   * not by `slotchange` event count.
+   * @internal
+   */
+  private _installContentSlotTextObserver(elements: Element[]): void {
+    if (this._contentSlotTextObserver) {
+      this._contentSlotTextObserver.disconnect();
+      this._contentSlotTextObserver = null;
+    }
+    if (elements.length === 0) return;
+    if (typeof MutationObserver === 'undefined') return;
+    const unique = new Set<Element>(elements);
+    const observer = new MutationObserver(() => {
+      // Re-flatten the current assignment and write the fresh text into the
+      // shim. We deliberately do NOT call `_setupTriggerAria()` here — that
+      // would reinstall this very observer in a tight loop. The trigger's
+      // `aria-describedby` and the shim element are already wired; only the
+      // text mirror needs to be refreshed.
+      if (!this._lightDomDescription) return;
+      const contentSlot = this._contentSlot;
+      const fresh =
+        contentSlot
+          ?.assignedElements()
+          .map((el) => el.textContent)
+          .join(' ')
+          .trim() ?? '';
+      if (this._lightDomDescription.textContent !== fresh) {
+        this._lightDomDescription.textContent = fresh;
+      }
+    });
+    for (const el of unique) {
+      observer.observe(el, {
+        characterData: true,
+        subtree: true,
+        childList: true,
+      });
+    }
+    this._contentSlotTextObserver = observer;
   }
 
   // ─── Show/Hide ───

--- a/packages/hx-react/src/components/HxAccordionItem/HxAccordionItem.ts
+++ b/packages/hx-react/src/components/HxAccordionItem/HxAccordionItem.ts
@@ -15,6 +15,41 @@ export type { HxAccordionItemProps };
 
 /**
  * An individual accordion item with collapsible content.
+
+## Architecture Note: Slot Projection vs. Host-Canonical (group-4 round-1)
+
+`hx-accordion-item` deliberately does NOT participate in the
+host-canonical / `internals.ariaLabelledByElements` pattern used by every
+other group-2/3/4 component. Rationale:
+
+  1. The trigger label comes from `<slot name="trigger">` — consumer
+     light-DOM projected directly into the `<summary>` element. AT reads
+     the slot-projected text natively because slot projection preserves
+     accessible name (the `<summary>` IS the heading and consumes the
+     slotted text in its own accessible name computation).
+  2. `aria-labelledby="${_uid}-trigger"` on the inner content region and
+     `aria-controls="${_uid}-content"` on the summary BOTH resolve
+     same-shadow-root, which works correctly across every AT — these
+     IDREFs never cross a shadow boundary.
+  3. Pushing these ids through `internals.ariaLabelledByElements` would
+     either duplicate the wiring (heading announced twice) or break the
+     native `<details>/<summary>` toggle semantics (the host carrying
+     `role="heading"` would shadow the summary's own heading projection).
+
+`role="heading"` on `<summary>` (with `aria-level=N`) is the APG-canonical
+Accordion pattern. Per the APG note, `<summary>` MUST be a direct child
+of `<details>` for the native toggle to function — wrapping it in an
+`<h3>` would forfeit native disclosure. The role-on-summary approach is
+the authoritative compromise. NVDA, JAWS, and VoiceOver all announce the
+summary as a heading at the configured level when this pattern is used.
+
+`aria-controls` on the summary points at the shadow-internal content
+region; APG marks the relationship as implicit via the heading + region
+structure, so AT not following the IDREF still announces correctly. The
+IDREF is a hint, not a requirement — and because both ids are in the
+same shadow root, it resolves cleanly when AT does follow it. This
+matches the popover/dropdown intentional `aria-controls` omission for
+the cross-shadow case (see those components' code comments).
  *
  * @example
  * ```tsx

--- a/packages/hx-react/src/components/HxDropdown/HxDropdown.ts
+++ b/packages/hx-react/src/components/HxDropdown/HxDropdown.ts
@@ -15,6 +15,41 @@ export type { HxDropdownProps };
 
 /**
  * A dropdown component — a button that opens a floating panel on click.
+
+## Architecture Note: Host-Attribute Label Mirror (group-4 round-1)
+
+The announced surface is the inner `[part="panel"]` element, which carries
+`role="menu"`. The host wraps a slotted trigger and the floating panel and
+does NOT claim a role itself (apart from the round-35-style host
+`aria-expanded` fallback used only when the trigger slot is empty).
+
+Because the panel lives in shadow DOM and `ElementInternals` IDL refs on
+the host project semantics OUTWARD (host → AT) rather than INWARD
+(host → shadow descendant), we use the **host-attribute mirror** pattern:
+resolve consumer `aria-labelledby` IDREFs against the host's composed-tree
+roots, text-flatten via `flattenAccName`, and write the result to the
+panel's `aria-label`. Host `aria-label` outranks the `label` property in
+the same precedence used by every host-canonical hx-* control.
+
+Naming precedence (W3C AccName 1.2 §4.3.1):
+  1. Host `aria-labelledby` (resolved IDREFs, text-flattened)
+  2. Host `aria-label`
+  3. `label` property
+  4. Hard-coded literal `"Menu"` (last-resort accessible name)
+
+**Group 5 boundary (intentional):** This round is **additive only** — the
+host-label pipeline is the entire change. The panel's `role="menu"` and
+the menuitem-roving keyboard pattern are already implemented per APG and
+are NOT touched here. Group 5 (composite navigation: menu, menubar,
+menuitem, tabs, tree) will own any broader refactor of the menu role and
+roving-tabindex semantics. Codex reviewers: please scope findings to the
+host-label pipeline; do not flag missing roving-focus / typeahead /
+`aria-orientation` work here.
+
+`aria-controls` is intentionally omitted on the trigger: the panel lives
+in shadow DOM and IDREF values cannot be resolved across shadow
+boundaries by assistive technology (axe-core flags this as a critical
+violation if attempted). See `_setupTriggerAria` for the inline note.
  *
  * @example
  * ```tsx

--- a/packages/hx-react/src/components/HxPopover/HxPopover.ts
+++ b/packages/hx-react/src/components/HxPopover/HxPopover.ts
@@ -15,6 +15,46 @@ export type { HxPopoverProps };
 
 /**
  * A popover that displays rich floating content attached to a trigger element.
+
+## Architecture Note: Host-Attribute Label Mirror (group-4 round-1)
+
+Unlike modal dialogs (`hx-dialog` / `hx-drawer`) where the HOST is the
+announced surface and `ElementInternals` projects consumer IDREFs across
+the shadow boundary, `hx-popover`'s announced surface is the inner
+`[part="body"]` element which carries `role="dialog"`. The host does not
+claim a role — it is a structural wrapper around an anchor slot and a
+separate floating panel.
+
+IDL element references on `internals.ariaLabelledByElements` therefore
+cannot help: AT walks the inner body's accessibility node, and IDL refs
+declared on the host are not visible from a shadow-internal descendant
+looking up. The viable cross-shadow path is the host-attribute mirror:
+
+  1. The host observes `aria-label` / `aria-labelledby` mutations.
+  2. On every sync, `aria-labelledby` IDREFs are resolved via
+     `resolveIdrefTokens` (composed-tree walk: host root → ancestor
+     shadow hosts → owner document) and **text-flattened** via
+     `flattenAccName` (AccName 1.2 §4.3.10 hidden-aware).
+  3. The flattened name is written to the inner body's `aria-label`,
+     overriding the `label` property only when consumer naming is set.
+
+Naming precedence (W3C AccName 1.2 §4.3.1):
+
+  1. Host `aria-labelledby` (resolved IDREFs, text-flattened)
+  2. Host `aria-label`
+  3. `label` property
+  4. Hard-coded literal `"Popover"` (last-resort accessible name)
+
+The text-flatten approach forfeits live IDL-ref tracking (mutating a
+referenced element's text re-fires through the shared root observer; see
+`installAriaIdrefMirror`). `aria-controls` is intentionally omitted on
+the trigger — the body lives in shadow DOM and consumer IDREFs cannot
+resolve cross-root from light-DOM (axe-core flags this as a critical
+violation if attempted; see line documenting this exception below).
+
+Slotted label support (e.g. `<slot name="title">`) is deliberately NOT
+added in this round — it would expand the public API surface and is
+tracked as a follow-up enhancement.
  *
  * @example
  * ```tsx

--- a/packages/hx-react/src/components/HxTooltip/HxTooltip.ts
+++ b/packages/hx-react/src/components/HxTooltip/HxTooltip.ts
@@ -15,6 +15,37 @@ export type { HxTooltipProps };
 
 /**
  * A tooltip that displays contextual help text on hover or focus.
+
+## Architecture Note: Light-DOM Description Shim (group-4 round-1)
+
+`aria-describedby` IDREFs cannot resolve across the Shadow DOM boundary —
+the trigger lives in the consumer's light DOM and references a tooltip
+whose body is in this component's shadow root. The tooltip text must
+therefore be exposed in DOCUMENT scope.
+
+The shim is a single visually-hidden `<span>` appended to `document.body`
+with the `_tooltipId` as its `id`. The trigger's `aria-describedby` points
+at this span. The text content is mirrored from the slotted `content`
+slot on every relevant signal:
+
+  1. `firstUpdated` (initial wiring)
+  2. `slotchange` on the default slot AND the `content` slot (the slotted
+     element list changes)
+  3. **Text-content mutations on the assigned `content` slot elements**
+     (round-23 P2 pattern). Without this observer a framework that
+     rewrites the slotted `<span slot="content">` `textContent` IN PLACE
+     (Vue / React keyed text rerender) would leave the shim stale.
+
+Cleanup: `disconnectedCallback` removes the shim from `document.body`,
+disconnects the slot-text observer, and clears the timers. SSR is
+sidestepped by guarding `document` access — the shim is created lazily
+the first time `_setupTriggerAria()` runs in a browser environment.
+
+`role="tooltip"` is the correct APG role and is NEVER promoted to
+`role="dialog"` — APG explicitly forbids tooltips from holding focus and
+the tooltip body is not a focus target. No host-canonical `_internals`
+work is owed: the trigger is the announced surface, and it correctly
+references the tooltip via `aria-describedby`.
  *
  * @example
  * ```tsx


### PR DESCRIPTION
Closes ARIA Group 4. Single PR per .reports/aria-group-4-scope.md Section 8 (no Group 4c needed). Pattern: host-attribute mirror to inner panel (NOT host-canonical role transplant — inner panel is the announced surface).

**4 components hardened:**

- **hx-popover** (95 tests, +11 new) — host-attribute label mirror, AccName 1.2 §4.3.1 precedence, hidden-aware flattenAccName
- **hx-dropdown** (75 tests, +13 new) — same mirror pattern, **Group 5 boundary documented** (additive only — no role=menu refactor)
- **hx-tooltip** (58 tests, +6 new) — slotted-content text observer (round-23 P2 pattern), preserved no-focus-trap per APG
- **hx-accordion + hx-accordion-item** (110 tests, +6 new) — audit-only, documents architectural deviation (no internals.ariaLabelledByElements; native details/summary projects naturally)

**Total: 338/338 tests passing. `pnpm run verify` clean.**

aria-controls intentionally omitted on popover/dropdown (cross-shadow IDREF limitation, documented inline). aria-controls retained on accordion-item (same-shadow-root, works correctly).

Auto-regenerated React wrappers + CEM. helix-028 standing risk-accept (filter wrapper #1633 confirms only rea-managed P1s remain in cumulative diff).

🚦 `@helixui/library` minor (additive — no breaking changes).

With this PR + #1641 (hx-drawer) + #1642 (hx-dialog), Group 4 is fully migrated. Group 5 (composite navigation) follows: menu/menubar/menuitem, hx-tabs, hx-overflow-menu, hx-split-button, hx-tree-view.