### PR TITLE
ci: enforce the 3.0 shelf with a blocking breaking-change gate

### DIFF
--- a/.github/workflows/audit-batch-ci.yml
+++ b/.github/workflows/audit-batch-ci.yml
@@ -207,10 +207,89 @@ jobs:
             # The changeset check in the main CI handles label detection
           fi
 
+  # ── API Breaking-Change Gate (batch) ────────────────────────────────────
+  # The same 3.0-shelf enforcement as the main CI gate, mirrored here so an audit
+  # batch branch can't bypass the breaking-change/semver contract. Compares the
+  # base-vs-head manifest + barrel and fails a breaking change that lacks a
+  # `@helixui/library: major` changeset. See scripts/ci/shelf-guard.mjs and
+  # docs/audit/AUDIT-3x-register.md §1.
+  api-breaking-change:
+    name: API Breaking Change Gate (Batch)
+    needs: [detect-batch]
+    if: needs.detect-batch.outputs.is_batch == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      - name: Generate + save head barrel
+        run: |
+          pnpm --filter=@helixui/library exec node scripts/generate-barrel.js
+          mkdir -p .cache
+          cp packages/hx-library/src/index.ts .cache/head-barrel.ts
+          cp packages/hx-library/package.json .cache/head-pkg.json
+      - name: Generate head CEM
+        run: pnpm --filter=@helixui/library exec custom-elements-manifest analyze --litelement --globs "src/components/**/*.ts" --exclude "**/*.stories.ts" --exclude "**/*.styles.ts"
+      - name: Save head CEM
+        run: cp packages/hx-library/custom-elements.json .cache/head-cem.json
+      - name: Check out base branch public-API inputs
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          # Fail loudly if the base ref is unavailable — otherwise the gate would
+          # silently compare head-vs-head and miss every breaking change.
+          git rev-parse --verify --quiet "$BASE" >/dev/null || {
+            echo "::error::shelf-guard: base ref $BASE is unavailable on the runner"
+            exit 1
+          }
+          # Restore the base version of each input. A path absent on base (new in
+          # this PR) is skipped; any other git failure is fatal.
+          for p in \
+            packages/hx-library/src \
+            packages/hx-library/custom-elements-manifest.config.mjs \
+            packages/hx-library/cem-plugins \
+            packages/hx-library/scripts/generate-barrel.js \
+            packages/hx-library/tsconfig.json \
+            tsconfig.base.json; do
+            if git cat-file -e "$BASE:$p" 2>/dev/null; then
+              git checkout "$BASE" -- "$p"
+            else
+              echo "Path $p not present on base — new in this PR, skipping."
+            fi
+          done
+          git show "$BASE:packages/hx-library/package.json" > .cache/base-pkg.json
+      - name: Generate + save base barrel
+        run: |
+          pnpm --filter=@helixui/library exec node scripts/generate-barrel.js
+          cp packages/hx-library/src/index.ts .cache/base-barrel.ts
+      - name: Generate base CEM
+        run: pnpm --filter=@helixui/library exec custom-elements-manifest analyze --litelement --globs "src/components/**/*.ts" --exclude "**/*.stories.ts" --exclude "**/*.styles.ts"
+      - name: Save base CEM
+        run: cp packages/hx-library/custom-elements.json .cache/base-cem.json
+      - name: Enforce 3.0 shelf (breaking API change requires a major changeset)
+        run: >
+          node scripts/ci/shelf-guard.mjs
+          --base-cem .cache/base-cem.json
+          --head-cem .cache/head-cem.json
+          --base-barrel .cache/base-barrel.ts
+          --head-barrel .cache/head-barrel.ts
+          --base-pkg .cache/base-pkg.json
+          --head-pkg .cache/head-pkg.json
+          --changesets .changeset
+          --base-ref "origin/${{ github.base_ref }}"
+          ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change-approved') && '--label-bypass' || '' }}
+
   # ── Summary gate ────────────────────────────────────────────────────────
   quality-gates:
     name: Quality Gates (Batch)
-    needs: [detect-batch, lint, format, type-check, build, test, changeset]
+    needs: [detect-batch, lint, format, type-check, build, test, changeset, api-breaking-change]
     if: always() && needs.detect-batch.outputs.is_batch == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 1
@@ -228,13 +307,15 @@ jobs:
           echo "  Build:      ${{ needs.build.result }}"
           echo "  Test:       ${{ needs.test.result }}"
           echo "  Changeset:  ${{ needs.changeset.result }}"
+          echo "  API Break:  ${{ needs.api-breaking-change.result }}"
 
           # Fail if any required gate failed
           if [[ "${{ needs.lint.result }}" == "failure" ]] || \
              [[ "${{ needs.format.result }}" == "failure" ]] || \
              [[ "${{ needs.type-check.result }}" == "failure" ]] || \
              [[ "${{ needs.build.result }}" == "failure" ]] || \
-             [[ "${{ needs.test.result }}" == "failure" ]]; then
+             [[ "${{ needs.test.result }}" == "failure" ]] || \
+             [[ "${{ needs.api-breaking-change.result }}" == "failure" ]]; then
             echo ""
             echo "❌ One or more quality gates failed"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -829,6 +829,108 @@ jobs:
             --repo ${{ github.repository }} \
             --body "$BODY"
 
+  # ── API Breaking-Change Gate (PR only) ──────────────────────────────────
+  # Enforces the 3.0 shelf: a breaking public-API change must carry a
+  # `@helixui/library: major` changeset. shelf-guard.mjs compares the base-vs-head
+  # Custom Elements Manifests directly and comprehensively — removed components,
+  # removed/renamed attributes, removed/narrowed public properties (incl. JS-only
+  # `attribute: false` props), removed public methods, and removed events/slots/
+  # parts/custom-properties. It is a SUPERSET of the informational "CEM API Diff"
+  # comment above (which only diffs attribute-backed props). Replaces the H18/H23
+  # hooks, which gated on git-staged files vs HEAD (a commit-time model that
+  # no-ops on PR runners). Runs on EVERY pull request (no path guard) so that a
+  # source, base/mixin, analyzer-config, plugin, or toolchain change can never
+  # skip it; it is a fast no-op when the manifest is unchanged. Blocking — wired
+  # into the quality-gates aggregate. See docs/audit/AUDIT-3x-register.md §1.
+
+  api-breaking-change:
+    name: API Breaking Change Gate
+    needs: [changes, secret-scan]
+    if: >
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.is_audit != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+      - run: pnpm install --frozen-lockfile
+      # The HEAD public-API surface: the manifest (component API) + the barrel
+      # (src/index.ts — the allowlist-gated named-export surface, incl. mixins,
+      # utilities, and the base class). The manifest is generated analyze-only —
+      # NOT `run cem`, which also runs validate-cem.mjs + the figma helper from the
+      # PR head; those would execute against the base checkout and could fail or
+      # differ. The analyze flags mirror the `cem` package script's analyze step.
+      - name: Generate + save head barrel
+        run: |
+          pnpm --filter=@helixui/library exec node scripts/generate-barrel.js
+          mkdir -p .cache
+          cp packages/hx-library/src/index.ts .cache/head-barrel.ts
+          cp packages/hx-library/package.json .cache/head-pkg.json
+      - name: Generate head CEM
+        run: pnpm --filter=@helixui/library exec custom-elements-manifest analyze --litelement --globs "src/components/**/*.ts" --exclude "**/*.stories.ts" --exclude "**/*.styles.ts"
+      - name: Save head CEM
+        run: cp packages/hx-library/custom-elements.json .cache/head-cem.json
+      # Check out the base versions of every public-API input — component source,
+      # analyzer config + plugins, AND the barrel generator (its allowlist defines
+      # the export surface) — so the base manifest and barrel reflect the base API.
+      # Note: both are produced with the PR's installed analyzer toolchain, so a
+      # toolchain-version bump that itself alters output is not differentially
+      # detected here — that rare case is covered by the informational CEM API Diff
+      # comment and review.
+      - name: Check out base branch public-API inputs
+        run: |
+          BASE="origin/${{ github.base_ref }}"
+          # Fail loudly if the base ref is unavailable — otherwise the gate would
+          # silently compare head-vs-head and miss every breaking change.
+          git rev-parse --verify --quiet "$BASE" >/dev/null || {
+            echo "::error::shelf-guard: base ref $BASE is unavailable on the runner"
+            exit 1
+          }
+          # Restore the base version of each input. A path absent on base (new in
+          # this PR) is skipped; any other git failure is fatal.
+          for p in \
+            packages/hx-library/src \
+            packages/hx-library/custom-elements-manifest.config.mjs \
+            packages/hx-library/cem-plugins \
+            packages/hx-library/scripts/generate-barrel.js \
+            packages/hx-library/tsconfig.json \
+            tsconfig.base.json; do
+            if git cat-file -e "$BASE:$p" 2>/dev/null; then
+              git checkout "$BASE" -- "$p"
+            else
+              echo "Path $p not present on base — new in this PR, skipping."
+            fi
+          done
+          git show "$BASE:packages/hx-library/package.json" > .cache/base-pkg.json
+      - name: Generate + save base barrel
+        run: |
+          pnpm --filter=@helixui/library exec node scripts/generate-barrel.js
+          cp packages/hx-library/src/index.ts .cache/base-barrel.ts
+      - name: Generate base CEM
+        run: pnpm --filter=@helixui/library exec custom-elements-manifest analyze --litelement --globs "src/components/**/*.ts" --exclude "**/*.stories.ts" --exclude "**/*.styles.ts"
+      - name: Save base CEM
+        run: cp packages/hx-library/custom-elements.json .cache/base-cem.json
+      - name: Enforce 3.0 shelf (breaking API change requires a major changeset)
+        run: >
+          node scripts/ci/shelf-guard.mjs
+          --base-cem .cache/base-cem.json
+          --head-cem .cache/head-cem.json
+          --base-barrel .cache/base-barrel.ts
+          --head-barrel .cache/head-barrel.ts
+          --base-pkg .cache/base-pkg.json
+          --head-pkg .cache/head-pkg.json
+          --changesets .changeset
+          --base-ref "origin/${{ github.base_ref }}"
+          ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change-approved') && '--label-bypass' || '' }}
+
   # ── Bundle Size Diff (PR only) ──────────────────────────────────────────
   # Downloads the base branch bundle size artifact, compares with the current
   # branch, posts a PR comment with per-component deltas, and blocks merge on
