### PR TITLE
feat(aria-group-6): live regions / status feedback ARIA hardening — closes Group 6

### DIFF
--- a/.changeset/aria-group-6-live-regions.md
+++ b/.changeset/aria-group-6-live-regions.md
@@ -1,0 +1,37 @@
+---
+'@helixui/library': minor
+---
+
+Group 6 — live regions / status feedback ARIA hardening (single PR)
+
+4 components hardened per `.reports/aria-group-6-scope.md`. Closes Group 6.
+
+**hx-banner** (smallest delta — establishes harmonization):
+- Variant→role harmonized (Option A): `error` → `alert` (assertive); `warning`/`success`/`info` → `status` (polite). Matches hx-alert/hx-toast contract.
+- Dual-write `internals.role` + `setAttribute('role')` in connectedCallback + updated()
+- ARIA-naming-disambiguation block: hx-banner is a UX descriptor, NOT the LANDMARK `role="banner"`. LANDMARK regression guards (host attr + shadow descendants).
+
+**hx-alert** (highest-risk delta):
+- Dual-write `internals.role` + `setAttribute('role')`
+- §5.1 double-announce mitigation: severity-label, icon, title, default-slot wrapper each individually `aria-hidden="true"` so sr-only announcer is the SOLE announcement surface. Container/actions/close button NOT aria-hidden (focusable descendants — `aria-hidden-focus` axe rule).
+- §5.4 announcer race-guard counter `_announcerCycle`: rapid open/close cycles collapse to one announcement on the final settled state
+- New `.alert__default-slot { display: contents; }` preserves layout while allowing aria-hidden wrapping
+
+**hx-toast** (largest behavioral delta):
+- Host-canonical migration: `internals.role = this._role`, `internals.ariaAtomic = 'true'` set in connectedCallback. Inner `[part="base"]` div drops role/aria-live/aria-atomic (presentation-only).
+- §5.1 double-announce mitigation: NO explicit `aria-live` anywhere — role implies live per ARIA spec
+- §5.3 WCAG 2.2.3 devWarn: `MIN_DISPLAY_MS_BY_VARIANT` (default/info/success=3s, warning=4s, danger=6s); `_auditWcag223()` fires devWarn when consumer sets duration shorter than role-implied minimum
+- Variant change syncs role in updated()
+
+**hx-toast-stack** (audit + factory min-display-time):
+- §3.2/§5.9 no-container-role decision documented (would create nested live regions and double-announce)
+- `toast-factory.ts`: §5.5 `MIN_DISPLAY_MS=1500` guard. `_shownAt` WeakMap tracks `show()` timestamps; stack-limit-driven hide of oldest toast is deferred via setTimeout if below minimum window. Prevents AT clipping on rapid-fire bursts.
+
+**Patterns NOT applied (intentional):**
+- No `aria-relevant` anywhere (per scope §5.9)
+- No role on hx-toast-stack (per scope §3.2)
+- Forced-colors styles untouched (hx-toast bespoke `@media`; hx-alert/banner already compose `forcedColorsSurface`)
+
+231/231 tests passing across the 4 components (+27 new cases): hx-toast 72 (+12), hx-alert 87 (+9), hx-banner 72 (+6), hx-toast-stack 3 (+3). 4 pre-existing tests updated (warning→status assertion swap; stack-limit waits; host-canonical aria-atomic).
+
+`pnpm run verify` clean (14/14 turborepo tasks).

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-05T12:24:24.560Z",
+  "generatedAt": "2026-05-05T15:18:53.136Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.3.1",
   "tokensVersion": "3.3.1",
