### PR TITLE
fix(admin): force-dynamic on /pipeline + /integration-test (unblocks release)

### DIFF
--- a/apps/admin/src/app/integration-test/page.tsx
+++ b/apps/admin/src/app/integration-test/page.tsx
@@ -1,16 +1,18 @@
 'use client';
 
-import dynamic from 'next/dynamic';
+// Renamed from `dynamic` to avoid collision with the route-segment
+// config export `dynamic` below (TS2395 / TS2440).
+import nextDynamic from 'next/dynamic';
 
 // Opt out of static export. This page mounts the full HELiX component
-// library client-side via `next/dynamic({ ssr: false })`, but the page
+// library client-side via `nextDynamic({ ssr: false })`, but the page
 // shell itself still tries to pre-render during `next build` and hits
 // the 60s static-export deadline on GitHub-hosted runners. Forcing
 // dynamic skips pre-render and the page works fine at runtime.
 export const dynamic = 'force-dynamic';
 
 // Load client-side only — web components require the DOM (no SSR)
-const HelixComponents = dynamic(() => import('./helix-components'), {
+const HelixComponents = nextDynamic(() => import('./helix-components'), {
   ssr: false,
   loading: () => (
     <div style={{ color: '#9ca3af', padding: '24px' }}>Loading HELIX integration test...</div>

--- a/apps/admin/src/app/integration-test/page.tsx
+++ b/apps/admin/src/app/integration-test/page.tsx
@@ -2,6 +2,13 @@
 
 import dynamic from 'next/dynamic';
 
+// Opt out of static export. This page mounts the full HELiX component
+// library client-side via `next/dynamic({ ssr: false })`, but the page
+// shell itself still tries to pre-render during `next build` and hits
+// the 60s static-export deadline on GitHub-hosted runners. Forcing
+// dynamic skips pre-render and the page works fine at runtime.
+export const dynamic = 'force-dynamic';
+
 // Load client-side only — web components require the DOM (no SSR)
 const HelixComponents = dynamic(() => import('./helix-components'), {
   ssr: false,

--- a/apps/admin/src/app/pipeline/page.tsx
+++ b/apps/admin/src/app/pipeline/page.tsx
@@ -10,6 +10,13 @@ import { PipelineFlow, ComponentPipelineRow } from '@/components/dashboard/Pipel
 import { Breadcrumb } from '@/components/dashboard/Breadcrumb';
 import { getBreadcrumbItems } from '@/lib/breadcrumb-utils';
 
+// Opt out of static export: this page processes the full component library
+// (90+ components) through cem-parser + jsdoc-analyzer + health-scorer +
+// drift-detector at render time, which exceeds the Next.js static-export
+// 60-second deadline on GitHub-hosted runners. Same pattern is already in
+// use on apps/admin/src/app/tests/page.tsx and components/[tag]/page.tsx.
+export const dynamic = 'force-dynamic';
+
 export default function PipelinePage() {
   const stats = getManifestStats();
   const components = getAllComponents();


### PR DESCRIPTION
## Summary

Hotfix off staging — admin's Next.js build was failing on `/pipeline` + `/integration-test` page static-export timeouts, blocking the staging→main release PR (#1701) and other CI jobs that depend on admin build.

## Root cause

GitHub-hosted runner Next.js static-export has a 60s-per-page deadline (3 retries). Both pages exceeded it:

- **/pipeline** processes the full 90+ component library at render time (cem-parser + jsdoc-analyzer + drift-detector + health-scorer)
- **/integration-test** mounts web components via `next/dynamic({ ssr: false })` but the page shell still pre-renders during build

## Fix

Add `export const dynamic = 'force-dynamic';` to both pages — same pattern already in use on `apps/admin/src/app/tests/page.tsx` and `components/[tag]/page.tsx`. These pages render at request time, not build time.

## Why this is safe

- Admin app is internal-only; no SEO concern from forced-dynamic
- All four heavy admin pages now follow the same pattern
- Pattern is established and Next.js-recommended for build-time-expensive routes

## Test plan

- [ ] CI on this PR passes admin build
- [ ] Auto-merge to staging
- [ ] Staging CI green → unblocks #1701 (staging → main release)