### PR TITLE
chore(release): add 3.4.0 release manifest

### DIFF
--- a/docs/releases/3.4.0-manifest.json
+++ b/docs/releases/3.4.0-manifest.json
@@ -1,0 +1,99 @@
+{
+  "tag": "@helixui/library@3.4.0",
+  "commit_sha": "0249b68b890f2de7d3e8d9b4a3c3ebd0bb67e078",
+  "ref": "refs/heads/main",
+  "repository": "bookedsolidtech/helix",
+  "published_at": "2026-05-06T11:06:52.299Z",
+  "publisher": "himerus",
+  "ci_run_id": "25431446173",
+  "ci_run_url": "https://github.com/bookedsolidtech/helix/actions/runs/25431446173",
+  "packages": {
+    "@helixui/library": "3.4.0",
+    "@helixui/tokens": "3.3.1",
+    "@helixui/react": "3.4.0"
+  },
+  "changeset_files": [],
+  "published_packages": [
+    {
+      "name": "@helixui/library",
+      "version": "3.4.0"
+    },
+    {
+      "name": "@helixui/react",
+      "version": "3.4.0"
+    }
+  ],
+  "merged_prs_since_last_tag": [
+    1656,
+    1653,
+    1651,
+    1652,
+    1649,
+    1623,
+    1635,
+    1648,
+    1650,
+    1647,
+    1646,
+    1639,
+    1638,
+    1643,
+    1642,
+    1640,
+    1636,
+    1630,
+    1631,
+    1637,
+    1634,
+    1633,
+    1629,
+    1625,
+    1627,
+    1624,
+    1626,
+    1622,
+    1621,
+    1620
+  ],
+  "last_tag": "@helixui/library@3.3.1",
+  "cem_sha256": "f01d828f4cfef56810b4773ca7a03ae8cc7c5392b8c6cd6035e857075a63b1f3",
+  "cdn_budget_snapshot": {
+    "comment": "CDN bundle size budgets for @helixui/library (gzipped bytes). Enforced in CI by scripts/check-cdn-size.mjs. Changes require code review and a justification in the PR description. The CDN build emits several artifacts with different size profiles — this file tracks per-artifact budgets rather than a single aggregate ceiling so drift in one strategy (A vs B) is surfaced precisely.",
+    "rationale": "Measured from packages/hx-library/dist/cdn/ on main at v2.1.2 (full JS=183.4 KB, full CSS=46.3 KB, core JS=8.4 KB, Strategy A=229.7 KB). Re-baselined 2026-04-25 after the 3.2.0 component-tier + palette expansion landed. Re-baselined 2026-05-04 for ARIA Group 2 (selection controls). Re-baselined 2026-05-05 for ARIA Group 3 (selects/combos/pickers). Re-baselined 2026-05-05 (late) for the ARIA epic PR #1649 covering Groups 5b + 5c + 7 + 8 + 9 + 10 — host-canonical migration across 16+ components plus four shared utils (menu-label, menu-roving, menu-tree, tree-walk), per-variant forced-colors fallbacks (hx-badge / hx-tag), AccName 1.2 §4.3.1 precedence ladders in fallback paths, origin guards on host-bound click+keydown handlers, idref characterData + visibility observation, mixin adoption for hx-icon-button / hx-link, hx-button-group host-canonical role, hx-tree-view + hx-tree-item host-canonical migration, hx-spinner host-canonical role mirror. Full JS measured at 236.0 KB gz / strategyATotal 291.1 KB gz at the epic head. New ceiling 245 KB / strategyATotal 310 KB / fullBundleCss 65 KB sized with ~9 KB headroom for any post-merge cleanup. Warn thresholds sit approximately halfway between current and ceiling.",
+    "budgets": {
+      "fullBundleJs": {
+        "file": "helix-{version}.min.js",
+        "description": "Strategy A full self-contained JS bundle (all 81 components + Lit).",
+        "ceilingBytes": 250880,
+        "warnBytes": 241664,
+        "currentBytes": 241664,
+        "currentNote": "236.0 KB gz at ARIA epic head (PR #1649 — Groups 5b + 5c + 7 + 8 + 9 + 10; was 216.7 KB at Group 3 partial-head). Epic adds ~19.3 KB across 16+ host-canonical migrations + 4 shared utils + per-variant HCM fallbacks + AccName ladders + origin guards."
+      },
+      "fullBundleCss": {
+        "file": "helix-{version}.min.css",
+        "description": "Strategy A full CSS bundle (all component shadow-root-adoptable CSS).",
+        "ceilingBytes": 66560,
+        "warnBytes": 60416,
+        "currentBytes": 56422,
+        "currentNote": "55.1 KB gz at ARIA epic head (was 54.0 KB at Group 3 partial-head; epic adds ~1.1 KB for per-variant HCM blocks + spinner/icon-button styles)."
+      },
+      "coreBundleJs": {
+        "file": "helix-core-{version}.min.js",
+        "description": "Strategy B shared Lit runtime (loaded once, cached across components).",
+        "ceilingBytes": 12288,
+        "warnBytes": 10240,
+        "currentBytes": 8602,
+        "currentNote": "8.4 KB gz at v2.1.2"
+      },
+      "strategyATotal": {
+        "description": "Aggregate Strategy A consumer payload (full JS + full CSS). This is what a page that loads the full bundle actually downloads.",
+        "ceilingBytes": 317440,
+        "warnBytes": 307200,
+        "currentBytes": 298086,
+        "currentNote": "291.1 KB gz at ARIA epic head (was 270.7 KB at Group 3 partial-head; tracks fullBundleJs + fullBundleCss growth)."
+      }
+    }
+  },
+  "coderabbit_final_review_sha": null,
+  "notes": "Emitted by scripts/generate-release-manifest.mjs during the publish workflow after changesets/action publishes to npm. Committed back to main via a dedicated step in publish.yml — not part of the version-bump PR."
+}


### PR DESCRIPTION
Post-publish manifest for `3.4.0`. Auto-opened by the publish workflow after npm publish succeeded. Documentation only — safe to auto-merge.