### PR TITLE
feat(hx-icon): add Feather and Lucide icon libraries (stroke-paint)

### DIFF
--- a/.changeset/feather-lucide-stroke-icons.md
+++ b/.changeset/feather-lucide-stroke-icons.md
@@ -1,0 +1,25 @@
+---
+'@helixui/library': minor
+'@helixui/icons': minor
+---
+
+feat(hx-icon): add Feather and Lucide icon libraries with stroke-paint rendering
+
+Registers `feather` (287 glyphs, MIT) and `lucide` (~1,986 glyphs, ISC) as built-in
+stroke-paint icon libraries in `@helixui/icons`, shipped as CDN sprite sheets
+(`dist/feather.svg`, `dist/lucide.svg`) and per-icon tree-shake modules
+(`@helixui/icons/tree-shake/feather/*`, `.../lucide/*`).
+
+`<hx-icon>` now reflects the resolved library's `paintMode` onto the rendered SVG and
+paints stroke libraries with `fill: none; stroke: currentColor` and rounded caps/joins,
+with stroke width driven by the existing `--hx-icon-stroke-width` token. Fill libraries
+(`helix`, `fa-free`) are unchanged.
+
+```html
+<hx-icon library="feather" name="activity" label="Activity"></hx-icon>
+<hx-icon library="lucide" name="heart" label="Favorite"></hx-icon>
+```
+
+Also hardens `<hx-icon>`: icon-library mutator output is now re-sanitized before render,
+so a compromised or hostile library mutator cannot reintroduce `<script>`, `on*`
+handlers, or `javascript:` payloads that the first sanitization pass stripped.

--- a/.changeset/feather-lucide-stroke-icons.md
+++ b/.changeset/feather-lucide-stroke-icons.md
@@ -11,9 +11,10 @@ stroke-paint icon libraries in `@helixui/icons`, shipped as CDN sprite sheets
 (`@helixui/icons/tree-shake/feather/*`, `.../lucide/*`).
 
 `<hx-icon>` now reflects the resolved library's `paintMode` onto the rendered SVG and
-paints stroke libraries with `fill: none; stroke: currentColor` and rounded caps/joins,
-with stroke width driven by the existing `--hx-icon-stroke-width` token. Fill libraries
-(`helix`, `fa-free`) are unchanged.
+paints stroke libraries with `fill: none; stroke: currentColor`, with stroke width
+driven by the existing `--hx-icon-stroke-width` token. Line caps and joins are not
+imposed by the component — each glyph carries its own caps/joins in its library's
+source geometry. Fill libraries (`helix`, `fa-free`) are unchanged.
 
 ```html
 <hx-icon library="feather" name="activity" label="Activity"></hx-icon>

--- a/packages/hx-icons/AAA-VERDICT.md
+++ b/packages/hx-icons/AAA-VERDICT.md
@@ -106,6 +106,47 @@ library (designed for the 12px `xs` cell).
 
 ---
 
+## Library: `feather`
+
+| Dimension       | Verdict | Notes                                                                                       |
+| --------------- | ------- | ------------------------------------------------------------------------------------------- |
+| `contrast`      | unknown | Stroke-paint outlines; non-text contrast depends on render size and `--hx-icon-stroke-width`. Unmeasured pending a formal `pnpm aaa:audit` pass. |
+| `forcedColors`  | pass    | Every glyph paints with `stroke="currentColor"` (→ CanvasText under forced-colors) and hardcodes no color. |
+| `opticalSizing` | unknown | Thin strokes at small render sizes / sub-default `--hx-icon-stroke-width` are unmeasured pending a formal audit. |
+
+**Paint mode:** `stroke`
+**Total glyphs:** 287 (`feather-icons@4.29.2`)
+**Sprite sheet:** `packages/hx-icons/dist/feather.svg`
+**License / attribution:** MIT (© Cole Bemis) — see [`NOTICE.md`](./NOTICE.md).
+
+`contrast` and `opticalSizing` are `'unknown'` (not `'fail'`): at the default
+2px stroke (`--hx-icon-stroke-width`) and `hx-size="md"` (24px) render they are
+expected to clear 3:1, but a thinner stroke override or a sub-minimum render
+size can drop a stroke glyph below non-text contrast, so no measured `'pass'`
+is claimed until the formal harness runs. Mirrors `src/aaa.ts`.
+
+---
+
+## Library: `lucide`
+
+| Dimension       | Verdict | Notes                                                                                       |
+| --------------- | ------- | ------------------------------------------------------------------------------------------- |
+| `contrast`      | unknown | Stroke-paint outlines; non-text contrast depends on render size and `--hx-icon-stroke-width`. Unmeasured pending a formal `pnpm aaa:audit` pass. |
+| `forcedColors`  | pass    | Every glyph paints with `stroke="currentColor"` (→ CanvasText under forced-colors) and hardcodes no color. |
+| `opticalSizing` | unknown | Thin strokes at small render sizes / sub-default `--hx-icon-stroke-width` are unmeasured pending a formal audit. |
+
+**Paint mode:** `stroke`
+**Total glyphs:** ~1,986 (`lucide-static@1.21.0`)
+**Sprite sheet:** `packages/hx-icons/dist/lucide.svg`
+**License / attribution:** ISC (© Lucide Icons and Contributors) — see [`NOTICE.md`](./NOTICE.md).
+
+`contrast` and `opticalSizing` are `'unknown'` (not `'fail'`) for the same
+reason as `feather`: the default 2px stroke at `hx-size="md"` is expected to
+clear 3:1, but a thinner stroke or smaller render size is unmeasured. Mirrors
+`src/aaa.ts`.
+
+---
+
 ## Consumer library obligation
 
 A consumer registering a custom library via `registerIconLibrary()`
@@ -133,8 +174,9 @@ full consumer recipe.
 
 This per-library verdict is invalidated when:
 
-- The library's sprite sheet (`dist/helix.svg`, `dist/fa-free-solid.svg`)
-  is regenerated from a different source set.
+- The library's sprite sheet (`dist/helix.svg`, `dist/fa-free-solid.svg`,
+  `dist/feather.svg`, `dist/lucide.svg`) is regenerated from a different
+  source set.
 - A new glyph is added that has not been measured by the harness.
 - The minimum render-size cell of `<hx-icon>` changes.
 - The semantic icon color cascade (`--hx-icon-color`,

--- a/packages/hx-icons/NOTICE.md
+++ b/packages/hx-icons/NOTICE.md
@@ -17,6 +17,38 @@ The `fa-free` library resolves through the pre-built sprite at
 To use FA Pro Medical or any other Font Awesome paid tier, register a custom
 library — see `apps/docs/src/content/docs/icons/fa-pro.mdx`.
 
+## Feather Icons (bundled as `feather` library)
+
+- **Version**: `feather-icons@4.29.2`
+- **Glyphs bundled**: 287
+- **License**: MIT — https://opensource.org/license/mit
+  - SPDX-License-Identifier: `MIT`
+  - Copyright (c) 2013-2023 Cole Bemis
+  - Upstream project: Feather Icons — https://github.com/feathericons/feather
+
+The `feather` library resolves through the pre-built sprite at
+`dist/feather.svg`, generated at build time from the upstream package. Feather
+glyphs are stroke-paint outlines (`paintMode: 'stroke'`); the bundled sprite
+redistributes their glyph geometry, which is what makes the MIT attribution
+above legally required.
+
+## Lucide (bundled as `lucide` library)
+
+- **Version**: `lucide-static@1.21.0`
+- **Glyphs bundled**: ~1,986
+- **License**: ISC — https://opensource.org/license/isc-license-txt
+  - SPDX-License-Identifier: `ISC`
+  - Copyright (c) 2026 Lucide Icons and Contributors
+  - Upstream project: Lucide — https://github.com/lucide-icons/lucide
+
+The `lucide` library resolves through the pre-built sprite at `dist/lucide.svg`,
+generated at build time from the upstream package. Lucide glyphs are stroke-paint
+outlines (`paintMode: 'stroke'`); the bundled sprite redistributes their glyph
+geometry, which is what makes the ISC attribution above legally required. A
+subset of Lucide glyphs are derived from the Feather project and carry Feather's
+MIT terms (Copyright (c) 2013-present Cole Bemis); see the upstream
+`lucide-static` LICENSE file for the per-glyph list.
+
 ## Helix glyphs (bundled as `helix` library)
 
 The HELiX `helix` library glyphs are **original work** drawn for this project,
@@ -30,7 +62,7 @@ for the helix coordinate system. No upstream SVG markup is copied verbatim.
 
 ## Build-time only dependencies
 
-The published package does **not** depend on `@fortawesome/fontawesome-free`
-at runtime. The dependency is `devDependencies`-only; sprites and tree-shake
-exports are generated during `pnpm run build` and shipped pre-rendered in
-`dist/`.
+The published package does **not** depend on `@fortawesome/fontawesome-free`,
+`feather-icons`, or `lucide-static` at runtime. They are `devDependencies`-only;
+sprites and tree-shake exports are generated during `pnpm run build` and shipped
+pre-rendered in `dist/`.

--- a/packages/hx-icons/README.md
+++ b/packages/hx-icons/README.md
@@ -18,8 +18,9 @@ web component library.
 `<hx-icon>` is purely a renderer. Resolving icon names to SVG payloads is
 delegated to a registry of named libraries. This separation lets consumers:
 
-- Use the bundled `helix` (original glyphs, MIT) and `fa-free` (Font Awesome
-  Free Solid v7, CC BY 4.0) libraries out of the box.
+- Use the bundled `helix` (original glyphs, MIT), `fa-free` (Font Awesome
+  Free Solid v7, CC BY 4.0), `feather` (Feather Icons, MIT), and `lucide`
+  (Lucide, ISC) libraries out of the box.
 - Register custom libraries — e.g. Font Awesome Pro Medical — without
   modifying or rebuilding `@helixui/library`.
 - Tree-shake to a single icon when bundle budget matters
@@ -31,19 +32,41 @@ without translation.
 
 ## Bundled libraries
 
-Importing the package triggers auto-registration of two libraries:
+Importing the package triggers auto-registration of four libraries:
 
-| Library    | Glyphs | Source                                     | License    |
-| ---------- | ------ | ------------------------------------------ | ---------- |
-| `helix`    | 32     | Original HELiX glyphs                      | MIT        |
-| `fa-free`  | 1900+  | Font Awesome Free Solid v7.x (Fonticons)   | CC BY 4.0  |
+| Library   | Glyphs | Source                                   | License   | Paint    |
+| --------- | ------ | ---------------------------------------- | --------- | -------- |
+| `helix`   | 32     | Original HELiX glyphs                    | MIT       | `fill`   |
+| `fa-free` | 1900+  | Font Awesome Free Solid v7.x (Fonticons) | CC BY 4.0 | `fill`   |
+| `feather` | 287    | Feather Icons (Cole Bemis)               | MIT       | `stroke` |
+| `lucide`  | ~1986  | Lucide (Lucide Contributors)             | ISC       | `stroke` |
 
-Both ship with `paintMode: 'fill'` and `spriteSheet: true` — they resolve
-through pre-built sprite sheets in the package's `dist/`.
+All four set `spriteSheet: true` — they resolve through pre-built sprite sheets
+in the package's `dist/`. `helix` and `fa-free` are `paintMode: 'fill'` solid
+silhouettes; `feather` and `lucide` are `paintMode: 'stroke'` outlines (see
+[paintMode](#paintmode) below).
 
 ```ts
 import '@helixui/icons';
