### PR TITLE
promote dev → staging (search fix)

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -64,13 +64,6 @@ export default defineConfig({
       customCss: ['./src/styles/custom.css'],
       head: [
         {
-          tag: 'meta',
-          attrs: {
-            name: 'robots',
-            content: 'noindex, nofollow',
-          },
-        },
-        {
           tag: 'link',
           attrs: {
             rel: 'preconnect',

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,16 +1,5 @@
 {
   "installCommand": "cd ../.. && corepack enable && pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=docs",
-  "outputDirectory": "dist",
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "X-Robots-Tag",
-          "value": "noindex, nofollow"
-        }
-      ]
-    }
-  ]
+  "outputDirectory": "dist"
 }


### PR DESCRIPTION
Promotes dev to staging. Includes PR #1727 — restore CMD+K search on helix.bookedsolid.tech by removing noindex meta + X-Robots-Tag header so Pagefind can build the index. Auto-merge enabled.