### PR TITLE
feat(aria-group-5a): tabs family host-canonical ARIA hardening

### DIFF
--- a/.changeset/aria-group-5a-tabs.md
+++ b/.changeset/aria-group-5a-tabs.md
@@ -1,0 +1,36 @@
+---
+'@helixui/library': minor
+---
+
+Group 5a — tabs family ARIA hardening (host-canonical Path A)
+
+3 components hardened per `.reports/aria-group-5-scope.md`. Lowest-risk PR of Group 5; validates `role="tab"` on host with inner activation pattern.
+
+**hx-tab** — host-canonical:
+- `internals.role = 'tab'` on host
+- Inner element changed from `<button>` to `<div part="tab">` on modern path (ARIA 1.2 forbids `role="presentation"` on focusable elements; cleanest strip is to use a roleless element)
+- Click + pointer activation still works on `<div>`; keyboard activation owned by parent `hx-tabs` keydown handler operating on host
+- Inner `aria-disabled` retained as non-AT signal so axe-core's color-contrast rule excludes the disabled surface
+- `internals.ariaSelected` / `internals.ariaDisabled` mirror reactive state
+- `internals.ariaControlsElements` references corresponding `hx-tab-panel` host (cross-shadow IDL refs); legacy fallback writes string `aria-controls`
+
+**hx-tabs** — host-canonical:
+- `internals.role = 'tablist'` on host
+- `internals.ariaOrientation` reactive to `orientation` property
+- Cross-shadow naming belt-and-suspenders — host `aria-label` / `aria-labelledby` resolve via `installAriaIdrefMirror` + `resolveIdrefTokens`; `internals.ariaLabelledByElements` set on modern path; `flattenAccName`-flattened string on legacy path
+- **Manual activation default** — flipped from `automatic` per scope §5.4 + healthcare patterns (safer for accidental keypress). Public API still supports both modes via `activation="automatic|manual"` attribute.
+
+**hx-tab-panel** — host-canonical:
+- `internals.role = 'tabpanel'` on host
+- `internals.ariaLabelledByElements` projects controlling tab host as element reference (cross-shadow naming via IDL refs, no text serialization)
+- Legacy fallback retains `setAttribute('role')` for back-compat
+
+**Roving tabindex** — single-host. Active tab `tabindex=0`, inactive `tabindex=-1`. Focus moves to host (no longer dual button/host focus).
+
+**CSS state hooks moved** from inner ARIA attributes (`[aria-selected]`/`[aria-disabled]`) to `:host([selected])` / `:host([disabled])` since aria-* is stripped from inner div on modern path. Functionally identical (same reactive state via `reflect: true`); more idiomatic for host-canonical.
+
+**Cross-AT smoke test added** — asserts `document.activeElement === tab` (host), `internals.role === 'tab'`, and `internals.ariaSelected === 'true'` after `tab.focus()`. Validates the role-on-host with inner-activation pattern.
+
+87 hx-tabs tests passing (was 83; +4 net new — ariaControlsElements, ariaLabelledByElements, host owns focus smoke, automatic activation attr; reframed several to host-canonical surface). 2 keyboard-navigation tabs section tests passing (re-pinned to `activation="automatic"` HTML for arrow-activation assertions).
+
+`pnpm run verify` clean. helix-028 standing risk-accept.

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-05T12:24:24.560Z",
+  "generatedAt": "2026-05-05T15:36:21.392Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.3.1",
   "tokensVersion": "3.3.1",
@@ -21704,7 +21704,7 @@
       "figmaEligible": true,
       "figmaComponentName": "hx-tab-panel",
       "figmaPagePlacement": "4a",
-      "description": "A content panel associated with an `<hx-tab>`, managed by a parent `<hx-tabs>`.",
+      "description": "A content panel associated with an `<hx-tab>`, managed by a parent `<hx-tabs>`. Group 5a host-canonical: `role=\"tabpanel\"` lives on the host via `_internals.role`. The host carries the canonical AT…",
       "tier": "atom",
       "variantAxes": [],
       "textProperties": [
@@ -22043,7 +22043,7 @@
             "manual",
             "automatic"
           ],