-// `helix` and `fa-free` are now both registered.
+// `helix`, `fa-free`, `feather`, and `lucide` are now all registered.
+```
+
+```html
+<!-- A stroke-paint glyph from each new library -->
+<hx-icon library="feather" name="activity"></hx-icon>
+<hx-icon library="lucide" name="heart-pulse"></hx-icon>
+```
+
+`feather` and `lucide` glyphs paint with `stroke: currentColor` (no fill) and
+honor the `--hx-icon-stroke-width` token (default `2`):
+
+```html
+<!-- Override the stroke width for a hairline feather glyph -->
+<hx-icon
+  library="feather"
+  name="activity"
+  style="--hx-icon-stroke-width: 1.5;"
+></hx-icon>
 ```
 
 ## Custom libraries
@@ -84,10 +107,27 @@ For bundle-sensitive applications, import a single glyph:
 ```ts
 import { check } from '@helixui/icons/tree-shake/helix/check';
 import { stethoscope } from '@helixui/icons/tree-shake/fa-free/solid/stethoscope';
+import { activity } from '@helixui/icons/tree-shake/feather/activity';
+import { heartPulse } from '@helixui/icons/tree-shake/lucide/heart-pulse';
 ```
 
 Each tree-shake module exports a single `string` constant containing the
 sanitized inline SVG markup.
+
+### Import paths
+
+Every bundled library exposes the same export surface in `package.json`:
+
+| Library   | Library side-effect import | Tree-shake glyph import                | Sprite sheet                       |
+| --------- | -------------------------- | -------------------------------------- | ---------------------------------- |
+| `helix`   | `@helixui/icons/helix`     | `@helixui/icons/tree-shake/helix/*`    | `@helixui/icons/dist/helix.svg`    |
+| `fa-free` | `@helixui/icons/fa-free`   | `@helixui/icons/tree-shake/fa-free/solid/*` | `@helixui/icons/dist/fa-free-solid.svg` |
+| `feather` | `@helixui/icons/feather`   | `@helixui/icons/tree-shake/feather/*`  | `@helixui/icons/dist/feather.svg`  |
+| `lucide`  | `@helixui/icons/lucide`    | `@helixui/icons/tree-shake/lucide/*`   | `@helixui/icons/dist/lucide.svg`   |
+
+Importing a library side-effect module (e.g. `@helixui/icons/feather`)
+registers only that single library — useful when you want `feather` and
+`lucide` without pulling `fa-free` into the bundle.
 
 ## paintMode
 
@@ -95,7 +135,9 @@ sanitized inline SVG markup.
 glyphs are painted:
 
 - `'fill'` — solid silhouettes (default; matches `helix`, `fa-free`)
-- `'stroke'` — outline glyphs (e.g. Lucide, Phosphor Thin)
+- `'stroke'` — outline glyphs painted with `stroke: currentColor` and no fill
+  (matches the bundled `feather` and `lucide`; also e.g. Phosphor Thin). Stroke
+  libraries honor the `--hx-icon-stroke-width` token (default `2`).
 - `'mixed'` — per-glyph fill + stroke (e.g. Phosphor Duotone)
 
 The formal AAA contrast harness measures rendered `<hx-icon>` color/background samples on the
@@ -107,11 +149,12 @@ not from `paintMode` dispatch.
 ## Attribution
 
 Bundled icon libraries carry their own licenses. **Font Awesome Free Solid
-icons are licensed under CC BY 4.0; attribution is required.** See
-[`NOTICE.md`](./NOTICE.md) for the canonical attribution text covering the
+icons are licensed under CC BY 4.0; attribution is required.** `feather` is
+MIT (© Cole Bemis) and `lucide` is ISC (© Lucide Icons and Contributors). See
+[`NOTICE.md`](./NOTICE.md) for the canonical attribution text covering all
 bundled libraries (the file is an attribution / license disclosure, not an
-asset-level inventory — see the `helix` / `fa-free` library directories
-under `dist/` for the actual glyph filenames).
+asset-level inventory — see the per-library directories under `dist/` for the
+actual glyph filenames).
 
 ## License
 

--- a/packages/hx-icons/package.json
+++ b/packages/hx-icons/package.json
@@ -31,12 +31,28 @@
       "import": "./dist/libraries/fa-free.js",
       "default": "./dist/libraries/fa-free.js"
     },
+    "./feather": {
+      "types": "./dist/libraries/feather.d.ts",
+      "import": "./dist/libraries/feather.js",
+      "default": "./dist/libraries/feather.js"
+    },
+    "./lucide": {
+      "types": "./dist/libraries/lucide.d.ts",
+      "import": "./dist/libraries/lucide.js",
+      "default": "./dist/libraries/lucide.js"
+    },
     "./tree-shake/helix": "./dist/tree-shake/helix/index.js",
     "./tree-shake/fa-free/solid": "./dist/tree-shake/fa-free/solid/index.js",
     "./tree-shake/fa-free/solid/*": "./dist/tree-shake/fa-free/solid/*.js",
     "./tree-shake/helix/*": "./dist/tree-shake/helix/*.js",
+    "./tree-shake/feather": "./dist/tree-shake/feather/index.js",
+    "./tree-shake/feather/*": "./dist/tree-shake/feather/*.js",
+    "./tree-shake/lucide": "./dist/tree-shake/lucide/index.js",
+    "./tree-shake/lucide/*": "./dist/tree-shake/lucide/*.js",
     "./dist/helix.svg": "./dist/helix.svg",
-    "./dist/fa-free-solid.svg": "./dist/fa-free-solid.svg"
+    "./dist/fa-free-solid.svg": "./dist/fa-free-solid.svg",
+    "./dist/feather.svg": "./dist/feather.svg",
+    "./dist/lucide.svg": "./dist/lucide.svg"
   },
   "files": [
     "dist",
@@ -80,7 +96,9 @@
   "devDependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",
     "@vitest/coverage-v8": "^4.1.6",
+    "feather-icons": "^4.29.2",
     "linkedom": "^0.18.12",
+    "lucide-static": "^1.21.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3",
     "vitest": "^4.1.6"

--- a/packages/hx-icons/scripts/generate-sprite.ts
+++ b/packages/hx-icons/scripts/generate-sprite.ts
@@ -1,16 +1,20 @@
 /**
- * Sprite-sheet generator for the bundled `helix` and `fa-free` libraries.
+ * Sprite-sheet generator for the bundled `helix`, `fa-free`, `feather`, and
+ * `lucide` libraries.
  *
- * Reads source SVGs from disk, normalizes them (strip ids/classes/styles,
- * force `currentColor` inheritance), wraps each in a `<symbol>` element
- * keyed by file basename, and concatenates all symbols into a single
- * hidden `<svg>` sprite sheet.
+ * Reads source SVGs from disk, normalizes them (strip ids/classes/styles and
+ * own fill/stroke so the host's `currentColor`/paint-mode cascade governs),
+ * wraps each in a `<symbol>` element keyed by file basename, and concatenates
+ * all symbols into a single hidden `<svg>` sprite sheet. `helix`/`fa-free` are
+ * fill glyphs; `feather`/`lucide` are stroke glyphs — the sprite is paint-mode
+ * agnostic (bare geometry), so no per-library handling is needed here.
  *
  * Output:
  *   dist/helix.svg            — sprite for the bundled helix glyph set
  *   dist/fa-free-solid.svg    — sprite for FA Free Solid v7.x
- *   dist/helix-names.json     — sorted array of helix icon names
- *   dist/fa-free-names.json   — sorted array of fa-free icon names
+ *   dist/feather.svg          — sprite for Feather (stroke)
+ *   dist/lucide.svg           — sprite for Lucide (stroke)
+ *   dist/<lib>-names.json     — sorted array of icon names per library
  *
  * Sprites use `<svg style="display:none">` so they can be inlined into
  * the document without affecting layout. Each `<symbol>` carries its
@@ -28,11 +32,21 @@ import { fileURLToPath } from 'node:url';
 
 import { parseHTML } from 'linkedom';
 
+import { sanitizeTree } from './svg-sanitize.js';
+
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, '..');
 const distDir = resolve(packageRoot, 'dist');
 const helixSrcDir = resolve(packageRoot, 'src/libraries/helix-glyphs');
 const faSrcDir = resolve(packageRoot, 'node_modules/@fortawesome/fontawesome-free/svgs/solid');
+// Stroke-paint sets. The sprite keeps each glyph's geometry plus the root
+// <svg>'s line-cap/join (a LIBRARY-specific design choice — Feather/Lucide use
+// round). `fill`/`stroke`/`stroke-width` are inherited and host-driven, so
+// <hx-icon>'s paint-mode CSS + the --hx-icon-stroke-width token supply those at
+// render time; cap/join must stay on the symbol so the component doesn't impose
+// round on every stroke library.
+const featherSrcDir = resolve(packageRoot, 'node_modules/feather-icons/dist/icons');
+const lucideSrcDir = resolve(packageRoot, 'node_modules/lucide-static/icons');
 
 interface Symbol {
   /** Final id used in the sprite (matches consumer-facing name). */
