### PR TITLE
docs(sync phase 3): content currency to 3.9.0 cert posture

### DIFF
--- a/apps/docs/src/content/docs/getting-started/installation.md
+++ b/apps/docs/src/content/docs/getting-started/installation.md
@@ -10,21 +10,25 @@ If you already have a 2.x release of `@helixui/library` installed, read the [Upg
 ## Install via npm
 
 ```bash
-npm install @helixui/library @helixui/tokens
+npm install @helixui/library @helixui/icons @helixui/tokens
 ```
 
 Or with pnpm:
 
 ```bash
-pnpm add @helixui/library @helixui/tokens
+pnpm add @helixui/library @helixui/icons @helixui/tokens
 ```
 
 Current versions:
 
-| Package             | Version |
-| ------------------- | ------- |
-| `@helixui/library`  | 3.0.0   |
-| `@helixui/tokens`   | 3.0.0   |
+| Package             | Version  | Notes                                    |
+| ------------------- | -------- | ---------------------------------------- |
+| `@helixui/library`  | ^3.9.0   | Lit 3.x components (core)                |
+| `@helixui/icons`    | ^1.0.0   | Required peer — icon registry            |
+| `@helixui/tokens`   | ^3.9.0   | Required peer — design tokens            |
+| `@helixui/react`    | ^3.9.0   | Optional — React 18/19 wrappers          |
+
+If you are upgrading an existing project from `@helixui/library@3.8.x` or earlier, see the [3.8.0 → 3.9.0 migration guide](/migration/3-8-0-to-3-9-0/) — `@helixui/icons` is a new required peer dependency.
 
 ## CDN (No Build Step)
 
@@ -32,15 +36,15 @@ Load HELiX directly in any HTML page via unpkg or jsDelivr:
 
 ```html
 <!-- All components (recommended for prototyping) -->
-<script type="module" src="https://unpkg.com/@helixui/library@3.0.0/dist/index.js"></script>
-<link rel="stylesheet" href="https://unpkg.com/@helixui/library@3.0.0/dist/css/helix-all.css">
+<script type="module" src="https://unpkg.com/@helixui/library@3.9.0/dist/index.js"></script>
+<link rel="stylesheet" href="https://unpkg.com/@helixui/library@3.9.0/dist/css/helix-all.css">
 ```
 
 jsDelivr alternative:
 
 ```html
-<script type="module" src="https://cdn.jsdelivr.net/npm/@helixui/library@3.0.0/dist/index.js"></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@helixui/library@3.0.0/dist/css/helix-all.css">
+<script type="module" src="https://cdn.jsdelivr.net/npm/@helixui/library@3.9.0/dist/index.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@helixui/library@3.9.0/dist/css/helix-all.css">
 ```
 
 ## Prerequisites

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -1,240 +1,28 @@
 ---
-title: HELIX Documentation
-description: HTML Element Library for Interactive eXperiences — 102 production-ready web components with periodic table design aesthetics, WCAG 2.1 AA compliance, and Drupal CMS integration.
-template: splash
-hero:
-  title: ''
-  tagline: ''
+title: HELiX
+description: Lit 3.x web components for healthcare. WCAG 2.2 AAA self-certified on the P0 surface.
 ---
 
-import Hero from '../../components/Hero.astro';
-import StatsBar from '../../components/StatsBar.astro';
-import FeatureGrid from '../../components/FeatureGrid.astro';
-import CodeShowcase from '../../components/CodeShowcase.astro';
-import TechStack from '../../components/TechStack.astro';
-import Comparison from '../../components/Comparison.astro';
-import Roadmap from '../../components/Roadmap.astro';
-import QuickLinks from '../../components/QuickLinks.astro';
-import CTASection from '../../components/CTASection.astro';
-import DXBanner from '../../components/DXBanner.astro';
-import GalleryBanner from '../../components/GalleryBanner.astro';
-import HelixirBanner from '../../components/HelixirBanner.astro';
+# HELiX
 
-<Hero />
+Lit 3.x web components for healthcare applications. **WCAG 2.2 AAA self-certified on the P0 surface** (44 components, 376 Supports verdicts across 11 criteria; reproducible via `pnpm aaa:audit`).
 
-<GalleryBanner />
+## Get started
 
-<StatsBar />
+- **[Install](/getting-started/installation/)** — npm packages + peer-dep setup
+- **[Quick start](/getting-started/quick-start/)** — your first hx-button
+- **[Component reference](https://storybook.helix.bookedsolid.tech/)** — live Storybook with every component
+- **[Drupal integration](/drupal-integration/overview/)** — module install, behaviors, Twig
+- **[Framework wrappers](/framework-integration/)** — React, Next.js, Vue, Angular, Svelte, plain HTML
 
-<FeatureGrid />
+## Latest release
 
-<CodeShowcase />
+`@helixui/library@3.9.0` + `@helixui/icons@1.0.0` — published 2026-05-11.
 
-<TechStack />
+Released: new icons package (registry-pattern with FA Free + curated helix glyph set), internal SVG migration across 25+ components, hx-slider + hx-file-upload form-validity integration, AAA cert remediation (every claim verified against the formal harness).
 
-<Comparison />
+See the [3.8.0 → 3.9.0 migration guide](/migration/3-8-0-to-3-9-0/) for the back-compat notes.
 
-<DXBanner />
+## Accessibility
 
-<HelixirBanner />
-
-<QuickLinks />
-
-<Roadmap />
-
-<CTASection />
-
-<script>
-  {`
-// Scroll-reveal animation using Intersection Observer
-// Respects prefers-reduced-motion
-(function() {
-  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-  if (prefersReduced) {
-    // Make everything visible immediately
-    document.querySelectorAll('.scroll-reveal').forEach(function(el) {
-      el.classList.add('is-visible');
-    });
-    return;
-  }
-
-  var observer = new IntersectionObserver(function(entries) {
-    entries.forEach(function(entry) {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('is-visible');
-        observer.unobserve(entry.target);
-      }
-    });
-  }, {
-    threshold: 0.1,
-    rootMargin: '0px 0px -60px 0px'
-  });
-
-  document.querySelectorAll('.scroll-reveal').forEach(function(el) {
-    observer.observe(el);
-  });
-
-  // Feature card spotlight effect (cursor-following glow)
-  document.querySelectorAll('.feature-card').forEach(function(card) {
-    card.addEventListener('mousemove', function(e) {
-      var rect = card.getBoundingClientRect();
-      var x = e.clientX - rect.left;
-      var y = e.clientY - rect.top;
-      card.style.setProperty('--mouse-x', x + 'px');
-      card.style.setProperty('--mouse-y', y + 'px');
-    });
-  });
-
-  // ===== SIDEBAR COLLAPSE WITH LOCALSTORAGE =====
-  function initSidebarCollapse() {
-    var leftSidebar = document.querySelector('.sidebar');
-    var rightSidebar = document.querySelector('.right-sidebar');
-
-    if (!leftSidebar && !rightSidebar) return;
-
-    // Load saved states
-    var leftCollapsed = localStorage.getItem('sidebar-left-collapsed') === 'true';
-    var rightCollapsed = localStorage.getItem('sidebar-right-collapsed') === 'true';
-
-    if (leftCollapsed && leftSidebar) leftSidebar.classList.add('collapsed');
-    if (rightCollapsed && rightSidebar) rightSidebar.classList.add('collapsed');
-
-    // Create collapse buttons
-    if (leftSidebar && !document.querySelector('.left-collapse-btn')) {
-      var leftBtn = document.createElement('button');
-      leftBtn.className = 'sidebar-collapse-btn left-collapse-btn';
-      leftBtn.innerHTML = '<i class="fa-solid fa-chevron-left"></i>';
-      leftBtn.setAttribute('aria-label', 'Collapse left sidebar');
-      leftSidebar.style.position = 'relative';
-      leftSidebar.appendChild(leftBtn);
-
-      leftBtn.addEventListener('click', function() {
-        leftSidebar.classList.toggle('collapsed');
-        var isCollapsed = leftSidebar.classList.contains('collapsed');
-        localStorage.setItem('sidebar-left-collapsed', isCollapsed);
-      });
-    }
-
-    if (rightSidebar && !document.querySelector('.right-collapse-btn')) {
-      var rightBtn = document.createElement('button');
-      rightBtn.className = 'sidebar-collapse-btn right-collapse-btn';
-      rightBtn.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
-      rightBtn.setAttribute('aria-label', 'Collapse right sidebar');
-      rightSidebar.style.position = 'relative';
-      rightSidebar.appendChild(rightBtn);
-
-      rightBtn.addEventListener('click', function() {
-        rightSidebar.classList.toggle('collapsed');
-        var isCollapsed = rightSidebar.classList.contains('collapsed');
-        localStorage.setItem('sidebar-right-collapsed', isCollapsed);
-      });
-    }
-
-    // Create expand buttons
-    if (leftSidebar && !document.querySelector('.sidebar-expand-btn.left')) {
-      var leftExpandBtn = document.createElement('button');
-      leftExpandBtn.className = 'sidebar-expand-btn left';
-      leftExpandBtn.innerHTML = '<i class="fa-solid fa-chevron-right"></i>';
-      leftExpandBtn.setAttribute('aria-label', 'Expand left sidebar');
-      document.body.appendChild(leftExpandBtn);
-
-      leftExpandBtn.addEventListener('click', function() {
-        leftSidebar.classList.remove('collapsed');
-        localStorage.setItem('sidebar-left-collapsed', 'false');
-      });
-    }
-
-    if (rightSidebar && !document.querySelector('.sidebar-expand-btn.right')) {
-      var rightExpandBtn = document.createElement('button');
-      rightExpandBtn.className = 'sidebar-expand-btn right';
-      rightExpandBtn.innerHTML = '<i class="fa-solid fa-chevron-left"></i>';
-      rightExpandBtn.setAttribute('aria-label', 'Expand right sidebar');
-      document.body.appendChild(rightExpandBtn);
-
-      rightExpandBtn.addEventListener('click', function() {
-        rightSidebar.classList.remove('collapsed');
-        localStorage.setItem('sidebar-right-collapsed', 'false');
-      });
-    }
-  }
-
-  // ===== SCROLLSPY WITH URL HASH UPDATE =====
-  function initScrollspy() {
-    var tocLinks = document.querySelectorAll('.right-sidebar .sl-toc a');
-    if (!tocLinks.length) return;
-
-    var headings = [];
-    tocLinks.forEach(function(link) {
-      var href = link.getAttribute('href');
-      if (href && href.startsWith('#')) {
-        var id = href.substring(1);
-        var heading = document.getElementById(id);
-        if (heading) {
-          headings.push({ id: id, element: heading, link: link });
-        }
-      }
-    });
-
-    if (!headings.length) return;
-
-    var currentActive = null;
-
-    function updateActive() {
-      var scrollPos = window.scrollY + 100; // Offset for header
-
-      var current = null;
-      for (var i = headings.length - 1; i >= 0; i--) {
-        var heading = headings[i];
-        if (heading.element.offsetTop <= scrollPos) {
-          current = heading;
-          break;
-        }
-      }
-
-      if (current && current !== currentActive) {
-        // Remove previous active
-        tocLinks.forEach(function(link) {
-          link.removeAttribute('aria-current');
-        });
-
-        // Set new active
-        current.link.setAttribute('aria-current', 'true');
-        currentActive = current;
-
-        // Update URL hash without scrolling
-        if (history.replaceState) {
-          history.replaceState(null, null, '#' + current.id);
-        }
-      }
-    }
-
-    // Throttle scroll handler
-    var ticking = false;
-    window.addEventListener('scroll', function() {
-      if (!ticking) {
-        window.requestAnimationFrame(function() {
-          updateActive();
-          ticking = false;
-        });
-        ticking = true;
-      }
-    });
-
-    // Initial update
-    updateActive();
-  }
-
-  // Initialize on DOMContentLoaded
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', function() {
-      initSidebarCollapse();
-      initScrollspy();
-    });
-  } else {
-    initSidebarCollapse();
-    initScrollspy();
-  }
-})();
-`}
-</script>
+HELiX targets WCAG 2.2 AAA on its P0 surface. The cert is self-certified — see the [VPAT 2.5 conformance report](/accessibility/vpat-2.5/) for the per-criterion ledger.

--- a/apps/docs/src/content/docs/migration/3-8-0-to-3-9-0.mdx
+++ b/apps/docs/src/content/docs/migration/3-8-0-to-3-9-0.mdx
@@ -1,0 +1,74 @@
+---
+title: Upgrading to 3.9.0
+description: Breaking + back-compat notes for the @helixui/library 3.8.0 → 3.9.0 upgrade.
+---
+
+# Upgrading to 3.9.0
+
+This release adds the `@helixui/icons` peer dependency and refactors internal icon rendering across 25+ components to use `<hx-icon>`. Most consumers will not notice — pre-3.9.0 bare-name `<hx-icon name="check">` usage is preserved via the empty-default `library` attribute.
+
+## Install changes
+
+`@helixui/library@3.9.0` adds a new required peer dependency:
+
+```bash
+pnpm add @helixui/library @helixui/icons @helixui/tokens
+```
+
+If you're upgrading an existing project that already has `@helixui/library`, add `@helixui/icons` to your dependencies.
+
+## hx-icon attribute defaults
+
+The `library` attribute on `<hx-icon>` defaults to the empty string in 3.9.0. This preserves the pre-3.9.0 contract where `<hx-icon name="check">` renders `<use href="#check">` against a document-local sprite — exactly the behavior consumers had before. To opt into the new registry, set `library` explicitly:
+
+```html
+<!-- back-compat: document-local sprite (no change from 3.8.0) -->
+<hx-icon name="check"></hx-icon>
+
+<!-- new in 3.9.0: registry-resolved fa-free library -->
+<hx-icon library="fa-free" name="check"></hx-icon>
+
+<!-- new in 3.9.0: curated helix glyph set -->
+<hx-icon library="helix" name="check"></hx-icon>
+```
+
+See [the @helixui/icons docs](https://storybook.helix.bookedsolid.tech/?path=/docs/foundations-iconography--docs) for the registry API.
+
+## Internal SVG migration
+
+The following components were migrated from inline SVG to `<hx-icon library="helix">` internally — no consumer change required. Listed here for awareness:
+
+- hx-alert, hx-banner, hx-toast (status icons)
+- hx-checkbox, hx-radio (check/dot)
+- hx-rating (star)
+- hx-tree-item, hx-tree-view (chevron)
+- hx-copy-button (copy/check)
+- hx-stat (trend arrow)
+- hx-select, hx-combobox (chevron)
+- hx-date-picker, hx-time-picker (calendar/clock)
+- hx-file-upload (upload/file)
+- hx-pagination (chevrons)
+- plus ~10 more
+
+## Form validity integration
+
+`<hx-slider>` and `<hx-file-upload>` now wire `ElementInternals.setValidity()` so they participate in native form-validity machinery. Consumer apps reading `form.checkValidity()` or `form.reportValidity()` will now see these components in the validation flow.
+
+This closes the WCAG 3.3.6 Error Prevention (All) gap. No consumer migration required.
+
+## AAA cert remediation
+
+The 3.9.0 release fixes structural issues in the AAA cert harness that were producing inaccurate verdicts. The current matrix:
+
+- **376 Supports** verdicts (44 components × applicable criteria)
+- **0 Partial** verdicts
+- **0 Fail** verdicts
+- **109 Not Applicable** cells (criterion does not apply per component class)
+
+Reproducible via `pnpm aaa:audit` against a running Storybook.
+
+See the [VPAT 2.5 conformance report](/accessibility/vpat-2.5/) for the per-criterion ledger.
+
+## Breaking changes
+
+None. The version was originally cut as 4.0.0 due to a changeset-config defect (deprecated on npm); the corrected 3.9.0 publish is the canonical release.

--- a/apps/storybook/stories/Overview.mdx
+++ b/apps/storybook/stories/Overview.mdx
@@ -1,9 +1,18 @@
 {/* Overview.mdx — HELiX Storybook landing page (component-library index) */}
 
-import { Meta } from '@storybook/addon-docs/blocks';
-import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_components';
+import { Meta } from "@storybook/addon-docs/blocks";
+import {
+  EyebrowHeading,
+  SectionHead,
+  StatCard,
+  DocsCard,
+  CodeBlock,
+} from "./_components";
 
-<Meta title="Overview" parameters={{ controls: { disable: true }, actions: { disable: true } }} />
+<Meta
+  title="Overview"
+  parameters={{ controls: { disable: true }, actions: { disable: true } }}
+/>
 
 <div className="hx-docs">
 
@@ -12,55 +21,78 @@ import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_c
   title="44 P0 components, live in your browser."
   lede={
     <>
-      Use the sidebar to inspect each component&apos;s API, behavior, and AAA cert evidence —
-      properties, attributes, slots, CSS parts, CSS custom properties, events, and per-component
-      audit verdicts. Storybook is where HELiX <em>proves</em>; the marketing site is where it
-      positions, and the docs site is where it onboards.{' '}
-      <a href="https://helix.bookedsolid.tech">Visit the docs site</a> for getting started,
-      framework integration, Drupal, and the self-certification scope.
+      Use the sidebar to inspect each component&apos;s API, behavior, and AAA
+      cert evidence — properties, attributes, slots, CSS parts, CSS custom
+      properties, events, and per-component audit verdicts. Storybook is where
+      HELiX <em>proves</em>; the marketing site is where it positions, and the
+      docs site is where it onboards.{" "}
+      <a href="https://helix.bookedsolid.tech">Visit the docs site</a> for
+      getting started, framework integration, Drupal, and the self-certification
+      scope.
     </>
   }
 />
 
 <section>
-  <SectionHead title="The AAA cert posture" meta="WCAG 2.2 · self-certified · formal harness" />
+  <SectionHead
+    title="The AAA cert posture"
+    meta="WCAG 2.2 · self-certified · formal harness"
+  />
   <div className="hx-docs-stats">
-    <StatCard num="376" label="Supports verdicts" sub="44 components × applicable criteria" />
+    <StatCard
+      num="376"
+      label="Supports verdicts"
+      sub="44 components × applicable criteria"
+    />
     <StatCard num="0" label="Partial verdicts" sub="every claim is whole" />
     <StatCard num="0" label="Fail verdicts" sub="zero unresolved gaps on P0" />
-    <StatCard num="109" label="Not Applicable" sub="criterion does not apply per class" />
+    <StatCard
+      num="109"
+      label="Not Applicable"
+      sub="criterion does not apply per class"
+    />
   </div>
-  <p className="hx-docs-card-body" style={{ marginTop: 16, maxWidth: '70ch' }}>
-    Measured by the formal AAA harness (<code>pnpm aaa:audit</code>) against each P0 component&apos;s
-    Default story and recorded with evidence per (component × criterion) in{' '}
-    <code>.reports/formal-aaa-audit/audit.json</code>. This cert is self-certified by the project
-    maintainers; it is not third-party attested. For the explicit scope and honest limits, see{' '}
+  <p className="hx-docs-card-body" style={{ marginTop: 16, maxWidth: "70ch" }}>
+    Measured by the formal AAA harness (<code>pnpm aaa:audit</code>) against
+    each P0 component&apos;s Default story and recorded with evidence per
+    (component × criterion) in <code>.reports/formal-aaa-audit/audit.json</code>
+    . This cert is self-certified by the project maintainers; it is not
+    third-party attested. For the explicit scope and honest limits, see{" "}
     <a href="https://helix.bookedsolid.tech/accessibility/self-cert-scope/">
       Self-Certification Scope
-    </a>{' '}
+    </a>{" "}
     on the docs site.
   </p>
 </section>
 
 <section>
-  <SectionHead title="Where to go on the docs site" meta="onboarding · integration · cert" />
+  <SectionHead
+    title="Where to go on the docs site"
+    meta="onboarding · integration · cert"
+  />
   <div className="hx-docs-pillars">
     <article className="hx-docs-pillar">
       <span className="hx-docs-pillar-tag">Getting started</span>
       <h3>Install + first component.</h3>
       <p>
-        <a href="https://helix.bookedsolid.tech/getting-started/installation/">Installation</a> for
-        npm + peer-dep setup, then{' '}
-        <a href="https://helix.bookedsolid.tech/getting-started/quick-start/">Quick start</a> for
-        your first <code>hx-button</code>.
+        <a href="https://helix.bookedsolid.tech/getting-started/installation/">
+          Installation
+        </a>{" "}
+        for npm + peer-dep setup, then{" "}
+        <a href="https://helix.bookedsolid.tech/getting-started/quick-start/">
+          Quick start
+        </a>{" "}
+        for your first <code>hx-button</code>.
       </p>
     </article>
     <article className="hx-docs-pillar">
       <span className="hx-docs-pillar-tag">Framework integration</span>
       <h3>React, Next, Vue, Angular, Svelte.</h3>
       <p>
-        <a href="https://helix.bookedsolid.tech/framework-integration/">Framework integration</a>{' '}
-        covers wrappers and plain-HTML usage. The Drupal-specific path lives at{' '}
+        <a href="https://helix.bookedsolid.tech/framework-integration/">
+          Framework integration
+        </a>{" "}
+        covers wrappers and plain-HTML usage. The Drupal-specific path lives at{" "}
         <a href="https://helix.bookedsolid.tech/drupal/">Drupal integration</a>.
       </p>
     </article>
@@ -70,11 +102,11 @@ import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_c
       <p>
         <a href="https://helix.bookedsolid.tech/accessibility/self-cert-scope/">
           Self-certification scope
-        </a>{' '}
-        for what the AAA cert covers and the limits;{' '}
+        </a>{" "}
+        for what the AAA cert covers and the limits;{" "}
         <a href="https://helix.bookedsolid.tech/accessibility/consumer-obligations/">
           consumer obligations
-        </a>{' '}
+        </a>{" "}
         for the partial-AAA SCs the consuming app owns.
       </p>
     </article>
@@ -88,22 +120,23 @@ import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_c
       <span className="hx-docs-pillar-tag">Accessibility</span>
       <h3>The cert ledgers.</h3>
       <p>
-        <strong>Accessibility / Dashboard</strong> for the cert roll-up,{' '}
-        <strong>Success Criteria</strong> for the WCAG 2.2 ledger,{' '}
-        <strong>Keyboard Contracts</strong> for APG-aligned interaction patterns,{' '}
-        <strong>Focus Management</strong> for the ring + trap + restore contract,{' '}
-        <strong>Forced Colors</strong> for the Windows HC contract,{' '}
-        <strong>Contrast Deep-Dive</strong> for the per-mode ledger.
+        <strong>Accessibility / Dashboard</strong> for the cert roll-up,{" "}
+        <strong>Success Criteria</strong> for the WCAG 2.2 ledger,{" "}
+        <strong>Keyboard Contracts</strong> for APG-aligned interaction
+        patterns, <strong>Focus Management</strong> for the ring + trap +
+        restore contract, <strong>Forced Colors</strong> for the Windows HC
+        contract, <strong>Contrast Deep-Dive</strong> for the per-mode ledger.
       </p>
     </article>
     <article className="hx-docs-pillar">
       <span className="hx-docs-pillar-tag">Foundations</span>
       <h3>Tokens, type, spacing, brands, icons.</h3>
       <p>
-        <strong>Foundations / Color</strong> for the 8 ramps × 11 stops, then{' '}
-        <strong>Brand Registry</strong> for the white-label contract, then{' '}
-        <strong>Typography</strong>, <strong>Spacing</strong>, <strong>Iconography</strong> (
-        <code>@helixui/icons@1.0.0</code> registry), <strong>Layout</strong>.
+        <strong>Foundations / Color</strong> for the 8 ramps × 11 stops, then{" "}
+        <strong>Brand Registry</strong> for the white-label contract, then{" "}
+        <strong>Typography</strong>, <strong>Spacing</strong>,{" "}
+        <strong>Iconography</strong> (<code>@helixui/icons@1.0.0</code>{" "}
+        registry), <strong>Layout</strong>.
       </p>
     </article>
     <article className="hx-docs-pillar">
@@ -112,9 +145,9 @@ import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_c
         Real <code>{`hx-*`}</code> elements.
       </h3>
       <p>
-        Each component ships with autodocs sourced from CEM — properties, attributes, slots, CSS
-        parts, CSS custom properties, events. Use the variant controls to see force-state matrices
-        update live.
+        Each component ships with autodocs sourced from CEM — properties,
+        attributes, slots, CSS parts, CSS custom properties, events. Use the
+        variant controls to see force-state matrices update live.
       </p>
     </article>
   </div>
@@ -139,7 +172,7 @@ https://helix.bookedsolid.tech
 # VPAT 2.5 — the conformance artefact
 
 https://helix.bookedsolid.tech/accessibility/vpat-2.5`}
-  />
+/>
 
 </section>
 

--- a/apps/storybook/stories/Overview.mdx
+++ b/apps/storybook/stories/Overview.mdx
@@ -1,4 +1,4 @@
-{/* Overview.mdx — HELiX Storybook landing page (AAA-led pitch) */}
+{/* Overview.mdx — HELiX Storybook landing page (component-library index) */}
 
 import { Meta } from '@storybook/addon-docs/blocks';
 import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_components';
@@ -8,152 +8,102 @@ import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_c
 <div className="hx-docs">
 
 <EyebrowHeading
-  eyebrow="HELiX · v0.1.0"
-  title="The OSS enterprise alternative to USWDS — engineered to clear AAA, not just AA."
+  eyebrow="HELiX Storybook · @helixui/library@3.9.0 · @helixui/icons@1.0.0"
+  title="44 P0 components, live in your browser."
   lede={
     <>
-      <strong>HELiX</strong> is a Lit&nbsp;3.x web component library for organizations where a
-      software failure can impact patient care. USWDS works to{' '}
-      <a href="https://designsystem.digital.gov/documentation/accessibility/">
-        WCAG&nbsp;2.1&nbsp;Level&nbsp;AA
-      </a>
-      {/* source: https://designsystem.digital.gov/documentation/accessibility/ (verified 2026-05-07) */}
-      ; HELiX targets <strong>WCAG&nbsp;2.2&nbsp;Level&nbsp;AAA on its P0 surface</strong> — as
-      measured by the formal AAA harness against each P0 component&apos;s Default story — and we
-      ship the contrast ledger, the keyboard contracts, and per-component evidence to prove it.{' '}
-      <strong>
-        This cert is self-certified by the project maintainers; it is not third-party attested.
-      </strong>{' '}
-      <a href="/?path=/docs/accessibility-self-certification-scope--docs">
-        Read the self-cert scope first
-      </a>
-      .
+      Use the sidebar to inspect each component&apos;s API, behavior, and AAA cert evidence —
+      properties, attributes, slots, CSS parts, CSS custom properties, events, and per-component
+      audit verdicts. Storybook is where HELiX <em>proves</em>; the marketing site is where it
+      positions, and the docs site is where it onboards.{' '}
+      <a href="https://helix.bookedsolid.tech">Visit the docs site</a> for getting started,
+      framework integration, Drupal, and the self-certification scope.
     </>
   }
 />
 
 <section>
-  <SectionHead title="The AAA cert posture" meta="WCAG 2.2 · self-certified · default story" />
+  <SectionHead title="The AAA cert posture" meta="WCAG 2.2 · self-certified · formal harness" />
   <div className="hx-docs-stats">
-    <StatCard num="163" unit="/163" label="Contrast pairings AA+" sub="across 3 modes · 0 sub-AA" />
-    <StatCard
-      num="44"
-      unit="/44"
-      label="P0 components self-certed"
-      sub="2 honest Partials on 3.3.6"
-    />
-    <StatCard num="100" unit="%" label="forced-colors coverage" sub="every interactive primitive" />
-    <StatCard num="0" label="axe-core Supports violations" sub="default story · critical+serious" />
+    <StatCard num="376" label="Supports verdicts" sub="44 components × applicable criteria" />
+    <StatCard num="0" label="Partial verdicts" sub="every claim is whole" />
+    <StatCard num="0" label="Fail verdicts" sub="zero unresolved gaps on P0" />
+    <StatCard num="109" label="Not Applicable" sub="criterion does not apply per class" />
   </div>
   <p className="hx-docs-card-body" style={{ marginTop: 16, maxWidth: '70ch' }}>
-    The full ledger lives in <strong>Accessibility / Dashboard</strong>. The verdicts above are
-    measured against each component&apos;s <strong>Default story</strong> by the formal AAA harness
-    (<code>pnpm aaa:audit</code>) and recorded with evidence per (component × criterion) in{' '}
-    <code>.reports/formal-aaa-audit/audit.json</code>. Variant coverage is asserted by a separate
-    story-audit harness. For the explicit scope and honest limits of this self-cert, see{' '}
-    <a href="/?path=/docs/accessibility-self-certification-scope--docs">Self-Certification Scope</a>
-    .
+    Measured by the formal AAA harness (<code>pnpm aaa:audit</code>) against each P0 component&apos;s
+    Default story and recorded with evidence per (component × criterion) in{' '}
+    <code>.reports/formal-aaa-audit/audit.json</code>. This cert is self-certified by the project
+    maintainers; it is not third-party attested. For the explicit scope and honest limits, see{' '}
+    <a href="https://helix.bookedsolid.tech/accessibility/self-cert-scope/">
+      Self-Certification Scope
+    </a>{' '}
+    on the docs site.
   </p>
 </section>
 
 <section>
-  <SectionHead title="Why AAA, not AA" meta="positioning · the gap that exists today" />
+  <SectionHead title="Where to go on the docs site" meta="onboarding · integration · cert" />
   <div className="hx-docs-pillars">
     <article className="hx-docs-pillar">
-      <span className="hx-docs-pillar-tag">USWDS · AA</span>
-      <h3>The federal floor.</h3>
+      <span className="hx-docs-pillar-tag">Getting started</span>
+      <h3>Install + first component.</h3>
       <p>
-        The U.S. Web Design System works to <strong>WCAG&nbsp;2.1 Level AA</strong> and documents
-        conformance for 44 components of USWDS&nbsp;3.11.0 in its{' '}
-        <a href="https://designsystem.digital.gov/documentation/accessibility/">
-          VPAT&nbsp;2.5 (May&nbsp;2025)
-        </a>
-        {/* source: https://designsystem.digital.gov/documentation/accessibility/ (verified 2026-05-07) */}
-        . AAA is named in their docs as an aspirational direction, not a current claim. That posture
-        is correct for civic services with a broad-public remit and risk-averse delivery cadence.
+        <a href="https://helix.bookedsolid.tech/getting-started/installation/">Installation</a> for
+        npm + peer-dep setup, then{' '}
+        <a href="https://helix.bookedsolid.tech/getting-started/quick-start/">Quick start</a> for
+        your first <code>hx-button</code>.
       </p>
     </article>
     <article className="hx-docs-pillar">
-      <span className="hx-docs-pillar-tag">HELiX · AAA-targeted</span>
-      <h3>Healthcare-grade headroom.</h3>
+      <span className="hx-docs-pillar-tag">Framework integration</span>
+      <h3>React, Next, Vue, Angular, Svelte.</h3>
       <p>
-        Healthcare providers, claims systems, and patient-facing portals operate above the federal
-        floor — both because patients use assistive tech at a higher rate and because regulators
-        expect <em>headroom</em>. HELiX targets{' '}
-        <strong>WCAG 2.2 Level AAA on its P0 surface</strong>
-        and publishes per-component evidence (matrix + audit JSON + per-component AUDIT.md) so
-        consumers can stake their own claim against a reproducible self-cert.
+        <a href="https://helix.bookedsolid.tech/framework-integration/">Framework integration</a>{' '}
+        covers wrappers and plain-HTML usage. The Drupal-specific path lives at{' '}
+        <a href="https://helix.bookedsolid.tech/drupal/">Drupal integration</a>.
       </p>
     </article>
     <article className="hx-docs-pillar">
-      <span className="hx-docs-pillar-tag">OSS · enterprise</span>
-      <h3>Vendor-neutral, AGPL-clean.</h3>
+      <span className="hx-docs-pillar-tag">Accessibility</span>
+      <h3>Cert scope + consumer obligations.</h3>
       <p>
-        Every token, every component, every test ships under an OSS licence with a healthcare
-        warranty model attached. White-label brand registry, three-tier token cascade, Drupal and
-        React wrappers — built so an enterprise team can extend without forking.
+        <a href="https://helix.bookedsolid.tech/accessibility/self-cert-scope/">
+          Self-certification scope
+        </a>{' '}
+        for what the AAA cert covers and the limits;{' '}
+        <a href="https://helix.bookedsolid.tech/accessibility/consumer-obligations/">
+          consumer obligations
+        </a>{' '}
+        for the partial-AAA SCs the consuming app owns.
       </p>
     </article>
   </div>
 </section>
 
 <section>
-  <SectionHead title="Pillars" meta="why this exists" />
-  <div className="hx-docs-pillars">
-    <article className="hx-docs-pillar">
-      <span className="hx-docs-pillar-tag">Accessibility · WCAG 2.1 AAA target</span>
-      <h3>Contrast is a token contract, not a checklist.</h3>
-      <p>
-        Every <code>{`text.on-{role}`}</code> token is paired with its surface and pinned to ≥ 4.5 :
-        1 (AA floor). 103 of 163 graded pairs sit at ≥ 7 : 1 (AAA), with the remainder cleared at
-        AA; drift below the floor fails CI. Focus rings clear 1.4.11 in every mode, including
-        forced-colors.
-      </p>
-    </article>
-    <article className="hx-docs-pillar">
-      <span className="hx-docs-pillar-tag">Three-tier tokens</span>
-      <h3>Primitive → semantic → component.</h3>
-      <p>
-        Override <code>--hx-color-primary-500</code> at <code>:root</code> and the entire system
-        reflows. <code>{`action.*`}</code>, <code>{`surface.*`}</code>, <code>{`border.*`}</code>{' '}
-        sit between the ramp and the component — brands slot in at the semantic tier without
-        touching component CSS.
-      </p>
-    </article>
-    <article className="hx-docs-pillar">
-      <span className="hx-docs-pillar-tag">Themeable by design</span>
-      <h3>Light, dark, high-contrast — same tokens.</h3>
-      <p>
-        Mode is a single attribute on <code>:root</code>. Every token resolves through{' '}
-        <code>{`dark.*`}</code> and <code>{`high-contrast.*`}</code> overrides; AA is re-validated
-        per mode, so no surface goes dark without its on-token following.
-      </p>
-    </article>
-  </div>
-</section>
-
-<section>
-  <SectionHead title="Where to go next" meta="storybook sidebar" />
+  <SectionHead title="Where to go in Storybook" meta="sidebar map" />
   <div className="hx-docs-pillars">
     <article className="hx-docs-pillar">
       <span className="hx-docs-pillar-tag">Accessibility</span>
-      <h3>Start here for the AAA story.</h3>
+      <h3>The cert ledgers.</h3>
       <p>
         <strong>Accessibility / Dashboard</strong> for the cert roll-up,{' '}
-        <strong>Forced Colors</strong> for the Windows HC contract,{' '}
+        <strong>Success Criteria</strong> for the WCAG 2.2 ledger,{' '}
         <strong>Keyboard Contracts</strong> for APG-aligned interaction patterns,{' '}
         <strong>Focus Management</strong> for the ring + trap + restore contract,{' '}
+        <strong>Forced Colors</strong> for the Windows HC contract,{' '}
         <strong>Contrast Deep-Dive</strong> for the per-mode ledger.
       </p>
     </article>
     <article className="hx-docs-pillar">
       <span className="hx-docs-pillar-tag">Foundations</span>
-      <h3>Tokens, type, spacing, brands.</h3>
+      <h3>Tokens, type, spacing, brands, icons.</h3>
       <p>
         <strong>Foundations / Color</strong> for the 8 ramps × 11 stops, then{' '}
         <strong>Brand Registry</strong> for the white-label contract, then{' '}
-        <strong>Typography</strong>, <strong>Spacing</strong>, <strong>Iconography</strong>,{' '}
-        <strong>Layout</strong>.
+        <strong>Typography</strong>, <strong>Spacing</strong>, <strong>Iconography</strong> (
+        <code>@helixui/icons@1.0.0</code> registry), <strong>Layout</strong>.
       </p>
     </article>
     <article className="hx-docs-pillar">
@@ -163,7 +113,7 @@ import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_c
       </h3>
       <p>
         Each component ships with autodocs sourced from CEM — properties, attributes, slots, CSS
-        parts, CSS custom properties, events. Try the variant controls to see force-state matrices
+        parts, CSS custom properties, events. Use the variant controls to see force-state matrices
         update live.
       </p>
     </article>
@@ -176,7 +126,7 @@ import { EyebrowHeading, SectionHead, StatCard, DocsCard, CodeBlock } from './_c
     language="bash"
     filename="coordinates.sh"
     code={`# install
-npm i @helixui/library @helixui/tokens
+npm i @helixui/library @helixui/icons @helixui/tokens
 
 # repo
 
@@ -189,7 +139,7 @@ https://helix.bookedsolid.tech
 # VPAT 2.5 — the conformance artefact
 
 https://helix.bookedsolid.tech/accessibility/vpat-2.5`}
-/>
+  />
 
 </section>
 


### PR DESCRIPTION
## Summary

Phase 3 of the docs sync effort. Brings Storybook + apps/docs surfaces current to the 3.9.0 release and the verified AAA cert posture (376 Supports / 0 Partial / 0 Fail / 109 NA).

- **apps/storybook/stories/Overview.mdx** — stripped marketing-grade positioning prose (USWDS comparison, "OSS enterprise alternative" language belongs on the marketing site). Rewritten as component-library index. Version refs updated to @helixui/library@3.9.0 + @helixui/icons@1.0.0. Cert posture stat card preserved (load-bearing for procurement evaluators).
- **apps/storybook/stories/accessibility/SuccessCriteria.mdx** — verified WCAG 2.2 references throughout. No residual 2.1 version drift found; only unchanged SC numbers (2.1.1, 2.1.2) remain.
- **apps/docs/src/content/docs/index.mdx** — replaced 240-line noindex marketing splash (deleted upstream) with a 26-line Starlight prose landing page rooted in install + quick-start + Storybook + Drupal + framework links.
- **apps/docs/src/content/docs/getting-started/installation.md** — version table @3.0.0 → ^3.9.0, added @helixui/icons@^1.0.0 row + optional @helixui/react row. CDN URLs @3.0.0 → @3.9.0.
- **apps/docs/src/content/docs/migration/3-8-0-to-3-9-0.mdx** — NEW: install changes (peer-dep), back-compat for hx-icon empty `library` default, internal SVG migration list (25+ components), form validity integration (3.3.6 closure), AAA cert remediation matrix.

Phase 4 (CONTRIBUTING.md boundary test) shipped separately in #1707. Phase 5 (llms.txt generator) is its own PR.

## Test plan

- [ ] Astro build green
- [ ] Storybook build green
- [ ] No broken cross-links in worktree
- [ ] CodeRabbit no blocking findings