### PR TITLE
fix(release): address codex deep-review blockers on staging→main (#1744)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -195,9 +195,14 @@ jobs:
     # with an "environment does not exist" error. See docs/releases/README.md.
     environment: npm-publish
     steps:
+      # The publish job runs changesets/action (which pushes the version PR
+      # + tags) and an explicit `git fetch origin main` in the manifest step,
+      # both of which need the GITHUB_TOKEN persisted in .git/config. The
+      # supply-chain hardening (persist-credentials: false) applied to every
+      # other checkout step is unsafe here — removing it would crash the
+      # release mid-run with an authentication failure on the private repo.
       - uses: actions/checkout@v6
         with:
-          persist-credentials: false
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4

--- a/packages/hx-react/package.json
+++ b/packages/hx-react/package.json
@@ -35,7 +35,8 @@
   },
   "dependencies": {
     "@helixui/library": "workspace:*",
-    "@lit/react": "^1.0.6"
+    "@lit/react": "^1.0.6",
+    "react": ">=18.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,9 @@ importers:
       '@lit/react':
         specifier: ^1.0.6
         version: 1.0.8(@types/react@19.2.14)
+      react:
+        specifier: '>=18.0.0'
+        version: 19.2.6
       react-dom:
         specifier: '>=18.0.0'
         version: 19.2.4(react@19.2.6)
@@ -488,9 +491,6 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
-      react:
-        specifier: ^19.2.6
-        version: 19.2.6
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

Codex deep review on the staging → main promotion (#1744) flagged two real release blockers. Fixing both before #1744 can merge.

## P1 — publish.yml credentials

The dependabot batch added `persist-credentials: false` to all 37 actions/checkout@v6 steps as supply-chain hardening. That's correct for the test/lint/build jobs but the **publish job** runs `changesets/action` (which pushes the version PR + tags) and a manifest step that runs `git fetch origin main` — both need the GITHUB_TOKEN persisted. Without it, the release pipeline crashes mid-run with an auth failure on the private repo.

Reverted `persist-credentials: false` on JUST the publish job's checkout step (publish.yml line 198) with an inline comment explaining the exception. Every other workflow checkout keeps the hardening.

## P2 — hx-react react in deps

The batch moved `react` from `@helixui/react` dependencies into devDependencies, motivated by the duplicate-React peer warning codex caught earlier. That's the right end state for a minor/major bump, but shipping it on this PATCH release silently breaks consumers on legacy package managers (yarn classic, pre-npm-7) that don't auto-install peers.

Restored `react: ">=18.0.0"` to dependencies — range matches the existing peerDependencies declaration so modern resolvers still hoist the consumer's existing react and don't create a nested copy. The peerDeps-only migration belongs in a future minor.

## Test plan

- [ ] verify clean
- [ ] test:smart clean (no component changes)
- [ ] Quality Gates pass

Once merged, #1744 auto-picks up these commits for the staging → main flow.