### PR TITLE
feat(aeo): add sitemap integration to docs

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
+import sitemap from '@astrojs/sitemap';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -38,6 +39,7 @@ export default defineConfig({
     },
   },
   integrations: [
+    sitemap(),
     starlight({
       expressiveCode: {
         themes: ['material-theme-palenight'],

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.0",
+    "@astrojs/sitemap": "^3.7.1",
     "@helixui/tokens": "workspace:*",
     "@astrojs/starlight": "^0.37.6",
     "@vercel/analytics": "^1.6.1",

--- a/apps/docs/public/robots.txt
+++ b/apps/docs/public/robots.txt
@@ -6,3 +6,5 @@
 
 User-agent: *
 Allow: /
+
+Sitemap: https://helix.bookedsolid.tech/sitemap-index.xml

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.0
         version: 0.9.8(prettier@3.8.1)(typescript@5.9.3)
+      '@astrojs/sitemap':
+        specifier: ^3.7.1
+        version: 3.7.1
       '@astrojs/starlight':
         specifier: ^0.37.6
         version: 0.37.7(astro@5.18.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.59.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3))
@@ -6213,8 +6216,8 @@ packages:
   third-party-web@0.27.0:
     resolution: {integrity: sha512-h0JYX+dO2Zr3abCQpS6/uFjujaOjA1DyDzGQ41+oFn9VW/ARiq9g5ln7qEP9+BTzDpOMyIfsfj4OvfgXAsMUSA==}
 
-  third-party-web@0.29.0:
-    resolution: {integrity: sha512-nBDSJw5B7Sl1YfsATG2XkW5qgUPODbJhXw++BKygi9w6O/NKS98/uY/nR/DxDq2axEjL6halHW1v+jhm/j1DBQ==}
+  third-party-web@0.29.2:
+    resolution: {integrity: sha512-fegtha91tq2DHphyoiBXVHjVi2YG9zFaRnboT9C28tO1en9Y3wJsfspuy40F+u5wl3hHVbw7cnd1b67kEGHb8g==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -8539,7 +8542,7 @@ snapshots:
   '@paulirish/trace_engine@0.0.59':
     dependencies:
       legacy-javascript: 0.0.1
-      third-party-web: 0.29.0
+      third-party-web: 0.29.2
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -13626,7 +13629,7 @@ snapshots:
 
   third-party-web@0.27.0: {}
 
-  third-party-web@0.29.0: {}
+  third-party-web@0.29.2: {}
 
   tiny-inflate@1.0.3: {}
 


### PR DESCRIPTION
## Summary

Adds `@astrojs/sitemap` to `apps/docs` and advertises the generated sitemap from `robots.txt`. Stacks on top of #1730 (canonical-domain + crawler-unblock fixes) — without that branch merged first, this sitemap is inert because the robots policy still says `Disallow: /`.

## Why

Starlight does not generate `sitemap.xml` by default. Without it, AI crawlers and search engines only discover doc pages by following the nav tree, which misses depth-4+ guides (e.g. `components/forms/validation`, `drupal/twig-templates/properties`). The newly-allowed canonical at `helix.bookedsolid.tech` becomes substantively crawlable instead of nominally crawlable.

## What changed

- `apps/docs/astro.config.mjs` — register `sitemap()` integration
- `apps/docs/package.json` — add `@astrojs/sitemap` dependency
- `apps/docs/public/robots.txt` — add `Sitemap:` directive pointing at `helix.bookedsolid.tech/sitemap-index.xml`
- `pnpm-lock.yaml` — lockfile update

## Scope

Intentionally tight — 4 files, additive only. No code changes. No component or CEM impact. Pure AEO infrastructure.

## Stacking note

This PR's base is `fix/docs-storybook-robots-allow-ai` (PR #1730), not `main`. After #1730 merges, this PR's base should auto-retarget to `main`. If the operator prefers, this can also be folded into #1730 directly.

## Verification

- Local pre-push gates: all passed (format, lint, type-check, smart test suite, shellcheck)
- Adversarial review (codex-cli, GPT-5.4 high): PASS, 0 findings against the stacking base. Earlier round flagged the missing `Sitemap:` directive in `robots.txt`; addressed in the second commit.

## Refs

- AEO audit P1 #5 (Helix docs sitemap)
- Audit findings doc: `.scratch/aeo-audit-findings.md` in `booked-solid-tech` repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic XML sitemap generation to enhance search engine indexing
  * Updated site crawler directives to include sitemap reference

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bookedsolidtech/helix/pull/1731?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->