@@ -1193,6 +1295,7 @@ jobs:
         vrt,
         audit,
         changeset,
+        api-breaking-change,
         storybook-tests,
         test-react,
       ]
@@ -1215,6 +1318,7 @@ jobs:
           echo "Bundle Size:        ${{ needs.bundle-size.result }}"
           echo "VRT:                ${{ needs.vrt.result }}"
           echo "Audit:              ${{ needs.audit.result }}"
+          echo "API Break Gate:     ${{ needs.api-breaking-change.result }}"
           echo "Storybook Tests:    ${{ needs.storybook-tests.result }}"
           echo "React Tests:        ${{ needs.test-react.result }}"
 
@@ -1245,13 +1349,14 @@ jobs:
           # Test, VRT, changeset, and bundle-size are allowed to be skipped
           # (non-PR / no source changes) or cancelled (concurrency group replaced a
           # running job).
-          for gate in test vrt changeset bundle-size; do
+          for gate in test vrt changeset bundle-size api-breaking-change; do
             result="${{ needs.test.result }}"
             case "$gate" in
-              test)        result="${{ needs.test.result }}" ;;
-              vrt)         result="${{ needs.vrt.result }}" ;;
-              changeset)   result="${{ needs.changeset.result }}" ;;
-              bundle-size) result="${{ needs.bundle-size.result }}" ;;
+              test)                result="${{ needs.test.result }}" ;;
+              vrt)                 result="${{ needs.vrt.result }}" ;;
+              changeset)           result="${{ needs.changeset.result }}" ;;
+              bundle-size)         result="${{ needs.bundle-size.result }}" ;;
+              api-breaking-change) result="${{ needs.api-breaking-change.result }}" ;;
             esac
             if [[ "$result" != "success" && "$result" != "skipped" && "$result" != "cancelled" ]]; then
               echo "::error::Gate '$gate' did not succeed: $result"

