### PR TITLE
chore(staging): sync 3.8.0 release manifest from main (unblocks #1701)

### DIFF
--- a/docs/releases/3.8.0-manifest.json
+++ b/docs/releases/3.8.0-manifest.json
@@ -1,0 +1,81 @@
+{
+  "tag": "@helixui/library@3.8.0",
+  "commit_sha": "4f53b77b5f34190c40f46982060dc1dc29cc4374",
+  "ref": "refs/heads/main",
+  "repository": "bookedsolidtech/helix",
+  "published_at": "2026-05-09T16:49:34.361Z",
+  "publisher": "himerus",
+  "ci_run_id": "25606393703",
+  "ci_run_url": "https://github.com/bookedsolidtech/helix/actions/runs/25606393703",
+  "packages": {
+    "@helixui/library": "3.8.0",
+    "@helixui/tokens": "3.8.0",
+    "@helixui/react": "3.8.0"
+  },
+  "changeset_files": [],
+  "published_packages": [
+    {
+      "name": "@helixui/library",
+      "version": "3.8.0"
+    },
+    {
+      "name": "@helixui/react",
+      "version": "3.8.0"
+    },
+    {
+      "name": "@helixui/tokens",
+      "version": "3.8.0"
+    }
+  ],
+  "merged_prs_since_last_tag": [
+    1694,
+    1687,
+    1693,
+    1692,
+    1691,
+    1690,
+    1689,
+    1688
+  ],
+  "last_tag": "@helixui/library@3.7.0",
+  "cem_sha256": "2b7d5866a877db2f52aaf5bea899136a2f5f5a998884bf8675024ab8d4205214",
+  "cdn_budget_snapshot": {
+    "comment": "CDN bundle size budgets for @helixui/library (gzipped bytes). Enforced in CI by scripts/check-cdn-size.mjs. Changes require code review and a justification in the PR description. The CDN build emits several artifacts with different size profiles — this file tracks per-artifact budgets rather than a single aggregate ceiling so drift in one strategy (A vs B) is surfaced precisely.",
+    "rationale": "Measured from packages/hx-library/dist/cdn/ on main at v2.1.2 (full JS=183.4 KB, full CSS=46.3 KB, core JS=8.4 KB, Strategy A=229.7 KB). Re-baselined 2026-04-25 after the 3.2.0 component-tier + palette expansion landed. Re-baselined 2026-05-04 for ARIA Group 2 (selection controls). Re-baselined 2026-05-05 for ARIA Group 3 (selects/combos/pickers). Re-baselined 2026-05-05 (late) for the ARIA epic PR #1649 covering Groups 5b + 5c + 7 + 8 + 9 + 10. Re-baselined 2026-05-09 for the AAA Tier 3 epic (3.8.0): 43/43 P0 formal cert work added roving-tabindex on group hosts, focus-trap fix on dialog/drawer/popover, target-size compliance (40→44 across button family), token chain shift for AAA-strict 7:1, expanded forced-colors mode bindings, helixMeta JSDoc cert metadata. Full JS measured at 249.7 KB gz post-epic. New ceiling 260 KB / strategyATotal 325 KB sized with ~10 KB headroom for the remaining P1/P2 cert work (Phase E) which will incrementally grow the bundle. Healthcare AAA conformance is the load-bearing constraint; bytes-on-the-wire are secondary.",
+    "budgets": {
+      "fullBundleJs": {
+        "file": "helix-{version}.min.js",
+        "description": "Strategy A full self-contained JS bundle (all 81 components + Lit).",
+        "ceilingBytes": 266240,
+        "warnBytes": 256000,
+        "currentBytes": 255693,
+        "currentNote": "249.7 KB gz at AAA Tier 3 epic head (3.8.0 — 43/43 P0 formal cert; was 236.0 KB at the ARIA Group 5b–10 epic). Epic adds ~13.7 KB across roving-tabindex on group hosts, focus-trap fix on overlays, target-size compliance, token chain shift, expanded forced-colors bindings, helixMeta JSDoc cert metadata."
+      },
+      "fullBundleCss": {
+        "file": "helix-{version}.min.css",
+        "description": "Strategy A full CSS bundle (all component shadow-root-adoptable CSS).",
+        "ceilingBytes": 66560,
+        "warnBytes": 60416,
+        "currentBytes": 56422,
+        "currentNote": "55.1 KB gz at ARIA epic head (was 54.0 KB at Group 3 partial-head; epic adds ~1.1 KB for per-variant HCM blocks + spinner/icon-button styles)."
+      },
+      "coreBundleJs": {
+        "file": "helix-core-{version}.min.js",
+        "description": "Strategy B shared Lit runtime (loaded once, cached across components).",
+        "ceilingBytes": 12288,
+        "warnBytes": 10240,
+        "currentBytes": 8602,
+        "currentNote": "8.4 KB gz at v2.1.2"
+      },
+      "strategyATotal": {
+        "description": "Aggregate Strategy A consumer payload (full JS + full CSS). This is what a page that loads the full bundle actually downloads.",
+        "ceilingBytes": 332800,
+        "warnBytes": 322560,
+        "currentBytes": 312832,
+        "currentNote": "305.5 KB gz at AAA Tier 3 epic head (was 291.1 KB at ARIA epic head; tracks fullBundleJs + fullBundleCss growth from 3.8.0 cert work)."
+      }
+    }
+  },
+  "coderabbit_final_review_sha": null,
+  "notes": "Emitted by scripts/generate-release-manifest.mjs during the publish workflow after changesets/action publishes to npm. Committed back to main via a dedicated step in publish.yml — not part of the version-bump PR."
+}


### PR DESCRIPTION
Pulls the 3.8.0 release-manifest commits forward from main into staging so the staging→main release PR #1701 stops reporting BEHIND. Only the 3.8.0 manifest JSON; no source changes.