### PR TITLE
fix(test): prevent anchor navigation in hx-link cross-browser tests

### DIFF
--- a/packages/hx-library/src/components/hx-link/hx-link.test.ts
+++ b/packages/hx-library/src/components/hx-link/hx-link.test.ts
@@ -1,9 +1,28 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { fixture, shadowQuery, oneEvent, cleanup, checkA11y } from '../../test-utils.js';
 import type { HelixLink } from './hx-link.js';
 import './index.js';
 
 afterEach(cleanup);
+
+// Vitest 4 browser-playwright propagates anchor click default actions to real
+// page navigation. Tests that fire `anchor.click()` on an <hx-link href="…">
+// would navigate the test iframe away and crash the whole file ("Cannot
+// connect to the iframe"). Intercepting click in capture phase before the
+// browser dispatches navigation keeps the iframe stable. hx-click fires from
+// the component independently of the default action, so this does not affect
+// any test's actual assertions.
+const preventNavigation = (event: Event): void => {
+  event.preventDefault();
+};
+
+beforeEach(() => {
+  document.addEventListener('click', preventNavigation, true);
+});
+
+afterEach(() => {
+  document.removeEventListener('click', preventNavigation, true);
+});
 
 describe('hx-link', () => {
   // --- Rendering ---


### PR DESCRIPTION
## Summary

Round-2 hotfix for #1744 (staging→main). The cross-browser CI job that runs only on main-targeted PRs failed across chromium/firefox/webkit:

\`\`\`
Error: Failed to run the test ...hx-link/hx-link.test.ts
Caused by: Error: Cannot connect to the iframe.
Received URL: http://localhost:63315/page
Expected: http://localhost:63315/?sessionId=...
\`\`\`

Vitest 4 + @vitest/browser-playwright propagates anchor click default actions through to real navigation. Three tests in the Events block fire \`anchor.click()\` on \`<hx-link href="/page">\` fixtures, which now navigates the test iframe to /page and kills the whole file.

## Fix

Added suite-level \`beforeEach\` / \`afterEach\` in hx-link.test.ts that registers a capture-phase click interceptor with \`event.preventDefault()\`. hx-click fires from the component independently of the default click action, so this does not affect any existing assertions.

## Test plan

- [ ] Quality Gates + Cross-Browser matrix pass on this PR
- [ ] Auto-merge into staging; #1744 then picks up the fix