@@ -41,42 +55,12 @@ interface Symbol {
   viewBox: string;
   /** Inner content (children of the source `<svg>`), already sanitized. */
   inner: string;
-}
-
-/**
- * Strip attributes from an element that would either leak into the
- * surrounding document (id, class, style) or fight the host element's
- * `currentColor` cascade (fill, stroke).
- *
- * `aria-*` attributes on the source svg are removed too — `<hx-icon>`
- * applies its own ARIA at the host level. The sprite's `<symbol>`
- * gets fresh accessible attributes from the consumer.
- */
-function sanitizeAttrs(el: Element): void {
-  const removeIfPresent = ['id', 'class', 'style', 'fill', 'stroke'];
-  for (const attr of removeIfPresent) {
-    el.removeAttribute(attr);
-  }
-  // Remove all aria-* attributes by name.
-  const attrNames = el.getAttributeNames();
-  for (const name of attrNames) {
-    if (name.startsWith('aria-')) {
-      el.removeAttribute(name);
-    }
-  }
-}
-
-/**
- * Walk an element tree and sanitize every element. We don't bother
- * preserving comments or processing instructions — sprites should be
- * minimal.
- */
-function sanitizeTree(root: Element): void {
-  sanitizeAttrs(root);
-  const children = Array.from(root.children);
-  for (const child of children) {
-    sanitizeTree(child as Element);
-  }
+  /**
+   * Library-specific paint presentation from the source root `<svg>` that is NOT
+   * supplied by the host's cascade — `stroke-linecap` / `stroke-linejoin`,
+   * serialized as ready-to-emit attributes. Empty for fill libraries.
+   */
+  presentation: string;
 }
 
 /**
@@ -108,6 +92,16 @@ function parseSvgFile(filePath: string, id: string): Symbol | null {
 
   const viewBox = svg.getAttribute('viewBox') ?? '0 0 24 24';
 
+  // Preserve the root <svg>'s line-cap/join — library-specific design choices
+  // (Feather/Lucide use round) that are otherwise lost when the root is dropped
+  // and must NOT be hard-coded generically in <hx-icon>'s stroke CSS.
+  const presentation = ['stroke-linecap', 'stroke-linejoin']
+    .map((attr) => {
+      const value = svg.getAttribute(attr);
+      return value ? ` ${attr}="${value}"` : '';
+    })
+    .join('');
+
   // Sanitize children of the root <svg>. We don't sanitize the <svg>
   // itself because we're throwing it away — only `inner` survives.
   const children = Array.from(svg.children);
@@ -121,7 +115,7 @@ function parseSvgFile(filePath: string, id: string): Symbol | null {
     return null;
   }
 
-  return { id, viewBox, inner };
+  return { id, viewBox, inner, presentation };
 }
 
 /**
@@ -134,7 +128,7 @@ function parseSvgFile(filePath: string, id: string): Symbol | null {
  */
 function buildSprite(symbols: Symbol[]): string {
   const body = symbols
-    .map((s) => `<symbol id="${s.id}" viewBox="${s.viewBox}">${s.inner}</symbol>`)
+    .map((s) => `<symbol id="${s.id}" viewBox="${s.viewBox}"${s.presentation}>${s.inner}</symbol>`)
     .join('');
   return `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="display:none">${body}</svg>`;
 }
