### PR TITLE
chore: migrate publish to npm Trusted Publishing (OIDC)

### DIFF
--- a/.changeset/trusted-publishing-migration.md
+++ b/.changeset/trusted-publishing-migration.md
@@ -1,0 +1,11 @@
+---
+'@helixui/icons': patch
+---
+
+chore: migrate npm publishing to Trusted Publishing (OIDC)
+
+Removes the long-lived NPM_TOKEN dependency from the publish workflow. The
+publish job now authenticates to npm via GitHub Actions OIDC token federation
+(Trusted Publishing), scoped through the `npm-publish` environment. Sigstore
+provenance attestations are preserved. This is an infrastructure-only change
+with no consumer-facing API impact.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -183,15 +183,18 @@ jobs:
     needs: secret-scan
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    # ── Human-in-the-loop release gate ──────────────────────────────────────
-    # The `npm-publish` GitHub Environment enforces required-reviewer approval
-    # before this job runs. Configure in repo Settings → Environments:
-    #   1. Create environment `npm-publish`
-    #   2. Add Jake as a required reviewer (Protection rules → Required reviewers)
-    #   3. Set wait timer to 0 — the gate is a reviewer click, not a delay
-    # Without this environment configured, the job will fail at queue time
-    # with an "environment does not exist" error. See docs/releases/README.md.
+    # ── npm Trusted Publishing (OIDC) ───────────────────────────────────────
+    # The `npm-publish` GitHub Environment scopes the OIDC identity that npm's
+    # Trusted Publisher entries federate against (org=bookedsolidtech,
+    # repo=helix, workflow=publish.yml, env=npm-publish). No long-lived
+    # NPM_TOKEN is used — auth is the GitHub Actions OIDC token via pnpm's
+    # native trusted-publishing support. `id-token: write` below is required
+    # for the runner to mint that token.
     environment: npm-publish
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -252,7 +255,9 @@ jobs:
           title: 'chore: version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESET_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # NODE_AUTH_TOKEN intentionally removed — auth is OIDC Trusted
+          # Publishing. An empty/legacy NODE_AUTH_TOKEN makes npm attempt
+          # token auth and skip OIDC, so the line is removed entirely.
           NPM_CONFIG_PROVENANCE: 'true'
           # Disable husky pre-push hooks during CI git operations (tag pushes,
           # version bump commits). The hook is designed for developer workflows,


### PR DESCRIPTION
## Summary

Migrates the helix monorepo publish pipeline off the long-lived `NPM_TOKEN` secret to npm **Trusted Publishing (OIDC)**, in response to the org-wide "Mini Shai-Hulud" token rotation event (2026-05-19).

All 7 publishable packages (`@helixui/library`, `tokens`, `react`, `icons`, `drupal-behaviors`, `drupal-starter`, `mcp`) publish from this single `publish.yml` via Changesets, so one workflow change covers all of them. Each package's Trusted Publisher entry (org=`bookedsolidtech`, repo=`helix`, workflow=`publish.yml`, env=`npm-publish`) is already configured on npmjs.com.

## Changes

- **`.github/workflows/publish.yml`** (publish job):
  - Removed `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` entirely (an empty/legacy value makes npm attempt token auth and skip OIDC).
  - Added explicit job-level `permissions` with `id-token: write` for OIDC token minting (least-privilege).
  - Kept `environment: npm-publish` and `NPM_CONFIG_PROVENANCE: 'true'`.
  - pnpm-based (pnpm 9.15.9, the confirmed-working version with native OIDC trusted-publishing) — no `npm install -g` step needed.
- **`npm-publish` GitHub Environment**: reconfigured to no required reviewers (`protection_rules: []`) so the Version Packages merge publishes automatically.
- **Changeset**: a `patch` on `@helixui/icons` (lowest blast radius — independent of the linked `library`/`tokens`/`react` trio; `@helixui/mcp` is ignored by changesets) to validate the pipeline end-to-end.

## Verification plan

- [ ] CI green on this PR
- [ ] Merge → Version Packages PR auto-opens → merge it → publish runs
- [ ] `@helixui/icons@1.0.2` publishes via OIDC; `npm view @helixui/icons@1.0.2 --json` shows `.dist.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`
- [ ] Publish log says "using npm trusted publishing" with no NPM_TOKEN

Rollback: `NPM_TOKEN` secret remains in repo (unused) as break-glass for the 2-week observation window.