### PR TITLE
fix(docs): use em-dash in site description for typographic consistency

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -55,7 +55,7 @@ export default defineConfig({
       },
       title: 'HELiX',
       description:
-        'HTML Element Library for Interactive eXperiences - Enterprise Web Components for Drupal CMS',
+        'HTML Element Library for Interactive eXperiences — Enterprise Web Components for Drupal CMS',
       social: [
         {
           icon: 'github',


### PR DESCRIPTION
## Summary

One-character typography fix: change \` - \` (hyphen with spaces) to \` — \` (em-dash) in the Starlight site description in \`apps/docs/astro.config.mjs\`. Matches the rest of the docs' typographic convention.

## Test purpose

Real fix, but also the test of the actual Vercel auto-deploy fix:

- Earlier hypothesis: \`enableAffectedProjectsDeployments: null\` → patched to \`true\`. PR #1735 merged with no auto-deploy → hypothesis wrong.
- Real root cause: \`helix-docs\` Vercel project was linked to GitHub via a stale credential (\`cred_a864...\`); \`helix-storybook\` uses \`cred_708043...\`. Disconnected + reconnected \`helix-docs\` Git integration — it now uses the same \`cred_708043...\` credential as the working storybook project.
- This PR is the live test. If \`Production – helix-docs\` deployment fires for the merge sha, the fix holds.

## Test plan

- [ ] Admin merge to main (non-md file but \`apps/docs\` changes don't need Quality Gates to be informative)
- [ ] Watch GitHub Deployments API for \`Production – helix-docs\` event on merge sha
- [ ] Verify https://helix.bookedsolid.tech reflects the description change in HTML \`<meta name=\"description\">\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation configuration description string with improved typography formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bookedsolidtech/helix/pull/1736?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->