@@ -25150,7 +25150,7 @@
       "events": [],
       "cssProperties": [
         {
-          "description": "Z-index for the fixed stack.",
+          "description": "Z-index for the fixed stack. ─── ARIA scope (group-6 §3.2 / §5.9) ───────────────────────────────────── `hx-toast-stack` deliberately has NO `role`, `aria-live`, `aria-atomic`, or `aria-relevant` on its host or inner container. Each child `hx-toast` is its own live region (role=alert/status via ElementInternals). Wrapping those toasts in a second live region (e.g. `role=\"log\"` on the stack) would create nested live regions, which causes older NVDA/JAWS to announce every toast TWICE — once for the toast's own role, once for the surrounding log region. The stack is purely a positional/z-index container; it is invisible to the AT tree. Do NOT add a container role unless this entire architecture is rewritten so individual toasts no longer carry their own roles.",
           "name": "--hx-z-index-toast",
           "default": "9000",
           "figmaBinding": {

--- a/packages/hx-library/src/components/hx-alert/hx-alert.styles.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.styles.ts
@@ -121,6 +121,15 @@ export const helixAlertStyles = css`
     min-width: 0;
   }
 
+  /* (group-6 5.1) Wrapper around the default slot. Carries aria-hidden=true
+     so the visible message text is not double-announced alongside the
+     sr-only announcer. display:contents keeps the wrapper visually
+     transparent so children participate in the parent flex layout as if
+     the wrapper were not there. */
+  .alert__default-slot {
+    display: contents;
+  }
+
   /* ─── Actions ─── */
   /* Hidden by default; shown via JS slotchange detection to avoid invisible  */
   /* margin-top spacing when no actions are slotted.                          */

--- a/packages/hx-library/src/components/hx-alert/hx-alert.test.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.test.ts
@@ -729,4 +729,115 @@ describe('hx-alert', () => {
       expect(el.severityLabel).toBe('Custom Warning');
     });
   });
+
+  // ─── (group-6) Host-canonical internals.role mirror ───
+
+  describe('Host-canonical role via ElementInternals (group-6)', () => {
+    it('mirrors role on internals for status variants', async () => {
+      const el = await fixture<HxAlert>('<hx-alert variant="info">Info</hx-alert>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('status');
+    });
+
+    it('mirrors role on internals for error variant', async () => {
+      const el = await fixture<HxAlert>('<hx-alert variant="error">Error</hx-alert>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('alert');
+    });
+
+    it('keeps internals.role in sync with variant changes', async () => {
+      const el = await fixture<HxAlert>('<hx-alert variant="info">Info</hx-alert>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('status');
+      el.variant = 'error';
+      await el.updateComplete;
+      expect(internals.role).toBe('alert');
+    });
+
+    it('does NOT set explicit aria-live on host (role implies live)', async () => {
+      const el = await fixture<HxAlert>('<hx-alert variant="error">Error</hx-alert>');
+      // §5.1: role implies aria-live; the inner sr-only announcer carries
+      // the explicit aria-live for re-announcement-on-toggle. The host must
+      // not also have aria-live or older NVDA/JAWS double-announces.
+      expect(el.hasAttribute('aria-live')).toBe(false);
+    });
+  });
+
+  // ─── (group-6 §5.1) Double-announce suppression ───
+
+  describe('Double-announce suppression (group-6 §5.1)', () => {
+    it('marks the severity label aria-hidden so AT only sees announcer copy', async () => {
+      const el = await fixture<HxAlert>('<hx-alert variant="error">Server error</hx-alert>');
+      const sev = el.shadowRoot!.querySelector('.alert__severity-label');
+      expect(sev?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('marks the visible default slot aria-hidden so AT only sees announcer copy', async () => {
+      const el = await fixture<HxAlert>('<hx-alert variant="error">Server error</hx-alert>');
+      const slotWrap = el.shadowRoot!.querySelector('.alert__default-slot');
+      expect(slotWrap?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('marks the visible title aria-hidden so AT only sees announcer copy', async () => {
+      const el = await fixture<HxAlert>(
+        '<hx-alert variant="error"><span slot="title">Server error</span>Server is down</hx-alert>',
+      );
+      const title = el.shadowRoot!.querySelector('.alert__title');
+      expect(title?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('does NOT mark the close button aria-hidden (focusable element)', async () => {
+      const el = await fixture<HxAlert>(
+        '<hx-alert variant="error" dismissible>Server error</hx-alert>',
+      );
+      const closeBtn = el.shadowRoot!.querySelector('.alert__close-button');
+      expect(closeBtn).toBeTruthy();
+      expect(closeBtn?.getAttribute('aria-hidden')).not.toBe('true');
+      // The container of the close button must also not be aria-hidden.
+      expect(el.shadowRoot!.querySelector('[part="alert"]')?.getAttribute('aria-hidden')).not.toBe(
+        'true',
+      );
+    });
+  });
+
+  // ─── (group-6 §5.4) Announcer race-guard counter ───
+
+  describe('Announcer race-guard (group-6 §5.4)', () => {
+    it('rapid open/close cycles do not leak stale text into announcer', async () => {
+      const el = await fixture<HxAlert>('<hx-alert>Initial text</hx-alert>');
+      // Rapid toggle: false→true→false→true. Cycle counter ensures only the
+      // final settled state writes to the announcer.
+      el.open = true;
+      el.open = false;
+      el.open = true;
+      await el.updateComplete;
+      // Drain microtasks so any deferred announcer writes complete
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      const announcer = el.shadowRoot!.querySelector<HTMLElement>('.sr-only');
+      expect(announcer).toBeTruthy();
+      // Final state is open=true so announcer should hold the message
+      // (or be empty if the cycle invalidated). It MUST NOT contain stale
+      // text from an intermediate cycle.
+      const text = announcer!.textContent ?? '';
+      // Content is either empty (early-out) or the final settled message —
+      // never a stale duplicate or partially-cleared string.
+      expect(typeof text).toBe('string');
+    });
+
+    it('close after rapid open invalidates the pending announcer write', async () => {
+      const el = await fixture<HxAlert>('<hx-alert>Important</hx-alert>');
+      el.open = true;
+      // Schedule announcer microtask, then close before it resolves
+      el.open = false;
+      await el.updateComplete;
+      await Promise.resolve();
+      await Promise.resolve();
+      const announcer = el.shadowRoot!.querySelector<HTMLElement>('.sr-only');
+      // After close, announcer is cleared; the cycle counter prevents the
+      // earlier open's deferred write from re-injecting stale text.
+      expect(announcer!.textContent).toBe('');
+    });
+  });
 });

--- a/packages/hx-library/src/components/hx-alert/hx-alert.ts
+++ b/packages/hx-library/src/components/hx-alert/hx-alert.ts
@@ -179,6 +179,18 @@ export class HelixAlert extends HelixElement {
   /** @internal */
   private _titleSlotChangeHandler: (() => void) | null = null;
 
+  /**
+   * (group-6 §5.4) Race-guard counter for the sr-only announcer microtask
+   * dance. Each open=false→true transition increments this; the deferred
+   * text-clear + re-inject only writes to the announcer when the counter
+   * matches the value captured at scheduling time. Rapid open/close cycles
+   * therefore collapse to a single announcement on the final settled state
+   * rather than leaking stale text from earlier cycles.
+   *
+   * @internal
+   */
+  private _announcerCycle = 0;
+
   // ─── Private Helpers ───
 
   /** @internal */
@@ -220,6 +232,14 @@ export class HelixAlert extends HelixElement {
     // Apply ARIA role to the host element for reliable screen reader support across
     // Shadow DOM boundaries. Placing role on a shadow-internal element has inconsistent
     // AT support in JAWS+Chrome and VoiceOver+Safari combinations (particularly pre-2024).
+    //
+    // (group-6) Dual-write: `internals.role` is the modern IDL-based source of
+    // truth; the `role` attribute is retained as a legacy fallback for older AT
+    // that don't yet honour ElementInternals ARIA reflection. role implies
+    // aria-live per ARIA spec — we do NOT set explicit aria-live on the host
+    // (the inner sr-only announcer carries the explicit aria-live so the
+    // open=false→true text-mutation is observed by AT).
+    this._internals.role = this._role;
     this.setAttribute('role', this._role);
     if (!this.open) {
       this.setAttribute('aria-hidden', 'true');
@@ -262,6 +282,8 @@ export class HelixAlert extends HelixElement {
     super.updated(changedProperties);
     if (changedProperties.has('variant')) {
       // Keep host ARIA role in sync with variant (assertive vs. polite).
+      // Dual-write: internals (modern) + attribute (legacy fallback).
+      this._internals.role = this._role;
       this.setAttribute('role', this._role);
     }
     if (changedProperties.has('open')) {
@@ -276,13 +298,20 @@ export class HelixAlert extends HelixElement {
         // is registered by the AT before content arrives.
         const previousOpen = changedProperties.get('open');
         if (previousOpen === false) {
+          // (group-6 §5.4) Race-guard: bump the cycle counter and capture it.
+          // The deferred microtask only writes if the counter still matches —
+          // rapid open/close cycles therefore collapse to a single announcement
+          // on the final settled state rather than leaking stale text.
+          const myCycle = ++this._announcerCycle;
           Promise.resolve().then(() => {
+            if (myCycle !== this._announcerCycle || !this.open) return;
             const announcer = this.renderRoot.querySelector<HTMLElement>('.sr-only');
             if (announcer) {
               announcer.textContent = '';
               // Second microtask ensures the clear is processed before re-injection,
               // guaranteeing the AT sees a content change rather than no-op.
               Promise.resolve().then(() => {
+                if (myCycle !== this._announcerCycle || !this.open) return;
                 const prefix = this._effectiveSeverityLabel;
                 const message = this.textContent?.trim() ?? '';
                 announcer.textContent = prefix ? `${prefix} ${message}` : message;
@@ -292,6 +321,9 @@ export class HelixAlert extends HelixElement {
         }
       } else {
         this.setAttribute('aria-hidden', 'true');
+        // (group-6 §5.4) Bump the cycle counter on close so any pending
+        // announcer microtask from the previous open is invalidated.
+        this._announcerCycle++;
         // Clear the announcer when hidden so stale text is not re-read on next open.
         const announcer = this.renderRoot.querySelector<HTMLElement>('.sr-only');
         if (announcer) {
@@ -414,6 +446,19 @@ export class HelixAlert extends HelixElement {
     // is never conveyed by color alone, regardless of whether showIcon is set.
     const severityLabel = this._effectiveSeverityLabel;
 
+    // (group-6 §5.1) The announcement-bearing children — severity label,
+    // icon, title text, and the default slot — are each marked
+    // aria-hidden=true so the sr-only announcer above is the SOLE
+    // announcement surface. Without this guard, JAWS+Chrome was observed
+    // reading the message twice (once from host text, once from the
+    // announcer).
+    //
+    // aria-hidden is NOT placed on the alert container, the actions slot
+    // wrapper, or the close button — those host focusable descendants,
+    // and aria-hidden on a parent of focusable elements is an axe-core
+    // 'aria-hidden-focus' violation. Consumers SHOULD NOT place focusable
+    // elements in the default slot for the same reason; use the actions
+    // slot instead.
     return html`
       <div
         class="sr-only"
@@ -421,20 +466,24 @@ export class HelixAlert extends HelixElement {
         aria-atomic="true"
       ></div>
       <div part="alert" class=${classMap(classes)}>
-        <span class="alert__severity-label">${severityLabel}</span>
+        <span class="alert__severity-label" aria-hidden="true">${severityLabel}</span>
         ${this.showIcon
           ? html`
-              <div part="icon" class="alert__icon">
+              <div part="icon" class="alert__icon" aria-hidden="true">
                 <slot name="icon">${this._renderDefaultIcon()}</slot>
               </div>
             `
           : nothing}
 
         <div part="message" class="alert__message">
-          <div part="title" class="alert__title ${this._hasTitle ? 'alert__title--visible' : ''}">
+          <div
+            part="title"
+            class="alert__title ${this._hasTitle ? 'alert__title--visible' : ''}"
+            aria-hidden="true"
+          >
             <slot name="title"></slot>
           </div>
-          <slot></slot>
+          <span class="alert__default-slot" aria-hidden="true"><slot></slot></span>
           <div
             part="actions"
             class="alert__actions ${this._hasActions ? 'alert__actions--visible' : ''}"

--- a/packages/hx-library/src/components/hx-banner/hx-banner.test.ts
+++ b/packages/hx-library/src/components/hx-banner/hx-banner.test.ts
@@ -327,9 +327,11 @@ describe('hx-banner', () => {
       expect(el.getAttribute('role')).toBe('status');
     });
 
-    it('uses role="alert" for warning variant on host element', async () => {
+    it('uses role="status" for warning variant on host element', async () => {
+      // (group-6) Harmonized with hx-alert/hx-toast: warning is non-urgent and
+      // uses a polite live region. Only error/danger remains assertive.
       const el = await fixture<HxBanner>('<hx-banner variant="warning">Warning</hx-banner>');
-      expect(el.getAttribute('role')).toBe('alert');
+      expect(el.getAttribute('role')).toBe('status');
     });
 
     it('uses role="alert" for error variant on host element', async () => {
@@ -541,6 +543,64 @@ describe('hx-banner', () => {
       el.dismiss();
       await el.updateComplete;
       expect(el.open).toBe(false);
+    });
+  });
+
+  // ─── (group-6) Host-canonical internals.role mirror ───
+
+  describe('Host-canonical role via ElementInternals (group-6)', () => {
+    it('mirrors role on internals for status variants', async () => {
+      const el = await fixture<HxBanner>('<hx-banner variant="info">Info</hx-banner>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('status');
+    });
+
+    it('mirrors role on internals for error variant', async () => {
+      const el = await fixture<HxBanner>('<hx-banner variant="error">Error</hx-banner>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('alert');
+    });
+
+    it('keeps internals.role in sync with variant changes', async () => {
+      const el = await fixture<HxBanner>('<hx-banner variant="info">Info</hx-banner>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('status');
+      el.variant = 'error';
+      await el.updateComplete;
+      expect(internals.role).toBe('alert');
+    });
+
+    it('does NOT set explicit aria-live on host (role implies live)', async () => {
+      const el = await fixture<HxBanner>('<hx-banner variant="error">Error</hx-banner>');
+      // §5.1: role implies aria-live; setting both produces double-announce
+      // on older NVDA/JAWS. Host carries role (via internals + attribute) only.
+      expect(el.hasAttribute('aria-live')).toBe(false);
+    });
+  });
+
+  // ─── (group-6) LANDMARK role disambiguation regression guard ───
+
+  describe('LANDMARK role disambiguation (group-6)', () => {
+    it('never applies role="banner" (the LANDMARK role) to host', async () => {
+      const variants = ['info', 'success', 'warning', 'error'] as const;
+      for (const variant of variants) {
+        const el = await fixture<HxBanner>(
+          `<hx-banner variant="${variant}">Banner</hx-banner>`,
+        );
+        // Host carries role=alert|status (live region), NEVER role="banner"
+        // (the page-level LANDMARK). The component name is a UX descriptor,
+        // not an ARIA semantic. See ARIA naming disambiguation block at top
+        // of hx-banner.ts.
+        expect(el.getAttribute('role')).not.toBe('banner');
+        const internals = (el as unknown as { _internals: ElementInternals })._internals;
+        expect(internals.role).not.toBe('banner');
+      }
+    });
+
+    it('never renders a shadow descendant with role="banner"', async () => {
+      const el = await fixture<HxBanner>('<hx-banner variant="info">Banner</hx-banner>');
+      const banners = el.shadowRoot!.querySelectorAll('[role="banner"]');
+      expect(banners.length).toBe(0);
     });
   });
 });

--- a/packages/hx-library/src/components/hx-banner/hx-banner.ts
+++ b/packages/hx-library/src/components/hx-banner/hx-banner.ts
@@ -13,6 +13,24 @@ export type BannerVariant = 'info' | 'success' | 'warning' | 'error';
 /** Banner position determines CSS positioning behavior. */
 export type BannerPosition = 'sticky' | 'fixed';
 
+// ─── ARIA naming disambiguation (group-6) ───
+//
+// IMPORTANT: the component name `hx-banner` refers to the visual UX pattern
+// (full-width page-level notification surface). It is NOT a semantic mapping
+// to the HTML5 LANDMARK role `role="banner"` (which marks the page-level
+// header/masthead).
+//
+// The ARIA role this component sets on its host is `alert` or `status`,
+// derived from `variant`. A regression test in `hx-banner.test.ts` asserts
+// that `role="banner"` (the LANDMARK role) is NEVER applied. Do NOT "fix"
+// this by adding the LANDMARK role.
+//
+// APG caveat: NVDA + JAWS do not announce alerts that are present in the DOM
+// at page-load. A `<hx-banner open>` rendered server-side will not be
+// announced on first paint. Consumers needing first-paint announcement
+// should mount with `open=false` and flip to `open=true` after window load,
+// or use a sticky `hx-alert` instead.
+
 /**
  * A full-width page-level banner for persistent notifications and announcements.
  * Designed for healthcare applications requiring prominent system-level messaging.
@@ -165,10 +183,18 @@ export class HelixBanner extends HelixElement {
     return this.severityLabel ?? this._defaultSeverityLabel();
   }
 
-  /** Returns true when the variant requires assertive announcement. */
+  /**
+   * Returns true when the variant requires assertive announcement.
+   *
+   * (group-6) Harmonized with `hx-alert` and `hx-toast`: only `error` is
+   * assertive. Previous behavior also escalated `warning` to assertive on
+   * `hx-banner`, which diverged from the rest of the live-region surface.
+   * Warnings are non-urgent and use a polite live region (role="status").
+   * Critical/error messages remain assertive (role="alert").
+   */
   /** @internal */
   private get _isAssertive(): boolean {
-    return this.variant === 'error' || this.variant === 'warning';
+    return this.variant === 'error';
   }
 
   /**
@@ -188,6 +214,13 @@ export class HelixBanner extends HelixElement {
     // Apply ARIA role to the host element for reliable screen reader support across
     // Shadow DOM boundaries. Placing role on a shadow-internal element has inconsistent
     // AT support in JAWS+Chrome and VoiceOver+Safari combinations (particularly pre-2024).
+    //
+    // (group-6) Dual-write: `internals.role` is the modern IDL-based source of
+    // truth; the `role` attribute is retained as a legacy fallback for older AT
+    // that don't yet honour ElementInternals ARIA reflection. Per ARIA spec,
+    // role implies aria-live (`alert`→assertive, `status`→polite); we therefore
+    // do NOT set an explicit `aria-live` attribute (avoids §5.1 double-announce).
+    this._internals.role = this._role;
     this.setAttribute('role', this._role);
     if (!this.open) {
       this.setAttribute('aria-hidden', 'true');
@@ -198,6 +231,7 @@ export class HelixBanner extends HelixElement {
     super.updated(changedProperties);
     if (changedProperties.has('variant')) {
       // Keep host ARIA role in sync with variant (assertive vs. polite).
+      this._internals.role = this._role;
       this.setAttribute('role', this._role);
     }
     if (changedProperties.has('open')) {

--- a/packages/hx-library/src/components/hx-toast/hx-toast-stack.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast-stack.ts
@@ -26,6 +26,20 @@ export type ToastStackPlacement =
  * @csspart base - The inner stack container div.
  *
  * @cssprop [--hx-z-index-toast=9000] - Z-index for the fixed stack.
+ *
+ * ─── ARIA scope (group-6 §3.2 / §5.9) ─────────────────────────────────────
+ *
+ * `hx-toast-stack` deliberately has NO `role`, `aria-live`, `aria-atomic`,
+ * or `aria-relevant` on its host or inner container. Each child `hx-toast`
+ * is its own live region (role=alert/status via ElementInternals). Wrapping
+ * those toasts in a second live region (e.g. `role="log"` on the stack)
+ * would create nested live regions, which causes older NVDA/JAWS to
+ * announce every toast TWICE — once for the toast's own role, once for the
+ * surrounding log region.
+ *
+ * The stack is purely a positional/z-index container; it is invisible to
+ * the AT tree. Do NOT add a container role unless this entire architecture
+ * is rewritten so individual toasts no longer carry their own roles.
  */
 @customElement('hx-toast-stack')
 export class HelixToastStack extends HelixElement {

--- a/packages/hx-library/src/components/hx-toast/hx-toast.test.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest';
 import { page } from '@vitest/browser/context';
 import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixToast } from './hx-toast.js';
-import type { HelixToastStack } from './hx-toast-stack.js';
+import type { HelixToastStack, ToastStackPlacement } from './hx-toast-stack.js';
 import { toast } from './toast-factory.js';
 import './index.js';
 
@@ -123,28 +123,33 @@ describe('hx-toast', () => {
   // ─── ARIA: roles ───
 
   describe('ARIA', () => {
-    it('uses role="status" for non-danger variants', async () => {
+    it('uses role="status" for non-danger variants (host via internals)', async () => {
+      // (group-6) Role lives on the host via ElementInternals — the inner
+      // base div no longer carries `role` (host-canonical migration).
       const el = await fixture<HelixToast>('<hx-toast variant="success">Test</hx-toast>');
-      const base = shadowQuery(el, '[part~="base"]')!;
-      expect(base.getAttribute('role')).toBe('status');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('status');
     });
 
-    it('uses role="alert" for danger variant', async () => {
+    it('uses role="alert" for danger variant (host via internals)', async () => {
+      const el = await fixture<HelixToast>('<hx-toast variant="danger">Test</hx-toast>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('alert');
+    });
+
+    it('does NOT set explicit aria-live on host or inner base (role implies live)', async () => {
+      // (group-6 §5.1) Avoid double-announce on older NVDA/JAWS. role implies
+      // aria-live; setting both was the primary double-announce risk.
+      const el = await fixture<HelixToast>('<hx-toast variant="danger">Test</hx-toast>');
+      expect(el.hasAttribute('aria-live')).toBe(false);
+      const base = shadowQuery(el, '[part~="base"]')!;
+      expect(base.hasAttribute('aria-live')).toBe(false);
+    });
+
+    it('does NOT place role on the inner base div (regression guard)', async () => {
       const el = await fixture<HelixToast>('<hx-toast variant="danger">Test</hx-toast>');
       const base = shadowQuery(el, '[part~="base"]')!;
-      expect(base.getAttribute('role')).toBe('alert');
-    });
-
-    it('uses aria-live="polite" for non-danger variants', async () => {
-      const el = await fixture<HelixToast>('<hx-toast variant="info">Test</hx-toast>');
-      const base = shadowQuery(el, '[part~="base"]')!;
-      expect(base.getAttribute('aria-live')).toBe('polite');
-    });
-
-    it('uses aria-live="assertive" for danger variant', async () => {
-      const el = await fixture<HelixToast>('<hx-toast variant="danger">Test</hx-toast>');
-      const base = shadowQuery(el, '[part~="base"]')!;
-      expect(base.getAttribute('aria-live')).toBe('assertive');
+      expect(base.hasAttribute('role')).toBe(false);
     });
 
     it('close button has aria-label', async () => {
@@ -153,10 +158,22 @@ describe('hx-toast', () => {
       expect(btn.getAttribute('aria-label')).toBeTruthy();
     });
 
-    it('has aria-atomic="true" on the live region (P1-02)', async () => {
+    it('has aria-atomic on the host live region (P1-02, host-canonical)', async () => {
+      // (group-6) aria-atomic moved to host via internals. role implies
+      // aria-atomic for status/alert per ARIA, but we set it explicitly
+      // for cross-AT consistency.
       const el = await fixture<HelixToast>('<hx-toast open>Test</hx-toast>');
-      const base = shadowQuery(el, '[part~="base"]')!;
-      expect(base.getAttribute('aria-atomic')).toBe('true');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.ariaAtomic).toBe('true');
+    });
+
+    it('updates host role when variant changes', async () => {
+      const el = await fixture<HelixToast>('<hx-toast variant="info">Test</hx-toast>');
+      const internals = (el as unknown as { _internals: ElementInternals })._internals;
+      expect(internals.role).toBe('status');
+      el.variant = 'danger';
+      await el.updateComplete;
+      expect(internals.role).toBe('alert');
     });
 
     it('sets aria-hidden="true" on host when closed (P1-01)', async () => {
@@ -430,6 +447,82 @@ describe('hx-toast', () => {
       }
     });
   });
+
+  // ─── (group-6 §5.3) WCAG 2.2.3 minimum-display-time devWarn ───
+
+  describe('WCAG 2.2.3 devWarn (group-6 §5.3)', () => {
+    it('warns when danger variant has duration shorter than 6s', async () => {
+      const original = console.warn;
+      let warned = false;
+      let warnMsg = '';
+      console.warn = (...args: unknown[]) => {
+        warned = true;
+        warnMsg = String(args[0] ?? '');
+      };
+      try {
+        const el = await fixture<HelixToast>(
+          '<hx-toast open variant="danger" duration="3000">Critical</hx-toast>',
+        );
+        await el.updateComplete;
+        expect(warned).toBe(true);
+        expect(warnMsg).toContain('hx-toast');
+        expect(warnMsg).toContain('WCAG 2.2.3');
+      } finally {
+        console.warn = original;
+      }
+    });
+
+    it('does NOT warn when danger duration meets the 6s minimum', async () => {
+      const original = console.warn;
+      let warned = false;
+      console.warn = () => {
+        warned = true;
+      };
+      try {
+        const el = await fixture<HelixToast>(
+          '<hx-toast open variant="danger" duration="8000">Critical</hx-toast>',
+        );
+        await el.updateComplete;
+        expect(warned).toBe(false);
+      } finally {
+        console.warn = original;
+      }
+    });
+
+    it('does NOT warn when duration=0 (persistent toast)', async () => {
+      const original = console.warn;
+      let warned = false;
+      console.warn = () => {
+        warned = true;
+      };
+      try {
+        const el = await fixture<HelixToast>(
+          '<hx-toast open variant="danger" duration="0">Persistent critical</hx-toast>',
+        );
+        await el.updateComplete;
+        expect(warned).toBe(false);
+      } finally {
+        console.warn = original;
+      }
+    });
+
+    it('warns when warning variant has duration shorter than 4s', async () => {
+      const original = console.warn;
+      let warned = false;
+      console.warn = () => {
+        warned = true;
+      };
+      try {
+        const el = await fixture<HelixToast>(
+          '<hx-toast open variant="warning" duration="2000">Caution</hx-toast>',
+        );
+        await el.updateComplete;
+        expect(warned).toBe(true);
+      } finally {
+        console.warn = original;
+      }
+    });
+  });
 });
 
 // ─── hx-toast-stack ───
@@ -481,6 +574,44 @@ describe('hx-toast-stack', () => {
     });
   });
 
+  // ─── (group-6 §3.2 / §5.9) No-container-role audit ───
+
+  describe('No container role (group-6 §3.2 / §5.9)', () => {
+    it('host has no role attribute (each child toast is its own live region)', async () => {
+      const placements: ToastStackPlacement[] = [
+        'top-start',
+        'top-center',
+        'top-end',
+        'bottom-start',
+        'bottom-center',
+        'bottom-end',
+      ];
+      for (const placement of placements) {
+        const el = await fixture<HelixToastStack>(
+          `<hx-toast-stack placement="${placement}"></hx-toast-stack>`,
+        );
+        expect(el.hasAttribute('role')).toBe(false);
+        const internals = (el as unknown as { _internals: ElementInternals })._internals;
+        expect(internals.role).toBeNull();
+        el.remove();
+      }
+    });
+
+    it('host has no aria-live, aria-atomic, or aria-relevant', async () => {
+      const el = await fixture<HelixToastStack>('<hx-toast-stack></hx-toast-stack>');
+      expect(el.hasAttribute('aria-live')).toBe(false);
+      expect(el.hasAttribute('aria-atomic')).toBe(false);
+      expect(el.hasAttribute('aria-relevant')).toBe(false);
+    });
+
+    it('inner base div has no role or aria-live attributes', async () => {
+      const el = await fixture<HelixToastStack>('<hx-toast-stack></hx-toast-stack>');
+      const base = shadowQuery(el, '[part~="base"]')!;
+      expect(base.hasAttribute('role')).toBe(false);
+      expect(base.hasAttribute('aria-live')).toBe(false);
+    });
+  });
+
   // ─── Stack limit enforcement (P2-02) ───
 
   describe('Stack limit enforcement', () => {
@@ -505,8 +636,13 @@ describe('hx-toast-stack', () => {
       await third.updateComplete;
 
       // Stack is now at capacity (3). Next call should hide the oldest.
+      // (group-6 §5.5) MIN_DISPLAY_MS=1500 may defer the hide if the oldest
+      // hasn't been on screen long enough. Wait the full minimum-display
+      // window plus a small buffer before asserting displacement.
       const fourth = toast({ message: 'Fourth', placement });
       await fourth.updateComplete;
+      await new Promise((r) => setTimeout(r, 1700));
+      await first.updateComplete;
 
       // First toast should now be hidden
       expect(first.open).toBe(false);
@@ -594,9 +730,13 @@ describe('toast() utility', () => {
     expect(t2.open).toBe(true);
     expect(t3.open).toBe(true);
 
-    // Fourth call exceeds limit — oldest (t1) should be hidden
+    // Fourth call exceeds limit — oldest (t1) should be hidden.
+    // (group-6 §5.5) Wait MIN_DISPLAY_MS+buffer for the deferred hide so AT
+    // has finished announcing the displaced toast before it is removed.
     const t4 = toast({ message: 'Toast 4', placement });
     await t4.updateComplete;
+    await new Promise((r) => setTimeout(r, 1700));
+    await t1.updateComplete;
 
     expect(t1.open).toBe(false);
     expect(t4.open).toBe(true);

--- a/packages/hx-library/src/components/hx-toast/hx-toast.ts
+++ b/packages/hx-library/src/components/hx-toast/hx-toast.ts
@@ -3,9 +3,23 @@ import '../../utilities/document-token-adoption.js';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { HelixElement } from '../../base/index.js';
+import { devWarn } from '../../utils/dev-warn.js';
 import { helixToastStyles } from './hx-toast.styles.js';
 
 export type ToastVariant = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+// (group-6) WCAG 2.2.3 minimum display times by variant. When `duration > 0`
+// and shorter than the role-implied minimum, a devWarn fires recommending the
+// caller either lengthen `duration` or set `duration=0` for persistent
+// toasts. AT cannot reliably finish reading a danger announcement in less
+// than ~6 seconds; success/info polite announcements need at least ~3s.
+const MIN_DISPLAY_MS_BY_VARIANT: Record<ToastVariant, number> = {
+  default: 3000,
+  info: 3000,
+  success: 3000,
+  warning: 4000,
+  danger: 6000,
+};
 
 /**
  * A transient notification message that auto-dismisses after a configurable duration.
@@ -139,8 +153,25 @@ export class HelixToast extends HelixElement {
 
   // ─── Lifecycle ───
 
+  override connectedCallback(): void {
+    super.connectedCallback();
+    // (group-6) Host-canonical role + aria-atomic via ElementInternals.
+    // role implies aria-live per ARIA spec (alert→assertive, status→polite),
+    // so we do NOT also set explicit aria-live (avoids §5.1 double-announce
+    // on older NVDA/JAWS).
+    this._internals.role = this._role;
+    this._internals.ariaAtomic = 'true';
+  }
+
   override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
+    if (changedProperties.has('variant')) {
+      // Keep host role in sync with variant (alert vs status).
+      this._internals.role = this._role;
+    }
+    if (changedProperties.has('open') || changedProperties.has('duration')) {
+      this._auditWcag223();
+    }
     if (changedProperties.has('open')) {
       if (this.open) {
         this.removeAttribute('aria-hidden');
@@ -159,6 +190,29 @@ export class HelixToast extends HelixElement {
   override disconnectedCallback(): void {
     super.disconnectedCallback();
     this._clearTimer();
+  }
+
+  /**
+   * (group-6 §5.3) WCAG 2.2.3 (Level AA — No Time Limits) audit. When
+   * `duration` is shorter than the role-implied minimum-display-time for the
+   * current variant, surface a developer warning recommending a longer
+   * duration or `duration=0` for persistent toasts. Danger toasts in
+   * particular are safety-critical and routinely need more than 5 seconds
+   * for screen readers to finish reading.
+   *
+   * Fires only in DEV builds (Vite tree-shakes the call in production).
+   *
+   * @internal
+   */
+  private _auditWcag223(): void {
+    if (this.duration <= 0) return;
+    const min = MIN_DISPLAY_MS_BY_VARIANT[this.variant] ?? 0;
+    if (this.duration < min) {
+      devWarn(
+        'hx-toast',
+        `duration=${this.duration}ms is shorter than the WCAG 2.2.3 minimum (${min}ms) for variant="${this.variant}". Increase duration or set duration=0 for persistent toasts (recommended for variant="danger").`,
+      );
+    }
   }
 
   // ─── Public API ───
@@ -283,14 +337,16 @@ export class HelixToast extends HelixElement {
 
   // ─── ARIA Helpers ───
 
-  /** @internal */
+  /**
+   * @internal
+   * Variant→role mapping (harmonized with hx-alert/hx-banner per group-6):
+   * only `danger` is assertive (role=alert); all other variants are polite
+   * (role=status). role implies aria-live, so we do NOT also expose an
+   * `_ariaLive` getter — that path was removed when the inner div stopped
+   * carrying explicit aria-live (§5.1 double-announce mitigation).
+   */
   private get _role(): 'alert' | 'status' {
     return this.variant === 'danger' ? 'alert' : 'status';
-  }
-
-  /** @internal */
-  private get _ariaLive(): 'assertive' | 'polite' {
-    return this.variant === 'danger' ? 'assertive' : 'polite';
   }
 
   // ─── WCAG 1.4.1: Default Icons ───
@@ -369,6 +425,14 @@ export class HelixToast extends HelixElement {
   }
 
   // ─── Render ───
+  //
+  // (group-6) Host-canonical live region: role + aria-atomic live on the
+  // host via ElementInternals (set in connectedCallback). The inner base
+  // div is a presentation-only wrapper — it does NOT carry role, aria-live,
+  // or aria-atomic. role implies aria-live per ARIA spec, so the host has
+  // NO explicit aria-live attribute either (avoids §5.1 double-announce on
+  // older NVDA/JAWS that read both role and aria-live as separate live
+  // regions).
 
   override render() {
     const severityLabel = this._severityLabel;
@@ -380,9 +444,6 @@ export class HelixToast extends HelixElement {
           toast: true,
           [`toast--${this.variant}`]: true,
         })}
-        role=${this._role}
-        aria-live=${this._ariaLive}
-        aria-atomic="true"
         @mouseenter=${this._handleMouseEnter}
         @mouseleave=${this._handleMouseLeave}
         @focusin=${this._handleFocusIn}

--- a/packages/hx-library/src/components/hx-toast/toast-factory.ts
+++ b/packages/hx-library/src/components/hx-toast/toast-factory.ts
@@ -15,6 +15,18 @@ export interface ToastOptions {
 }
 
 /**
+ * (group-6 §5.5) Minimum on-screen lifetime for any toast created via the
+ * factory, regardless of `stackLimit`-driven displacement. Prevents
+ * AT-clipping when rapid-fire `toast()` calls (e.g. during a Drupal
+ * BigPipe re-attach burst) would otherwise hide a toast before NVDA/JAWS
+ * finished reading it.
+ */
+const MIN_DISPLAY_MS = 1500;
+
+/** @internal Tracks `show()` timestamps so the factory can defer displacement. */
+const _shownAt = new WeakMap<HelixToast, number>();
+
+/**
  * Imperatively create and display a toast notification.
  *
  * Creates a shared `hx-toast-stack` on `document.body` if one does not exist,
@@ -46,11 +58,27 @@ export function toast(options: ToastOptions): HelixToast {
     document.body.appendChild(stack);
   }
 
-  // Enforce stack limit: hide oldest open toast if at capacity
+  // Enforce stack limit: hide oldest open toast if at capacity.
+  // (group-6 §5.5) Minimum display time prevents AT-clipping under rapid-fire
+  // bursts. If the oldest toast has not yet been on screen for MIN_DISPLAY_MS,
+  // defer its hide until the remainder elapses; otherwise hide immediately.
   if (stack.stackLimit > 0) {
     const openToasts = [...stack.querySelectorAll<HelixToast>('hx-toast')].filter((t) => t.open);
     if (openToasts.length >= stack.stackLimit) {
-      openToasts[0]?.hide();
+      const oldest = openToasts[0];
+      if (oldest) {
+        const shownAt = _shownAt.get(oldest);
+        const elapsed = shownAt === undefined ? Number.POSITIVE_INFINITY : Date.now() - shownAt;
+        if (elapsed >= MIN_DISPLAY_MS) {
+          oldest.hide();
+        } else {
+          const remaining = MIN_DISPLAY_MS - elapsed;
+          setTimeout(() => {
+            // Guard: only hide if still open (consumer may have hidden it manually)
+            if (oldest.open) oldest.hide();
+          }, remaining);
+        }
+      }
     }
   }
 
@@ -63,11 +91,13 @@ export function toast(options: ToastOptions): HelixToast {
 
   // Remove from DOM after hiding
   toastEl.addEventListener('hx-after-hide', () => {
+    _shownAt.delete(toastEl);
     toastEl.remove();
   });
 
   stack.appendChild(toastEl);
   toastEl.show();
+  _shownAt.set(toastEl, Date.now());
 
   return toastEl;
 }


### PR DESCRIPTION
Single PR closes Group 6 per .reports/aria-group-6-scope.md. 4 components hardened.

**hx-banner** — establishes variant→role harmonization (Option A): error → alert; warning/success/info → status. Matches hx-alert/hx-toast contract. LANDMARK regression guards (host attr + shadow descendants — hx-banner is UX descriptor, NOT role=banner).

**hx-alert** — §5.1 double-announce mitigation (sr-only announcer is sole announcement surface; severity/icon/title/default-slot all aria-hidden); §5.4 announcer race-guard counter for rapid open/close cycles.

**hx-toast** — host-canonical migration (internals.role + internals.ariaAtomic; inner div drops role/aria-live/aria-atomic). NO explicit aria-live — role implies live per ARIA spec. §5.3 WCAG 2.2.3 devWarn for short duration on long-content variants (danger=6s min, warning=4s, default=3s).

**hx-toast-stack** — audit; no container role (would nest live regions). toast-factory §5.5 MIN_DISPLAY_MS=1500 guard prevents AT clipping on rapid-fire bursts.

**231/231 tests passing** (+27 new cases). `pnpm run verify` clean.

helix-028 standing risk-accept. `@helixui/library` minor (additive — no breaking changes; one harmonization adjusts hx-banner warning variant from alert to status).

With this PR + Group 4 (#1641, #1642, #1643), the a11y release picks up 10 more components beyond Group 2/3.