### PR TITLE
fix(docs): restore CMD+K search — remove noindex meta + X-Robots-Tag header

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -64,13 +64,6 @@ export default defineConfig({
       customCss: ['./src/styles/custom.css'],
       head: [
         {
-          tag: 'meta',
-          attrs: {
-            name: 'robots',
-            content: 'noindex, nofollow',
-          },
-        },
-        {
           tag: 'link',
           attrs: {
             rel: 'preconnect',

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,16 +1,5 @@
 {
   "installCommand": "cd ../.. && corepack enable && pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=docs",
-  "outputDirectory": "dist",
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "X-Robots-Tag",
-          "value": "noindex, nofollow"
-        }
-      ]
-    }
-  ]
+  "outputDirectory": "dist"
 }


### PR DESCRIPTION
## Problem

CMD+K search on `helix.bookedsolid.tech` is empty — the Pagefind index has zero pages indexed, so no results ever surface.

## Root cause

Two layers told Pagefind (Starlight's built-in search backend) to skip every page during build:

1. **`apps/docs/astro.config.mjs`** added `<meta name="robots" content="noindex, nofollow">` to every page's `<head>`
2. **`apps/docs/vercel.json`** sent `X-Robots-Tag: noindex, nofollow` as an HTTP header for every response

Pagefind respects both `<meta name="robots">` and `X-Robots-Tag` per its [exclusion rules](https://pagefind.app/docs/excluding/) — it sees "noindex" on every URL and skips them all during indexing.

## Fix

Strip both noindex directives. ~3-line change. Site becomes Pagefind-indexable → CMD+K works.

## What this does NOT change

`apps/docs/public/robots.txt` still contains `User-agent: * / Disallow: /` — that file blocks Google/Bing crawlers but is **not read by Pagefind** (which only honors page-level meta + HTTP-header directives). The site remains hidden from external search engines; CMD+K (in-page Pagefind) is the only thing restored.

If you want the site to become Google-indexable too, that's a separate change to `robots.txt` (out of scope for this PR — happy to follow up).

## Test plan
- [ ] CI passes
- [ ] After merge → staging → main, visit helix.bookedsolid.tech, press CMD+K, type "button" → results appear (was empty before)