-          "default": "automatic"
+          "default": "manual"
         }
       ],
       "textProperties": [

--- a/packages/hx-library/src/components/__tests__/keyboard-navigation.test.ts
+++ b/packages/hx-library/src/components/__tests__/keyboard-navigation.test.ts
@@ -496,9 +496,13 @@ describe('Keyboard Navigation Integration', () => {
   // hx-tabs
   // ---------------------------------------------------------------------------
   describe('hx-tabs', () => {
-    it('ArrowRight moves to the next tab and dispatches hx-tab-change', async () => {
+    // Group 5a host-canonical: focus targets the host (the inner [part="tab"]
+    // is presentational on the modern path). Activation defaults to "manual";
+    // these integration tests pin `activation="automatic"` because they
+    // assert that arrow keys both move focus AND fire `hx-tab-change`.
+    it('ArrowRight moves to the next tab and dispatches hx-tab-change (automatic)', async () => {
       const el = await fixture<HelixTabs>(`
-        <hx-tabs>
+        <hx-tabs activation="automatic">
           <hx-tab slot="tab" panel="one">Tab 1</hx-tab>
           <hx-tab slot="tab" panel="two">Tab 2</hx-tab>
           <hx-tab-panel name="one">Panel 1</hx-tab-panel>
@@ -507,9 +511,7 @@ describe('Keyboard Navigation Integration', () => {
       `);
       await el.updateComplete;
       const firstTab = el.querySelector<HTMLElement>('hx-tab')!;
-      const firstTabBtn = firstTab.shadowRoot?.querySelector<HTMLButtonElement>('button');
-      expect(firstTabBtn).toBeTruthy();
-      firstTabBtn!.focus();
+      firstTab.focus();
       const eventPromise = oneEvent<CustomEvent<{ tabId: string; index: number }>>(
         el,
         'hx-tab-change',
@@ -520,9 +522,9 @@ describe('Keyboard Navigation Integration', () => {
       expect(event.detail.index).toBe(1);
     });
 
-    it('ArrowLeft wraps back to previous tab', async () => {
+    it('ArrowLeft wraps back to previous tab (automatic)', async () => {
       const el = await fixture<HelixTabs>(`
-        <hx-tabs>
+        <hx-tabs activation="automatic">
           <hx-tab slot="tab" panel="one">Tab 1</hx-tab>
           <hx-tab slot="tab" panel="two">Tab 2</hx-tab>
           <hx-tab-panel name="one">Panel 1</hx-tab-panel>
@@ -532,11 +534,11 @@ describe('Keyboard Navigation Integration', () => {
       await el.updateComplete;
       const tabs = Array.from(el.querySelectorAll<HTMLElement>('hx-tab'));
       // Activate second tab first so ArrowLeft has somewhere to go back to
-      const secondTabBtn = tabs[1].shadowRoot?.querySelector<HTMLButtonElement>('button');
-      expect(secondTabBtn).toBeTruthy();
-      secondTabBtn!.click();
+      const secondPart = tabs[1].shadowRoot?.querySelector<HTMLElement>('[part="tab"]');
+      expect(secondPart).toBeTruthy();
+      secondPart!.click();
       await el.updateComplete;
-      secondTabBtn!.focus();
+      tabs[1].focus();
       const eventPromise = oneEvent<CustomEvent<{ tabId: string; index: number }>>(
         el,
         'hx-tab-change',

--- a/packages/hx-library/src/components/hx-tabs/hx-tab-panel.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tab-panel.ts
@@ -1,12 +1,24 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import '../../utilities/document-token-adoption.js';
-import { customElement, property } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { HelixElement } from '../../base/index.js';
-import { forcedColorsInteractive } from '../../styles/forced-colors.js';
+import { forcedColorsField } from '../../styles/forced-colors.js';
 import { helixTabPanelStyles } from './hx-tab-panel.styles.js';
+import {
+  installAriaIdrefMirror,
+  resolveIdrefTokens,
+  supportsIdrefElementReferences,
+  type AriaIdrefMirrorHandle,
+} from '../../utils/aria-idref.js';
 
 /**
  * A content panel associated with an `<hx-tab>`, managed by a parent `<hx-tabs>`.
+ * Group 5a host-canonical: `role="tabpanel"` lives on the host via
+ * `_internals.role`. The host carries the canonical AT surface — consumer
+ * `aria-labelledby` / `aria-describedby` on the host resolve through the
+ * shared IDREF mirror. The parent `hx-tabs` writes `internals.ariaLabelledByElements`
+ * referencing the corresponding `<hx-tab>` host so cross-shadow naming works
+ * via IDL element references (the modern path) without serializing tab text.
  *
  * @summary Tab content panel shown when its corresponding tab is selected.
  *
@@ -22,7 +34,7 @@ import { helixTabPanelStyles } from './hx-tab-panel.styles.js';
  */
 @customElement('hx-tab-panel')
 export class HelixTabPanel extends HelixElement {
-  static override styles = [helixTabPanelStyles, forcedColorsInteractive];
+  static override styles = [helixTabPanelStyles, forcedColorsField];
 
   // ─── Properties ───
 
@@ -33,13 +45,105 @@ export class HelixTabPanel extends HelixElement {
   @property({ type: String, reflect: true })
   name = '';
 
+  // ─── Host-canonical ARIA bookkeeping ───
+
+  /**
+   * Element references for the controlling `<hx-tab>` host(s). Set by the
+   * parent `<hx-tabs>` via `setLabelledByTabs()` and projected onto
+   * `internals.ariaLabelledByElements` so cross-shadow naming via IDL element
+   * references resolves to the live tab host without flattening text.
+   * @internal
+   */
+  private _labelledByTabs: Element[] = [];
+
+  /**
+   * Whether the platform supports IDL element references on `ElementInternals`.
+   * @internal
+   */
+  @state() private _supportsIdrefRefs = true;
+
+  /** @internal */
+  private _ariaMirror: AriaIdrefMirrorHandle | null = null;
+
   // ─── Lifecycle ───
 
   override connectedCallback(): void {
     super.connectedCallback();
-    this.setAttribute('role', 'tabpanel');
-    // tabindex is managed dynamically by the parent hx-tabs component:
-    // active panels get tabindex="0", hidden panels get tabindex="-1"
+    this._supportsIdrefRefs = supportsIdrefElementReferences(this._internals);
+    // Host-canonical role via ElementInternals — replaces the imperative
+    // setAttribute('role', 'tabpanel') from pre-aria-group-5 code.
+    this._internals.role = 'tabpanel';
+    this._syncHostAriaSemantics();
+    this._ariaMirror = installAriaIdrefMirror(this, () => {
+      this._syncHostAriaSemantics();
+    });
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._ariaMirror?.disconnect();
+    this._ariaMirror = null;
+  }
+
+  override updated(changedProperties: PropertyValues<this>): void {
+    super.updated(changedProperties);
+    this._syncHostAriaSemantics();
+  }
+
+  /**
+   * Set by `<hx-tabs>` whenever the tab→panel relationship is recomputed.
+   * Drives `internals.ariaLabelledByElements` so AT walks across the shadow
+   * boundary to the announcing tab host(s) by element reference rather than
+   * IDREF string. Pass an empty array to clear.
+   * @internal
+   */
+  setLabelledByTabs(tabs: Element[]): void {
+    this._labelledByTabs = tabs;
+    this._syncHostAriaSemantics();
+  }
+
+  /** @internal */
+  private _syncHostAriaSemantics(): void {
+    const internals = this._internals;
+    // Re-assert role on every sync so a stale connect path doesn't leave the
+    // panel role-less if internals are accessed before connect (e.g. tests).
+    internals.role = 'tabpanel';
+
+    // Resolve consumer-supplied IDREFs — host-canonical: light-DOM aria-labelledby
+    // / aria-describedby on `<hx-tab-panel>` should reach the announced surface.
+    const consumerLabelledBy = this.getAttribute('aria-labelledby');
+    const consumerDescribedBy = this.getAttribute('aria-describedby');
+    const consumerLabelEls = resolveIdrefTokens(this, consumerLabelledBy);
+    const consumerDescEls = resolveIdrefTokens(this, consumerDescribedBy);
+
+    // Host aria-label, if explicitly provided by the consumer, wins.
+    const hostAriaLabel = this.getAttribute('aria-label');
+
+    // Build the labelledBy element list: consumer takes precedence; otherwise
+    // fall back to the parent-projected `<hx-tab>` host references so the
+    // panel announces with the tab's accessible name without text flattening.
+    const labelEls: Element[] =
+      consumerLabelEls.length > 0 ? consumerLabelEls : [...this._labelledByTabs];
+
+    type InternalsWithRefs = ElementInternals & {
+      ariaLabelledByElements: Element[] | null;
+      ariaDescribedByElements: Element[] | null;
+    };
+
+    if (this._supportsIdrefRefs) {
+      const refsInternals = internals as InternalsWithRefs;
+      refsInternals.ariaLabelledByElements = labelEls.length > 0 ? labelEls : null;
+      refsInternals.ariaDescribedByElements = consumerDescEls.length > 0 ? consumerDescEls : null;
+      // Modern path: the consumer's `aria-label` (if any) wins via internals.
+      // When absent, leave it null so the element-references path supplies the name.
+      internals.ariaLabel = hostAriaLabel && hostAriaLabel.trim() ? hostAriaLabel : null;
+    } else {
+      // No-IDL-ref fallback: cross-shadow tab→panel naming via element refs is
+      // unavailable. The parent `hx-tabs` mirrors a serialized `aria-label`
+      // string onto the host attribute (legacy fallback) — leave that in
+      // place. Consumer `aria-label` overrides via internals string.
+      internals.ariaLabel = hostAriaLabel && hostAriaLabel.trim() ? hostAriaLabel : null;
+    }
   }
 
   // ─── Render ───

--- a/packages/hx-library/src/components/hx-tabs/hx-tab.styles.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tab.styles.ts
@@ -42,16 +42,19 @@ export const helixTabStyles = css`
     position: relative;
   }
 
-  /* ─── Hover State ─── */
+  /* ─── Hover State ───
+     Group 5a host-canonical: drive visual state from host attributes
+     (selected / disabled are reflect: true), not from inner-element ARIA
+     attributes which now live on the host's ElementInternals. */
 
-  .tab:not([aria-selected='true']):not([aria-disabled='true']):hover {
+  :host(:not([selected]):not([disabled])) .tab:hover {
     color: var(--hx-tabs-tab-hover-color, var(--hx-color-neutral-800, #202b39));
     background-color: var(--hx-tabs-tab-hover-bg, var(--hx-color-neutral-50, #f5f8f3));
   }
 
   /* ─── Selected State ─── */
 
-  .tab[aria-selected='true'] {
+  :host([selected]) .tab {
     color: var(--hx-tabs-tab-active-color, var(--hx-color-primary-600, #0f7078));
     border-bottom-color: var(
       --_tab-indicator-bottom-color,
@@ -61,13 +64,21 @@ export const helixTabStyles = css`
     font-weight: var(--hx-tabs-tab-active-font-weight, var(--hx-font-weight-semibold, 600));
   }
 
-  /* ─── Focus State ─── */
+  /* ─── Focus State ───
+     Focus lands on the HOST in Group 5a host-canonical mode. The inner
+     [part="tab"] is presentational (tabindex=-1). Use :host(:focus-visible). */
 
-  .tab:focus-visible {
+  :host(:focus-visible) .tab {
     outline: var(--hx-focus-ring-width, 2px) solid
       var(--hx-tabs-focus-ring-color, var(--hx-focus-ring-color, #0f7078));
     outline-offset: var(--hx-focus-ring-offset, 2px);
     border-radius: var(--hx-border-radius-sm, 0.25rem);
+  }
+
+  /* Strip the default host focus ring — outline lands on the inner [part="tab"]
+     surface above for visual continuity with the existing component appearance. */
+  :host(:focus) {
+    outline: none;
   }
 
   /* ─── Disabled State ─── */
@@ -76,7 +87,7 @@ export const helixTabStyles = css`
     cursor: not-allowed;
   }
 
-  .tab[aria-disabled='true'] {
+  :host([disabled]) .tab {
     pointer-events: none;
     color: var(--hx-tabs-tab-disabled-color, var(--hx-color-neutral-400, #8e9c98));
   }
@@ -108,18 +119,18 @@ export const helixTabStyles = css`
       background-color: ButtonFace;
     }
 
-    .tab[aria-selected='true'] {
+    :host([selected]) .tab {
       color: HighlightText;
       background-color: Highlight;
       border-bottom-color: Highlight;
     }
 
-    .tab:focus-visible {
+    :host(:focus-visible) .tab {
       outline: 3px solid Highlight;
       outline-offset: 2px;
     }
 
-    .tab[aria-disabled='true'] {
+    :host([disabled]) .tab {
       color: GrayText;
     }
   }

--- a/packages/hx-library/src/components/hx-tabs/hx-tab.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tab.ts
@@ -1,14 +1,31 @@
-import { html, nothing } from 'lit';
+import { html, nothing, type PropertyValues } from 'lit';
 import '../../utilities/document-token-adoption.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { HelixElement } from '../../base/index.js';
 import { forcedColorsInteractive } from '../../styles/forced-colors.js';
 import { helixTabStyles } from './hx-tab.styles.js';
 import { devWarn } from '../../utils/dev-warn.js';
+import {
+  installAriaIdrefMirror,
+  resolveIdrefTokens,
+  supportsIdrefElementReferences,
+  type AriaIdrefMirrorHandle,
+} from '../../utils/aria-idref.js';
+import { flattenAccName } from '../../utils/aria-flatten.js';
 
 /**
  * An individual tab button, designed to be used inside an `<hx-tabs>` container.
  * Must be placed in the `tab` named slot of `<hx-tabs>`.
+ *
+ * Group 5a host-canonical: `role="tab"` lives on the **host** via
+ * `_internals.role`. The host is the focusable surface (carries the roving
+ * tabindex); the inner `<button>` retains click activation semantics
+ * (Enter/Space and pointer events) but is no longer the AT-announced surface
+ * — its role and ARIA state are stripped on the modern path so the host's
+ * canonical surface wins. `internals.ariaSelected`, `ariaDisabled`, and
+ * `ariaControlsElements` mirror reactive state. The host `aria-label` /
+ * `aria-labelledby` resolved via the shared IDREF mirror name the tab
+ * cross-shadow.
  *
  * @summary Presentational tab button that activates a corresponding panel.
  *
@@ -64,19 +81,129 @@ export class HelixTab extends HelixElement {
   disabled = false;
 
   /**
-   * The id of the panel this tab controls. Set by the parent `<hx-tabs>` to establish the
-   * aria-controls relationship on the inner button element (which carries role="tab").
+   * The id of the panel this tab controls. Set by the parent `<hx-tabs>` to
+   * establish the aria-controls relationship via element references on the
+   * host (modern path) or as a string fallback (legacy path).
    * @internal
    */
   @property({ type: String, attribute: false })
   controls = '';
 
+  // ─── Host-canonical ARIA bookkeeping ───
+
+  /** @internal */
+  @state() private _supportsIdrefRefs = true;
+
+  /** @internal */
+  private _ariaMirror: AriaIdrefMirrorHandle | null = null;
+
+  /**
+   * Element reference for the controlled `<hx-tab-panel>` host. Set by the
+   * parent `<hx-tabs>` via `setControlsPanel()` and projected onto
+   * `internals.ariaControlsElements` so cross-shadow controls resolution
+   * works via IDL element references. Falls through to the `controls`
+   * string property on the legacy path.
+   * @internal
+   */
+  private _controlledPanel: Element | null = null;
+
   // ─── Lifecycle ───
 
   override connectedCallback(): void {
     super.connectedCallback();
+    this._supportsIdrefRefs = supportsIdrefElementReferences(this._internals);
     if (!this.closest('hx-tabs')) {
       devWarn('hx-tab', 'hx-tab must be a direct child of hx-tabs to function correctly.');
+    }
+    this._syncHostAriaSemantics();
+    this._ariaMirror = installAriaIdrefMirror(this, () => {
+      this._syncHostAriaSemantics();
+    });
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this._ariaMirror?.disconnect();
+    this._ariaMirror = null;
+  }
+
+  override updated(changedProperties: PropertyValues<this>): void {
+    super.updated(changedProperties);
+    if (
+      changedProperties.has('selected') ||
+      changedProperties.has('disabled') ||
+      changedProperties.has('controls') ||
+      changedProperties.has('panel')
+    ) {
+      this._syncHostAriaSemantics();
+    }
+  }
+
+  /**
+   * Set by `<hx-tabs>` whenever the tab→panel relationship is recomputed.
+   * Drives `internals.ariaControlsElements` (modern path) so AT walks across
+   * the shadow boundary to the controlled panel by element reference.
+   * @internal
+   */
+  setControlsPanel(panel: Element | null): void {
+    this._controlledPanel = panel;
+    this._syncHostAriaSemantics();
+  }
+
+  /**
+   * Mirror reactive ARIA state onto ElementInternals on the **host**. The
+   * inner `<button>` no longer carries role/aria-* on the modern path — the
+   * host is the canonical AT-announced surface. The button stays as the
+   * activation surface (Enter/Space/click) but is `tabindex=-1` and
+   * presentational from AT's perspective.
+   * @internal
+   */
+  private _syncHostAriaSemantics(): void {
+    const internals = this._internals;
+    internals.role = 'tab';
+    internals.ariaSelected = this.selected ? 'true' : 'false';
+    internals.ariaDisabled = this.disabled ? 'true' : null;
+
+    // ariaControls — modern path uses element references; legacy path falls
+    // back to a string IDREF (set on the host element directly via
+    // setAttribute below so AT that does not implement element references
+    // still has a token to walk).
+    type InternalsWithRefs = ElementInternals & {
+      ariaControlsElements: Element[] | null;
+      ariaLabelledByElements: Element[] | null;
+    };
+
+    if (this._supportsIdrefRefs) {
+      const refsInternals = internals as InternalsWithRefs;
+      refsInternals.ariaControlsElements = this._controlledPanel ? [this._controlledPanel] : null;
+    }
+
+    // Resolve consumer host aria-labelledby / aria-label so the tab announces
+    // with the consumer's chosen name when present. Default name comes from
+    // the slotted text content (handled by AT walking the host's children
+    // through the shadow slot — works for accessible name computation in
+    // modern engines because the host carries the role).
+    const consumerLabelledBy = this.getAttribute('aria-labelledby');
+    const hostAriaLabel = this.getAttribute('aria-label');
+    const labelEls = resolveIdrefTokens(this, consumerLabelledBy);
+
+    if (this._supportsIdrefRefs) {
+      const refsInternals = internals as InternalsWithRefs;
+      refsInternals.ariaLabelledByElements = labelEls.length > 0 ? labelEls : null;
+    }
+
+    if (hostAriaLabel && hostAriaLabel.trim()) {
+      internals.ariaLabel = hostAriaLabel;
+    } else if (!this._supportsIdrefRefs && labelEls.length > 0) {
+      // Legacy fallback: flatten consumer aria-labelledby targets into a
+      // string so AT without IDL refs still names the tab.
+      internals.ariaLabel =
+        labelEls
+          .map((el) => flattenAccName(el))
+          .filter(Boolean)
+          .join(' ') || null;
+    } else {
+      internals.ariaLabel = null;
     }
   }
 
@@ -123,15 +250,70 @@ export class HelixTab extends HelixElement {
   // ─── Render ───
 
   override render() {
+    // Host-canonical Path A: `role="tab"`, `aria-selected`, `aria-disabled`,
+    // and `aria-controls` are projected onto the HOST via `_internals` —
+    // NOT on the inner button. The inner button is the activation surface
+    // (Enter/Space/click) but is presentational from AT's perspective:
+    // tabindex=-1 keeps focus on the host (which carries the roving tabindex
+    // managed by `<hx-tabs>`), and no role/aria-* attributes leak through.
+    //
+    // Legacy fallback: when the platform lacks IDL element references on
+    // ElementInternals, mirror `aria-controls` as a string IDREF on the host
+    // so AT that walks string tokens still resolves the panel relationship.
+    if (!this._supportsIdrefRefs && this.controls) {
+      this.setAttribute('aria-controls', this.controls);
+    } else if (this._supportsIdrefRefs && this.hasAttribute('aria-controls')) {
+      this.removeAttribute('aria-controls');
+    }
+
+    // Modern path: the inner element is a presentational <div> click
+    // surface — no native button semantics to leak to AT alongside the
+    // host's `role="tab"`. ARIA 1.2 forbids `role="presentation"` on
+    // focusable elements, so the cleanest strip is to use a non-button
+    // tag. Click handler still fires; keyboard activation is owned by the
+    // parent `<hx-tabs>` keydown handler operating on the host (which
+    // carries the canonical `role="tab"` + roving tabindex).
+    //
+    // Legacy fallback (no IDL element references): keep the `<button>`
+    // with `role="tab"` and ARIA state on the button, since `_internals`
+    // can't expose element-references on engines without that API. The
+    // host attribute mirror (this.controls → aria-controls string) is
+    // applied above for AT that walks string IDREFs.
+    if (this._supportsIdrefRefs) {
+      // `aria-disabled` is mirrored on the inner element so axe-core's
+      // color-contrast rule recognizes the disabled state and excludes the
+      // surface from contrast checks (axe excludes `aria-disabled="true"`
+      // elements). The HOST is the canonical AT surface — its
+      // `internals.ariaDisabled` is what AT announces; this attribute on the
+      // inner div is a presentational signal for static analyzers and CSS.
+      return html`
+        <div
+          part="tab"
+          class="tab"
+          tabindex="-1"
+          aria-disabled=${this.disabled ? 'true' : nothing}
+          @click=${this._handleClick}
+        >
+          <span part="prefix" class="tab__prefix" ?hidden=${!this._hasPrefixSlot}>
+            <slot name="prefix" @slotchange=${this._handlePrefixSlotChange}></slot>
+          </span>
+          <slot></slot>
+          <span part="suffix" class="tab__suffix" ?hidden=${!this._hasSuffixSlot}>
+            <slot name="suffix" @slotchange=${this._handleSuffixSlotChange}></slot>
+          </span>
+        </div>
+      `;
+    }
+
     return html`
       <button
         part="tab"
         class="tab"
         role="tab"
+        tabindex="-1"
         aria-selected=${this.selected ? 'true' : 'false'}
         aria-disabled=${this.disabled ? 'true' : 'false'}
         aria-controls=${this.controls || nothing}
-        tabindex=${this.selected ? '0' : '-1'}
         @click=${this._handleClick}
       >
         <span part="prefix" class="tab__prefix" ?hidden=${!this._hasPrefixSlot}>

--- a/packages/hx-library/src/components/hx-tabs/hx-tabs.test.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tabs.test.ts
@@ -15,6 +15,12 @@ function assertEl<T extends Element>(el: T | null | undefined, label: string): T
   return el;
 }
 
+/** Reads `_internals` off a host that elevates ARIA semantics via ElementInternals. */
+function getInternals(el: HTMLElement): ElementInternals {
+  return (el as unknown as { _internals: ElementInternals })._internals;
+}
+
+
 // ─── Fixture Helpers ───────────────────────────────────────────────────────────
 
 const DEFAULT_TABS_HTML = `
@@ -37,6 +43,23 @@ const TWO_TABS_HTML = `
   </hx-tabs>
 `;
 
+/**
+ * Fixture HTML with `activation="automatic"` for keyboard tests that exercise
+ * focus-follows-selection semantics. The library default flipped to `manual`
+ * in Group 5a; tests covering automatic-mode behaviour pin the activation
+ * mode explicitly.
+ */
+const AUTO_TABS_HTML = `
+  <hx-tabs activation="automatic">
+    <hx-tab slot="tab" panel="alpha">Alpha</hx-tab>
+    <hx-tab slot="tab" panel="beta">Beta</hx-tab>
+    <hx-tab slot="tab" panel="gamma">Gamma</hx-tab>
+    <hx-tab-panel name="alpha">Alpha content</hx-tab-panel>
+    <hx-tab-panel name="beta">Beta content</hx-tab-panel>
+    <hx-tab-panel name="gamma">Gamma content</hx-tab-panel>
+  </hx-tabs>
+`;
+
 // ─── Rendering ────────────────────────────────────────────────────────────────
 
 describe('hx-tabs', () => {
@@ -46,10 +69,9 @@ describe('hx-tabs', () => {
       expect(el.shadowRoot).toBeTruthy();
     });
 
-    it('renders a tablist with role="tablist"', async () => {
+    it('renders a tablist with role="tablist" on the host (host-canonical)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
-      const tablist = shadowQuery(el, '[role="tablist"]');
-      expect(tablist).toBeTruthy();
+      expect(getInternals(el).role).toBe('tablist');
     });
 
     it('renders tablist with part="tablist"', async () => {
@@ -64,20 +86,19 @@ describe('hx-tabs', () => {
       expect(panels).toBeTruthy();
     });
 
-    it('light-DOM hx-tab children have role="tab" via shadow button', async () => {
+    it('hx-tab hosts carry role="tab" via ElementInternals (host-canonical)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       for (const tab of tabs) {
-        const btn = shadowQuery<HTMLButtonElement>(tab, 'button[role="tab"]');
-        expect(btn).toBeTruthy();
+        expect(getInternals(tab).role).toBe('tab');
       }
     });
 
-    it('hx-tab-panel children have role="tabpanel"', async () => {
+    it('hx-tab-panel hosts carry role="tabpanel" via ElementInternals', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const panelEls = Array.from(el.querySelectorAll('hx-tab-panel')) as HelixTabPanel[];
       for (const panel of panelEls) {
-        expect(panel.getAttribute('role')).toBe('tabpanel');
+        expect(getInternals(panel).role).toBe('tabpanel');
       }
     });
 
@@ -115,22 +136,21 @@ describe('hx-tabs', () => {
   // ─── Tab Selection ────────────────────────────────────────────────────────────
 
   describe('Tab Selection', () => {
-    it('clicking a tab activates it (aria-selected="true")', async () => {
+    it('clicking a tab activates it (aria-selected="true" on host internals)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       await el.updateComplete;
-      const btnBetaAfter = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      expect(btnBetaAfter?.getAttribute('aria-selected')).toBe('true');
+      expect(getInternals(tabs[1]).ariaSelected).toBe('true');
     });
 
     it('clicking a tab shows its panel', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       const panels = Array.from(el.querySelectorAll('hx-tab-panel')) as HelixTabPanel[];
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       await el.updateComplete;
       expect(panels[1].hasAttribute('hidden')).toBe(false);
     });
@@ -139,8 +159,8 @@ describe('hx-tabs', () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       const panels = Array.from(el.querySelectorAll('hx-tab-panel')) as HelixTabPanel[];
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       await el.updateComplete;
       expect(panels[0].hasAttribute('hidden')).toBe(true);
       expect(panels[2].hasAttribute('hidden')).toBe(true);
@@ -150,8 +170,8 @@ describe('hx-tabs', () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-tab-change');
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       const event = await eventPromise;
       expect(event).toBeTruthy();
     });
@@ -160,8 +180,8 @@ describe('hx-tabs', () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-tab-change');
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       const event = await eventPromise;
       expect(event.bubbles).toBe(true);
       expect(event.composed).toBe(true);
@@ -174,8 +194,8 @@ describe('hx-tabs', () => {
         el,
         'hx-tab-change',
       );
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       const event = await eventPromise;
       expect(event.detail.index).toBe(1);
     });
@@ -187,8 +207,8 @@ describe('hx-tabs', () => {
         el,
         'hx-tab-change',
       );
-      const btnGamma = shadowQuery<HTMLButtonElement>(tabs[2], 'button');
-      assertEl(btnGamma, 'button').click();
+      const btnGamma = shadowQuery<HTMLElement>(tabs[2], '[part="tab"]');
+      assertEl(btnGamma, '[part=tab]').click();
       const event = await eventPromise;
       expect(event.detail.tabId).toBe(tabs[2].id);
     });
@@ -200,8 +220,8 @@ describe('hx-tabs', () => {
       el.addEventListener('hx-tab-change', () => {
         eventFired = true;
       });
-      const btnAlpha = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnAlpha, 'button').click();
+      const btnAlpha = shadowQuery<HTMLElement>(tabs[0], '[part="tab"]');
+      assertEl(btnAlpha, '[part=tab]').click();
       await el.updateComplete;
       expect(eventFired).toBe(false);
     });
@@ -209,70 +229,68 @@ describe('hx-tabs', () => {
 
   // ─── Keyboard Navigation — Horizontal / Automatic (default) ──────────────────
 
-  describe('Keyboard Navigation — Horizontal Automatic (default)', () => {
+  describe('Keyboard Navigation — Horizontal Automatic', () => {
+    // Note: focus the HOST (host-canonical Path A) — the tab host is the
+    // single roving-tabindex surface; the inner [part="tab"] is presentational
+    // (tabindex=-1) on the modern path.
     it('ArrowRight moves focus to the next tab and activates it', async () => {
-      const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      const el = await fixture<HelixTabs>(AUTO_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnAlpha = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnAlpha, 'button').focus();
+      tabs[0].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       await el.updateComplete;
       expect(tabs[1].selected).toBe(true);
     });
 
     it('ArrowLeft moves focus to the previous tab and activates it', async () => {
-      const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      const el = await fixture<HelixTabs>(AUTO_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      // First activate beta so focus is on it
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       await el.updateComplete;
-      assertEl(btnBeta, 'button').focus();
+      tabs[1].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
       await el.updateComplete;
       expect(tabs[0].selected).toBe(true);
     });
 
     it('Home key moves focus to the first tab', async () => {
-      const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      const el = await fixture<HelixTabs>(AUTO_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      // Activate last tab first
-      const btnGamma = shadowQuery<HTMLButtonElement>(tabs[2], 'button');
-      assertEl(btnGamma, 'button').click();
+      const btnGamma = shadowQuery<HTMLElement>(tabs[2], '[part="tab"]');
+      assertEl(btnGamma, '[part=tab]').click();
       await el.updateComplete;
-      assertEl(btnGamma, 'button').focus();
+      tabs[2].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }));
       await el.updateComplete;
       expect(tabs[0].selected).toBe(true);
     });
 
     it('End key moves focus to the last tab', async () => {
-      const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      const el = await fixture<HelixTabs>(AUTO_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnAlpha = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnAlpha, 'button').focus();
+      tabs[0].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
       await el.updateComplete;
       expect(tabs[2].selected).toBe(true);
     });
 
     it('ArrowRight wraps from last tab to first tab', async () => {
-      const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      const el = await fixture<HelixTabs>(AUTO_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnGamma = shadowQuery<HTMLButtonElement>(tabs[2], 'button');
-      assertEl(btnGamma, 'button').click();
+      const btnGamma = shadowQuery<HTMLElement>(tabs[2], '[part="tab"]');
+      assertEl(btnGamma, '[part=tab]').click();
       await el.updateComplete;
-      assertEl(btnGamma, 'button').focus();
+      tabs[2].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       await el.updateComplete;
       expect(tabs[0].selected).toBe(true);
     });
 
     it('ArrowLeft wraps from first tab to last tab', async () => {
-      const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      const el = await fixture<HelixTabs>(AUTO_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnAlpha = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnAlpha, 'button').focus();
+      tabs[0].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
       await el.updateComplete;
       expect(tabs[2].selected).toBe(true);
@@ -294,8 +312,8 @@ describe('hx-tabs', () => {
         </hx-tabs>
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnOne = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnOne, 'button').focus();
+      const btnOne = shadowQuery<HTMLElement>(tabs[0], '[part="tab"]');
+      assertEl(btnOne, '[part=tab]').focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       await el.updateComplete;
       // Tab 0 should still be selected since activation is manual
@@ -314,13 +332,13 @@ describe('hx-tabs', () => {
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       // Navigate to tab two with ArrowRight (no activation)
-      const btnOne = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnOne, 'button').focus();
+      const btnOne = shadowQuery<HTMLElement>(tabs[0], '[part="tab"]');
+      assertEl(btnOne, '[part=tab]').focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       await el.updateComplete;
       // Now the button for tab two should be focused — press Space
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').focus();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').focus();
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-tab-change');
       el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       const event = await eventPromise;
@@ -339,8 +357,8 @@ describe('hx-tabs', () => {
         </hx-tabs>
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').focus();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').focus();
       const eventPromise = oneEvent<CustomEvent>(el, 'hx-tab-change');
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       const event = await eventPromise;
@@ -353,9 +371,9 @@ describe('hx-tabs', () => {
   // ─── Keyboard Navigation — Vertical Orientation ───────────────────────────────
 
   describe('Keyboard Navigation — Vertical Orientation', () => {
-    it('ArrowDown navigates to the next tab in vertical mode', async () => {
+    it('ArrowDown navigates to the next tab in vertical mode (automatic)', async () => {
       const el = await fixture<HelixTabs>(`
-        <hx-tabs orientation="vertical">
+        <hx-tabs orientation="vertical" activation="automatic">
           <hx-tab slot="tab" panel="one">One</hx-tab>
           <hx-tab slot="tab" panel="two">Two</hx-tab>
           <hx-tab slot="tab" panel="three">Three</hx-tab>
@@ -365,16 +383,15 @@ describe('hx-tabs', () => {
         </hx-tabs>
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnOne = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnOne, 'button').focus();
+      tabs[0].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
       await el.updateComplete;
       expect(tabs[1].selected).toBe(true);
     });
 
-    it('ArrowUp navigates to the previous tab in vertical mode', async () => {
+    it('ArrowUp navigates to the previous tab in vertical mode (automatic)', async () => {
       const el = await fixture<HelixTabs>(`
-        <hx-tabs orientation="vertical">
+        <hx-tabs orientation="vertical" activation="automatic">
           <hx-tab slot="tab" panel="one">One</hx-tab>
           <hx-tab slot="tab" panel="two">Two</hx-tab>
           <hx-tab-panel name="one">Panel One</hx-tab-panel>
@@ -382,10 +399,10 @@ describe('hx-tabs', () => {
         </hx-tabs>
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').click();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').click();
       await el.updateComplete;
-      assertEl(btnTwo, 'button').focus();
+      tabs[1].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
       await el.updateComplete;
       expect(tabs[0].selected).toBe(true);
@@ -401,10 +418,10 @@ describe('hx-tabs', () => {
         </hx-tabs>
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').click();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').click();
       await el.updateComplete;
-      assertEl(btnTwo, 'button').focus();
+      assertEl(btnTwo, '[part=tab]').focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
       await el.updateComplete;
       // Tab two should still be active because ArrowLeft does not apply in vertical
@@ -421,8 +438,8 @@ describe('hx-tabs', () => {
         </hx-tabs>
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnOne = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnOne, 'button').focus();
+      const btnOne = shadowQuery<HTMLElement>(tabs[0], '[part="tab"]');
+      assertEl(btnOne, '[part=tab]').focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       await el.updateComplete;
       // Tab one should still be active because ArrowRight does not apply in vertical
@@ -447,8 +464,8 @@ describe('hx-tabs', () => {
       el.addEventListener('hx-tab-change', () => {
         eventFired = true;
       });
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').click();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').click();
       await el.updateComplete;
       expect(eventFired).toBe(false);
       expect(tabs[0].selected).toBe(true);
@@ -467,8 +484,8 @@ describe('hx-tabs', () => {
         </hx-tabs>
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnOne = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      assertEl(btnOne, 'button').focus();
+      const btnOne = shadowQuery<HTMLElement>(tabs[0], '[part="tab"]');
+      assertEl(btnOne, '[part=tab]').focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       await el.updateComplete;
       // Disabled tab two receives focus but is NOT activated — tab one stays selected
@@ -477,9 +494,9 @@ describe('hx-tabs', () => {
       expect(document.activeElement).toBe(tabs[1]);
     });
 
-    it('ArrowRight past a disabled tab continues to the next enabled tab', async () => {
+    it('ArrowRight past a disabled tab continues to the next enabled tab (automatic)', async () => {
       const el = await fixture<HelixTabs>(`
-        <hx-tabs>
+        <hx-tabs activation="automatic">
           <hx-tab slot="tab" panel="one">One</hx-tab>
           <hx-tab slot="tab" panel="two" disabled>Two</hx-tab>
           <hx-tab slot="tab" panel="three">Three</hx-tab>
@@ -490,8 +507,7 @@ describe('hx-tabs', () => {
       `);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       // Focus disabled tab two, then press ArrowRight
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').focus();
+      tabs[1].focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
       await el.updateComplete;
       // Tab three is enabled so it gets focus and activated
@@ -513,8 +529,8 @@ describe('hx-tabs', () => {
         eventFired = true;
       });
       // Focus disabled tab two
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').focus();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', bubbles: true }));
       await el.updateComplete;
       expect(eventFired).toBe(false);
@@ -535,8 +551,8 @@ describe('hx-tabs', () => {
       el.addEventListener('hx-tab-change', () => {
         eventFired = true;
       });
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').focus();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').focus();
       el.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
       await el.updateComplete;
       expect(eventFired).toBe(false);
@@ -575,55 +591,55 @@ describe('hx-tabs', () => {
   // ─── ARIA ─────────────────────────────────────────────────────────────────────
 
   describe('ARIA', () => {
-    it('tablist has aria-orientation="horizontal" by default', async () => {
+    it('host has aria-orientation="horizontal" by default (host-canonical)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
-      const tablist = shadowQuery(el, '[role="tablist"]');
-      expect(tablist?.getAttribute('aria-orientation')).toBe('horizontal');
+      expect(getInternals(el).ariaOrientation).toBe('horizontal');
     });
 
-    it('tablist has aria-orientation="vertical" when orientation is vertical', async () => {
+    it('host has aria-orientation="vertical" when orientation is vertical', async () => {
       const el = await fixture<HelixTabs>(`
         <hx-tabs orientation="vertical">
           <hx-tab slot="tab" panel="one">One</hx-tab>
           <hx-tab-panel name="one">Panel One</hx-tab-panel>
         </hx-tabs>
       `);
-      const tablist = shadowQuery(el, '[role="tablist"]');
-      expect(tablist?.getAttribute('aria-orientation')).toBe('vertical');
+      expect(getInternals(el).ariaOrientation).toBe('vertical');
     });
 
-    it('tab button has aria-selected="true" when selected', async () => {
+    it('tab host has aria-selected="true" when selected (host-canonical)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btn = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      expect(btn?.getAttribute('aria-selected')).toBe('true');
+      expect(getInternals(tabs[0]).ariaSelected).toBe('true');
     });
 
-    it('tab button has aria-selected="false" when not selected', async () => {
+    it('tab host has aria-selected="false" when not selected', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btn = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      expect(btn?.getAttribute('aria-selected')).toBe('false');
+      expect(getInternals(tabs[1]).ariaSelected).toBe('false');
     });
 
-    it('tab button has aria-controls referencing its panel id', async () => {
+    it('tab host references its panel via internals.ariaControlsElements (modern path)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       const panels = Array.from(el.querySelectorAll('hx-tab-panel')) as HelixTabPanel[];
-      // aria-controls belongs on the button (role="tab"), not the host element
-      const btn = shadowQuery<HTMLButtonElement>(tabs[0], 'button');
-      const controlsAttr = btn?.getAttribute('aria-controls');
-      expect(controlsAttr).toBeTruthy();
-      expect(controlsAttr).toBe(panels[0].id);
+      type RefsInternals = ElementInternals & {
+        ariaControlsElements: Element[] | null;
+      };
+      const refs = (getInternals(tabs[0]) as RefsInternals).ariaControlsElements;
+      expect(refs).toBeTruthy();
+      expect(refs?.[0]).toBe(panels[0]);
     });
 
-    it('panel has aria-label matching its tab text content', async () => {
+    it('panel host references its tab via internals.ariaLabelledByElements (modern path)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       const panels = Array.from(el.querySelectorAll('hx-tab-panel')) as HelixTabPanel[];
-      const ariaLabel = panels[0].getAttribute('aria-label');
-      expect(ariaLabel).toBeTruthy();
-      expect(ariaLabel).toBe(tabs[0].textContent?.trim());
+      type RefsInternals = ElementInternals & {
+        ariaLabelledByElements: Element[] | null;
+      };
+      const refs = (getInternals(panels[0]) as RefsInternals).ariaLabelledByElements;
+      expect(refs).toBeTruthy();
+      expect(refs?.[0]).toBe(tabs[0]);
     });
 
     it('panel has tabindex="0" for keyboard accessibility', async () => {
@@ -643,11 +659,25 @@ describe('hx-tabs', () => {
     it('tabindex updates on tabs when selection changes', async () => {
       const el = await fixture<HelixTabs>(TWO_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnTwo = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnTwo, 'button').click();
+      const btnTwo = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnTwo, '[part=tab]').click();
       await el.updateComplete;
       expect(tabs[0].tabIndex).toBe(-1);
       expect(tabs[1].tabIndex).toBe(0);
+    });
+
+    // Cross-AT smoke test: validates the role-on-host with inner-button
+    // activation pattern. Confirms `document.activeElement` matches the host
+    // (not an inner shadow node) when focus lands on a tab, and that the
+    // host's `internals.role` / `ariaSelected` reflect the announced surface.
+    it('host owns focus + ARIA when a tab is focused (cross-AT smoke)', async () => {
+      const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
+      tabs[0].focus();
+      expect(document.activeElement).toBe(tabs[0]);
+      const internals = getInternals(tabs[0]);
+      expect(internals.role).toBe('tab');
+      expect(internals.ariaSelected).toBe('true');
     });
   });
 
@@ -669,8 +699,18 @@ describe('hx-tabs', () => {
       expect(el.getAttribute('orientation')).toBe('vertical');
     });
 
-    it('activation defaults to "automatic"', async () => {
+    it('activation defaults to "manual" (Group 5a healthcare default)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
+      expect(el.activation).toBe('manual');
+    });
+
+    it('activation="automatic" is settable via attribute', async () => {
+      const el = await fixture<HelixTabs>(`
+        <hx-tabs activation="automatic">
+          <hx-tab slot="tab" panel="one">One</hx-tab>
+          <hx-tab-panel name="one">Panel One</hx-tab-panel>
+        </hx-tabs>
+      `);
       expect(el.activation).toBe('automatic');
     });
 
@@ -738,8 +778,8 @@ describe('hx-tabs', () => {
       el.appendChild(newPanel);
       await el.updateComplete;
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btn = shadowQuery<HTMLButtonElement>(tabs[2], 'button');
-      assertEl(btn, 'button').click();
+      const btn = shadowQuery<HTMLElement>(tabs[2], '[part="tab"]');
+      assertEl(btn, '[part=tab]').click();
       await el.updateComplete;
       const panels = Array.from(el.querySelectorAll('hx-tab-panel')) as HelixTabPanel[];
       expect(panels[2].hasAttribute('hidden')).toBe(false);
@@ -788,21 +828,51 @@ describe('hx-tabs', () => {
   // ─── Label Property ──────────────────────────────────────────────────────────
 
   describe('Label Property', () => {
-    it('tablist has aria-label="Tabs" by default', async () => {
+    it('host has no internals.ariaLabel by default (no `label` set)', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
-      const tablist = shadowQuery(el, '[role="tablist"]');
-      expect(tablist?.getAttribute('aria-label')).toBe('Tabs');
+      // Group 5a host-canonical: when `label` is empty and no consumer
+      // aria-label/aria-labelledby is supplied, internals.ariaLabel is null.
+      // The dev warning at firstUpdated still surfaces the WCAG concern.
+      expect(getInternals(el).ariaLabel).toBeFalsy();
     });
 
-    it('tablist has aria-label when label is set', async () => {
+    it('host carries internals.ariaLabel when `label` is set', async () => {
       const el = await fixture<HelixTabs>(`
         <hx-tabs label="Patient record sections">
           <hx-tab slot="tab" panel="one">One</hx-tab>
           <hx-tab-panel name="one">Panel One</hx-tab-panel>
         </hx-tabs>
       `);
-      const tablist = shadowQuery(el, '[role="tablist"]');
-      expect(tablist?.getAttribute('aria-label')).toBe('Patient record sections');
+      expect(getInternals(el).ariaLabel).toBe('Patient record sections');
+    });
+
+    it('host aria-label attribute overrides `label` property via internals', async () => {
+      const el = await fixture<HelixTabs>(`
+        <hx-tabs label="Property label" aria-label="Attribute label">
+          <hx-tab slot="tab" panel="one">One</hx-tab>
+          <hx-tab-panel name="one">Panel One</hx-tab-panel>
+        </hx-tabs>
+      `);
+      expect(getInternals(el).ariaLabel).toBe('Attribute label');
+    });
+
+    it('host aria-labelledby resolves to internals.ariaLabelledByElements (modern path)', async () => {
+      const el = await fixture<HelixTabs>(`
+        <div>
+          <h2 id="tabs-heading">Patient sections</h2>
+          <hx-tabs aria-labelledby="tabs-heading">
+            <hx-tab slot="tab" panel="one">One</hx-tab>
+            <hx-tab-panel name="one">Panel One</hx-tab-panel>
+          </hx-tabs>
+        </div>
+      `);
+      const tabs = el.querySelector('hx-tabs') as HelixTabs;
+      type RefsInternals = ElementInternals & {
+        ariaLabelledByElements: Element[] | null;
+      };
+      const refs = (getInternals(tabs) as RefsInternals).ariaLabelledByElements;
+      expect(refs).toBeTruthy();
+      expect(refs?.[0]).toBe(el.querySelector('#tabs-heading'));
     });
 
     it('label property reflects as attribute', async () => {
@@ -827,8 +897,8 @@ describe('hx-tabs', () => {
     it('selectedIndex returns correct index after clicking second tab', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnBeta = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnBeta, 'button').click();
+      const btnBeta = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnBeta, '[part=tab]').click();
       await el.updateComplete;
       expect(el.selectedIndex).toBe(1);
     });
@@ -965,8 +1035,8 @@ describe('hx-tabs', () => {
     it('tab activated by click updates selectedIndex correctly', async () => {
       const el = await fixture<HelixTabs>(DEFAULT_TABS_HTML);
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
-      const btnGamma = shadowQuery<HTMLButtonElement>(tabs[2], 'button');
-      assertEl(btnGamma, 'button').click();
+      const btnGamma = shadowQuery<HTMLElement>(tabs[2], '[part="tab"]');
+      assertEl(btnGamma, '[part=tab]').click();
       await el.updateComplete;
       expect(el.selectedIndex).toBe(2);
     });
@@ -978,8 +1048,8 @@ describe('hx-tabs', () => {
         el,
         'hx-tab-change',
       );
-      const btnAlphaSecond = shadowQuery<HTMLButtonElement>(tabs[1], 'button');
-      assertEl(btnAlphaSecond, 'button').click();
+      const btnAlphaSecond = shadowQuery<HTMLElement>(tabs[1], '[part="tab"]');
+      assertEl(btnAlphaSecond, '[part=tab]').click();
       const event = await eventPromise;
       expect(event.detail.tabId).toBeTruthy();
       expect(event.detail.index).toBe(1);
@@ -994,8 +1064,8 @@ describe('hx-tabs', () => {
       const tabs = Array.from(el.querySelectorAll('hx-tab')) as HelixTab[];
       const panels = Array.from(el.querySelectorAll('hx-tab-panel')) as HelixTabPanel[];
       // Select gamma (index 2)
-      const btnGamma = shadowQuery<HTMLButtonElement>(tabs[2], 'button');
-      assertEl(btnGamma, 'button').click();
+      const btnGamma = shadowQuery<HTMLElement>(tabs[2], '[part="tab"]');
+      assertEl(btnGamma, '[part=tab]').click();
       await el.updateComplete;
       expect(panels[2].hasAttribute('hidden')).toBe(false);
       expect(panels[0].hasAttribute('hidden')).toBe(true);

--- a/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
+++ b/packages/hx-library/src/components/hx-tabs/hx-tabs.ts
@@ -7,6 +7,13 @@ import { helixTabsStyles } from './hx-tabs.styles.js';
 import type { HelixTab } from './hx-tab.js';
 import type { HelixTabPanel } from './hx-tab-panel.js';
 import { devWarn } from '../../utils/dev-warn.js';
+import {
+  installAriaIdrefMirror,
+  resolveIdrefTokens,
+  supportsIdrefElementReferences,
+  type AriaIdrefMirrorHandle,
+} from '../../utils/aria-idref.js';
+import { flattenAccName } from '../../utils/aria-flatten.js';
 
 const _nextTabsId = createIdCounter('hx-tabs');
 
@@ -20,6 +27,16 @@ export interface HxTabChangeDetail {
  * A tabbed content organizer that manages a set of `<hx-tab>` and `<hx-tab-panel>` children.
  * Supports horizontal and vertical orientations, automatic and manual activation modes,
  * and full keyboard navigation per the ARIA Authoring Practices Guide.
+ *
+ * Group 5a host-canonical: `role="tablist"` lives on the host via
+ * `_internals.role`. `aria-orientation`, `aria-label`, and consumer
+ * `aria-labelledby` resolve through the host. Per-tab `role="tab"` and
+ * per-panel `role="tabpanel"` likewise live on their respective hosts.
+ *
+ * Activation defaults to **manual** per healthcare patterns — keyboard arrow
+ * keys move focus only; Enter/Space activates. APG explicitly allows both
+ * automatic and manual activation; manual is safer when panels are heavy or
+ * announce changes via live regions.
  *
  * @summary Tab container that organizes content into selectable panels.
  *
@@ -78,14 +95,22 @@ export class HelixTabs extends HelixElement {
    * Controls how keyboard navigation activates tabs.
    * In `automatic` mode, focus also activates the tab.
    * In `manual` mode, focus moves independently; Space or Enter activates.
+   *
+   * Group 5a default: `manual` — safer for healthcare patterns where panel
+   * content may be heavy or announce updates via live regions. APG explicitly
+   * allows both modes; manual avoids disorienting auto-activation when users
+   * scan tabs with arrow keys.
+   *
    * @attr activation
    */
   @property({ type: String, attribute: 'activation', reflect: true })
-  activation: 'manual' | 'automatic' = 'automatic';
+  activation: 'manual' | 'automatic' = 'manual';
 
   /**
-   * Accessible label for the tablist. Rendered as `aria-label` on the tablist container.
-   * Provide a brief description of what the tabs represent (e.g., "Patient record sections").
+   * Accessible label for the tablist. Drives the host `internals.ariaLabel`.
+   * Provide a brief description of what the tabs represent (e.g., "Patient
+   * record sections"). Consumer `aria-label` / `aria-labelledby` on the host
+   * override this property when present.
    * @attr label
    */
   @property({ type: String, reflect: true })
@@ -95,6 +120,14 @@ export class HelixTabs extends HelixElement {
 
   /** @internal */
   @state() private _activePanel = '';
+
+  /** @internal */
+  @state() private _supportsIdrefRefs = true;
+
+  // ─── Host-canonical ARIA bookkeeping ───
+
+  /** @internal */
+  private _ariaMirror: AriaIdrefMirrorHandle | null = null;
 
   // ─── Child Accessors ───
 
@@ -184,6 +217,7 @@ export class HelixTabs extends HelixElement {
 
   override connectedCallback(): void {
     super.connectedCallback();
+    this._supportsIdrefRefs = supportsIdrefElementReferences(this._internals);
     this.addEventListener('hx-tab-select', this._handleTabSelect);
     this.addEventListener('keydown', this._handleKeydown);
     // Watch for panel/name attribute changes on child tabs and panels
@@ -198,6 +232,11 @@ export class HelixTabs extends HelixElement {
         attributeFilter: ['panel', 'name'],
       });
     }
+    // Seed host-canonical semantics so the role/label appear before first paint.
+    this._syncHostAriaSemantics();
+    this._ariaMirror = installAriaIdrefMirror(this, () => {
+      this._syncHostAriaSemantics();
+    });
   }
 
   override disconnectedCallback(): void {
@@ -206,6 +245,8 @@ export class HelixTabs extends HelixElement {
     this.removeEventListener('keydown', this._handleKeydown);
     this._observer?.disconnect();
     this._observer = null;
+    this._ariaMirror?.disconnect();
+    this._ariaMirror = null;
   }
 
   override firstUpdated(): void {
@@ -242,6 +283,63 @@ export class HelixTabs extends HelixElement {
     if ((changedProperties as Map<PropertyKey, unknown>).has('_activePanel')) {
       this._updateTabsAndPanels();
     }
+    if (
+      (changedProperties as Map<PropertyKey, unknown>).has('orientation') ||
+      (changedProperties as Map<PropertyKey, unknown>).has('label')
+    ) {
+      this._syncHostAriaSemantics();
+    }
+  }
+
+  // ─── Host ARIA Sync ───
+
+  /**
+   * Mirror tablist semantics onto the host via ElementInternals so consumer-
+   * supplied `aria-label`, `aria-labelledby`, and the `label` property all
+   * reach the announced control. The host carries `role="tablist"` and the
+   * orientation reflects the `orientation` property reactively.
+   * @internal
+   */
+  private _syncHostAriaSemantics(): void {
+    const internals = this._internals;
+    internals.role = 'tablist';
+    internals.ariaOrientation = this.orientation;
+
+    const hostAriaLabel = this.getAttribute('aria-label')?.trim() || '';
+    const consumerLabelledBy = this.getAttribute('aria-labelledby');
+    const labelEls = resolveIdrefTokens(this, consumerLabelledBy);
+    const hasEffectiveLabelledBy = labelEls.length > 0;
+
+    type InternalsWithRefs = ElementInternals & {
+      ariaLabelledByElements: Element[] | null;
+    };
+
+    if (this._supportsIdrefRefs) {
+      const refsInternals = internals as InternalsWithRefs;
+      refsInternals.ariaLabelledByElements = hasEffectiveLabelledBy ? labelEls : null;
+    }
+
+    // Precedence: consumer aria-label > consumer aria-labelledby (resolved) >
+    // `label` property. When labelledby resolves on the modern path, the IDL
+    // refs above carry the live target; clear ariaLabel so the element refs
+    // win. On the fallback path, flatten the labelledby targets to a string.
+    if (hostAriaLabel) {
+      internals.ariaLabel = hostAriaLabel;
+    } else if (hasEffectiveLabelledBy) {
+      if (this._supportsIdrefRefs) {
+        internals.ariaLabel = null;
+      } else {
+        internals.ariaLabel =
+          labelEls
+            .map((el) => flattenAccName(el))
+            .filter(Boolean)
+            .join(' ') ||
+          this.label ||
+          null;
+      }
+    } else {
+      internals.ariaLabel = this.label || null;
+    }
   }
 
   // ─── Tab / Panel Sync ───
@@ -261,30 +359,46 @@ export class HelixTabs extends HelixElement {
       if (panel) {
         const panelId = panel.id || `hx-panel-${this._id}-${i}`;
         panel.id = panelId;
-        // Set controls on the tab so aria-controls lands on the inner button (role="tab")
+        // String IDREF (legacy fallback path) — the inner button mirrors this
+        // when the platform lacks IDL element references.
         tab.controls = panelId;
-        // Use aria-label instead of aria-labelledby to avoid shadow boundary failures.
-        // aria-labelledby pointing to hx-tab host IDs fails because the host element's
-        // accessible text is inside its shadow DOM (the inner <button>), which AT cannot
-        // traverse via aria-labelledby references across shadow roots.
-        // Extract only default-slot children (no `slot` attribute) to exclude prefix/suffix
-        // slot content (e.g. badge counts) from the panel accessible name (WCAG 1.3.1).
-        const tabLabel = Array.from(tab.childNodes)
-          .filter(
-            (node) =>
-              node.nodeType === Node.TEXT_NODE ||
-              (node.nodeType === Node.ELEMENT_NODE && !(node as Element).hasAttribute('slot')),
-          )
-          .map((node) => node.textContent ?? '')
-          .join('')
-          .trim();
-        if (tabLabel) {
-          panel.setAttribute('aria-label', tabLabel);
-          panel.removeAttribute('aria-labelledby');
+        // Modern path: project the panel host as an element reference so AT
+        // walks across the shadow boundary by reference rather than IDREF.
+        tab.setControlsPanel(panel);
+        // Project the tab host as the panel's labelledby reference. Cross-
+        // shadow naming via IDL element references resolves the tab's
+        // accessible name (its slotted label content) without serialization.
+        // Legacy fallback: the parent additionally writes a flattened
+        // `aria-label` string on the panel host so AT without IDL refs still
+        // names the panel.
+        panel.setLabelledByTabs([tab]);
+
+        if (!this._supportsIdrefRefs) {
+          // Extract only default-slot children (no `slot` attribute) to exclude
+          // prefix/suffix slot content (e.g. badge counts) from the panel
+          // accessible name (WCAG 1.3.1).
+          const tabLabel = Array.from(tab.childNodes)
+            .filter(
+              (node) =>
+                node.nodeType === Node.TEXT_NODE ||
+                (node.nodeType === Node.ELEMENT_NODE && !(node as Element).hasAttribute('slot')),
+            )
+            .map((node) => node.textContent ?? '')
+            .join('')
+            .trim();
+          if (tabLabel) {
+            panel.setAttribute('aria-label', tabLabel);
+            panel.removeAttribute('aria-labelledby');
+          } else {
+            // Fall back to aria-labelledby string ID if no text content yet;
+            // this gets corrected on the next slotchange.
+            panel.setAttribute('aria-labelledby', tabId);
+          }
         } else {
-          // Fall back to aria-labelledby if no text content is yet available;
-          // this will be corrected on slotchange once content is assigned.
-          panel.setAttribute('aria-labelledby', tabId);
+          // Modern path: scrub legacy fallback attributes so a previously-
+          // mounted-on-legacy panel doesn't leak stale strings.
+          panel.removeAttribute('aria-label');
+          panel.removeAttribute('aria-labelledby');
         }
       }
     });
@@ -300,11 +414,10 @@ export class HelixTabs extends HelixElement {
     tabs.forEach((tab) => {
       const isSelected = tab.panel === this._activePanel;
       tab.selected = isSelected;
-      // Dual tabindex is intentional: the inner button in hx-tab manages its own tabindex
-      // via the `selected` property. We also set it on the host element for the roving
-      // tabindex pattern so document.activeElement comparisons work correctly when the
-      // inner button is focused. This is safe because the inner button is the only
-      // focusable element in hx-tab's shadow DOM (WCAG 2.4.3).
+      // Single-host roving tabindex (Group 5a): the host is the only focusable
+      // surface for the tab. The inner button is `tabindex=-1` and
+      // presentational on the modern path. document.activeElement compares
+      // directly against the host.
       tab.tabIndex = isSelected ? 0 : -1;
     });
 
@@ -427,8 +540,13 @@ export class HelixTabs extends HelixElement {
       return;
     }
 
-    // Determine focused tab — when a button inside shadow DOM is focused,
-    // document.activeElement returns the shadow host (hx-tab), not the inner button.
+    // Determine focused tab — host-canonical: the host IS the focusable
+    // surface, so document.activeElement matches the hx-tab host directly
+    // (no shadow-DOM activeElement traversal needed on the modern path).
+    // On the legacy fallback path, focus may land on the inner button; the
+    // tab host is still the focused element in document.activeElement
+    // because the shadow root is closed at the host boundary for outer-tree
+    // queries.
     const focusedTab = allTabs.find((tab) => tab === document.activeElement);
 
     if (e.key === ' ' || e.key === 'Enter') {
@@ -436,7 +554,7 @@ export class HelixTabs extends HelixElement {
       if (focusedTab && !focusedTab.disabled) {
         e.preventDefault();
         this._activateTab(focusedTab);
-        focusedTab.shadowRoot?.querySelector('button')?.focus();
+        focusedTab.focus();
       }
       return;
     }
@@ -468,8 +586,9 @@ export class HelixTabs extends HelixElement {
       return;
     }
 
-    // Focus the tab button inside the shadow root
-    targetTab.shadowRoot?.querySelector('button')?.focus();
+    // Focus the host directly — single-host roving tabindex (Group 5a).
+    // The host owns the tab stop; the inner button is presentational.
+    targetTab.focus();
 
     // Only activate in automatic mode if the target tab is not disabled
     if (this.activation === 'automatic' && !targetTab.disabled) {
@@ -482,13 +601,7 @@ export class HelixTabs extends HelixElement {
   override render() {
     return html`
       <div class="tabs">
-        <div
-          part="tablist"
-          class="tablist"
-          role="tablist"
-          aria-orientation=${this.orientation}
-          aria-label=${this.label || 'Tabs'}
-        >
+        <div part="tablist" class="tablist">
           <slot name="tab" @slotchange=${this._handleSlotChange}></slot>
         </div>
         <div part="panels" class="panels">

--- a/packages/hx-react/src/components/HxTab/HxTab.ts
+++ b/packages/hx-react/src/components/HxTab/HxTab.ts
@@ -16,6 +16,16 @@ export type { HxTabProps };
 /**
  * An individual tab button, designed to be used inside an `<hx-tabs>` container.
 Must be placed in the `tab` named slot of `<hx-tabs>`.
+
+Group 5a host-canonical: `role="tab"` lives on the **host** via
+`_internals.role`. The host is the focusable surface (carries the roving
+tabindex); the inner `<button>` retains click activation semantics
+(Enter/Space and pointer events) but is no longer the AT-announced surface
+— its role and ARIA state are stripped on the modern path so the host's
+canonical surface wins. `internals.ariaSelected`, `ariaDisabled`, and
+`ariaControlsElements` mirror reactive state. The host `aria-label` /
+`aria-labelledby` resolved via the shared IDREF mirror name the tab
+cross-shadow.
  *
  * @example
  * ```tsx

--- a/packages/hx-react/src/components/HxTabPanel/HxTabPanel.ts
+++ b/packages/hx-react/src/components/HxTabPanel/HxTabPanel.ts
@@ -15,6 +15,12 @@ export type { HxTabPanelProps };
 
 /**
  * A content panel associated with an `<hx-tab>`, managed by a parent `<hx-tabs>`.
+Group 5a host-canonical: `role="tabpanel"` lives on the host via
+`_internals.role`. The host carries the canonical AT surface — consumer
+`aria-labelledby` / `aria-describedby` on the host resolve through the
+shared IDREF mirror. The parent `hx-tabs` writes `internals.ariaLabelledByElements`
+referencing the corresponding `<hx-tab>` host so cross-shadow naming works
+via IDL element references (the modern path) without serializing tab text.
  *
  * @example
  * ```tsx

--- a/packages/hx-react/src/components/HxTabs/HxTabs.ts
+++ b/packages/hx-react/src/components/HxTabs/HxTabs.ts
@@ -17,6 +17,16 @@ export type { HxTabsProps };
  * A tabbed content organizer that manages a set of `<hx-tab>` and `<hx-tab-panel>` children.
 Supports horizontal and vertical orientations, automatic and manual activation modes,
 and full keyboard navigation per the ARIA Authoring Practices Guide.
+
+Group 5a host-canonical: `role="tablist"` lives on the host via
+`_internals.role`. `aria-orientation`, `aria-label`, and consumer
+`aria-labelledby` resolve through the host. Per-tab `role="tab"` and
+per-panel `role="tabpanel"` likewise live on their respective hosts.
+
+Activation defaults to **manual** per healthcare patterns — keyboard arrow
+keys move focus only; Enter/Space activates. APG explicitly allows both
+automatic and manual activation; manual is safer when panels are heavy or
+announce changes via live regions.
  *
  * @example
  * ```tsx

--- a/packages/hx-react/src/components/HxTabs/types.ts
+++ b/packages/hx-react/src/components/HxTabs/types.ts
@@ -16,10 +16,17 @@ export interface HxTabsProps {
   orientation?: 'horizontal' | 'vertical';
   /** Controls how keyboard navigation activates tabs.
 In `automatic` mode, focus also activates the tab.
-In `manual` mode, focus moves independently; Space or Enter activates. */
+In `manual` mode, focus moves independently; Space or Enter activates.
+
+Group 5a default: `manual` — safer for healthcare patterns where panel
+content may be heavy or announce updates via live regions. APG explicitly
+allows both modes; manual avoids disorienting auto-activation when users
+scan tabs with arrow keys. */
   activation?: 'manual' | 'automatic';
-  /** Accessible label for the tablist. Rendered as `aria-label` on the tablist container.
-Provide a brief description of what the tabs represent (e.g., "Patient record sections"). */
+  /** Accessible label for the tablist. Drives the host `internals.ariaLabel`.
+Provide a brief description of what the tabs represent (e.g., "Patient
+record sections"). Consumer `aria-label` / `aria-labelledby` on the host
+override this property when present. */
   label?: string;
   /** Gets or sets the zero-based index of the currently selected tab.
 Setting this programmatically activates the tab at the given index.


### PR DESCRIPTION
First PR of **Group 5 (Composite navigation)**. 3 components hardened per .reports/aria-group-5-scope.md. Lowest-risk PR of Group 5; validates role='tab' on host with inner activation pattern.

**Smart pivot:** Inner activation surface changed from `<button>` to `<div part='tab'>` on modern path. ARIA 1.2 forbids `role='presentation'` on focusable elements; a roleless `<div>` is the cleanest strip. Click + pointer activation still works on `<div>`; keyboard activation is owned by parent `hx-tabs` keydown handler operating on the host.

**Activation default flipped from automatic → manual** per scope §5.4 + healthcare patterns (safer for accidental keypress). Public API still supports both modes via `activation='automatic|manual'` attribute.

**Cross-AT smoke test added** — asserts host owns focus + announced role/state. Validates the role-on-host with inner-activation pattern that Group 5b/5c (menu/tree families) will inherit.

**87/87 hx-tabs tests passing** (+4 net new). `pnpm run verify` clean.

helix-028 standing risk-accept. `@helixui/library` minor (additive — but **manual activation is the new default**; existing consumers relying on arrow-key activation must explicitly set `activation='automatic'`).

Group 5b (menu family + overflow-menu + split-button + hx-dropdown deferred refactor) and Group 5c (tree) follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility with canonical ARIA roles properly set on tab components for improved screen reader announcements.
  * Updated keyboard activation behavior to default to manual mode (arrow keys navigate, Enter/Space activates) instead of automatic.

* **Documentation**
  * Expanded JSDoc comments and accessibility guidance for tab components and their configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->