### PR TITLE
fix(hx-checkbox): close figgy hx-015 — accessiblelabel migration

### DIFF
--- a/.changeset/hx-checkbox-hx015-accessiblelabel.md
+++ b/.changeset/hx-checkbox-hx015-accessiblelabel.md
@@ -1,0 +1,9 @@
+---
+'@helixui/library': patch
+---
+
+fix(hx-checkbox): close Figgy HX-015 — read attribute storage instead of `this.ariaLabel` IDL property
+
+`hx-checkbox._effectiveLabel` and the visible-label-conflict devWarn block both read `this.ariaLabel` (the native `HTMLElement` IDL property, populated by `mixinDelegatesAria`'s `Object.defineProperty` shadow). Under fallback browsers and the v3 `accessibleLabel` migration guide, consumers who stop setting `ariaLabel` get a silent label disappearance.
+
+Migration parity with `hx-action-bar.ts:102-125`, `hx-button.ts:204` (Group 8), and the rest of the v3 component surface — read `accessibleLabel` first, then `data-aria-label` (mixin storage), then `aria-label` attribute, then empty string. Closes Figgy HX-015 for `hx-checkbox`.

--- a/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
+++ b/packages/hx-library/src/components/hx-checkbox/hx-checkbox.ts
@@ -198,7 +198,12 @@ export class HelixCheckbox extends mixinDelegatesAria(FormMixin(HelixElement)) {
    * @internal
    */
   private get _effectiveLabel(): string {
-    return this.accessibleLabel?.trim() || this.ariaLabel?.trim() || '';
+    return (
+      this.accessibleLabel?.trim() ||
+      this.getAttribute('data-aria-label')?.trim() ||
+      this.getAttribute('aria-label')?.trim() ||
+      ''
+    );
   }
 
   /** @internal */
@@ -410,10 +415,14 @@ export class HelixCheckbox extends mixinDelegatesAria(FormMixin(HelixElement)) {
     // current without depending on observer scheduling.
     this._syncHostAriaSemantics();
     // Warn when accessible-label is set alongside a visible label — they are mutually exclusive.
-    // Checked unconditionally (not gated on changedProperties) because ariaLabel is provided by
-    // mixinDelegatesAria via Object.defineProperty and never appears in changedProperties.
+    // Checked unconditionally (not gated on changedProperties) because aria-label is supplied
+    // via data-aria-label by mixinDelegatesAria and never appears in changedProperties.
     {
-      const hasAccessibleLabel = !!(this.accessibleLabel?.trim() || this.ariaLabel?.trim());
+      const hasAccessibleLabel = !!(
+        this.accessibleLabel?.trim() ||
+        this.getAttribute('data-aria-label')?.trim() ||
+        this.getAttribute('aria-label')?.trim()
+      );
       const hasVisibleLabel =
         !!this.label ||
         (this.shadowRoot


### PR DESCRIPTION
## Summary

Closes Figgy **HX-015** for `hx-checkbox` (deferred from Group 8 epic PR #1649).

`hx-checkbox._effectiveLabel` and the visible-label-conflict devWarn block both read `this.ariaLabel` (the native `HTMLElement.ariaLabel` IDL property, populated by `mixinDelegatesAria`'s `Object.defineProperty` shadow). Reading the IDL property breaks under fallback browsers and silently regresses for consumers who follow the v3 `accessibleLabel` migration guide.

Changed to read attribute storage instead — same pattern as `hx-action-bar.ts:102-125`, `hx-button.ts:204` (Group 8 PR #1649), and the rest of the v3 surface:

\`\`\`ts
this.accessibleLabel?.trim() ||
  this.getAttribute('data-aria-label')?.trim() ||
  this.getAttribute('aria-label')?.trim() ||
  '';
\`\`\`

Two call sites migrated (`_effectiveLabel` + the visible-label conflict devWarn).

## Test plan

- [x] 207/207 hx-checkbox tests pass via direct vitest
- [ ] CI Quality Gates pass
- [ ] CodeRabbit review

## Related

- Closes Figgy report: \`/Volumes/Development/booked/create-helix-app/.helix-issues/filed/HX-015-arialabel-migration-incomplete.md\`
- Companion PR: #1649 (Group 8 closed HX-015 for `hx-button`)