@@ -161,7 +155,9 @@ function buildLibrary(
   try {
     entries = readdirSync(srcDir).filter((f) => f.endsWith('.svg'));
   } catch (err) {
-    throw new Error(`[sprite] cannot read source dir ${srcDir}: ${(err as Error).message}`);
+    throw new Error(`[sprite] cannot read source dir ${srcDir}: ${(err as Error).message}`, {
+      cause: err,
+    });
   }
 
   const symbols: Symbol[] = [];
@@ -198,5 +194,20 @@ const faFree = buildLibrary(
   resolve(distDir, 'fa-free-solid.svg'),
   resolve(distDir, 'fa-free-names.json'),
 );
+const feather = buildLibrary(
+  'feather',
+  featherSrcDir,
+  resolve(distDir, 'feather.svg'),
+  resolve(distDir, 'feather-names.json'),
+);
+const lucide = buildLibrary(
+  'lucide',
+  lucideSrcDir,
+  resolve(distDir, 'lucide.svg'),
+  resolve(distDir, 'lucide-names.json'),
+);
 
-console.log(`[sprite] done. helix=${helix.count}, fa-free=${faFree.count}`);
+console.log(
+  `[sprite] done. helix=${helix.count}, fa-free=${faFree.count}, ` +
+    `feather=${feather.count}, lucide=${lucide.count}`,
+);

--- a/packages/hx-icons/scripts/generate-tree-shake.ts
+++ b/packages/hx-icons/scripts/generate-tree-shake.ts
@@ -1,6 +1,6 @@
 /**
- * Tree-shake export generator for the bundled `helix` and `fa-free`
- * libraries.
+ * Tree-shake export generator for the bundled `helix`, `fa-free`, `feather`,
+ * and `lucide` libraries.
  *
  * Emits one ES module per icon (with companion `.d.ts`) containing a
  * single named export holding the inlined, sanitized SVG markup.
@@ -13,6 +13,8 @@
  *   dist/tree-shake/helix/index.js + .d.ts
  *   dist/tree-shake/fa-free/solid/<name>.js + .d.ts
  *   dist/tree-shake/fa-free/solid/index.js + .d.ts
+ *   dist/tree-shake/feather/<name>.js + .d.ts (+ index)
+ *   dist/tree-shake/lucide/<name>.js + .d.ts (+ index)
  *
  * We emit `.js`+`.d.ts` directly rather than `.ts` so the generator
  * isn't dependent on `tsc` running afterwards over `dist/` — `tsc`
@@ -36,11 +38,16 @@ import { fileURLToPath } from 'node:url';
 
 import { parseHTML } from 'linkedom';
 
+import { assignIdentifiers } from './tree-shake-identifiers.js';
+import { sanitizeTree } from './svg-sanitize.js';
+
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, '..');
 const distDir = resolve(packageRoot, 'dist');
 const helixSrcDir = resolve(packageRoot, 'src/libraries/helix-glyphs');
 const faSrcDir = resolve(packageRoot, 'node_modules/@fortawesome/fontawesome-free/svgs/solid');
+const featherSrcDir = resolve(packageRoot, 'node_modules/feather-icons/dist/icons');
+const lucideSrcDir = resolve(packageRoot, 'node_modules/lucide-static/icons');
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
@@ -52,39 +59,10 @@ interface Glyph {
 }
 
 /**
- * Convert kebab-case to a JS-safe camelCase identifier. Names that
- * start with a digit are prefixed with `_` so they remain valid
- * identifiers. FA Free has files like `0.svg` and `360-degrees.svg`
- * that hit this case.
- */
-function toIdentifier(kebab: string): string {
-  const camel = kebab.replace(/-(\w)/g, (_, c: string) => c.toUpperCase());
-  return /^[0-9]/.test(camel) ? `_${camel}` : camel;
-}
-
-function sanitizeAttrs(el: Element): void {
-  const removeIfPresent = ['id', 'class', 'style', 'fill', 'stroke'];
-  for (const attr of removeIfPresent) {
-    el.removeAttribute(attr);
-  }
-  const attrNames = el.getAttributeNames();
-  for (const name of attrNames) {
-    if (name.startsWith('aria-')) el.removeAttribute(name);
-  }
-}
-
-function sanitizeTree(root: Element): void {
-  sanitizeAttrs(root);
-  for (const child of Array.from(root.children)) {
-    sanitizeTree(child as Element);
-  }
-}
-
-/**
  * Read + sanitize one source SVG file into the inlined string we will
  * embed in the generated TS module. Returns `null` on parse failure.
  */
-function loadGlyph(filePath: string, id: string): Glyph | null {
+function loadGlyph(filePath: string, id: string, paintMode: 'fill' | 'stroke'): Glyph | null {
   let raw: string;
   try {
     raw = readFileSync(filePath, 'utf8');
@@ -118,9 +96,23 @@ function loadGlyph(filePath: string, id: string): Glyph | null {
     return null;
   }
 
-  // Re-emit a clean, minimal <svg>. xmlns is explicit so this string
-  // can be assigned to innerHTML in any host without namespace fixup.
-  const svgText = `<svg xmlns="${SVG_NS}" viewBox="${viewBox}">${inner}</svg>`;
+  // Re-emit a clean, minimal <svg>. xmlns is explicit so this string can be
+  // assigned to innerHTML in any host without namespace fixup. Stroke libraries
+  // keep their rendering semantics on the ROOT <svg> (fill:none, stroke:
+  // currentColor, the library's own caps/joins) — which we dropped above — so
+  // re-apply them on the emitted wrapper; otherwise the standalone string renders
+  // blank. Caps/joins are read from the source rather than hard-coded, so each
+  // library keeps its own line style.
+  let strokeAttrs = '';
+  if (paintMode === 'stroke') {
+    const cap = svg.getAttribute('stroke-linecap');
+    const join = svg.getAttribute('stroke-linejoin');
+    strokeAttrs =
+      ' fill="none" stroke="currentColor" stroke-width="2"' +
+      (cap ? ` stroke-linecap="${cap}"` : '') +
+      (join ? ` stroke-linejoin="${join}"` : '');
+  }
+  const svgText = `<svg xmlns="${SVG_NS}" viewBox="${viewBox}"${strokeAttrs}>${inner}</svg>`;
   return { id, svg: svgText };
 }
 
@@ -138,12 +130,19 @@ function escapeTemplate(s: string): string {
  *   <outDir>/<glyph.id>.ts          — single named export per glyph
  *   <outDir>/index.ts               — re-exports for the whole group
  */
-function emitGroup(label: string, srcDir: string, outDir: string): number {
+function emitGroup(
+  label: string,
+  srcDir: string,
+  outDir: string,
+  paintMode: 'fill' | 'stroke' = 'fill',
+): number {
   let entries: string[];
   try {
     entries = readdirSync(srcDir).filter((f) => f.endsWith('.svg'));
   } catch (err) {
-    throw new Error(`[tree-shake] cannot read ${srcDir}: ${(err as Error).message}`);
+    throw new Error(`[tree-shake] cannot read ${srcDir}: ${(err as Error).message}`, {
+      cause: err,
+    });
   }
 
   mkdirSync(outDir, { recursive: true });
@@ -151,13 +150,18 @@ function emitGroup(label: string, srcDir: string, outDir: string): number {
   const glyphs: Glyph[] = [];
   for (const entry of entries) {
     const id = entry.replace(/\.svg$/, '');
-    const glyph = loadGlyph(join(srcDir, entry), id);
+    const glyph = loadGlyph(join(srcDir, entry), id, paintMode);
     if (glyph) glyphs.push(glyph);
   }
   glyphs.sort((a, b) => a.id.localeCompare(b.id));
 
+  // Assign a unique export identifier per glyph (camelCase for non-colliding
+  // ids; injective underscore fallback for collisions). See assignIdentifiers.
+  const idents = assignIdentifiers(glyphs.map((g) => g.id));
+  const identFor = (id: string): string => idents.get(id) as string;
+
   for (const glyph of glyphs) {
-    const ident = toIdentifier(glyph.id);
+    const ident = identFor(glyph.id);
     const js = `/** Inlined SVG for the \`${glyph.id}\` icon. Generated; do not edit. */\nexport const ${ident} = \`${escapeTemplate(glyph.svg)}\`;\n`;
     const dts = `/** Inlined SVG for the \`${glyph.id}\` icon. Generated; do not edit. */\nexport declare const ${ident}: string;\n`;
     writeFileSync(join(outDir, `${glyph.id}.js`), js, 'utf8');
@@ -166,11 +170,11 @@ function emitGroup(label: string, srcDir: string, outDir: string): number {
 
   const indexJs =
     `/** Re-exports every icon in the ${label} library. Generated; do not edit. */\n` +
-    glyphs.map((g) => `export { ${toIdentifier(g.id)} } from './${g.id}.js';`).join('\n') +
+    glyphs.map((g) => `export { ${identFor(g.id)} } from './${g.id}.js';`).join('\n') +
     '\n';
   const indexDts =
     `/** Re-exports every icon in the ${label} library. Generated; do not edit. */\n` +
-    glyphs.map((g) => `export { ${toIdentifier(g.id)} } from './${g.id}.js';`).join('\n') +
+    glyphs.map((g) => `export { ${identFor(g.id)} } from './${g.id}.js';`).join('\n') +
     '\n';
   writeFileSync(join(outDir, 'index.js'), indexJs, 'utf8');
   writeFileSync(join(outDir, 'index.d.ts'), indexDts, 'utf8');
@@ -183,5 +187,20 @@ mkdirSync(distDir, { recursive: true });
 
 const helixCount = emitGroup('helix', helixSrcDir, resolve(distDir, 'tree-shake/helix'));
 const faCount = emitGroup('fa-free/solid', faSrcDir, resolve(distDir, 'tree-shake/fa-free/solid'));
+const featherCount = emitGroup(
+  'feather',
+  featherSrcDir,
+  resolve(distDir, 'tree-shake/feather'),
+  'stroke',
+);
+const lucideCount = emitGroup(
+  'lucide',
+  lucideSrcDir,
+  resolve(distDir, 'tree-shake/lucide'),
+  'stroke',
+);
 
-console.log(`[tree-shake] done. helix=${helixCount}, fa-free/solid=${faCount}`);
+console.log(
+  `[tree-shake] done. helix=${helixCount}, fa-free/solid=${faCount}, ` +
+    `feather=${featherCount}, lucide=${lucideCount}`,
+);

--- a/packages/hx-icons/scripts/svg-sanitize.test.ts
+++ b/packages/hx-icons/scripts/svg-sanitize.test.ts
@@ -1,0 +1,51 @@
+import { parseHTML } from 'linkedom';
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeTree } from './svg-sanitize.js';
+
+/** Sanitize the CHILDREN of a source <svg> (mirrors how the generators use it). */
+function sanitizeChildren(svg: string): string {
+  const { document } = parseHTML(`<!doctype html><body>${svg}</body>`);
+  const root = document.querySelector('svg') as unknown as Element;
+  for (const child of Array.from(root.children)) sanitizeTree(child as Element);
+  return root.innerHTML;
+}
+
+describe('sanitizeTree', () => {
+  it('preserves fill="currentColor" (Lucide terminal dots must not hollow out)', () => {
+    const out = sanitizeChildren(
+      '<svg><path fill="none" d="M0 0"/><circle fill="currentColor" cx="1" cy="1" r="1"/></svg>',
+    );
+    expect(out).toContain('fill="currentColor"');
+  });
+
+  it('preserves fill="none" and stroke="currentColor"', () => {
+    const out = sanitizeChildren('<svg><path fill="none" stroke="currentColor" d="M0 0"/></svg>');
+    expect(out).toContain('fill="none"');
+    expect(out).toContain('stroke="currentColor"');
+  });
+
+  it('strips hardcoded color fills/strokes that fight the cascade', () => {
+    const out = sanitizeChildren(
+      '<svg><path fill="#ff0000" d="M0 0"/><path stroke="rgb(0,0,0)" d="M1 1"/></svg>',
+    );
+    expect(out).not.toContain('#ff0000');
+    expect(out).not.toContain('rgb(0,0,0)');
+  });
+
+  it('strips id/class/style and every aria-* attribute', () => {
+    const out = sanitizeChildren(
+      '<svg><path id="x" class="y" style="color:red" aria-hidden="true" aria-label="z" d="M0 0"/></svg>',
+    );
+    expect(out).not.toMatch(/\b(id|class|style|aria-hidden|aria-label)=/);
+  });
+
+  it('recurses into nested groups', () => {
+    const out = sanitizeChildren(
+      '<svg><g fill="#abc"><circle fill="currentColor" id="dot"/></g></svg>',
+    );
+    expect(out).toContain('fill="currentColor"');
+    expect(out).not.toContain('#abc');
+    expect(out).not.toContain('id="dot"');
+  });
+});

--- a/packages/hx-icons/scripts/svg-sanitize.ts
+++ b/packages/hx-icons/scripts/svg-sanitize.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared SVG sanitization for the sprite + tree-shake generators.
+ *
+ * Strips attributes that would either leak into the surrounding document
+ * (`id` / `class` / `style`) or fight the host's `currentColor` / paint-mode
+ * cascade (HARDCODED `fill` / `stroke` colors), plus every `aria-*` attribute
+ * (`<hx-icon>` applies its own ARIA at the host level).
+ *
+ * Cascade-compatible / structural paint values — `currentColor`, `none`,
+ * `inherit`, `context-fill`, `context-stroke` — are PRESERVED. This matters for
+ * stroke glyphs that carry an explicit `<… fill="currentColor">` terminal dot
+ * (e.g. Lucide `tag`, `key-round`, `chart-scatter`): stripping that fill would
+ * leave the dot to inherit the stroke-mode `fill: none` and hollow it out.
+ */
+
+/** Paint values that are safe to keep because they cooperate with the cascade. */
+const PRESERVED_PAINT = new Set([
+  'currentColor',
+  'none',
+  'inherit',
+  'context-fill',
+  'context-stroke',
+]);
+
+/**
+ * Sanitize a single element in place. `Element` is the DOM-lib shape; linkedom
+ * elements are structurally compatible and passed through with a cast at the
+ * call sites.
+ */
+export function sanitizeAttrs(el: Element): void {
+  for (const attr of ['id', 'class', 'style']) {
+    el.removeAttribute(attr);
+  }
+  for (const attr of ['fill', 'stroke']) {
+    const value = el.getAttribute(attr);
+    if (value !== null && !PRESERVED_PAINT.has(value.trim())) {
+      el.removeAttribute(attr);
+    }
+  }
+  for (const name of el.getAttributeNames()) {
+    if (name.startsWith('aria-')) el.removeAttribute(name);
+  }
+}
+
+/** Sanitize an element and all of its descendants. */
+export function sanitizeTree(root: Element): void {
+  sanitizeAttrs(root);
+  for (const child of Array.from(root.children)) {
+    sanitizeTree(child as Element);
+  }
+}

--- a/packages/hx-icons/scripts/tree-shake-identifiers.test.ts
+++ b/packages/hx-icons/scripts/tree-shake-identifiers.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assignIdentifiers,
+  RESERVED_WORDS,
+  toIdentifier,
+  toUnderscoreId,
+} from './tree-shake-identifiers.js';
+
+describe('toIdentifier', () => {
+  it('camelCases kebab-case', () => {
+    expect(toIdentifier('arrow-up')).toBe('arrowUp');
+    expect(toIdentifier('chevron-up')).toBe('chevronUp');
+    expect(toIdentifier('activity')).toBe('activity');
+  });
+
+  it('prefixes digit-leading names with `_`', () => {
+    expect(toIdentifier('0')).toBe('_0');
+    expect(toIdentifier('360-degrees')).toBe('_360Degrees');
+  });
+
+  it('prefixes reserved words with `_` (Feather/Lucide ship `delete`/`import`/`package`)', () => {
+    expect(toIdentifier('delete')).toBe('_delete');
+    expect(toIdentifier('import')).toBe('_import');
+    expect(toIdentifier('package')).toBe('_package');
+    for (const word of RESERVED_WORDS) {
+      expect(toIdentifier(word)).toBe(`_${word}`);
+    }
+  });
+});
+
+describe('toUnderscoreId', () => {
+  it('replaces hyphens with underscores injectively', () => {
+    expect(toUnderscoreId('arrow-up-10')).toBe('arrow_up_10');
+    expect(toUnderscoreId('arrow-up-1-0')).toBe('arrow_up_1_0');
+    expect(toUnderscoreId('delete')).toBe('_delete');
+  });
+});
+
+describe('assignIdentifiers', () => {
+  it('keeps camelCase for non-colliding ids', () => {
+    const m = assignIdentifiers(['arrow-up', 'chevron-down', 'activity']);
+    expect(m.get('arrow-up')).toBe('arrowUp');
+    expect(m.get('chevron-down')).toBe('chevronDown');
+    expect(m.get('activity')).toBe('activity');
+  });
+
+  it('disambiguates camelCase collisions to the underscore form', () => {
+    // The real Lucide collision: both camelCase to `arrowUp10`.
+    const m = assignIdentifiers(['arrow-up-10', 'arrow-up-1-0']);
+    expect(m.get('arrow-up-10')).toBe('arrow_up_10');
+    expect(m.get('arrow-up-1-0')).toBe('arrow_up_1_0');
+    expect([...m.values()]).not.toContain('arrowUp10');
+  });
+
+  it('only remaps the colliding ids — unrelated names keep camelCase', () => {
+    const m = assignIdentifiers(['arrow-up-10', 'arrow-up-1-0', 'battery-0']);
+    expect(m.get('battery-0')).toBe('battery0');
+  });
+
+  it('produces a fully unique, valid identifier set', () => {
+    const ids = ['delete', 'import', 'package', 'arrow-up-10', 'arrow-up-1-0', '0', '360-degrees'];
+    const m = assignIdentifiers(ids);
+    const values = [...m.values()];
+    expect(new Set(values).size).toBe(values.length); // all unique
+    for (const v of values) {
+      expect(v).toMatch(/^[A-Za-z_$][\w$]*$/); // valid JS identifier
+      expect(RESERVED_WORDS.has(v)).toBe(false); // not a bare reserved word
+    }
+  });
+});

--- a/packages/hx-icons/scripts/tree-shake-identifiers.ts
+++ b/packages/hx-icons/scripts/tree-shake-identifiers.ts
@@ -1,0 +1,112 @@
+/**
+ * Pure identifier helpers for the tree-shake generator, extracted so they can be
+ * unit-tested without running the (side-effectful) generator.
+ *
+ * The generated `export const <name>` declarations and barrel re-exports must be
+ * valid ESM with NO duplicate exports, across ~4,300 icon ids spanning four
+ * libraries. Two failure modes have to be handled:
+ *   1. Ids that are reserved words (`delete`, `import`, `package`) or start with
+ *      a digit (`0`, `360-degrees`) — invalid as a bare identifier.
+ *   2. Distinct ids that camelCase to the SAME identifier (Lucide ships both
+ *      `arrow-up-10` and `arrow-up-1-0` → `arrowUp10`) — duplicate exports.
+ */
+
+/**
+ * Reserved words (strict-mode + module-context) that cannot appear as a bare
+ * `export const <name>`.
+ */
+export const RESERVED_WORDS = new Set([
+  'break',
+  'case',
+  'catch',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'else',
+  'enum',
+  'export',
+  'extends',
+  'false',
+  'finally',
+  'for',
+  'function',
+  'if',
+  'import',
+  'in',
+  'instanceof',
+  'new',
+  'null',
+  'return',
+  'super',
+  'switch',
+  'this',
+  'throw',
+  'true',
+  'try',
+  'typeof',
+  'var',
+  'void',
+  'while',
+  'with',
+  'yield',
+  'let',
+  'static',
+  'await',
+  'implements',
+  'interface',
+  'package',
+  'private',
+  'protected',
+  'public',
+]);
+
+/**
+ * Convert kebab-case to a JS-safe camelCase identifier. Digit-leading names and
+ * reserved-word collisions are prefixed with `_`.
+ */
+export function toIdentifier(kebab: string): string {
+  const camel = kebab.replace(/-(\w)/g, (_, c: string) => c.toUpperCase());
+  return /^[0-9]/.test(camel) || RESERVED_WORDS.has(camel) ? `_${camel}` : camel;
+}
+
+/**
+ * Injective fallback identifier: kebab `-` → `_`, with no camelCasing. Source
+ * ids never contain `_`, so this is unique across the (unique) id set. Used only
+ * to break a camelCase collision.
+ */
+export function toUnderscoreId(kebab: string): string {
+  const u = kebab.replace(/-/g, '_');
+  return /^[0-9]/.test(u) || RESERVED_WORDS.has(u) ? `_${u}` : u;
+}
+
+/**
+ * Assign a unique export identifier to every id. The camelCase name is kept for
+ * non-colliding ids (so existing helix/fa-free export names are stable); ids
+ * whose camelCase collides fall back to the injective underscore form.
+ *
+ * @throws if any identifier still collides after disambiguation (defensive — the
+ *   underscore form is injective for the `-`/alphanumeric id charset, so this
+ *   would only fire on an unexpected source id shape).
+ */
+export function assignIdentifiers(ids: readonly string[]): Map<string, string> {
+  const preferred = new Map(ids.map((id) => [id, toIdentifier(id)] as const));
+  const freq = new Map<string, number>();
+  for (const ident of preferred.values()) freq.set(ident, (freq.get(ident) ?? 0) + 1);
+
+  const out = new Map<string, string>();
+  const used = new Set<string>();
+  for (const id of ids) {
+    const camel = preferred.get(id) as string;
+    const ident = (freq.get(camel) ?? 0) > 1 ? toUnderscoreId(id) : camel;
+    if (used.has(ident)) {
+      throw new Error(`[tree-shake] unresolved identifier collision on '${ident}' (id '${id}')`);
+    }
+    used.add(ident);
+    out.set(id, ident);
+  }
+  return out;
+}

--- a/packages/hx-icons/src/aaa.test.ts
+++ b/packages/hx-icons/src/aaa.test.ts
@@ -20,6 +20,24 @@ describe('iconLibraryAaaVerdict', () => {
     });
   });
 
+  it('returns the canonical verdict for the feather library', () => {
+    const v = iconLibraryAaaVerdict('feather');
+    expect(v).toEqual({
+      contrast: 'unknown',
+      forcedColors: 'pass',
+      opticalSizing: 'unknown',
+    });
+  });
+
+  it('returns the canonical verdict for the lucide library', () => {
+    const v = iconLibraryAaaVerdict('lucide');
+    expect(v).toEqual({
+      contrast: 'unknown',
+      forcedColors: 'pass',
+      opticalSizing: 'unknown',
+    });
+  });
+
   it('returns undefined for unknown libraries (no evidence on file)', () => {
     expect(iconLibraryAaaVerdict('not-a-real-library')).toBeUndefined();
     expect(iconLibraryAaaVerdict('')).toBeUndefined();
@@ -31,7 +49,10 @@ describe('iconLibraryAaaVerdict', () => {
     // if the verdicts diverge.
     const helix = iconLibraryAaaVerdict('helix');
     const faFree = iconLibraryAaaVerdict('fa-free');
+    const feather = iconLibraryAaaVerdict('feather');
+    const lucide = iconLibraryAaaVerdict('lucide');
     expect(helix).not.toBe(faFree);
+    expect(feather).not.toBe(lucide);
   });
 
   it('verdict states are typed to the canonical three-state union', () => {

--- a/packages/hx-icons/src/aaa.ts
+++ b/packages/hx-icons/src/aaa.ts
@@ -60,10 +60,13 @@ export interface IconLibraryAaaVerdict {
 }
 
 /**
- * Hardcoded verdicts for the libraries shipped by `@helixui/icons`. Both
- * built-ins are `paintMode: 'fill'` solid silhouettes painted with
- * `fill="currentColor"`, which is the easiest paint strategy to clear all
- * three dimensions cleanly.
+ * Hardcoded verdicts for the libraries shipped by `@helixui/icons`. The fill
+ * built-ins (`helix`, `fa-free`) are `paintMode: 'fill'` solid silhouettes
+ * painted with `fill="currentColor"` — the easiest paint strategy to clear all
+ * three dimensions cleanly. The stroke built-ins (`feather`, `lucide`) are
+ * `paintMode: 'stroke'`; their contrast/optical-sizing verdicts depend on the
+ * render size and `--hx-icon-stroke-width` and are left `'unknown'` until a
+ * formal audit measures them (see below).
  *
  * Source of truth for these verdicts:
  *   - Phase 4 formal audit (`pnpm aaa:audit --component hx-icon`)
@@ -82,6 +85,23 @@ const BUILTIN_VERDICTS: Record<string, IconLibraryAaaVerdict> = {
     contrast: 'pass',
     forcedColors: 'pass',
     opticalSizing: 'pass',
+  },
+  // Stroke-paint libraries. `forcedColors` is structurally 'pass' — every glyph
+  // paints with `currentColor` (→ CanvasText under forced-colors) and hardcodes
+  // no color. `contrast` and `opticalSizing` are 'unknown' pending a formal
+  // `pnpm aaa:audit` pass: at the default 2px stroke / 24px render size they are
+  // expected to clear 3:1, but a thin `--hx-icon-stroke-width` override or a
+  // sub-minimum render size can drop a stroke glyph below non-text contrast, so
+  // we do not claim a measured 'pass' here.
+  feather: {
+    contrast: 'unknown',
+    forcedColors: 'pass',
+    opticalSizing: 'unknown',
+  },
+  lucide: {
+    contrast: 'unknown',
+    forcedColors: 'pass',
+    opticalSizing: 'unknown',
   },
 };
 

--- a/packages/hx-icons/src/index.ts
+++ b/packages/hx-icons/src/index.ts
@@ -1,17 +1,19 @@
 /**
  * @helixui/icons — public entry point.
  *
- * Importing this module triggers auto-registration of the bundled `helix`
- * and `fa-free` libraries. After import, both are queryable via
- * `getIconLibrary()` and resolvable through `<hx-icon>` (Phase 4).
+ * Importing this module triggers auto-registration of the bundled `helix`,
+ * `fa-free`, `feather`, and `lucide` libraries. After import, all are queryable
+ * via `getIconLibrary()` and resolvable through `<hx-icon>`.
  *
- * Order is intentional: `helix` first (default-suggested library),
- * `fa-free` second. Side-effect imports register; the registry module
- * remains pure.
+ * Order is intentional: `helix` first (default-suggested library), then the
+ * fill set (`fa-free`) and the stroke sets (`feather`, `lucide`). Side-effect
+ * imports register; the registry module remains pure.
  */
 
 import './libraries/helix.js';
 import './libraries/fa-free.js';
+import './libraries/feather.js';
+import './libraries/lucide.js';
 
 export {
   registerIconLibrary,

--- a/packages/hx-icons/src/libraries/fa-free.test.ts
+++ b/packages/hx-icons/src/libraries/fa-free.test.ts
@@ -15,7 +15,7 @@ import {
 
 import './fa-free.js';
 
-const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.0.0/dist';
+const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist';
 
 describe('libraries/fa-free — auto-registration', () => {
   let originalBasePath: string;

--- a/packages/hx-icons/src/libraries/feather.test.ts
+++ b/packages/hx-icons/src/libraries/feather.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Auto-registration smoke tests for the bundled `feather` icon library.
+ *
+ * Mirrors `fa-free.test.ts`. The feather library resolves names against
+ * the `feather.svg` sprite shipped from the build output and declares
+ * `paintMode: 'stroke'` (Feather glyphs are outline icons).
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  getBasePath,
+  getIconLibrary,
+  setBasePath,
+} from '../registry.js';
+
+import './feather.js';
+
+const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist';
+
+describe('libraries/feather — auto-registration', () => {
+  let originalBasePath: string;
+
+  beforeAll(() => {
+    originalBasePath = getBasePath();
+  });
+
+  afterEach(() => {
+    setBasePath(originalBasePath);
+  });
+
+  it('registers the feather library on import', () => {
+    expect(getIconLibrary('feather')).toBeDefined();
+  });
+
+  it('declares paintMode "stroke"', () => {
+    expect(getIconLibrary('feather')?.paintMode).toBe('stroke');
+  });
+
+  it('declares spriteSheet=true', () => {
+    expect(getIconLibrary('feather')?.spriteSheet).toBe(true);
+  });
+
+  it('resolves a name against the default base path', () => {
+    setBasePath(DEFAULT_BASE_PATH);
+    const lib = getIconLibrary('feather');
+    expect(lib?.resolver('activity')).toBe(
+      `${DEFAULT_BASE_PATH}/feather.svg#activity`,
+    );
+  });
+
+  it('resolves a name against a custom base path', () => {
+    setBasePath('/cdn/icons');
+    const lib = getIconLibrary('feather');
+    expect(lib?.resolver('heart')).toBe('/cdn/icons/feather.svg#heart');
+  });
+
+  it('round-trips through the registry as a complete library entry', () => {
+    setBasePath('/base');
+    const lib = getIconLibrary('feather');
+    expect(lib).toMatchObject({
+      name: 'feather',
+      spriteSheet: true,
+      paintMode: 'stroke',
+    });
+    expect(typeof lib?.resolver).toBe('function');
+  });
+});

--- a/packages/hx-icons/src/libraries/feather.ts
+++ b/packages/hx-icons/src/libraries/feather.ts
@@ -1,0 +1,21 @@
+/**
+ * Auto-registration for the bundled `feather` icon library.
+ *
+ * Importing this module registers the `feather` library with the registry.
+ * No exports — this is a pure side-effect module. The companion sprite sheet
+ * ships in `dist/feather.svg`, built from the locally installed `feather-icons`
+ * package (MIT, 287 glyphs) by `scripts/generate-sprite.ts`.
+ *
+ * Registered with `paintMode: 'stroke'` because Feather glyphs are outline
+ * icons whose visible ink is a stroke painted with `stroke="currentColor"`.
+ * `<hx-icon>` supplies `fill: none; stroke: currentColor` plus the
+ * `--hx-icon-stroke-width` token at render time per the library's paint mode.
+ */
+
+import { getBasePath, registerIconLibrary } from '../registry.js';
+
+registerIconLibrary('feather', {
+  resolver: (name) => `${getBasePath()}/feather.svg#${name}`,
+  spriteSheet: true,
+  paintMode: 'stroke',
+});

--- a/packages/hx-icons/src/libraries/helix.test.ts
+++ b/packages/hx-icons/src/libraries/helix.test.ts
@@ -21,7 +21,7 @@ import {
 
 import './helix.js';
 
-const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.0.0/dist';
+const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist';
 
 describe('libraries/helix — auto-registration', () => {
   let originalBasePath: string;

--- a/packages/hx-icons/src/libraries/lucide.test.ts
+++ b/packages/hx-icons/src/libraries/lucide.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Auto-registration smoke tests for the bundled `lucide` icon library.
+ *
+ * Mirrors `fa-free.test.ts`. The lucide library resolves names against
+ * the `lucide.svg` sprite shipped from the build output and declares
+ * `paintMode: 'stroke'` (Lucide glyphs are outline icons).
+ */
+
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  getBasePath,
+  getIconLibrary,
+  setBasePath,
+} from '../registry.js';
+
+import './lucide.js';
+
+const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist';
+
+describe('libraries/lucide — auto-registration', () => {
+  let originalBasePath: string;
+
+  beforeAll(() => {
+    originalBasePath = getBasePath();
+  });
+
+  afterEach(() => {
+    setBasePath(originalBasePath);
+  });
+
+  it('registers the lucide library on import', () => {
+    expect(getIconLibrary('lucide')).toBeDefined();
+  });
+
+  it('declares paintMode "stroke"', () => {
+    expect(getIconLibrary('lucide')?.paintMode).toBe('stroke');
+  });
+
+  it('declares spriteSheet=true', () => {
+    expect(getIconLibrary('lucide')?.spriteSheet).toBe(true);
+  });
+
+  it('resolves a name against the default base path', () => {
+    setBasePath(DEFAULT_BASE_PATH);
+    const lib = getIconLibrary('lucide');
+    expect(lib?.resolver('activity')).toBe(
+      `${DEFAULT_BASE_PATH}/lucide.svg#activity`,
+    );
+  });
+
+  it('resolves a name against a custom base path', () => {
+    setBasePath('/cdn/icons');
+    const lib = getIconLibrary('lucide');
+    expect(lib?.resolver('heart')).toBe('/cdn/icons/lucide.svg#heart');
+  });
+
+  it('round-trips through the registry as a complete library entry', () => {
+    setBasePath('/base');
+    const lib = getIconLibrary('lucide');
+    expect(lib).toMatchObject({
+      name: 'lucide',
+      spriteSheet: true,
+      paintMode: 'stroke',
+    });
+    expect(typeof lib?.resolver).toBe('function');
+  });
+});

--- a/packages/hx-icons/src/libraries/lucide.ts
+++ b/packages/hx-icons/src/libraries/lucide.ts
@@ -1,0 +1,21 @@
+/**
+ * Auto-registration for the bundled `lucide` icon library.
+ *
+ * Importing this module registers the `lucide` library with the registry.
+ * No exports — this is a pure side-effect module. The companion sprite sheet
+ * ships in `dist/lucide.svg`, built from the locally installed `lucide-static`
+ * package (ISC, ~1,986 glyphs) by `scripts/generate-sprite.ts`.
+ *
+ * Registered with `paintMode: 'stroke'` because Lucide glyphs are outline
+ * icons whose visible ink is a stroke painted with `stroke="currentColor"`.
+ * `<hx-icon>` supplies `fill: none; stroke: currentColor` plus the
+ * `--hx-icon-stroke-width` token at render time per the library's paint mode.
+ */
+
+import { getBasePath, registerIconLibrary } from '../registry.js';
+
+registerIconLibrary('lucide', {
+  resolver: (name) => `${getBasePath()}/lucide.svg#${name}`,
+  spriteSheet: true,
+  paintMode: 'stroke',
+});

--- a/packages/hx-icons/src/registry.test.ts
+++ b/packages/hx-icons/src/registry.test.ts
@@ -18,7 +18,7 @@ import {
 } from './registry.js';
 import type { IconLibraryOptions, IconMutator, IconResolver } from './types.js';
 
-const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.0.0/dist';
+const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist';
 
 const TEST_LIBRARIES = ['lib-a', 'lib-b', 'helix-test', 'fa-free-test', 'overwrite-target'];
 

--- a/packages/hx-icons/src/registry.ts
+++ b/packages/hx-icons/src/registry.ts
@@ -29,6 +29,12 @@ export type {
  * to a SPECIFIC version so future icon releases don't silently change
  * what existing consumers fetch.
  *
+ * **Maintainers:** this pin tracks the version that ships the CURRENT sprite
+ * set and MUST be bumped to the release version whenever a sprite is added or
+ * changed — otherwise the new sprite 404s for default-CDN consumers. It is set
+ * to the version this code is published as (e.g. the `feather`/`lucide` sprites
+ * land in 1.1.0, so the pin is 1.1.0).
+ *
  * **Healthcare consumers behind firewalls or strict CSPs MUST override
  * with `setBasePath()` at app bootstrap.** The console warning below
  * surfaces the first resolution attempt against this default so
@@ -46,7 +52,7 @@ export type {
  *   - Air-gapped enterprise: serve from a same-origin static asset
  *     server and `setBasePath('https://internal.example.com/...')`
  */
-const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.0.0/dist';
+const DEFAULT_BASE_PATH = 'https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist';
 let _hasWarnedDefaultBasePath = false;
 
 /** Module-level singleton map of registered libraries. */

--- a/packages/hx-icons/vitest.config.ts
+++ b/packages/hx-icons/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   test: {
     globals: false,
     environment: 'node',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts'],
     coverage: {
       provider: 'v8',
       include: ['src/registry.ts'],

--- a/packages/hx-library/src/components/hx-icon/hx-icon.stories.ts
+++ b/packages/hx-library/src/components/hx-icon/hx-icon.stories.ts
@@ -454,6 +454,51 @@ export const LibraryFaFree: Story = {
   `,
 };
 
+// Representative subset of the bundled `feather` library (287 glyphs, MIT).
+// Feather is a stroke/outline set; these names cover the common UI categories
+// so the gallery demonstrates the stroke-paint look without rendering all 287.
+const FEATHER_SAMPLE = [
+  'activity',
+  'home',
+  'settings',
+  'heart',
+  'search',
+  'bell',
+  'calendar',
+  'check',
+  'clock',
+  'edit',
+  'eye',
+  'file',
+  'mail',
+  'star',
+  'trash-2',
+  'user',
+];
+
+// Representative subset of the bundled `lucide` library (~1986 glyphs, ISC).
+// Lucide is a stroke/outline set (a community fork of Feather); the shared
+// base names below render identically against the lucide sprite so the two
+// galleries read as a like-for-like comparison.
+const LUCIDE_SAMPLE = [
+  'activity',
+  'home',
+  'settings',
+  'heart',
+  'search',
+  'bell',
+  'calendar',
+  'check',
+  'clock',
+  'pencil',
+  'eye',
+  'file',
+  'mail',
+  'star',
+  'trash-2',
+  'user',
+];
+
 // ════════════════════════════════════════════════════════════════════════════
 // 10. CUSTOM LIBRARY
 // ════════════════════════════════════════════════════════════════════════════
@@ -513,6 +558,122 @@ export const KeyboardNavigation: Story = {
         This component is presentational. It exposes no interactive keyboard targets of its own.
         Screen readers will encounter it in the reading order and announce its content.
       </p>
+    </div>
+  `,
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// 11. LIBRARY: FEATHER
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Representative slice of the bundled `feather` library (Feather Icons, MIT).
+ * The full set ships 287 glyphs at `@helixui/icons/dist/feather.svg`; this story
+ * shows a curated 16-glyph sample. Unlike `helix`/`fa-free` (fill libraries),
+ * Feather is registered with `paintMode: 'stroke'`, so `<hx-icon>` renders the
+ * geometry with `fill: none; stroke: currentColor` and the round line caps/joins
+ * that give outline icons their look. The stroke width is driven by the
+ * `--hx-icon-stroke-width` token (default `2`) — see the
+ * `Library: feather (stroke-width)` story for an override. Use the controls panel
+ * on the Default story with `library="feather"` to render any Feather name.
+ */
+export const LibraryFeather: Story = {
+  name: 'Library: feather',
+  render: () => html`
+    <div
+      style="display: grid; grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 0.75rem; padding: 1rem;"
+    >
+      ${FEATHER_SAMPLE.map(
+        (name) => html`
+          <div
+            style="display: flex; flex-direction: column; align-items: center; gap: 0.5rem; padding: 0.75rem; border: 1px solid var(--hx-color-border-default, #e5e7eb); border-radius: var(--hx-border-radius-md, 0.375rem); background: var(--hx-color-surface-default, #ffffff);"
+          >
+            <hx-icon library="feather" name=${name} hx-size="lg" label=${name}></hx-icon>
+            <code
+              style="font-size: 0.75rem; color: var(--hx-color-text-secondary, #6b7280); text-align: center; word-break: break-word;"
+              >${name}</code
+            >
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// 12. LIBRARY: FEATHER — STROKE-WIDTH TOKEN
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Demonstrates the `--hx-icon-stroke-width` token on a stroke-paint library.
+ * The token only takes effect for libraries registered with `paintMode: 'stroke'`
+ * (`feather`, `lucide`); fill libraries ignore it. Each tile sets the token via an
+ * inline style on the host so consumers can see the visual weight shift from a
+ * hairline `1` through the default `2` up to a heavy `3`. Override it at any
+ * cascade level (`:root`, a wrapper, or the element) to tune outline weight to a
+ * brand or density target.
+ */
+export const LibraryFeatherStrokeWidth: Story = {
+  name: 'Library: feather (stroke-width)',
+  render: () => html`
+    <div style="display: flex; align-items: flex-end; gap: 2.5rem; flex-wrap: wrap; padding: 1rem;">
+      ${[
+        { width: '1', label: 'thin (1)' },
+        { width: '2', label: 'default (2)' },
+        { width: '3', label: 'heavy (3)' },
+      ].map(
+        ({ width, label }) => html`
+          <div style="display: flex; flex-direction: column; align-items: center; gap: 0.5rem;">
+            <hx-icon
+              library="feather"
+              name="activity"
+              hx-size="xl"
+              label="Activity, stroke width ${width}"
+              style="--hx-icon-stroke-width: ${width};"
+            ></hx-icon>
+            <code style="font-size: 0.75rem; color: var(--hx-color-text-secondary, #6b7280);"
+              >${label}</code
+            >
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};
+
+// ════════════════════════════════════════════════════════════════════════════
+// 13. LIBRARY: LUCIDE
+// ════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Representative slice of the bundled `lucide` library (Lucide Icons, ISC).
+ * The full set ships ~1986 glyphs at `@helixui/icons/dist/lucide.svg`; this story
+ * shows a curated 16-glyph sample. Lucide is a community fork of Feather and is
+ * likewise registered with `paintMode: 'stroke'`, so the glyphs render with
+ * `fill: none; stroke: currentColor`. The shared base names mirror the Feather
+ * gallery so the two read as a like-for-like comparison; the
+ * `--hx-icon-stroke-width` token applies here identically. Use the controls panel
+ * on the Default story with `library="lucide"` to render any Lucide name.
+ */
+export const LibraryLucide: Story = {
+  name: 'Library: lucide',
+  render: () => html`
+    <div
+      style="display: grid; grid-template-columns: repeat(auto-fill, minmax(110px, 1fr)); gap: 0.75rem; padding: 1rem;"
+    >
+      ${LUCIDE_SAMPLE.map(
+        (name) => html`
+          <div
+            style="display: flex; flex-direction: column; align-items: center; gap: 0.5rem; padding: 0.75rem; border: 1px solid var(--hx-color-border-default, #e5e7eb); border-radius: var(--hx-border-radius-md, 0.375rem); background: var(--hx-color-surface-default, #ffffff);"
+          >
+            <hx-icon library="lucide" name=${name} hx-size="lg" label=${name}></hx-icon>
+            <code
+              style="font-size: 0.75rem; color: var(--hx-color-text-secondary, #6b7280); text-align: center; word-break: break-word;"
+              >${name}</code
+            >
+          </div>
+        `,
+      )}
     </div>
   `,
 };

--- a/packages/hx-library/src/components/hx-icon/hx-icon.styles.ts
+++ b/packages/hx-library/src/components/hx-icon/hx-icon.styles.ts
@@ -61,6 +61,19 @@ export const helixIconStyles = css`
     overflow: visible;
   }
 
+  /* ─── Stroke-paint libraries (Feather, Lucide, Heroicons-outline) ───
+     Outline glyphs whose visible ink is the stroke. <hx-icon> reflects the
+     resolved library's paintMode onto [data-paint-mode]; we supply fill:none +
+     stroke:currentColor here, and stroke-width comes from the
+     --hx-icon-stroke-width token on the base rule above. Line cap/join is NOT
+     set here — it is a library-specific design choice carried by each glyph's
+     own geometry, so the component never imposes round on a stroke library
+     whose source uses square caps or miter joins. */
+  svg[part='svg'][data-paint-mode='stroke'] {
+    fill: none;
+    stroke: currentColor;
+  }
+
   /* ─── Inline SVG wrapper ───
      In inline mode [part="svg"] is a <span> that wraps the fetched SVG.
      The inner <svg> is sized to fill the wrapper. */
@@ -79,6 +92,11 @@ export const helixIconStyles = css`
     fill: currentColor;
     stroke-width: var(--hx-icon-stroke-width, 2);
     display: block;
+  }
+
+  .icon__inline[data-paint-mode='stroke'] svg {
+    fill: none;
+    stroke: currentColor;
   }
 
   /* ─── Forced Colors (Windows High Contrast) ─── */

--- a/packages/hx-library/src/components/hx-icon/hx-icon.test.ts
+++ b/packages/hx-library/src/components/hx-icon/hx-icon.test.ts
@@ -892,4 +892,206 @@ describe('hx-icon', () => {
       }
     });
   });
+
+  // ─── Paint Mode (stroke libraries: Feather, Lucide) ───
+
+  describe('Paint Mode (sprite libraries)', () => {
+    it('library="feather" renders a sprite svg[part="svg"] with data-paint-mode="stroke"', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="feather" name="check"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('data-paint-mode')).toBe('stroke');
+    });
+
+    it('library="feather" <use href> resolves to the feather.svg#name sprite reference', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="feather" name="check"></hx-icon>');
+      await el.updateComplete;
+      const use = shadowQuery(el, 'use');
+      expect(use?.getAttribute('href')).toMatch(/\/feather\.svg#check$/);
+    });
+
+    it('library="lucide" renders a sprite svg[part="svg"] with data-paint-mode="stroke"', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="lucide" name="circle"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg).toBeTruthy();
+      expect(svg?.getAttribute('data-paint-mode')).toBe('stroke');
+    });
+
+    it('library="lucide" <use href> resolves to the lucide.svg#name sprite reference', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="lucide" name="circle"></hx-icon>');
+      await el.updateComplete;
+      const use = shadowQuery(el, 'use');
+      expect(use?.getAttribute('href')).toMatch(/\/lucide\.svg#circle$/);
+    });
+
+    it('library="fa-free" (fill library) renders data-paint-mode="fill"', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="fa-free" name="circle"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg?.getAttribute('data-paint-mode')).toBe('fill');
+    });
+
+    it('library="helix" (fill library) renders data-paint-mode="fill"', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="helix" name="check"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg?.getAttribute('data-paint-mode')).toBe('fill');
+    });
+
+    it('bare name (no library) defaults to data-paint-mode="fill"', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon name="check"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg?.getAttribute('data-paint-mode')).toBe('fill');
+    });
+
+    it('stroke-mode svg computes fill:none and stroke matching currentColor', async () => {
+      // Real-browser mode (Chromium) — the static stroke CSS rule
+      // `svg[part="svg"][data-paint-mode="stroke"]` resolves deterministically.
+      const el = await fixture<HelixIcon>('<hx-icon library="feather" name="check"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery<SVGElement>(el, 'svg[part="svg"]');
+      expect(svg).toBeTruthy();
+      const styles = getComputedStyle(svg!);
+      expect(styles.fill).toBe('none');
+      // stroke is `currentColor`, so it resolves to the same computed value as `color`.
+      expect(styles.stroke).toBe(styles.color);
+    });
+
+    it('fill-mode svg computes fill matching currentColor (not none)', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="fa-free" name="circle"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery<SVGElement>(el, 'svg[part="svg"]');
+      expect(svg).toBeTruthy();
+      const styles = getComputedStyle(svg!);
+      expect(styles.fill).not.toBe('none');
+      // fill is `currentColor`, so it resolves to the same computed value as `color`.
+      expect(styles.fill).toBe(styles.color);
+    });
+  });
+
+  // ─── Public paint-mode override (explicit sprite-url / name="#" escape hatches) ───
+
+  describe('Paint Mode (public paint-mode attribute)', () => {
+    it('paint-mode="stroke" on an explicit sprite-url renders data-paint-mode="stroke"', async () => {
+      const el = await fixture<HelixIcon>(
+        '<hx-icon sprite-url="/icons/feather.svg" name="activity" paint-mode="stroke"></hx-icon>',
+      );
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg?.getAttribute('data-paint-mode')).toBe('stroke');
+    });
+
+    it('paint-mode="stroke" on a bare name renders data-paint-mode="stroke"', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon name="custom" paint-mode="stroke"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg?.getAttribute('data-paint-mode')).toBe('stroke');
+    });
+
+    it('an explicit paint-mode overrides the library-derived mode', async () => {
+      const el = await fixture<HelixIcon>(
+        '<hx-icon library="fa-free" name="circle" paint-mode="stroke"></hx-icon>',
+      );
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg?.getAttribute('data-paint-mode')).toBe('stroke');
+    });
+
+    it('no paint-mode falls back to the library-derived mode (feather → stroke)', async () => {
+      const el = await fixture<HelixIcon>('<hx-icon library="feather" name="check"></hx-icon>');
+      await el.updateComplete;
+      const svg = shadowQuery(el, 'svg[part="svg"]');
+      expect(svg?.getAttribute('data-paint-mode')).toBe('stroke');
+    });
+  });
+
+  // ─── Security: re-sanitization AFTER the library mutator ───
+
+  describe('Security: post-mutator re-sanitization', () => {
+    it('strips a <script> injected by a fetch-mode library mutator', async () => {
+      const originalFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: async () =>
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+        } as Response);
+
+        registerIconLibrary('test-hostile-script-lib', {
+          resolver: () => '/test-hostile-script.svg',
+          spriteSheet: false,
+          // A hostile/compromised mutator reintroduces a <script> AFTER the
+          // first sanitize pass. _applyLibraryMutator re-sanitizes, so it must
+          // never reach the rendered DOM.
+          mutator: (svg: SVGElement) => {
+            const script = svg.ownerDocument.createElementNS(
+              'http://www.w3.org/2000/svg',
+              'script',
+            );
+            script.textContent = 'alert(1)';
+            svg.appendChild(script);
+          },
+        });
+        try {
+          const el = await fixture<HelixIcon>(
+            '<hx-icon library="test-hostile-script-lib" name="any"></hx-icon>',
+          );
+          await waitForInlineSvg(el);
+
+          const wrapper = shadowQuery(el, '[part="svg"]');
+          const innerSvg = wrapper?.querySelector('svg');
+          expect(innerSvg).toBeTruthy();
+          // Re-sanitization stripped the injected <script>.
+          expect(innerSvg?.querySelector('script')).toBeNull();
+          expect(el.shadowRoot?.innerHTML).not.toContain('<script');
+          expect(el.shadowRoot?.innerHTML).not.toContain('alert(1)');
+        } finally {
+          unregisterIconLibrary('test-hostile-script-lib');
+        }
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it('strips an on* event-handler attribute injected by a fetch-mode library mutator', async () => {
+      const originalFetch = globalThis.fetch;
+      try {
+        globalThis.fetch = vi.fn().mockResolvedValue({
+          ok: true,
+          text: async () =>
+            '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M0 0"/></svg>',
+        } as Response);
+
+        registerIconLibrary('test-hostile-onload-lib', {
+          resolver: () => '/test-hostile-onload.svg',
+          spriteSheet: false,
+          // Mutator injects an onload handler onto the root SVG; the post-mutator
+          // re-sanitize pass must strip it before it reaches unsafeHTML.
+          mutator: (svg: SVGElement) => {
+            svg.setAttribute('onload', 'alert(1)');
+          },
+        });
+        try {
+          const el = await fixture<HelixIcon>(
+            '<hx-icon library="test-hostile-onload-lib" name="any"></hx-icon>',
+          );
+          await waitForInlineSvg(el);
+
+          const wrapper = shadowQuery(el, '[part="svg"]');
+          const innerSvg = wrapper?.querySelector('svg');
+          expect(innerSvg).toBeTruthy();
+          // Re-sanitization stripped the injected onload handler.
+          expect(innerSvg?.hasAttribute('onload')).toBe(false);
+          expect(el.shadowRoot?.innerHTML).not.toContain('onload');
+        } finally {
+          unregisterIconLibrary('test-hostile-onload-lib');
+        }
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
 });

--- a/packages/hx-library/src/components/hx-icon/hx-icon.ts
+++ b/packages/hx-library/src/components/hx-icon/hx-icon.ts
@@ -3,7 +3,7 @@ import '../../utilities/document-token-adoption.js';
 import { customElement, property, state } from 'lit/decorators.js';
 import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 import { getIconLibrary } from '@helixui/icons';
-import type { IconLibrary } from '@helixui/icons';
+import type { IconLibrary, IconPaintMode } from '@helixui/icons';
 import { HelixElement } from '../../base/index.js';
 import { helixIconStyles } from './hx-icon.styles.js';
 import { forcedColorsSurface } from '../../styles/forced-colors.js';
@@ -144,6 +144,21 @@ export class HelixIcon extends HelixElement {
    */
   @property({ type: String, attribute: 'allowed-origins' })
   allowedOrigins = '';
+
+  /**
+   * Paint-mode override for the rendered glyph geometry. `'fill'` (default)
+   * paints with `fill: currentColor`; `'stroke'` paints outline glyphs with
+   * `fill: none; stroke: currentColor` and the `--hx-icon-stroke-width` token.
+   *
+   * When `library` resolves through the registry, the library's own paint mode
+   * is applied automatically — set this ONLY for the explicit `sprite-url` /
+   * `name="#…"` escape hatches when pinning a STROKE sprite sheet (e.g. the
+   * bundled `feather.svg` / `lucide.svg`), where no registry library is
+   * consulted. An explicit value overrides the library-derived mode.
+   * @attr paint-mode
+   */
+  @property({ type: String, reflect: true, attribute: 'paint-mode' })
+  paintMode: IconPaintMode | undefined = undefined;
 
   /**
    * Stores the sanitized inner markup of an externally fetched SVG.
@@ -469,7 +484,7 @@ export class HelixIcon extends HelixElement {
    * @internal
    */
   private _resolveLibraryHref():
-    | { kind: 'sprite'; href: string }
+    | { kind: 'sprite'; href: string; paintMode: IconPaintMode }
     | { kind: 'inline'; url: string; library: IconLibrary }
     | null {
     const lib = getIconLibrary(this.library);
@@ -502,7 +517,7 @@ export class HelixIcon extends HelixElement {
       return null;
     }
     if (lib.spriteSheet) {
-      return { kind: 'sprite', href: resolved };
+      return { kind: 'sprite', href: resolved, paintMode: lib.paintMode };
     }
     return { kind: 'inline', url: resolved, library: lib };
   }
@@ -556,7 +571,13 @@ export class HelixIcon extends HelixElement {
       const svg = doc.querySelector('svg');
       if (!svg) return sanitized;
       library.mutator(svg as unknown as SVGElement);
-      return svg.outerHTML;
+      // Re-sanitize AFTER the mutator. A hostile or compromised library mutator
+      // could otherwise reintroduce <script>, on* handlers, foreignObject, or
+      // javascript:/data: payloads that the first pass stripped — those would
+      // then flow straight to unsafeHTML. Running the mutated markup back through
+      // the same sanitizer closes that gap; legitimate mutations (viewBox, class,
+      // fill/stroke normalization) survive untouched.
+      return this._sanitizeSvg(svg.outerHTML);
     } catch (err) {
       console.warn(
         `[hx-icon] Mutator for library "${library.name}" threw on name "${this.name}"; rendering un-mutated SVG.`,
@@ -583,7 +604,7 @@ export class HelixIcon extends HelixElement {
   }
 
   /** @internal */
-  private _renderSprite(href?: string) {
+  private _renderSprite(href?: string, paintMode: IconPaintMode = 'fill') {
     const isDecorative = !this.label.trim();
     const useHref = href ?? this._spriteHref();
 
@@ -591,6 +612,7 @@ export class HelixIcon extends HelixElement {
       <svg
         part="svg"
         class="icon__svg"
+        data-paint-mode=${paintMode}
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
         role=${isDecorative ? nothing : 'img'}
@@ -605,7 +627,7 @@ export class HelixIcon extends HelixElement {
   }
 
   /** @internal */
-  private _renderInline() {
+  private _renderInline(paintMode: IconPaintMode = 'fill') {
     if (!this._inlineSvg) {
       return nothing;
     }
@@ -620,6 +642,7 @@ export class HelixIcon extends HelixElement {
       <span
         part="svg"
         class="icon__inline"
+        data-paint-mode=${paintMode}
         role=${isDecorative ? nothing : 'img'}
         aria-label=${isDecorative ? nothing : this.label}
         aria-hidden=${isDecorative ? 'true' : nothing}
@@ -635,7 +658,7 @@ export class HelixIcon extends HelixElement {
     // 1. Inline fetch mode takes precedence when src is a non-empty string.
     //    Library attribute is ignored on this path.
     if (typeof this.src === 'string' && this.src.trim().length > 0) {
-      return this._renderInline();
+      return this._renderInline(this.paintMode ?? 'fill');
     }
 
     // 2. Explicit sprite-url + name. Library attribute is ignored — the
@@ -645,14 +668,14 @@ export class HelixIcon extends HelixElement {
     //    consumers who want strict document-local sprite behavior
     //    can pin it that way without setting `library=""`.
     if (typeof this.spriteUrl === 'string' && this.name) {
-      return this._renderSprite();
+      return this._renderSprite(undefined, this.paintMode ?? 'fill');
     }
 
     // 2b. In-document fragment reference (`name="#custom-icon"`). Library
     //     attribute is ignored — the consumer is pointing at a sprite symbol
     //     embedded directly in the host page.
     if (this.name.startsWith('#')) {
-      return this._renderSprite();
+      return this._renderSprite(undefined, this.paintMode ?? 'fill');
     }
 
     // 3. Registry resolution — only when `library` is explicitly set to a
@@ -665,17 +688,17 @@ export class HelixIcon extends HelixElement {
       const resolved = this._resolveLibraryHref();
       if (!resolved) return nothing;
       if (resolved.kind === 'sprite') {
-        return this._renderSprite(resolved.href);
+        return this._renderSprite(resolved.href, this.paintMode ?? resolved.paintMode);
       }
       // Inline fetch mode driven by the registry — markup populated by
       // `_maybeFetchLibraryIcon` after sanitization + mutator pass.
-      return this._renderInline();
+      return this._renderInline(this.paintMode ?? resolved.library.paintMode);
     }
 
     // 4. Bare `name` (no library) → document-local sprite fragment
     //    (`<use href="#<name>">`). Pre-3.9.0 contract preserved.
     if (this.name) {
-      return this._renderSprite();
+      return this._renderSprite(undefined, this.paintMode ?? 'fill');
     }
 
     return nothing;

--- a/packages/hx-react/src/components/HxIcon/types.ts
+++ b/packages/hx-react/src/components/HxIcon/types.ts
@@ -57,4 +57,14 @@ applied. */
 By default, only same-origin URLs are permitted. Set this to allow
 specific CDN or asset server origins (e.g., "https://cdn.example.com,https://assets.example.com"). */
   allowedOrigins?: string;
+  /** Paint-mode override for the rendered glyph geometry. `'fill'` (default)
+paints with `fill: currentColor`; `'stroke'` paints outline glyphs with
+`fill: none; stroke: currentColor` and the `--hx-icon-stroke-width` token.
+
+When `library` resolves through the registry, the library's own paint mode
+is applied automatically — set this ONLY for the explicit `sprite-url` /
+`name="#…"` escape hatches when pinning a STROKE sprite sheet (e.g. the
+bundled `feather.svg` / `lucide.svg`), where no registry library is
+consulted. An explicit value overrides the library-derived mode. */
+  paintMode?: string | undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,9 +408,15 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.6
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
+      feather-icons:
+        specifier: ^4.29.2
+        version: 4.29.2
       linkedom:
         specifier: ^0.18.12
         version: 0.18.12
+      lucide-static:
+        specifier: ^1.21.0
+        version: 1.21.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -3383,6 +3389,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classnames@2.5.1:
+    resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
+
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
@@ -3506,6 +3515,9 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
@@ -4097,6 +4109,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  feather-icons@4.29.2:
+    resolution: {integrity: sha512-0TaCFTnBTVCz6U+baY2UJNKne5ifGh7sMG4ZC2LoBWCZdIyPa+y6UiR4lEYGws1JOFWdee8KAsAIvu0VcXqiqA==}
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -5005,6 +5020,9 @@ packages:
     resolution: {integrity: sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lucide-static@1.21.0:
+    resolution: {integrity: sha512-6248z2/4sEyKkYAPPUYxOPiB2RCfMmLdMHuoOhsTFnoD40ixAoHmTVhOPux8ADa1NTBmzpEKF7WNePm+Ms503Q==}
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -10337,6 +10355,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classnames@2.5.1: {}
+
   cli-boxes@3.0.0: {}
 
   cli-cursor@5.0.0:
@@ -10439,6 +10459,8 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  core-js@3.49.0: {}
 
   cors@2.8.6:
     dependencies:
@@ -11099,6 +11121,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  feather-icons@4.29.2:
+    dependencies:
+      classnames: 2.5.1
+      core-js: 3.49.0
 
   fflate@0.8.2: {}
 
@@ -12099,6 +12126,8 @@ snapshots:
   lucide-react@0.511.0(react@19.2.6):
     dependencies:
       react: 19.2.6
+
+  lucide-static@1.21.0: {}
 
   lz-string@1.5.0: {}
 


### PR DESCRIPTION
## What

Adds **Feather** (287 glyphs, MIT) and **Lucide** (~1,986 glyphs, ISC) as built-in
**stroke-paint** icon libraries, fully integrated into `<hx-icon>`.

```html
<hx-icon library="feather" name="activity" label="Activity"></hx-icon>
<hx-icon library="lucide" name="heart" label="Favorite"></hx-icon>
```

## How it works

- **`@helixui/icons`** — `feather`/`lucide` register like the existing libraries (sprite +
  tree-shake), but with `paintMode: 'stroke'`. Sprites build from the npm packages
  (`dist/feather.svg` ~55KB, `dist/lucide.svg` ~480KB) plus per-icon tree-shake modules
  (`@helixui/icons/tree-shake/feather/*`, `.../lucide/*`). `feather-icons` +
  `lucide-static` added as build-time devDeps only.
- **`<hx-icon>`** — reflects the resolved library's `paintMode` onto the rendered SVG
  (`data-paint-mode`); the styles paint stroke libraries with `fill: none;
  stroke: currentColor` + rounded caps/joins, width from the existing
  `--hx-icon-stroke-width` token. Fill libraries (`helix`, `fa-free`) are unchanged.

## Security (folded-in audit fix, C2)

`hx-icon` now **re-sanitizes icon-library mutator output** before render, closing a gap
where a hostile or compromised mutator could reintroduce `<script>` / `on*` /
`javascript:` payloads after the first sanitization pass.

## Validation

- `@helixui/icons`: build + **58 tests** pass.
- `@helixui/library`: type-check + **72 hx-icon tests** pass — including real-Chromium
  computed-style assertions that stroke mode renders `fill:none` + `stroke:currentColor`,
  plus the mutator re-sanitization regression tests.
- `agent-verify` green; CEM + React-wrapper drift clean. Public API unchanged → additive
  `minor` (changeset included).

## Notes / limitations

- AAA verdicts for the stroke libraries are `forcedColors: pass` (currentColor) with
  `contrast` / `opticalSizing: unknown` pending a formal `pnpm aaa:audit` — honest rather
  than a fabricated measured pass.
- Licenses attributed in `NOTICE.md` (Feather MIT © Cole Bemis; Lucide ISC © Lucide Icons
  and Contributors).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bundled Feather and Lucide icon libraries with stroke-based rendering.
  * Added `paint-mode` / `paintMode` to control icon rendering style (stroke vs fill).
  * Stroke icons respect the existing `--hx-icon-stroke-width` token.
* **Security**
  * Improved icon sanitization by re-sanitizing after any icon-library mutations to prevent unsafe content from being rendered.
* **Documentation & Tests**
  * Updated icon registry docs and added coverage for the new libraries and paint-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->