### PR TITLE
fix(docs): correct stale 3.0.0 tarball reference in Drupal CDN snippet

### DIFF
--- a/apps/docs/src/content/docs/drupal/installation/cdn.md
+++ b/apps/docs/src/content/docs/drupal/installation/cdn.md
@@ -497,8 +497,8 @@ Download the local copy to include in your theme:
 ```bash
 cd web/themes/custom/mytheme/libraries/helix
 npm pack @helixui/library@3.9.0
-tar -xf helixui-library-3.0.0.tgz --strip-components=1 package/dist
-rm helixui-library-3.0.0.tgz
+tar -xf helixui-library-3.9.0.tgz --strip-components=1 package/dist
+rm helixui-library-3.9.0.tgz
 ```
 
 ---


### PR DESCRIPTION
## Summary

One-line typo fix in the Drupal CDN install snippet. The \`npm pack\` line produces \`helixui-library-3.9.0.tgz\` (matching the requested version), but the subsequent \`tar -xf\` and \`rm\` lines referenced \`helixui-library-3.0.0.tgz\` — a copy-paste leftover from an earlier 3.0.0-era version of the docs. Anyone following the snippet would have hit \`No such file or directory\`.

## Why direct-to-main

Two reasons:

1. **Pure docs typo, zero risk.** Two character changes in a code block, no logic, no behavior.
2. **Live test of the Vercel auto-deploy fix.** The \`helix-docs\` Vercel project had \`enableAffectedProjectsDeployments: null\` (vs \`true\` on \`helix-storybook\`), which silently broke main → production auto-deploys since 2026-05-11. Patched it to \`true\` via Vercel API. This PR is the first main merge after the patch — if the auto-deploy fires and the live site updates without a manual API kick, the fix holds.

## Test plan

- [x] Local rea/codex review: pass, 0 findings
- [ ] CI green on PR
- [ ] Merge to main
- [ ] **Watch for \`Production – helix-docs\` deployment in GitHub Deployments API**
- [ ] Verify https://helix.bookedsolid.tech/drupal/installation/cdn/ reflects \`3.9.0.tgz\` post-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CDN fallback guidance to reference the latest HELiX library version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bookedsolidtech/helix/pull/1735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->