--- a/docs/audit/AUDIT-3x-register.md
+++ b/docs/audit/AUDIT-3x-register.md
@@ -1,0 +1,211 @@
+# HELiX 3.x Audit Register
+
+**Scope:** the `@helixui/library` product and its downstream distribution —
+`hx-library` (components + foundation: base class, mixins, adopted-stylesheet
+machinery), `hx-tokens`, `hx-react` wrappers, the Drupal slotted-content surface
+(`starters/drupal`, `packages/drupal-starter`), and the CI / release / packaging
+machinery that governs how it ships.
+**Out of scope (separate backlog):** `apps/admin`, `apps/mcp-servers`,
+`packages/helixui-mcp` — see [BREAKING-CHANGES-4.0.md](./BREAKING-CHANGES-4.0.md) appendix.
+
+**Library version at audit:** `@helixui/library` 3.10.0
+**Constraint:** every remediation ships under 3.x (non-breaking). Genuinely-breaking
+improvements are cataloged in [BREAKING-CHANGES-4.0.md](./BREAKING-CHANGES-4.0.md), not landed.
+Where a breaking fix has a non-breaking on-ramp, we ship the compat shim now (dual
+accept + DEV-only deprecation warning) and defer removal to 4.0.
+
+**Method:** 6-dimension reconnaissance sweep, then a 7-agent adversarial verification
+pass (refute-by-default) that confirmed each load-bearing finding against source with
+file:line evidence and pinned the exact fix site + semver category. Findings below are
+post-verification; recon claims that did **not** survive verification are listed in
+§7 so they are not re-introduced.
+
+**Semver legend:**
+`NB` = non-breaking-3x (pure fix) · `SHIM` = additive on-ramp now, removal parked for 4.0 ·
+`4.0` = breaking, parked entirely.
+
+---
+
+## 0. Executive summary
+
+The foundation is genuinely strong: a clean `HelixElement` base + `FormMixin` /
+`FocusMixin` / `mixinDelegatesAria` composition, a disciplined three-tier
+`--hx-*` token cascade adopted idempotently into `document.adoptedStyleSheets`, a
+CEM-driven React-wrapper pipeline with a real blocking drift gate, universal
+ElementInternals form participation, and a 44-component P0 surface formally
+AAA-certified. This is infrastructure built to a high bar.
+
+The defects cluster in **enforcement, not construction** — the gates that are
+supposed to protect the contract are wired loosely or not at all:
+
+1. **The 3.0 shelf is not enforced by automation (CRITICAL).** The breaking-change
+   detector (H18) and semver validator (H23) exist and are feature-complete, but
+   run in **zero** automated paths — not CI, not preflight, not even the active
+   husky pre-commit hook. The "Changeset Required" gate checks only that a changeset
+   *file exists*, never that its bump matches the API delta. A deleted public
+   property labeled `patch` passes every gate and publishes as a 3.x patch.
+2. **Bundle-budget enforcement is three competing systems, and the enforced one was
+   quietly relaxed** to 16KB/component & 200KB/bundle (vs the documented 5KB/50KB)
+   on 2026-04-25 and never restored; a second script has a NaN-comparison bug that
+   silently un-gates every over-budget component; a third is dormant.
+3. **A publish-time CEM-staleness guard is dead code** (`git status --porcelain` on
+   a gitignored file is always empty), giving false assurance.
+4. **Security hardening gaps on the distribution surface:** no SRI on the jsDelivr
+   Drupal loader (pinned to a stale 2.1.2), an unsanitized post-mutator path in
+   `hx-icon`, attribute-**name** injection in 13 Drupal Twig templates, and no
+   `SECURITY.md` / `THREAT_MODEL.md`.
+5. **A11y consistency gaps:** the button family has *no* focus delegation at all
+   (host `focus()` is a no-op), 37 components lack an `AAA-AUDIT.md`, `hx-link`'s
+   axe suite is fully `describe.skip`ed (and it's its only a11y gate), and the two
+   PHI components are P1/uncertified despite being foundational healthcare surfaces.
+
+Every item is fixable under 3.x. Priority order: **B (lock the shelf) → C (security)
+→ D (foundation/a11y) → E (API ergonomics)**, with breaking normalizations parked.
+
+---
+
+## 1. Workstream B — Release Integrity & the 3.0 Shelf Guard `[PRIORITY]`
+
+| # | Finding | Sev | Semver | Fix site |
+|---|---------|-----|--------|----------|
+| B1 | **H18 (api-breaking-change-detection) runs in no automated path.** Only consumer is `scripts/pre-commit-check.sh:375`, which is itself orphaned — the active `.husky/pre-commit` runs only gitleaks + an env check. Not in CI, preflight, or the Docker `act` gate. | Critical | SHIM | `.github/workflows/ci.yml` (new required job) |
+| B2 | **H23 (semantic-versioning) runs nowhere at all** — no shell script references it. It is the exact guard that fails when a breaking change lacks a `major` changeset. Its `CONFIG.workspacePackages` also omits `@helixui/react`. | Critical | SHIM | `ci.yml` + `scripts/hooks/semantic-versioning.ts:124,127` |
+| B3 | **"Changeset Required" gate checks existence only**, never bump correctness (`ci.yml:1022-1061`). Same blind spot in preflight Gate 7. | High | SHIM | covered by B1/B2 job |
+| B4 | **CEM API Diff job is informational-only** (`ci.yml:775-830`, comment "does not block merge"); `cem-diff.js` exits 0 on a successful diff and isn't in `quality-gates.needs[]`. | Medium | NB | leave as PR-comment; enforcement lands in B1 job |
+| B5 | **publish.yml / release.yml re-run no tests and no API gate** — the changeset bump is taken at face value at publish time. | High | SHIM | making B1 job required on dev/staging/main covers it (no publish.yml edit) |
+| B6 | **Enforced bundle budget was relaxed to 16KB/200KB** (`bundle-budgets.json`, commit `10cae84f` 2026-04-25, "temporary" per its own comment, Task #44) vs documented 5KB/50KB. | High | NB | `bundle-budgets.json` + reconcile w/ CLAUDE.md |
+| B7 | **`check-bundle-size.mjs` NaN bug:** `OVERRIDES[name] ?? PER_COMPONENT` returns the `{budget,reason}` object, so `gzBytes > object` is always `false` — every overridden component is un-gated. Script is also orphaned (not in CI/preflight). | High | NB | `scripts/check-bundle-size.mjs:51-53` |
+| B8 | **Dead CEM-staleness guard in publish.yml** (`:66-77`, `:245-249`): `git status --porcelain` on the gitignored `custom-elements.json` is always empty, so the gate can never fire. Shipped CEM is still fresh (build regenerates), but the guard is misleading dead code. | High | NB | `publish.yml` (remove or replace w/ before/after temp-diff) |
+| B9 | **`SKIP_CDN_SIZE` local bypass** in preflight Gate 4.5; CDN gate is correctly blocking in CI. | Medium | NB | `scripts/preflight.sh:104-116` (ignore when `CI=true`) |
+
+**Implementation subtlety (load-bearing):** H18/H23 gate on **git-staged files vs HEAD
+CEM** — a commit-time model. A naive CI wiring that shells out to the hook's `main()`
+will mis-scope or no-op on PR runners (nothing staged; HEAD is the merge commit). The
+CI job must drive the **exported** `detectBreakingChanges` / `parseCEM`
+(`api-breaking-change-detection.ts:275,376`) against explicitly-generated **base vs
+head** CEM JSON. Add the new job to `quality-gates.needs[]` + the hard-fail loop
+(`ci.yml:1229-1243`); because `quality-gates` is already the single required check and
+the `pull_request` trigger covers dev/staging/main, no branch-protection API change is
+needed.
+
+---
+
+## 2. Workstream C — Security & Distribution Integrity
+
+| # | Finding | Sev | Semver | Fix site |
+|---|---------|-----|--------|----------|
+| C1 | **No SRI on the jsDelivr Drupal loader**, pinned to a stale `@2.1.2`. Exactly one real CDN-loading YML. Docs already prescribe the fix (doc/reality gap). | High | NB | `starters/drupal/helix_module/helix_module.libraries.yml:6,14` |
+| C2 | **`hx-icon` trusts post-mutator output:** sanitize → `library.mutator(svg)` → `svg.outerHTML` → `unsafeHTML` with **no re-sanitization**. A hostile/compromised icon-library mutator can reintroduce `<script>`/`on*`/`javascript:`. Untested gap. | High | NB | `hx-icon.ts:551-567` (`_applyLibraryMutator`) |
+| C3 | **13 Drupal Twig templates emit unescaped attribute *names*** (`{% for key,val in attributes %}{{ key }}="{{ val }}"` escapes value, not key → `onfocus=` breaks out). `attributes` is a raw PHP array, not a Drupal `Attribute` object. `packages/drupal-starter` templates already do this safely. | High | NB | `starters/drupal/helix_module/templates/*.html.twig` (13) + `helix_module.theme.inc` |
+| C4 | **`hx-prose` renders raw CMS HTML in Light DOM with zero sanitization** (upstream-trust by design); no opt-in `sanitize` hook or per-component security note. (`hx-tooltip`/`hx-toast` are slot-projection-only — *not* injection sinks; recon over-flagged them.) | Medium | SHIM | `hx-prose.ts` (opt-in `sanitize` prop, default off) |
+| C5 | **No `SECURITY.md` / `THREAT_MODEL.md`** at repo root (a strong `apps/docs/.../drupal/security-xss.md` exists and is the natural anchor). | Low | NB | repo root |
+| C6 | **`hx-phi-field` SSR `data`-attribute exposure** has only post-hoc rescue, no opt-in fail-closed `strict` mode. (Note: strict mode is a *detector*, not a cure — the PHI already serialized server-side; it forces the misconfig to fail loudly in dev/test.) | High | SHIM | `hx-phi-field.ts:177-189` (new `strict` prop, default false) |
+
+`hx-icon` is the **only** component-source file with an `unsafeHTML`/`innerHTML` sink.
+
+---
+
+## 3. Workstream D — Foundation & A11y Consistency
+
+### 3a. FocusMixin adoption (API-preserving)
+
+`FocusMixin` delegates host `focus()`/`blur()` to a single inner `_focusableNode` and
+reflects `focused`/`focused-visible`. **Only `hx-text-input` adopts it today.** The
+sweep bucketed every interactive component:
+
+**(b) SAFE NON-BREAKING ADOPT (8) — host `focus()` currently broken or hand-rolled,
+no `:host([focused])` styling exists so reflected attrs are purely additive:**
+- `hx-button`, `hx-icon-button`, `hx-link`, `hx-copy-button` — **zero focus delegation
+  today** (host `focus()` is a no-op); highest-value, lowest-risk win.
+- `hx-textarea` — replace hand-rolled `focus()` with `_focusableNode` (cleanest; no
+  `firstUpdated` to merge).
+- `hx-number-input`, `hx-slider` — same, **but must thread `super.firstUpdated()`**
+  through their existing override or autofocus/pending-focus flush breaks.
+- `hx-file-upload` — `_focusableNode` must target `.dropzone` (role=button), **not**
+  the hidden `.file-input`.
+
+**(c) PARK FOR 4.0 — adoption changes observable focus semantics:** `hx-checkbox`,
+`hx-switch`, `hx-toggle-button`, `hx-color-picker` (dual-mode host-focusable via
+`_supportsIdrefRefs`); `hx-select` (host *is* the combobox surface); `hx-combobox`,
+`hx-date-picker`, `hx-time-picker` (composite popups + ARIA-mirror). FocusMixin's
+inner-only contract would *regress* these — they are **correct as-is**. Roving-tabindex
+composites (`hx-menu`, `hx-tabs`, `hx-tree-view`, `hx-dialog`, `hx-drawer`, …) have no
+single focusable node and are not FocusMixin candidates at all.
+
+### 3b. Accessibility coverage
+
+| # | Finding | Sev | Semver | Fix site |
+|---|---------|-----|--------|----------|
+| D1 | **37 components lack `AAA-AUDIT.md`** (8 interactive: phi-field, patient-banner, link, pagination, data-table, table, structured-list, list; 29 presentational). Generated by `scripts/regenerate-audits.mjs` from formal-audit JSON. | Medium | NB | per-component, via formal audit → regenerate |
+| D2 | **`hx-link` `describe.skip('Accessibility (axe-core)')`** disables 5 axe cases (`hx-link.test.ts:281`). hx-link is P1 and **not** on the AAA allowlist, so the formal audit doesn't cover it — the skipped unit tests are its **only** a11y gate. Root cause: axe × `hx-icon` shadow-root vitest deadlock. | High | NB | `hx-link.test.ts:281` |
+| D3 | **72 `it.todo()` placeholders** across 3 `hx-theme` test files (13/21/38; headers claim 12/20/24 — stale). Includes forced-colors/high-contrast brand-split (cert-relevant). | Medium | NB | `hx-theme-{replacesync-hardening,hc-brand-split,data-brand-reflection}.test.ts` |
+| D4 | **`hx-phi-field` + `hx-patient-banner` are P1, uncertified, zero helixMeta tags.** Promotion to P0 is **metadata + audit only — non-breaking** (no exported property/attr/event/slot/part changes). phi-field is genuinely interactive (has `<button part=toggle>`); patient-banner is a landmark (interactive SCs resolve N/A). | Medium | NB | `p0-priority-tiers.json`, JSDoc, allowlist, VPAT |
+| D5 | **`hx-phi-field` copy/paste doesn't reset the auto-hide timer** — a clinician actively copying revealed PHI can have it auto-mask mid-workflow. | Medium | NB | `hx-phi-field.ts:470-481` |
+| D6 | **`hx-form` + `hx-prose` never bootstrap tokens.** 98 components import the auto-running `document-token-adoption.js`; these two Light-DOM components (the Drupal pattern) don't — if a page loads only them, the `:root` token layer is never adopted and styling silently degrades. | High | NB | `hx-form.ts`, `hx-prose.ts` (add side-effect import + `ensureDocumentTokens()` in `connectedCallback`) |
+| D7 | **`hx-phi-access` analytics-forwarding boundary** lacks a tag-shaped `@note` at the event/interface site (class-level prose exists). | Low | NB | `hx-phi-field.ts:550-559`, `@fires` |
+
+`aaa-cert.mjs` refuses `@aaa-certified` unless all 11 criteria resolve Supports/Not
+Applicable from the **formal audit** — promotion (D4) cannot be faked. It needs an
+explicit `--pattern` (no heuristic for these two) and `detectPhiHandles` hardcodes
+phi-field + clinical-status (not patient-banner — a one-line detector tweak).
+
+---
+
+## 4. Workstream E — API Consistency & Flexibility (additive compat shims)
+
+| # | Finding | Sev | Semver | Fix site |
+|---|---------|-----|--------|----------|
+| E1 | **Legacy `size` alias is on only 10 of 29 size components.** (The `size`-vs-`hx-size` "split" is **refuted** — all 29 uniformly use the `hx-size` attribute.) 13 non-form components should gain the alias via a shared helper; **exclude the 6 form controls** (native `<input size>` collision — the reason `hx-size` exists). | Medium | SHIM | new `src/utils/apply-legacy-size-alias.ts` + 13 `connectedCallback`s |
+| E2 | **18 of ~28 event-emitting components lack `HTMLElementEventMap` augmentation** — `detail` is `any` for `addEventListener` consumers. All change/input details already carry `value`. | Medium | SHIM | per-component `declare global` blocks + exported named detail types |
+| E3 | **Variant additive gaps:** `hx-icon-button` lacks `outline`; `hx-toggle-button` lacks `danger`. Safe to add now. | Medium | SHIM | `hx-icon-button.ts:100`, `hx-toggle-button.ts:133` |
+| E4 | **`mixinDelegatesAria` is unexported** (FocusMixin/FormMixin are **already** public — recon partially refuted). Add to the `generate-barrel.js` allowlist; regenerate (never hand-edit the generated `src/index.ts`). | Low | SHIM | `scripts/generate-barrel.js:58-59` |
+| E5 | **CEM `./custom-elements.json` is already a published export** (recon's "not exported" branch refuted). Additive: advertise the subpath + `customElements` field for tooling. | Low | NB | docs only |
+| E6 | **`danger`↔`error` value naming diverges** (`hx-tag` uses `danger`; `hx-alert`/`hx-banner`/`hx-badge` use `error`). Unification removes a value → **4.0**. 3.x bridge: dual-accept alias + DEV warn. | Low | 4.0 (+SHIM) | parked |
+
+`devWarn` (`src/utils/dev-warn.ts`) is DEV/test-gated and tree-shaken from prod, so all
+proposed deprecation warnings are **zero-cost in production**.
+
+---
+
+## 5. Workstream F — 4.0 Breaking Backlog (parked)
+
+Cataloged in [BREAKING-CHANGES-4.0.md](./BREAKING-CHANGES-4.0.md). Headline items:
+deprecated-token removal (`--hx-color-border-on-dark-*`), legacy `size` attribute
+removal, `danger`↔`error` value unification, variant-enum normalization,
+host-focusable FocusMixin mode for the parked (c) components, and a possible
+`hx-prose` `sanitize`-default flip. Plus the out-of-scope `apps/admin` + MCP security
+backlog (no-auth dashboard, test-runner process-spawn, FS race conditions).
+
+---
+
+## 6. Remediation sequencing
+
+1. **B — shelf guard** (protected paths, codex-review required). Lock the contract
+   first; the new gate then proves every later PR is non-breaking.
+2. **C — security/distribution.** SRI, `hx-icon` re-sanitize, Twig attribute names,
+   `hx-prose` opt-in sanitize, `hx-phi-field` strict mode, SECURITY/THREAT_MODEL docs.
+3. **D — foundation/a11y.** FocusMixin (8), token-bootstrap self-heal, `hx-link`
+   un-skip, `hx-theme` todos, PHI promotion, copy/paste timer, telemetry `@note`.
+4. **E — API ergonomics.** Legacy-size helper (13), event-map typing, variant adds,
+   `mixinDelegatesAria` export.
+
+Each workstream is a batched PR through `pnpm run preflight` (12 gates) + codex-review
+for protected paths. The B gate is the proof obligation for C/D/E.
+
+---
+
+## 7. Recon claims that did NOT survive verification (do not re-introduce)
+
+- ❌ "size vs hx-size split across components" — **all 29 use `hx-size`**; the real gap
+  is the legacy-`size` *compat shim* coverage (E1).
+- ❌ "FocusMixin/FormMixin/mixinDelegatesAria are unexported" — FocusMixin & FormMixin
+  are **already public**; only `mixinDelegatesAria` is internal (E4).
+- ❌ "CEM not published as an export" — it **is** (`exports`, `files`, `customElements`);
+  it's simultaneously gitignored + generated-on-build + published (E5).
+- ❌ "hx-tooltip/hx-toast render unsanitized HTML" — slot-projection only; **`hx-icon`
+  is the sole `unsafeHTML` sink** (C2/C4).
+- ❌ "the bundle/CDN gate has a CI bypass" — the CDN gate is genuinely blocking in CI;
+  the real issues are the relaxed budget (B6), the NaN bug (B7), and the local
+  `SKIP_CDN_SIZE` (B9).
+- ⚠️ "hx-phi-access telemetry boundary undocumented" — class-level prose exists; only a
+  targeted `@note` is missing (D7, downgraded to low).

--- a/docs/audit/BREAKING-CHANGES-4.0.md
+++ b/docs/audit/BREAKING-CHANGES-4.0.md
@@ -1,0 +1,129 @@
+# HELiX 4.0 Breaking-Change Backlog
+
+Every item here is a **deliberately deferred** breaking change surfaced by the 3.x
+audit ([AUDIT-3x-register.md](./AUDIT-3x-register.md)). None of these land under 3.x.
+Each lists the **3.x compat shim** (if any) that bridges consumers toward it, so the
+4.0 migration is a removal of already-deprecated behavior rather than a surprise.
+
+**Rule of thumb:** a change is 4.0 if it *removes or renames* a public
+attribute, property, event field, slot, CSS part, CSS custom property, or variant
+value — i.e. anything `api-breaking-change-detection` (H18) flags as a removal/retype.
+Once the B-workstream gate is live, H18 is the automated arbiter of this list.
+
+---
+
+## 1. Design tokens
+
+### 1.1 Remove deprecated `--hx-color-border-on-dark-*` tokens
+- **What:** drop `--hx-color-border-on-dark-subtle` / `--hx-color-border-on-dark-default`
+  (renamed to `--hx-color-surface-on-dark-overlay-*`; the old names paint translucent
+  fills, not borders — the rename is also a semantic correction).
+- **Where:** `hx-button.ts` (~`:77`), `hx-side-nav.ts`, and any consume site reading
+  both names via the deprecated-first fallback chain.
+- **3.x shim (already shipped):** both names resolve via CSS fallback, so existing
+  overrides keep working.
+- **Migration:** consumers replace `--hx-color-border-on-dark-*` overrides with
+  `--hx-color-surface-on-dark-overlay-*`.
+- **4.0 action:** delete the deprecated fallback arm.
+
+---
+
+## 2. Component attributes
+
+### 2.1 Remove legacy `size` attribute acceptance
+- **What:** drop the `size` → `hx-size` backward-compat shim across all components
+  (the 10 that have it today + the 13 the E1 workstream adds).
+- **3.x shim:** `size` is honored only when `hx-size` is absent, with a DEV-only
+  one-time `devWarn`. `hx-size` always wins.
+- **Migration:** consumers rename `size="…"` → `hx-size="…"` in Twig/HTML.
+- **4.0 action:** delete `applyLegacySizeAlias` + the inline shims + their back-compat
+  tests. Keep `hx-size` only.
+
+---
+
+## 3. Event payloads
+
+### 3.1 Unify single-control change/input detail shape
+- **What:** collapse the intentional `{checked,value}` (boolean controls) vs `{value}`
+  (text controls) vs `{values}` (`hx-checkbox-group`) divergence into one universal
+  envelope.
+- **3.x shim:** all single-value controls already carry `{value}`; additive fields and
+  full `HTMLElementEventMap` typing land in 3.x (E2) so consumers can migrate types
+  early. No field is removed in 3.x.
+- **4.0 action:** standardize the shape (e.g. always `{value, checked?}`), removing the
+  per-family divergence.
+
+---
+
+## 4. Variant enums
+
+### 4.1 Unify `danger` ↔ `error` value naming
+- **What:** pick one canonical error-state value. Today `hx-tag` + button family use
+  `danger`; `hx-alert`/`hx-banner`/`hx-badge` use `error`.
+- **3.x shim:** dual-accept both values (alias → canonical styling) with a DEV warn on
+  the non-canonical one.
+- **Migration:** consumers move to the single canonical value.
+- **4.0 action:** remove the deprecated value from each enum.
+- **Note:** `hx-status-indicator`'s `status` axis (`online|offline|away|busy|unknown`)
+  is intentionally distinct from `variant` and is **not** merged.
+
+---
+
+## 5. Focus architecture
+
+### 5.1 Host-focusable `FocusMixin` mode for dual-mode / composite controls
+- **What:** the components parked from the 3.x FocusMixin adoption — `hx-checkbox`,
+  `hx-switch`, `hx-toggle-button`, `hx-select`, `hx-color-picker`, `hx-combobox`,
+  `hx-date-picker`, `hx-time-picker` — use a deliberate host-focusable or composite
+  model that the current inner-only `FocusMixin` would regress.
+- **Why 4.0:** unifying them requires a `FocusMixin` host-focusable mode that changes
+  observable focus target / tabindex / reflected-attribute state for these components.
+- **3.x posture:** they are **correct as-is**; no shim. Tracked here only so the
+  consistency work is not lost.
+- **4.0 action:** extend `FocusMixin` with a host-focusable mode and migrate the 8.
+
+---
+
+## 6. Component defaults
+
+### 6.1 (Candidate) flip `hx-prose` `sanitize` default to `true`
+- **What:** the 3.x C4 fix adds an opt-in `sanitize` prop defaulting **off** (preserves
+  current upstream-trust behavior). A fail-safe-by-default posture would flip it on.
+- **Why 4.0:** changing a default that alters rendered output for existing consumers is
+  breaking.
+- **3.x shim:** opt-in `sanitize` available now.
+- **4.0 action:** evaluate flipping the default to `true` with an explicit
+  `sanitize="false"` escape hatch.
+
+### 6.2 (Candidate) `hx-phi-field` `strict` mode as default
+- **What:** the 3.x C6 fix adds an opt-in `strict` prop (fail-closed on SSR
+  `data`-attribute exposure) defaulting **off**.
+- **4.0 action:** consider making fail-closed the default.
+
+---
+
+## Appendix A — Out-of-scope platform security backlog
+
+These are **real, verified** findings outside this cycle's scope (the operator scoped
+remediation to the library + downstream distribution, not the internal tooling). They
+are **not** part of 4.0 of the library — they belong to the `apps/` platform and want
+their own remediation cycle. Recorded here so they are not lost.
+
+- **`apps/admin` has no authentication/authorization.** All API routes
+  (`/api/issues`, `/api/libraries/[id]/score`, `/api/tests/run`) are unprotected;
+  the dashboard mutates issues/libraries/test state on an "assume trusted internal"
+  basis with no enforcement.
+- **`apps/admin` test runner spawns child processes over unauthenticated HTTP**
+  (`/api/tests/run` → `child_process.spawn(vitest)`), gated only by `NODE_ENV`.
+  No auth, rate limit, or concurrency control → resource-exhaustion DoS vector.
+- **Filesystem persistence without locking** (`health-history-writer.ts`,
+  `issues-loader.ts` use `writeFileSync` with no atomic write/lock → TOCTOU races).
+- **MCP session/resource leaks** (`mcp-client.ts` — no overall session timeout; hung
+  child processes accumulate).
+- **Silent sync failure** (`syncToMcpHealthHistory()` swallows errors with no logging →
+  MCP consumers see stale scores indefinitely).
+- **Library-registry ID collisions** (kebab-case derivation, no UUID/uniqueness).
+- **MCP error categorization** lacks Transport/Network/Timeout variants.
+
+Suggested owners: `apps/admin` → backend/security; MCP servers → mcp-protocol +
+security. Track as a separate epic.

--- a/scripts/ci/shelf-guard.mjs
+++ b/scripts/ci/shelf-guard.mjs
@@ -1,0 +1,604 @@
+#!/usr/bin/env node
+
+/**
+ * Shelf Guard — HELiX 3.0-shelf enforcement (the H18 + H23 CI gate)
+ *
+ * Enforces the release contract: a breaking public-API change must carry a
+ * `@helixui/library: major` changeset. On the 3.x shelf an *accidental* breaking
+ * change (a removed prop, renamed attribute, dropped method, or narrowed enum
+ * labeled `patch`/`minor`) is blocked at PR time — the gap the audit found
+ * (AUDIT-3x-register.md §1, B1–B3, B5): the breaking-change detector (H18) and
+ * semver validator (H23) existed but ran in NO automated path.
+ *
+ * Detection compares the base-vs-head Custom Elements Manifests directly. It
+ * flags, with high confidence and zero false positives:
+ *   - removed components
+ *   - removed attributes (so an attribute RENAME is caught — the old name is gone)
+ *   - removed public properties, INCLUDING JS-only `attribute: false` props
+ *     (e.g. hx-phi-field.data, hx-tabs.selectedIndex)
+ *   - removed public methods (e.g. hx-dialog.show), a new required parameter, or
+ *     a dropped parameter
+ *   - removed events, and removed event-detail object fields / slots (incl. the
+ *     default slot) / CSS parts / CSS props
+ *   - removed/renamed named public exports AND removed barrel side-effect imports
+ *     (e.g. the token-adoption prelude) — incl. non-component exports (mixins like
+ *     FocusMixin, utilities like ensureDocumentTokens, the HelixElement base
+ *     class) — diffed from the generated barrel (src/index.ts), the package's
+ *     allowlist-gated export surface
+ *   - removed public package subpath exports (package.json `exports`, e.g.
+ *     ./fouc.css, ./custom-elements.json)
+ *   - a settable property made readonly
+ *   - a NARROWED settable type — attribute, settable property, or method
+ *     parameter — for simple top-level unions of literals/identifiers
+ *     (e.g. `'sm' | 'md' | 'lg'` → `'sm' | 'md'`). Widening (adding a `variant`
+ *     value) is additive and passes. Readonly (output-only) properties are not
+ *     narrowing-checked — tightening a value consumers only read is compatible.
+ *
+ * SCOPE / known limitations — by design, NOT defects:
+ *   - Non-component exports are diffed by NAME (removal/rename), not by deep
+ *     signature: the CEM analyzes only `src/components`, so a member/parameter
+ *     change inside a non-component export (a mixin interface, an exported type
+ *     alias, or a HelixAuditController method not inherited by a component) is not
+ *     inspected here. Base-class/mixin members that a component DOES inherit are
+ *     inlined into that component's manifest, so their removal IS caught.
+ *   - Beyond field REMOVAL, it does not classify type changes INSIDE nested type
+ *     strings (event-detail field type changes, generic type arguments, return
+ *     types) — that needs TypeScript-compiler-level variance analysis
+ *     (input-contravariant vs output-covariant); string heuristics there risk
+ *     false positives that would erode trust in a required gate.
+ * Both are surfaced for human judgement by the informational "CEM API Diff" PR
+ * comment (scripts/cem-diff.js), the react-wrapper-drift gate, type-check, and
+ * review; any outright removal is still caught above.
+ *
+ * Why not wire the H18/H23 hooks directly: they gate on git-STAGED files and read
+ * the previous CEM from HEAD (a commit-time model). On a PR runner nothing is
+ * staged and HEAD is the merge commit, so a naive wiring no-ops. This gate
+ * compares two explicitly-generated CEM files instead.
+ *
+ * Usage:
+ *   node scripts/ci/shelf-guard.mjs --base-cem <b.json> --head-cem <h.json> \
+ *     [--base-barrel <b.ts> --head-barrel <h.ts>] [--base-pkg <b.json> --head-pkg <h.json>] \
+ *     [--changesets <dir>] [--base-ref <ref>] [--label-bypass]
+ *
+ * Exit codes:
+ *   0 — no breaking changes, OR declared `@helixui/library: major`, OR an explicit
+ *       `breaking-change-approved` label bypass.
+ *   1 — breaking public-API change(s) without a major library changeset.
+ *   2 — usage / IO error.
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const LIBRARY_PKG = '@helixui/library';
+
+// ── CLI args ────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+function getArg(flag) {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : null;
+}
+const baseCemPath = getArg('--base-cem');
+const headCemPath = getArg('--head-cem');
+// Generated barrels (src/index.ts) — the package's allowlist-gated named-export
+// surface. Optional; when both are given, removed public exports are flagged.
+const baseBarrelPath = getArg('--base-barrel');
+const headBarrelPath = getArg('--head-barrel');
+// package.json snapshots — to diff the public subpath `exports` map. Optional.
+const basePkgPath = getArg('--base-pkg');
+const headPkgPath = getArg('--head-pkg');
+const changesetsDir = getArg('--changesets') ?? '.changeset';
+// Base ref to scope changeset discovery to THIS PR (so a pre-existing/queued
+// changeset on the base branch can't satisfy the gate for a new change).
+const baseRef = getArg('--base-ref');
+const labelBypass = args.includes('--label-bypass');
+
+if (!baseCemPath || !headCemPath) {
+  console.error('::error::shelf-guard: --base-cem and --head-cem are required');
+  console.error(
+    'Usage: shelf-guard.mjs --base-cem <base.json> --head-cem <head.json> [--changesets <dir>] [--base-ref <ref>] [--label-bypass]',
+  );
+  process.exit(2);
+}
+
+function readCem(path) {
+  try {
+    return JSON.parse(readFileSync(resolve(path), 'utf8'));
+  } catch (err) {
+    console.error(`::error::shelf-guard: failed to read CEM at ${path}: ${err.message}`);
+    process.exit(2);
+  }
+}
+
+/**
+ * Parse a generated barrel (src/index.ts) into its value and type export name
+ * sets — `export { … } from` (values, plus inline `type X` → types) and
+ * `export type { … } from` (types). The barrel uses no `export *`. This is the
+ * package's true, allowlist-gated public export surface: it includes
+ * non-component exports (FocusMixin, ensureDocumentTokens, HelixElement) and
+ * excludes internal helpers. Tracking the value/type KIND matters: demoting a
+ * value export to type-only breaks runtime consumers.
+ */
+function barrelExports(path) {
+  let src;
+  try {
+    src = readFileSync(resolve(path), 'utf8');
+  } catch (err) {
+    console.error(`::error::shelf-guard: failed to read barrel at ${path}: ${err.message}`);
+    process.exit(2);
+  }
+  const values = new Set();
+  const types = new Set();
+  // Side-effect imports (`import './x.js';`, no binding) are part of the runtime
+  // contract — e.g. the token-adoption prelude; dropping one breaks consumers.
+  const sideEffects = new Set();
+  const seRe = /^\s*import\s+['"]([^'"]+)['"]\s*;?\s*$/gm;
+  let s;
+  while ((s = seRe.exec(src))) sideEffects.add(s[1]);
+  const re = /export\s+(type\s+)?\{([^}]*)\}\s*from/g;
+  let m;
+  while ((m = re.exec(src))) {
+    const allType = Boolean(m[1]); // `export type { … }`
+    for (let entry of m[2].split(',')) {
+      entry = entry.trim();
+      if (!entry) continue;
+      // Inline `type Foo` is type-only even inside a value `export { … }`.
+      let isType = allType;
+      if (/^type\s+/.test(entry)) {
+        isType = true;
+        entry = entry.replace(/^type\s+/, '');
+      }
+      const parts = entry.split(/\s+as\s+/); // `X as Y` exports Y
+      const name = parts[parts.length - 1].trim();
+      if (name) (isType ? types : values).add(name);
+    }
+  }
+  return { values, types, sideEffects };
+}
+
+/** Set of public subpath keys from a package.json `exports` map. */
+function pkgExportKeys(path) {
+  let pkg;
+  try {
+    pkg = JSON.parse(readFileSync(resolve(path), 'utf8'));
+  } catch (err) {
+    console.error(`::error::shelf-guard: failed to read package.json at ${path}: ${err.message}`);
+    process.exit(2);
+  }
+  const exp = pkg.exports;
+  if (!exp || typeof exp === 'string') return new Set(['.']);
+  return new Set(Object.keys(exp));
+}
+
+// ── CEM comparison ──────────────────────────────────────────────────────────
+
+/** Map tagName -> custom-element declaration. */
+function componentMap(cem) {
+  const map = new Map();
+  for (const mod of cem.modules ?? []) {
+    for (const decl of mod.declarations ?? []) {
+      if (decl.tagName) map.set(decl.tagName, decl);
+    }
+  }
+  return map;
+}
+
+/**
+ * Map item.name -> item for any named CEM array. The default (unnamed) slot is
+ * represented with a null/empty name in the CEM (hx-button, hx-dialog, hx-tabs,
+ * …); it is keyed on '' so its removal is still detected.
+ */
+function byName(arr) {
+  const map = new Map();
+  for (const item of arr ?? []) if (item) map.set(item.name ?? '', item);
+  return map;
+}
+
+// Public = not private/protected and not underscore-prefixed (the CEM marks
+// HELiX's protected lifecycle hooks both ways; either signal excludes them).
+const isPublic = (m) =>
+  m && m.privacy !== 'private' && m.privacy !== 'protected' && !String(m.name).startsWith('_');
+
+const publicFields = (decl) =>
+  byName((decl.members ?? []).filter((m) => m.kind === 'field' && isPublic(m)));
+const publicMethods = (decl) =>
+  byName((decl.members ?? []).filter((m) => m.kind === 'method' && isPublic(m)));
+
+const typeText = (x) => x?.type?.text ?? '';
+
+/** Depth-aware split of a type string into top-level union members. */
+function splitUnion(text) {
+  const parts = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of String(text)) {
+    if (ch === '<' || ch === '(' || ch === '{' || ch === '[') depth++;
+    else if (ch === '>' || ch === ')' || ch === '}' || ch === ']') depth--;
+    if (depth === 0 && ch === '|') {
+      if (cur.trim()) parts.push(cur.trim());
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.trim()) parts.push(cur.trim());
+  return parts;
+}
+
+/**
+ * Field names of the outermost object literal in a type string, or null if there
+ * is none. Used for event-detail payloads (e.g. `CustomEvent<{value, date}>`).
+ * Optionality and field types are intentionally ignored — see the events check.
+ */
+function objectFieldNames(text) {
+  const t = String(text);
+  const start = t.indexOf('{');
+  const end = t.lastIndexOf('}');
+  if (start === -1 || end <= start) return null;
+  const names = new Set();
+  for (const field of splitTopLevelChars(t.slice(start + 1, end), [';', ','])) {
+    const idx = topLevelColon(field);
+    if (idx === -1) continue; // index/call signature — skip
+    const name = field.slice(0, idx).trim().replace(/\?$/, '').trim();
+    if (name) names.add(name);
+  }
+  return names.size ? names : null;
+}
+
+/** Split on top-level occurrences of any char in `seps`, respecting nesting. */
+function splitTopLevelChars(text, seps) {
+  const sep = new Set(seps);
+  const parts = [];
+  let depth = 0;
+  let cur = '';
+  for (const ch of String(text)) {
+    if (ch === '<' || ch === '(' || ch === '{' || ch === '[') depth++;
+    else if (ch === '>' || ch === ')' || ch === '}' || ch === ']') depth--;
+    if (depth === 0 && sep.has(ch)) {
+      if (cur.trim()) parts.push(cur.trim());
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  if (cur.trim()) parts.push(cur.trim());
+  return parts;
+}
+
+/** Index of the first top-level `:`, else -1. */
+function topLevelColon(text) {
+  let depth = 0;
+  for (let i = 0; i < text.length; i++) {
+    const c = text[i];
+    if (c === '<' || c === '(' || c === '{' || c === '[') depth++;
+    else if (c === '>' || c === ')' || c === '}' || c === ']') depth--;
+    else if (depth === 0 && c === ':') return i;
+  }
+  return -1;
+}
+
+// A leaf `base` is still accepted by leaf `head` when head is strictly wider:
+// `unknown`/`any` accept everything; a primitive accepts its own literals.
+const isLeafWidening = (b, h) => {
+  if (h === 'unknown' || h === 'any') return true;
+  if (h === 'string' && /^(['"]).*['"]$/.test(b)) return true;
+  if (h === 'number' && /^-?[\d.]/.test(b)) return true;
+  if (h === 'boolean' && (b === 'true' || b === 'false')) return true;
+  return false;
+};
+
+/**
+ * Breaking iff an INPUT type (attribute / settable property / method parameter)
+ * NARROWS — the head no longer accepts a value the base did. Applied only to
+ * SIMPLE top-level unions of literals/identifiers, where narrowing is
+ * unambiguous; widening is additive. Nested/complex types are out of scope (see
+ * the header scope note) and are treated as non-breaking here.
+ */
+const NARROWING_PRIMS = new Set([
+  'string',
+  'number',
+  'boolean',
+  'null',
+  'undefined',
+  'void',
+  'never',
+  'unknown',
+  'any',
+  'object',
+  'symbol',
+  'bigint',
+  'true',
+  'false',
+]);
+// A member is comparable only if it is a primitive or a literal — NOT a bare
+// type-alias identifier (e.g. `ButtonVariant`), which the CEM string can't
+// expand, so extracting a union into a named alias must not read as narrowing.
+const isResolvable = (m) =>
+  NARROWING_PRIMS.has(m) || /^(['"]).*['"]$/.test(m) || /^-?[\d.]/.test(m);
+
+function isInputNarrowing(baseT, headT) {
+  const b = String(baseT ?? '').trim();
+  const h = String(headT ?? '').trim();
+  if (b === h || !b || !h) return false;
+  const bU = splitUnion(b);
+  const hU = splitUnion(h);
+  const simple = (arr) => arr.every((m) => !/[<>(){}[\];|&]/.test(m));
+  if (!simple(bU) || !simple(hU)) return false;
+  if (!bU.every(isResolvable) || !hU.every(isResolvable)) return false;
+  const head = new Set(hU);
+  return bU.some((m) => !head.has(m) && !hU.some((hm) => isLeafWidening(m, hm)));
+}
+
+/**
+ * Compare base vs head CEM and return a flat list of breaking-change
+ * descriptions. See the header for the precise, intentionally-bounded scope.
+ */
+function detectBreaking(baseCem, headCem) {
+  const out = [];
+  const base = componentMap(baseCem);
+  const head = componentMap(headCem);
+
+  for (const tag of base.keys()) {
+    if (!head.has(tag)) out.push(`${tag}: component removed`);
+  }
+
+  for (const [tag, headDecl] of head) {
+    const baseDecl = base.get(tag);
+    if (!baseDecl) continue; // new component — additive
+
+    // Removal-only named surfaces.
+    for (const [arr, label] of [
+      ['slots', 'slot'],
+      ['cssParts', 'CSS part'],
+      ['cssProperties', 'CSS custom property'],
+    ]) {
+      const b = byName(baseDecl[arr]);
+      const h = byName(headDecl[arr]);
+      for (const name of b.keys()) {
+        if (!h.has(name)) out.push(`${tag}: removed ${label} \`${name || '(default)'}\``);
+      }
+    }
+
+    // Events (output / covariant). A removed event is breaking; so is a removed
+    // event-detail FIELD (a reader loses it). Field ADDITIONS and field-type
+    // changes are NOT classified: additions are additive for readers, and an
+    // output narrowing is consumer-compatible while a widening would need full
+    // variance analysis (see the header scope note) — those are surfaced by the
+    // informational CEM diff. Field removal is checked only when BOTH details are
+    // object literals, so extracting a detail into a named type is not flagged.
+    {
+      const b = byName(baseDecl.events);
+      const h = byName(headDecl.events);
+      for (const [name, be] of b) {
+        const he = h.get(name);
+        if (!he) {
+          out.push(`${tag}: removed event \`${name}\``);
+          continue;
+        }
+        const bf = objectFieldNames(typeText(be));
+        const hf = objectFieldNames(typeText(he));
+        if (bf && hf) {
+          for (const f of bf) {
+            if (!hf.has(f)) out.push(`${tag}: event \`${name}\` detail field \`${f}\` removed`);
+          }
+        }
+      }
+    }
+
+    // Attributes (input) — removal (catches renames) + narrowing.
+    {
+      const b = byName(baseDecl.attributes);
+      const h = byName(headDecl.attributes);
+      for (const [name, ba] of b) {
+        const ha = h.get(name);
+        if (!ha) out.push(`${tag}: removed attribute \`${name}\``);
+        else if (isInputNarrowing(typeText(ba), typeText(ha)))
+          out.push(
+            `${tag}: attribute \`${name}\` type narrowed (\`${typeText(ba)}\` → \`${typeText(ha)}\`)`,
+          );
+      }
+    }
+
+    // Public properties (incl. JS-only attribute:false). Removal is breaking.
+    // Narrowing is breaking only for SETTABLE props — a readonly (output-only)
+    // property can narrow its value type compatibly; making a settable property
+    // readonly is breaking (consumers can no longer set it).
+    {
+      const b = publicFields(baseDecl);
+      const h = publicFields(headDecl);
+      for (const [name, bf] of b) {
+        const hf = h.get(name);
+        if (!hf) {
+          out.push(`${tag}: removed property \`${name}\``);
+          continue;
+        }
+        if (bf.readonly) continue; // output-only — narrowing is consumer-compatible
+        if (hf.readonly) out.push(`${tag}: property \`${name}\` became readonly`);
+        else if (isInputNarrowing(typeText(bf), typeText(hf)))
+          out.push(
+            `${tag}: property \`${name}\` type narrowed (\`${typeText(bf)}\` → \`${typeText(hf)}\`)`,
+          );
+      }
+    }
+
+    // Public methods — removal, arity tightening, parameter narrowing.
+    {
+      const b = publicMethods(baseDecl);
+      const h = publicMethods(headDecl);
+      const requiredCount = (m) => (m.parameters ?? []).filter((p) => !p.optional).length;
+      for (const [name, bm] of b) {
+        const hm = h.get(name);
+        if (!hm) {
+          out.push(`${tag}: removed method \`${name}\``);
+          continue;
+        }
+        const bp = bm.parameters ?? [];
+        const hp = hm.parameters ?? [];
+        if (requiredCount(hm) > requiredCount(bm)) {
+          out.push(
+            `${tag}: method \`${name}\` now requires more parameters (${requiredCount(bm)} → ${requiredCount(hm)})`,
+          );
+        }
+        if (bp.length > hp.length) {
+          out.push(`${tag}: method \`${name}\` dropped a parameter (${bp.length} → ${hp.length})`);
+        }
+        for (let i = 0; i < Math.min(bp.length, hp.length); i++) {
+          if (isInputNarrowing(typeText(bp[i]), typeText(hp[i]))) {
+            out.push(
+              `${tag}: method \`${name}\` parameter \`${hp[i].name ?? i}\` type narrowed (\`${typeText(bp[i])}\` → \`${typeText(hp[i])}\`)`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return out;
+}
+
+const breaking = detectBreaking(readCem(baseCemPath), readCem(headCemPath));
+
+// Named public exports (from the barrel). A removed value export breaks runtime
+// consumers — and demoting a value export to type-only is the same break. A
+// removed type export breaks type consumers unless the name still exists as a
+// value (which `import type` resolves). Promoting type→value, or adding either,
+// is additive.
+if (baseBarrelPath && headBarrelPath) {
+  const base = barrelExports(baseBarrelPath);
+  const head = barrelExports(headBarrelPath);
+  for (const name of base.values) {
+    if (!head.values.has(name)) breaking.push(`removed value export \`${name}\``);
+  }
+  for (const name of base.types) {
+    if (!head.types.has(name) && !head.values.has(name))
+      breaking.push(`removed type export \`${name}\``);
+  }
+  for (const se of base.sideEffects) {
+    if (!head.sideEffects.has(se)) breaking.push(`removed barrel side-effect import \`${se}\``);
+  }
+}
+
+// Public package subpath exports (package.json `exports`). Removing or renaming a
+// subpath (e.g. ./fouc.css, ./custom-elements.json) breaks consumers importing it.
+if (basePkgPath && headPkgPath) {
+  const baseKeys = pkgExportKeys(basePkgPath);
+  const headKeys = pkgExportKeys(headPkgPath);
+  for (const k of baseKeys) {
+    if (!headKeys.has(k)) breaking.push(`removed package export subpath \`${k}\``);
+  }
+}
+
+// ── No breaking changes → the shelf holds ───────────────────────────────────
+
+if (breaking.length === 0) {
+  console.log('✓ shelf-guard: no breaking public-API changes detected. 3.0 shelf intact.');
+  process.exit(0);
+}
+
+// ── Breaking changes detected → require a major library changeset ────────────
+
+/**
+ * The changeset `.md` files INTRODUCED by this PR. With a base ref we diff
+ * against it (three-dot, i.e. since the merge-base) so a pre-existing/queued
+ * changeset on the base branch can't satisfy the gate for a NEW breaking change.
+ * Falls back to every changeset in the directory if git is unavailable.
+ */
+function prChangesetFiles(dir, base) {
+  if (base) {
+    try {
+      const out = execFileSync(
+        'git',
+        ['diff', '--name-only', '--diff-filter=AM', `${base}...HEAD`, '--', dir],
+        { encoding: 'utf8' },
+      );
+      return out
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.endsWith('.md') && !l.endsWith('/README.md'));
+    } catch (err) {
+      console.error(
+        `::warning::shelf-guard: could not diff changesets against ${base} (${err.message}); scanning all changesets in ${dir}.`,
+      );
+    }
+  }
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.md') && f !== 'README.md')
+    .map((f) => join(dir, f));
+}
+
+/**
+ * Highest bump this PR's changesets declare specifically for @helixui/library
+ * (the package whose CEM produced the breaking diff). Package-specific: a `major`
+ * on some OTHER package does not satisfy the gate. Frontmatter is the standard
+ * changesets format:
+ *   ---
+ *   '@helixui/library': major
+ *   ---
+ */
+function libraryBump(files) {
+  const order = { patch: 0, minor: 1, major: 2 };
+  let best = null;
+  for (const file of files) {
+    let content;
+    try {
+      content = readFileSync(file, 'utf8').replace(/\r\n/g, '\n'); // tolerate CRLF
+    } catch {
+      continue;
+    }
+    const fm = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!fm) continue;
+    for (const line of fm[1].split('\n')) {
+      const m = line.match(/^\s*['"]?([^'":]+?)['"]?\s*:\s*(major|minor|patch)\s*$/);
+      if (!m || m[1].trim() !== LIBRARY_PKG) continue;
+      const bump = m[2];
+      if (best === null || order[bump] > order[best]) best = bump;
+    }
+  }
+  return best;
+}
+
+const bump = libraryBump(prChangesetFiles(changesetsDir, baseRef));
+
+console.error('::group::Breaking public-API changes detected');
+for (const line of breaking) console.error(`  • ${line}`);
+console.error('::endgroup::');
+
+if (bump === 'major') {
+  console.log(
+    `✓ shelf-guard: ${breaking.length} breaking change(s) detected AND this PR declares \`${LIBRARY_PKG}: major\`.`,
+  );
+  console.log(
+    '::warning::This PR declares a MAJOR (4.0) release. Confirm this is intentional — the 3.0 shelf is being broken on purpose.',
+  );
+  process.exit(0);
+}
+
+if (labelBypass) {
+  console.log(
+    `✓ shelf-guard: ${breaking.length} breaking change(s) detected but overridden by the \`breaking-change-approved\` label.`,
+  );
+  console.log(
+    '::warning::Breaking-change gate bypassed by label. Ensure a 4.0 backlog entry exists.',
+  );
+  process.exit(0);
+}
+
+console.error(
+  `::error::3.0 shelf violated — ${breaking.length} breaking public-API change(s) without a \`${LIBRARY_PKG}: major\` changeset (this PR declares for ${LIBRARY_PKG}: ${bump ?? 'no bump'}).`,
+);
+console.error('');
+console.error('Resolve one of these ways:');
+console.error(
+  '  1. Make the change non-breaking (add a compat shim / dual-name alias — see docs/audit/BREAKING-CHANGES-4.0.md), OR',
+);
+console.error(
+  `  2. If this is deliberate 4.0 work, set this PR's changeset to \`${LIBRARY_PKG}: major\`, OR`,
+);
+console.error(
+  '  3. For a documented false-positive, add the `breaking-change-approved` PR label, then',
+);
+console.error('     re-run this job (a label change does not by itself re-trigger CI).');
+process.exit(1);


### PR DESCRIPTION
## What

Adds a **required, blocking** `api-breaking-change` CI gate (in both `ci.yml` and
`audit-batch-ci.yml`) backed by a new `scripts/ci/shelf-guard.mjs`, plus the deep-audit
deliverables (`docs/audit/AUDIT-3x-register.md`, `docs/audit/BREAKING-CHANGES-4.0.md`).

The gate fails any PR that introduces a breaking public-API change without a
`@helixui/library: major` changeset — holding the **3.0 shelf**.

## Why

Audit finding #1 (see the register): the 3.0 shelf was **not enforced by any
automation**. The breaking-change detector (H18) and semver validator (H23) existed but
ran in *zero* automated paths — not CI, not preflight, not the active husky hook. The
"Changeset Required" gate only checks a changeset *exists*, never that its bump matches
the API delta. A deleted prop labeled `patch` would publish as a 3.x patch.

H18/H23 gate on git-staged files vs HEAD (a commit-time model that no-ops on PR
runners), so rather than wire them, this drives a direct **base-vs-head** comparison of
the public-API surface.

## What it catches (zero false positives across ~50 validation scenarios)

- **Component API (CEM):** removed component / attribute / property (incl. JS-only
  `attribute:false`) / method / event / slot (incl. default) / CSS part / CSS prop;
  attribute renames; method arity tightening + parameter narrowing; settable-type
  narrowing (widening stays additive); writable→readonly; removed event-detail fields.
- **Named exports (barrel `src/index.ts`):** removed value/type exports (kind-aware —
  a value→type demotion is breaking), removed side-effect imports (e.g. the
  token-adoption prelude).
- **Package surface:** removed `package.json` subpath exports (`./fouc.css`, etc.).
- **Changeset enforcement:** package-specific, PR-scoped (diffs against the base ref so a
  pre-existing changeset can't satisfy it), CRLF-tolerant. `breaking-change-approved`
  label bypass for documented false-positives.

Runs on every PR (no path guard to bypass) and is mirrored into the audit-batch
workflow. Base CEM/barrel are regenerated from base source + analyzer config + plugins +
generator + tsconfig, analyze-only, with a fail-loud base-ref check.

## Documented limitations (backstopped by type-check + the informational CEM API Diff comment + review)

- Deep **signatures** of non-component exports (mixin interfaces, exported type aliases,
  helper signatures) are diffed by name, not signature — that needs api-extractor-level
  modeling.
- Type changes *inside* nested type strings (event-detail field types, generics) are not
  variance-classified.
- A few niche cases (config-only glob changes, front-inserted optional params, export
  *condition* changes) are out of scope for the same reason.

## Validation

`agent-verify` green (format / lint / type-check / test:smart). Hardened through 14
rounds of `rea hook codex-review`. The gate is proven end-to-end: removing the real
`hx-accordion-item.expanded` property fails with a patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced release integrity with automated breaking API change detection and enforcement in pull request and batch workflows
  * Enforced major version requirement to accompany any breaking API changes

* **Documentation**
  * Added audit register documenting framework assessment scope and prioritized remediation workstreams
  * Added breaking-changes guide for future version planning and reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->