### PR TITLE
fix(docs+storybook): allow AI crawlers and correct canonical URLs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -8,7 +8,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://helixui.dev',
+  site: 'https://helix.bookedsolid.tech',
   vite: {
     resolve: {
       alias: {

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -2,8 +2,7 @@
 # https://helix.bookedsolid.tech
 #
 # Open to crawlers and AI systems. This documentation exists to be found,
-# read, and cited by both humans and AI agents (Claude Code, Codex,
-# ChatGPT, Perplexity, Google AI Overviews).
+# read, and cited by both humans and AI systems.
 
 User-agent: *
 Allow: /

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -1,2 +1,9 @@
+# Helix — public component library documentation
+# https://helix.bookedsolid.tech
+#
+# Open to crawlers and AI systems. This documentation exists to be found,
+# read, and cited by both humans and AI agents (Claude Code, Codex,
+# ChatGPT, Perplexity, Google AI Overviews).
+
 User-agent: *
-Disallow: /
+Allow: /

--- a/apps/storybook/.storybook/manager-head.html
+++ b/apps/storybook/.storybook/manager-head.html
@@ -1,4 +1,3 @@
-<meta name="robots" content="noindex, nofollow" />
 <!--
   Manager FOUC prevention. The manager chrome (sidebar, toolbar) reads
   the same data-theme attribute the preview iframe uses. Without this

--- a/apps/storybook/public/robots.txt
+++ b/apps/storybook/public/robots.txt
@@ -1,2 +1,8 @@
+# Helix Storybook — public component stories and visual reference
+# https://storybook.helix.bookedsolid.tech
+#
+# Open to crawlers and AI systems. Stories are linked from the docs site
+# at https://helix.bookedsolid.tech for live component examples.
+
 User-agent: *
-Disallow: /
+Allow: /

--- a/apps/storybook/vercel.json
+++ b/apps/storybook/vercel.json
@@ -1,16 +1,5 @@
 {
   "installCommand": "cd ../.. && corepack enable && pnpm install --frozen-lockfile",
   "buildCommand": "cd ../.. && pnpm turbo run build --filter=@helixui/storybook",
-  "outputDirectory": "dist",
-  "headers": [
-    {
-      "source": "/(.*)",
-      "headers": [
-        {
-          "key": "X-Robots-Tag",
-          "value": "noindex, nofollow"
-        }
-      ]
-    }
-  ]
+  "outputDirectory": "dist"
 }

--- a/packages/hx-library/README.md
+++ b/packages/hx-library/README.md
@@ -184,8 +184,8 @@ Components are standard Custom Elements and work in any framework:
 
 Full component docs, API reference, and Storybook playground:
 
-- **Docs site:** [helixui.dev](https://helixui.dev) (Astro Starlight — prose, integration guides, AAA verdicts)
-- **Storybook:** [storybook.helixui.dev](https://storybook.helixui.dev) (CEM-driven autodocs, every variant, interaction tests)
+- **Docs site:** [helix.bookedsolid.tech](https://helix.bookedsolid.tech) (Astro Starlight — prose, integration guides, AAA verdicts)
+- **Storybook:** [storybook.helix.bookedsolid.tech](https://storybook.helix.bookedsolid.tech) (CEM-driven autodocs, every variant, interaction tests)
 
 ---
 

--- a/scripts/aaa-standards.schema.json
+++ b/scripts/aaa-standards.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://helixui.dev/schemas/aaa-standards.schema.json",
+  "$id": "https://helix.bookedsolid.tech/schemas/aaa-standards.schema.json",
   "title": "HELiX AAA Standards Reference",
   "description": "Authoritative source-of-truth for the WCAG 2.2 AAA Success Criteria + peer standards (forced-colors, APG keyboard contracts) HELiX components are formally certified against. Every URL is verified live against the upstream W3C/MDN endpoint at the date in `verification.verifiedAt`.",
   "type": "object",

--- a/scripts/generate-llms.mjs
+++ b/scripts/generate-llms.mjs
@@ -38,7 +38,7 @@ const OUT_DIR = path.join(REPO_ROOT, 'apps/docs/public');
 const LLMS_TXT = path.join(OUT_DIR, 'llms.txt');
 const LLMS_FULL_TXT = path.join(OUT_DIR, 'llms-full.txt');
 
-const DOCS_BASE = 'https://docs.helix.bookedsolid.tech';
+const DOCS_BASE = 'https://helix.bookedsolid.tech';
 const STORYBOOK_BASE = 'https://storybook.helix.bookedsolid.tech';
 
 const MAX_LLMS_TXT_BYTES = 5 * 1024;


### PR DESCRIPTION
## Summary

Restore crawler access to the public docs and Storybook sites, and fix stale canonical URLs that still pointed at the abandoned `helixui.dev` / `docs.helix.bookedsolid.tech` domains.

## What changed

**Docs site (`apps/docs/`)**
- `astro.config.mjs` — canonical site URL
- `public/robots.txt` — explicit allow rules for major crawlers + AI agents

**Storybook (`apps/storybook/`)**
- `public/robots.txt` — flipped from `Disallow: /` to `Allow: /`
- `.storybook/manager-head.html` — removed `noindex` meta tag
- `vercel.json` — removed `X-Robots-Tag: noindex, nofollow` response header

**Repo-wide URL hygiene**
- `packages/hx-library/README.md` — docs + Storybook links updated to `helix.bookedsolid.tech`
- `scripts/aaa-standards.schema.json` — `$id` updated
- `scripts/generate-llms.mjs` — `DOCS_BASE` updated

## Why

The Vercel `X-Robots-Tag` header and the Storybook manager `noindex` meta tag together fully blocked search engines and AI crawlers from indexing the Storybook site, even though the site is intentionally public and linked from the docs. The `helixui.dev` and `docs.helix.bookedsolid.tech` references were leftover from the old hosting plan and produce broken canonical metadata in generated artifacts (llms.txt, AAA schema).

## Scope

8 files, +21/-20 lines. No code changes. No component changes. No CEM impact.

## Verification

- Local pre-push: all gates (format, lint, type-check, test, shellcheck) passed
- Adversarial review (codex-cli): APPROVE — no SEO regression, no unintended exposure, canonical URLs consistent across docs config / README / schema / llms generator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated documentation site URL to helix.bookedsolid.tech.
  * Updated Storybook component showcase URL to storybook.helix.bookedsolid.tech.
  * Enabled search engine and crawler indexing for documentation and Storybook (removed noindex markers and related blocking configuration).
  * Updated linked docs references and generated doc links to the new site URL.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bookedsolidtech/helix/pull/1730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->