### PR TITLE
fix(release): reset to 3.9.0 / 1.0.0 — corrects mistaken 4.0.0 ship

### DIFF
--- a/packages/hx-icons/CHANGELOG.md
+++ b/packages/hx-icons/CHANGELOG.md
@@ -1,8 +1,12 @@
 # @helixui/icons
 
-## 2.0.0
+## 2.0.0 [UNPUBLISHED]
 
-### Major Changes
+Mistakenly published as MAJOR — package.json was at 1.0.0 (initial-publish placeholder) and a `major` changeset bumped it to 2.0.0. Should have been the initial 1.0.0 publish. The 2.0.0 version was unpublished from npm; 1.0.0 below is the corrected initial publish (same code).
+
+## 1.0.0
+
+### Initial Release
 
 - 723eec6: initial release of @helixui/icons — registry-pattern icon system for hx-icon.
   - public api wire-compatible with shoelace's `registerIconLibrary` / `unregisterIconLibrary` / `getIconLibrary` / `setBasePath` / `getBasePath`

--- a/packages/hx-icons/package.json
+++ b/packages/hx-icons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helixui/icons",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Icon registry and curated icon libraries for the HELiX enterprise healthcare web component library",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/hx-library/CHANGELOG.md
+++ b/packages/hx-library/CHANGELOG.md
@@ -1,6 +1,10 @@
 # @helixui/library
 
-## 4.0.0
+## 4.0.0 [DEPRECATED]
+
+Mistakenly published as MAJOR via a changeset-metadata defect (icons-1-0-0-initial.md was marked `major`, which cascaded through the linked-package group and peerDep range rules). The 4.0.0 release contains only additive minor changes — same code as 3.9.0. The 4.0.0 version is deprecated on npm; consumers should use 3.9.0.
+
+## 3.9.0
 
 ### Minor Changes
 

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-05-11T05:21:15.003Z",
+  "generatedAt": "2026-05-11T11:45:04.904Z",
   "sourceCem": "custom-elements.json",
-  "helixVersion": "4.0.0",
-  "tokensVersion": "4.0.0",
+  "helixVersion": "3.9.0",
+  "tokensVersion": "3.9.0",
   "components": [
     {
       "tag": "hx-accordion",

--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helixui/library",
-  "version": "4.0.0",
+  "version": "3.9.0",
   "description": "Enterprise Web Component Library built with Lit 3.x",
   "type": "module",
   "sideEffects": [

--- a/packages/hx-react/CHANGELOG.md
+++ b/packages/hx-react/CHANGELOG.md
@@ -1,6 +1,10 @@
 # @helixui/react
 
-## 4.0.0
+## 4.0.0 [UNPUBLISHED]
+
+Mistakenly published as MAJOR via the [library, tokens, react] linked-package group cascade. The 4.0.0 release was unpublished from npm; `latest` dist-tag is on 3.8.0 with 3.9.0 the corrected republish below. Same code — regenerated wrappers only.
+
+## 3.9.0
 
 ### Patch Changes
 

--- a/packages/hx-react/package.json
+++ b/packages/hx-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helixui/react",
-  "version": "4.0.0",
+  "version": "3.9.0",
   "description": "React wrappers for HELiX web components",
   "type": "module",
   "sideEffects": false,

--- a/packages/hx-tokens/CHANGELOG.md
+++ b/packages/hx-tokens/CHANGELOG.md
@@ -1,6 +1,10 @@
 # @helixui/tokens
 
-## 4.0.0
+## 4.0.0 [DEPRECATED]
+
+Mistakenly published as MAJOR via the [library, tokens, react] linked-package group cascade. The 4.0.0 release contains only a text-muted + success-text contrast tweak — same code as 3.9.0. The 4.0.0 version is deprecated on npm; consumers should use 3.9.0.
+
+## 3.9.0
 
 ### Minor Changes
 

--- a/packages/hx-tokens/package.json
+++ b/packages/hx-tokens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@helixui/tokens",
-  "version": "4.0.0",
+  "version": "3.9.0",
   "description": "Design tokens for the HELiX enterprise healthcare web component library",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Resets package versions DOWN from the mistakenly-published 4.0.0 / 2.0.0 to the intended 3.9.0 / 1.0.0. Annotates the bad 4.0.0 entries in CHANGELOGs as deprecated/unpublished with explanation of the changeset-metadata defect that caused them.

## Why

Previous release (PR #1704) shipped:
- `@helixui/library@4.0.0` (intended 3.9.0) — deprecated on npm
- `@helixui/tokens@4.0.0` (intended 3.9.0) — deprecated on npm
- `@helixui/react@4.0.0` (intended 3.9.0) — unpublished
- `@helixui/icons@2.0.0` (intended 1.0.0) — unpublished

Root cause: `icons-1-0-0-initial.md` changeset was marked `major`. Changesets bumped icons 1.0.0 → 2.0.0 (instead of the intended 1.0.0 initial publish). The peerDep cascade rule + linked-package group `[library, tokens, react]` elevated all three to 4.0.0.

npm cleanup already done:
- icons@2.0.0 + react@4.0.0 unpublished
- library@4.0.0 + tokens@4.0.0 deprecated (can't unpublish — workspace-dep references from drupal-behaviors/starter@3.0.1)
- `latest` dist-tag rolled back to 3.8.0 on all three

## Test plan

- [ ] Merge to main
- [ ] Run `pnpm install` to update workspace lockfile
- [ ] Run `pnpm build` to rebuild all packages at the corrected versions
- [ ] Publish from local: `cd packages/hx-icons && npm publish` (and same for library, tokens, react)
- [ ] Verify npm: `npm view @helixui/library@3.9.0 version` returns 3.9.0; `@helixui/library@latest` returns 3.9.0
- [ ] Update `latest` dist-tag if needed

## Notes

- 3.9.0 < 4.0.0 numerically but npm allows out-of-order publish; on publish the `latest` dist-tag updates to the most-recently-published unless `--tag` is specified
- The 4.0.0 deprecated versions stay on npm as historical record with warning messages explaining the mistake
- Process change saved to memory: never auto-merge MAJOR version-packages PR without explicit per-version confirmation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Revert**
  * Corrected package versions for multiple libraries: hx-icons now at 1.0.0, and hx-library, hx-react, and hx-tokens all at 3.9.0. Major versions (2.0.0/4.0.0) recently published contained only minor updates and were mistakenly released as major versions. Users should upgrade to the corrected versions immediately.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bookedsolidtech/helix/pull/1705)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->