### PR TITLE
chore: pin npm 11.5.1 in publish job for OIDC trusted publishing

### DIFF
--- a/.changeset/trusted-publishing-npm-bump.md
+++ b/.changeset/trusted-publishing-npm-bump.md
@@ -1,0 +1,13 @@
+---
+'@helixui/icons': patch
+---
+
+chore: pin npm 11.5.1 in publish job for OIDC trusted publishing
+
+The publish job authenticates to npm via GitHub Actions OIDC token federation
+(Trusted Publishing), but `changeset publish` delegates the registry PUT to the
+global `npm` binary. Node 22 bundles npm 10.x, which signs provenance but lacks
+trusted-publishing OIDC auth, so the PUT went out unauthenticated and the
+registry returned a misleading `E404 ... is not in this registry`. Pinning npm
+to 11.5.1 before publish gives `changeset publish` a TP-capable npm. This is an
+infrastructure-only change with no consumer-facing API impact.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -208,6 +208,18 @@ jobs:
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
+      # `changeset publish` shells out to the global `npm` binary for the
+      # actual registry PUT. Node 22 bundles npm 10.x, which signs provenance
+      # but does NOT support trusted-publishing OIDC auth — the PUT goes out
+      # unauthenticated and the registry returns a misleading
+      # `E404 ... is not in this registry`. Pin npm to 11.5.1 (first version
+      # with working TP-OIDC) before any publish. `--force` is required to get
+      # past Node 22's bundled-npm arborist on the global upgrade.
+      - name: Install npm 11.5.1+ for OIDC trusted publishing
+        run: |
+          npm install -g npm@11.5.1 --force
+          npm --version
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Follow-up fix to PR #1737. The publish workflow correctly removed `NODE_AUTH_TOKEN` to authenticate via OIDC Trusted Publishing, but the first real publish (run [26138228845](https://github.com/bookedsolidtech/helix/actions/runs/26138228845)) failed with `E404 ... is not in this registry` for all three packages.

## Root cause

`changeset publish` shells out to the **global `npm` binary** for the registry PUT. Node 22 bundles **npm 10.x**, which signs provenance but does **not** support trusted-publishing OIDC auth. The log confirms the failure mode exactly:

```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
npm notice publish Signed provenance statement ...
error '@helixui/react@3.9.2' is not in this registry.   <- E404, unauthenticated PUT
```

This is the documented anti-pattern: provenance gets signed, but the PUT goes out without working TP auth and the registry returns a misleading 404.

## Fix

Add an `npm install -g npm@11.5.1 --force` step after `setup-node`, before publish — the same pin used by every other migrated repo. pnpm 9.15.9 handles workspace install; npm 11.5.1 handles the TP-OIDC PUT that `changeset publish` delegates to.

## Why no new changeset is needed

The failed run already bumped versions on main (`icons@1.0.2`, `library@3.9.2`, `react@3.9.2`) and consumed the changeset, but **published nothing** (all three still at old versions on npm). When this workflow-only fix merges to main, `changeset publish` will detect those unpublished versions and ship them.

## Verification plan

- [ ] CI green
- [ ] Merge → publish run logs `npm --version` == 11.5.1
- [ ] `npm view @helixui/icons@1.0.2 --json` shows `.dist.attestations.provenance.predicateType == "https://slsa.dev/provenance/v1"`