### PR TITLE
fix: resolve 3.11.0 release-review findings (carousel/form/icons/CI/docs)

### DIFF
--- a/.changeset/release-3.11-coderabbit-major-fixes.md
+++ b/.changeset/release-3.11-coderabbit-major-fixes.md
@@ -1,0 +1,22 @@
+---
+"@helixui/library": patch
+---
+
+fix two release-review findings surfaced on the 3.11 release.
+
+hx-carousel now normalizes `slides-per-page` through an internal integer-`>= 1`
+getter for all layout, bounds, and navigation math. A `slides-per-page="0"`,
+negative, or fractional value no longer divides by zero in the per-slide width
+expression nor pushes the maximum selectable index past the last real slide
+(which could report an empty state while slides exist); such values degrade to a
+1-up carousel (fractional floors to whole slides per page). The public
+`slidesPerPage` property is unchanged — only internal math reads the normalized
+value.
+
+hx-form now discovers validatable custom elements via the same
+`static formAssociated = true` path `getFormData()` serializes over, instead of a
+hardcoded tag allowlist. This keeps validation and serialization in lockstep: a
+form-associated control that is serialized is also covered by
+`checkValidity()`/`reportValidity()`/submit validation and `hx-invalid`, and a
+control excluded from one is excluded from the other — closing a gap where a
+value could be submitted while its validity was silently skipped.

--- a/.changeset/release-3.11-coderabbit-major-fixes.md
+++ b/.changeset/release-3.11-coderabbit-major-fixes.md
@@ -40,3 +40,14 @@ hx-icon's `paintMode` property is now annotated with its literal
 `'fill' | 'stroke' | 'mixed'` union so the CEM and the generated `@helixui/react`
 wrapper expose the exact union type instead of a bare `string` — restoring
 autocomplete and compile-time validation for React consumers.
+
+CI hardening (no package runtime impact): the shelf-guard breaking-change gate
+in `ci.yml` and `audit-batch-ci.yml` now passes `github.base_ref` through a
+`BASE_REF` env var instead of interpolating it directly into the shell, closing a
+workflow template-injection vector. Both aggregate quality-gate summaries now
+require the API breaking-change gate to resolve to `success` (a `cancelled` or
+`skipped` result no longer counts as a pass), so a breaking API change cannot
+merge when the gate did not run to completion. `scripts/ci/shelf-guard.mjs`
+`objectFieldNames()` now always returns a Set (even when empty), so an event
+detail that drops all fields (`{ foo }` → `{}`) is still compared and its removed
+fields are detected.

--- a/.changeset/release-3.11-coderabbit-major-fixes.md
+++ b/.changeset/release-3.11-coderabbit-major-fixes.md
@@ -1,8 +1,9 @@
 ---
 "@helixui/library": patch
+"@helixui/icons": patch
 ---
 
-fix two release-review findings surfaced on the 3.11 release.
+fix release-review findings surfaced on the 3.11 release.
 
 hx-carousel now normalizes `slides-per-page` through an internal integer-`>= 1`
 getter for all layout, bounds, and navigation math. A `slides-per-page="0"`,
@@ -20,3 +21,22 @@ form-associated control that is serialized is also covered by
 `checkValidity()`/`reportValidity()`/submit validation and `hx-invalid`, and a
 control excluded from one is excluded from the other — closing a gap where a
 value could be submitted while its validity was silently skipped.
+
+`@helixui/icons` sprite/tree-shake generators now escape preserved root-`<svg>`
+attribute values (`viewBox`, `stroke-linecap`, `stroke-linejoin`, and the symbol
+`id`) before interpolating them into the serialized `<symbol>` / inlined `<svg>`.
+A third-party source SVG carrying a malformed attribute value (e.g. an embedded
+`"`, `<`, or `>`) can no longer break out of its attribute and inject arbitrary
+markup into the published sprite or tree-shake artifacts.
+
+`@helixui/icons` SVG sanitization now compares paint keywords
+case-insensitively. Valid cascade-cooperative values such as `fill="currentcolor"`
+or `stroke="CONTEXT-STROKE"` are preserved (previously only exact-case
+`currentColor` / `context-stroke` survived), while genuinely-unsafe paints
+(hardcoded colors, `url(...)`) are still stripped. `transparent` was also added
+to the preserved set.
+
+hx-icon's `paintMode` property is now annotated with its literal
+`'fill' | 'stroke' | 'mixed'` union so the CEM and the generated `@helixui/react`
+wrapper expose the exact union type instead of a bare `string` — restoring
+autocomplete and compile-time validation for React consumers.

--- a/.github/workflows/audit-batch-ci.yml
+++ b/.github/workflows/audit-batch-ci.yml
@@ -318,7 +318,8 @@ jobs:
              [[ "${{ needs.format.result }}" == "failure" ]] || \
              [[ "${{ needs.type-check.result }}" == "failure" ]] || \
              [[ "${{ needs.build.result }}" == "failure" ]] || \
-             [[ "${{ needs.test.result }}" == "failure" ]]; then
+             [[ "${{ needs.test.result }}" == "failure" ]] || \
+             [[ "${{ needs.changeset.result }}" == "failure" ]]; then
             echo ""
             echo "❌ One or more quality gates failed"
             exit 1

--- a/.github/workflows/audit-batch-ci.yml
+++ b/.github/workflows/audit-batch-ci.yml
@@ -241,8 +241,10 @@ jobs:
       - name: Save head CEM
         run: cp packages/hx-library/custom-elements.json .cache/head-cem.json
       - name: Check out base branch public-API inputs
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          BASE="origin/${{ github.base_ref }}"
+          BASE="origin/${BASE_REF}"
           # Fail loudly if the base ref is unavailable — otherwise the gate would
           # silently compare head-vs-head and miss every breaking change.
           git rev-parse --verify --quiet "$BASE" >/dev/null || {
@@ -274,6 +276,8 @@ jobs:
       - name: Save base CEM
         run: cp packages/hx-library/custom-elements.json .cache/base-cem.json
       - name: Enforce 3.0 shelf (breaking API change requires a major changeset)
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: >
           node scripts/ci/shelf-guard.mjs
           --base-cem .cache/base-cem.json
@@ -283,7 +287,7 @@ jobs:
           --base-pkg .cache/base-pkg.json
           --head-pkg .cache/head-pkg.json
           --changesets .changeset
-          --base-ref "origin/${{ github.base_ref }}"
+          --base-ref "origin/${BASE_REF}"
           ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change-approved') && '--label-bypass' || '' }}
 
   # ── Summary gate ────────────────────────────────────────────────────────
@@ -314,10 +318,18 @@ jobs:
              [[ "${{ needs.format.result }}" == "failure" ]] || \
              [[ "${{ needs.type-check.result }}" == "failure" ]] || \
              [[ "${{ needs.build.result }}" == "failure" ]] || \
-             [[ "${{ needs.test.result }}" == "failure" ]] || \
-             [[ "${{ needs.api-breaking-change.result }}" == "failure" ]]; then
+             [[ "${{ needs.test.result }}" == "failure" ]]; then
             echo ""
             echo "❌ One or more quality gates failed"
+            exit 1
+          fi
+
+          # The API breaking-change gate must actively SUCCEED — a cancelled or
+          # skipped result must not be treated as a pass, otherwise a breaking
+          # change could merge whenever the gate did not run to completion.
+          if [[ "${{ needs.api-breaking-change.result }}" != "success" ]]; then
+            echo ""
+            echo "❌ API breaking-change gate did not succeed: ${{ needs.api-breaking-change.result }}"
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -886,8 +886,10 @@ jobs:
       # detected here — that rare case is covered by the informational CEM API Diff
       # comment and review.
       - name: Check out base branch public-API inputs
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          BASE="origin/${{ github.base_ref }}"
+          BASE="origin/${BASE_REF}"
           # Fail loudly if the base ref is unavailable — otherwise the gate would
           # silently compare head-vs-head and miss every breaking change.
           git rev-parse --verify --quiet "$BASE" >/dev/null || {
@@ -919,6 +921,8 @@ jobs:
       - name: Save base CEM
         run: cp packages/hx-library/custom-elements.json .cache/base-cem.json
       - name: Enforce 3.0 shelf (breaking API change requires a major changeset)
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: >
           node scripts/ci/shelf-guard.mjs
           --base-cem .cache/base-cem.json
@@ -928,7 +932,7 @@ jobs:
           --base-pkg .cache/base-pkg.json
           --head-pkg .cache/head-pkg.json
           --changesets .changeset
-          --base-ref "origin/${{ github.base_ref }}"
+          --base-ref "origin/${BASE_REF}"
           ${{ contains(github.event.pull_request.labels.*.name, 'breaking-change-approved') && '--label-bypass' || '' }}
 
   # ── Bundle Size Diff (PR only) ──────────────────────────────────────────
@@ -1349,20 +1353,31 @@ jobs:
           # Test, VRT, changeset, and bundle-size are allowed to be skipped
           # (non-PR / no source changes) or cancelled (concurrency group replaced a
           # running job).
-          for gate in test vrt changeset bundle-size api-breaking-change; do
+          for gate in test vrt changeset bundle-size; do
             result="${{ needs.test.result }}"
             case "$gate" in
               test)                result="${{ needs.test.result }}" ;;
               vrt)                 result="${{ needs.vrt.result }}" ;;
               changeset)           result="${{ needs.changeset.result }}" ;;
               bundle-size)         result="${{ needs.bundle-size.result }}" ;;
-              api-breaking-change) result="${{ needs.api-breaking-change.result }}" ;;
             esac
             if [[ "$result" != "success" && "$result" != "skipped" && "$result" != "cancelled" ]]; then
               echo "::error::Gate '$gate' did not succeed: $result"
               FAIL=1
             fi
           done
+
+          # The API breaking-change gate must actively SUCCEED on pull requests —
+          # a cancelled or skipped result must not pass, otherwise a breaking API
+          # change could merge whenever the gate did not run to completion. The
+          # gate only runs on PRs (and never on audit branches, which return
+          # above), so require success only for the pull_request event.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            if [[ "${{ needs.api-breaking-change.result }}" != "success" ]]; then
+              echo "::error::Gate 'api-breaking-change' did not succeed: ${{ needs.api-breaking-change.result }}"
+              FAIL=1
+            fi
+          fi
 
           # Coverage is informational-only while issue #1556 is open. The
           # vitest --coverage.enabled + browser-mode + chromium combination

--- a/docs/audit/AUDIT-3x-register.md
+++ b/docs/audit/AUDIT-3x-register.md
@@ -158,7 +158,7 @@ phi-field + clinical-status (not patient-banner — a one-line detector tweak).
 | E1 | **Legacy `size` alias is on only 10 of 29 size components.** (The `size`-vs-`hx-size` "split" is **refuted** — all 29 uniformly use the `hx-size` attribute.) 13 non-form components should gain the alias via a shared helper; **exclude the 6 form controls** (native `<input size>` collision — the reason `hx-size` exists). | Medium | SHIM | new `src/utils/apply-legacy-size-alias.ts` + 13 `connectedCallback`s |
 | E2 | **18 of ~28 event-emitting components lack `HTMLElementEventMap` augmentation** — `detail` is `any` for `addEventListener` consumers. All change/input details already carry `value`. | Medium | SHIM | per-component `declare global` blocks + exported named detail types |
 | E3 | **Variant additive gaps:** `hx-icon-button` lacks `outline`; `hx-toggle-button` lacks `danger`. Safe to add now. | Medium | SHIM | `hx-icon-button.ts:100`, `hx-toggle-button.ts:133` |
-| E4 | **`mixinDelegatesAria` is unexported** (FocusMixin/FormMixin are **already** public — recon partially refuted). Add to the `generate-barrel.js` allowlist; regenerate (never hand-edit the generated `src/index.ts`). | Low | SHIM | `scripts/generate-barrel.js:58-59` |
+| E4 | **`mixinDelegatesAria` is now publicly re-exported** from `packages/hx-library/src/index.ts` (resolved in 3.11.0 alongside the `@helixui/library/authoring` subpath; FocusMixin/FormMixin were already public). | Low | DONE (3.11.0) | `src/index.ts` re-export + `@helixui/library/authoring` subpath |
 | E5 | **CEM `./custom-elements.json` is already a published export** (recon's "not exported" branch refuted). Additive: advertise the subpath + `customElements` field for tooling. | Low | NB | docs only |
 | E6 | **`danger`↔`error` value naming diverges** (`hx-tag` uses `danger`; `hx-alert`/`hx-banner`/`hx-badge` use `error`). Unification removes a value → **4.0**. 3.x bridge: dual-accept alias + DEV warn. | Low | 4.0 (+SHIM) | parked |
 
@@ -198,8 +198,9 @@ for protected paths. The B gate is the proof obligation for C/D/E.
 
 - ❌ "size vs hx-size split across components" — **all 29 use `hx-size`**; the real gap
   is the legacy-`size` *compat shim* coverage (E1).
-- ❌ "FocusMixin/FormMixin/mixinDelegatesAria are unexported" — FocusMixin & FormMixin
-  are **already public**; only `mixinDelegatesAria` is internal (E4).
+- ❌ "FocusMixin/FormMixin/mixinDelegatesAria are unexported" — FocusMixin, FormMixin
+  **and** `mixinDelegatesAria` are all public as of 3.11.0 (E4 resolved via the
+  `src/index.ts` re-export + the `@helixui/library/authoring` subpath).
 - ❌ "CEM not published as an export" — it **is** (`exports`, `files`, `customElements`);
   it's simultaneously gitignored + generated-on-build + published (E5).
 - ❌ "hx-tooltip/hx-toast render unsanitized HTML" — slot-projection only; **`hx-icon`

--- a/packages/hx-icons/scripts/generate-sprite.ts
+++ b/packages/hx-icons/scripts/generate-sprite.ts
@@ -32,7 +32,7 @@ import { fileURLToPath } from 'node:url';
 
 import { parseHTML } from 'linkedom';
 
-import { sanitizeTree } from './svg-sanitize.js';
+import { escapeAttr, sanitizeTree } from './svg-sanitize.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, '..');
@@ -98,7 +98,7 @@ function parseSvgFile(filePath: string, id: string): Symbol | null {
   const presentation = ['stroke-linecap', 'stroke-linejoin']
     .map((attr) => {
       const value = svg.getAttribute(attr);
-      return value ? ` ${attr}="${value}"` : '';
+      return value ? ` ${attr}="${escapeAttr(value)}"` : '';
     })
     .join('');
 
@@ -128,7 +128,13 @@ function parseSvgFile(filePath: string, id: string): Symbol | null {
  */
 function buildSprite(symbols: Symbol[]): string {
   const body = symbols
-    .map((s) => `<symbol id="${s.id}" viewBox="${s.viewBox}"${s.presentation}>${s.inner}</symbol>`)
+    // `id` (file basename) and `viewBox` (source attribute) are escaped here;
+    // `presentation` is already escaped at collection time and serialized as
+    // ready-to-emit attributes, so it is interpolated as-is (no double-escape).
+    .map(
+      (s) =>
+        `<symbol id="${escapeAttr(s.id)}" viewBox="${escapeAttr(s.viewBox)}"${s.presentation}>${s.inner}</symbol>`,
+    )
     .join('');
   return `<svg xmlns="http://www.w3.org/2000/svg" aria-hidden="true" style="display:none">${body}</svg>`;
 }

--- a/packages/hx-icons/scripts/generate-tree-shake.ts
+++ b/packages/hx-icons/scripts/generate-tree-shake.ts
@@ -39,7 +39,7 @@ import { fileURLToPath } from 'node:url';
 import { parseHTML } from 'linkedom';
 
 import { assignIdentifiers } from './tree-shake-identifiers.js';
-import { sanitizeTree } from './svg-sanitize.js';
+import { escapeAttr, sanitizeTree } from './svg-sanitize.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(here, '..');
@@ -103,16 +103,19 @@ function loadGlyph(filePath: string, id: string, paintMode: 'fill' | 'stroke'): 
   // re-apply them on the emitted wrapper; otherwise the standalone string renders
   // blank. Caps/joins are read from the source rather than hard-coded, so each
   // library keeps its own line style.
+  // `cap`/`join`/`viewBox` originate from third-party source SVGs; escape them
+  // before interpolation so a malformed value containing `"`/`<`/`>`/`&` cannot
+  // break out of its attribute and inject markup into the published module.
   let strokeAttrs = '';
   if (paintMode === 'stroke') {
     const cap = svg.getAttribute('stroke-linecap');
     const join = svg.getAttribute('stroke-linejoin');
     strokeAttrs =
       ' fill="none" stroke="currentColor" stroke-width="2"' +
-      (cap ? ` stroke-linecap="${cap}"` : '') +
-      (join ? ` stroke-linejoin="${join}"` : '');
+      (cap ? ` stroke-linecap="${escapeAttr(cap)}"` : '') +
+      (join ? ` stroke-linejoin="${escapeAttr(join)}"` : '');
   }
-  const svgText = `<svg xmlns="${SVG_NS}" viewBox="${viewBox}"${strokeAttrs}>${inner}</svg>`;
+  const svgText = `<svg xmlns="${SVG_NS}" viewBox="${escapeAttr(viewBox)}"${strokeAttrs}>${inner}</svg>`;
   return { id, svg: svgText };
 }
 

--- a/packages/hx-icons/scripts/svg-sanitize.test.ts
+++ b/packages/hx-icons/scripts/svg-sanitize.test.ts
@@ -1,7 +1,7 @@
 import { parseHTML } from 'linkedom';
 import { describe, expect, it } from 'vitest';
 
-import { sanitizeTree } from './svg-sanitize.js';
+import { escapeAttr, sanitizeTree } from './svg-sanitize.js';
 
 /** Sanitize the CHILDREN of a source <svg> (mirrors how the generators use it). */
 function sanitizeChildren(svg: string): string {
@@ -47,5 +47,74 @@ describe('sanitizeTree', () => {
     expect(out).toContain('fill="currentColor"');
     expect(out).not.toContain('#abc');
     expect(out).not.toContain('id="dot"');
+  });
+
+  // Paint keywords are case-INSENSITIVE per SVG/CSS: lowercase, uppercase, and
+  // mixed-case spellings of a preserved keyword must all survive sanitization.
+  it('preserves case-variant paint keywords (currentcolor, CONTEXT-STROKE, CurrentColor)', () => {
+    const out = sanitizeChildren(
+      '<svg>' +
+        '<path fill="currentcolor" d="M0 0"/>' +
+        '<path stroke="CONTEXT-STROKE" d="M1 1"/>' +
+        '<path fill="CurrentColor" d="M2 2"/>' +
+        '<path fill="NONE" stroke="Context-Fill" d="M3 3"/>' +
+        '<path fill="TRANSPARENT" d="M4 4"/>' +
+        '</svg>',
+    );
+    expect(out).toContain('fill="currentcolor"');
+    expect(out).toContain('stroke="CONTEXT-STROKE"');
+    expect(out).toContain('fill="CurrentColor"');
+    expect(out).toContain('fill="NONE"');
+    expect(out).toContain('stroke="Context-Fill"');
+    expect(out).toContain('fill="TRANSPARENT"');
+  });
+
+  it('still strips genuinely-unsafe paints regardless of case', () => {
+    const out = sanitizeChildren(
+      '<svg>' +
+        '<path fill="url(#evil)" d="M0 0"/>' +
+        '<path stroke="JavaScript:alert(1)" d="M1 1"/>' +
+        '<path fill="#FF0000" d="M2 2"/>' +
+        '</svg>',
+    );
+    expect(out).not.toContain('url(#evil)');
+    expect(out).not.toContain('JavaScript:alert(1)');
+    expect(out).not.toContain('#FF0000');
+  });
+});
+
+describe('escapeAttr', () => {
+  it('escapes the four XML-significant characters', () => {
+    expect(escapeAttr('a"b')).toBe('a&quot;b');
+    expect(escapeAttr('a<b')).toBe('a&lt;b');
+    expect(escapeAttr('a>b')).toBe('a&gt;b');
+    expect(escapeAttr('a&b')).toBe('a&amp;b');
+  });
+
+  it('escapes `&` first so entities are not double-encoded', () => {
+    // If `"` were escaped before `&`, the resulting `&quot;` would then have its
+    // `&` re-escaped to `&amp;quot;`. Escaping `&` first prevents that.
+    expect(escapeAttr('"')).toBe('&quot;');
+    expect(escapeAttr('&quot;')).toBe('&amp;quot;');
+  });
+
+  it('neutralizes an attribute-breakout payload so no raw markup survives', () => {
+    // A malformed third-party stroke-linecap that tries to close the attribute
+    // and inject a <script>. After escaping, no raw `"`, `<`, or `>` remain, so
+    // the serialized `<symbol id=".." stroke-linecap="${escaped}">` cannot be
+    // structurally altered.
+    const payload = 'round"><script>alert(1)</script><symbol id="x';
+    const escaped = escapeAttr(payload);
+    expect(escaped).not.toMatch(/[<>"]/);
+    expect(escaped).toContain('&quot;');
+    expect(escaped).toContain('&lt;script&gt;');
+    // Sanity: interpolating the escaped value keeps the attribute intact.
+    const serialized = `<symbol stroke-linecap="${escaped}"></symbol>`;
+    const { document } = parseHTML(`<!doctype html><body>${serialized}</body>`);
+    const symbol = document.querySelector('symbol');
+    expect(symbol).not.toBeNull();
+    expect(symbol?.getAttribute('stroke-linecap')).toBe(payload);
+    // No injected <script> element made it into the DOM.
+    expect(document.querySelector('script')).toBeNull();
   });
 });

--- a/packages/hx-icons/scripts/svg-sanitize.ts
+++ b/packages/hx-icons/scripts/svg-sanitize.ts
@@ -13,14 +13,35 @@
  * leave the dot to inherit the stroke-mode `fill: none` and hollow it out.
  */
 
-/** Paint values that are safe to keep because they cooperate with the cascade. */
-const PRESERVED_PAINT = new Set([
-  'currentColor',
-  'none',
-  'inherit',
-  'context-fill',
-  'context-stroke',
-]);
+/**
+ * Paint values that are safe to keep because they cooperate with the cascade.
+ *
+ * SVG/CSS paint keywords are case-INSENSITIVE, so the lookup lowercases both the
+ * candidate value and these entries before comparing (see {@link sanitizeAttrs}).
+ * Entries are stored lowercase; the ORIGINAL author-cased value is preserved in
+ * the output — only the comparison is case-folded.
+ */
+const PRESERVED_PAINT = new Set(
+  ['currentColor', 'none', 'inherit', 'context-fill', 'context-stroke', 'transparent'].map((v) =>
+    v.toLowerCase(),
+  ),
+);
+
+/**
+ * Escape a string for safe interpolation into a double-quoted XML/SVG attribute
+ * value. Third-party source SVGs (under node_modules) can carry malformed
+ * attribute values containing `"`, `<`, `>`, or `&`; concatenating those raw
+ * into a serialized `<symbol>` could break out of the attribute and inject
+ * arbitrary markup into a published sprite artifact. Every preserved attribute
+ * value MUST pass through this helper before interpolation.
+ */
+export function escapeAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
 
 /**
  * Sanitize a single element in place. `Element` is the DOM-lib shape; linkedom
@@ -33,7 +54,10 @@ export function sanitizeAttrs(el: Element): void {
   }
   for (const attr of ['fill', 'stroke']) {
     const value = el.getAttribute(attr);
-    if (value !== null && !PRESERVED_PAINT.has(value.trim())) {
+    // Paint keywords are case-insensitive: compare lowercased against the
+    // lowercased PRESERVED_PAINT set (e.g. `currentcolor`, `CONTEXT-STROKE`
+    // must survive) while keeping the original author-cased value in output.
+    if (value !== null && !PRESERVED_PAINT.has(value.trim().toLowerCase())) {
       el.removeAttribute(attr);
     }
   }

--- a/packages/hx-library/figma-inventory.json
+++ b/packages/hx-library/figma-inventory.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "1.0.0",
-  "generatedAt": "2026-06-27T03:09:06.653Z",
+  "generatedAt": "2026-07-01T11:43:31.843Z",
   "sourceCem": "custom-elements.json",
   "helixVersion": "3.10.0",
   "tokensVersion": "3.9.4",
@@ -3867,7 +3867,7 @@
           }
         },
         {
-          "description": "Width override for each slide. Defaults to the per-page width computed from slides-per-page (100% / slides-per-page).",
+          "description": "Width override for each slide. Defaults to the gap-aware per-page width computed from slides-per-page.",
           "name": "--hx-carousel-slide-width",
           "figmaBinding": null
         },
@@ -12134,6 +12134,18 @@
             "xl"
           ],
           "default": "md"
+        },
+        {
+          "figmaAxisName": "paintMode",
+          "cemAttribute": "paint-mode",
+          "cemFieldName": "paintMode",
+          "type": "enum",
+          "values": [
+            "fill",
+            "stroke",
+            "mixed"
+          ],
+          "default": "undefined"
         }
       ],
       "textProperties": [

--- a/packages/hx-library/src/components/hx-carousel/hx-carousel.test.ts
+++ b/packages/hx-library/src/components/hx-carousel/hx-carousel.test.ts
@@ -789,6 +789,77 @@ describe('hx-carousel', () => {
       await el.updateComplete;
       expect(el['_currentIndex']).toBe(2);
     });
+
+    it('slides-per-page="0" degrades to 1-up: no /0 width, valid maxIndex, goTo works', async () => {
+      const el = await fixture<HelixCarousel>(`
+        <hx-carousel slides-per-page="0" style="display: block; width: 400px;">
+          <hx-carousel-item>1</hx-carousel-item>
+          <hx-carousel-item>2</hx-carousel-item>
+          <hx-carousel-item>3</hx-carousel-item>
+        </hx-carousel>
+      `);
+      await el.updateComplete;
+
+      // Width math normalizes to 1 slide per page — no division by zero.
+      expect(el['_effectiveSlidesPerPage']).toBe(1);
+      const widthExpr = el['_computedSlideWidthExpr']();
+      expect(widthExpr).toBe('calc((100% - 0 * var(--hx-carousel-gap, 0px)) / 1)');
+      expect(widthExpr).not.toContain('/ 0');
+
+      // Non-loop selection bound is the last real slide (n - 1), not n.
+      expect(el['_maxIndex']).toBe(2);
+
+      // The track transform is a finite CSS value (no NaN / Infinity).
+      const transform = el['_trackTransform'];
+      expect(transform).not.toContain('NaN');
+      expect(transform).not.toContain('Infinity');
+
+      // goTo(last) lands on the final slide and stays clamped there.
+      el.goTo(el['_slides'].length - 1);
+      await el.updateComplete;
+      expect(el['_currentIndex']).toBe(2);
+      el.goTo(99);
+      await el.updateComplete;
+      expect(el['_currentIndex']).toBe(2);
+    });
+
+    it('negative slides-per-page degrades to 1-up: valid width and bounds', async () => {
+      const el = await fixture<HelixCarousel>(`
+        <hx-carousel slides-per-page="-2" style="display: block; width: 400px;">
+          <hx-carousel-item>1</hx-carousel-item>
+          <hx-carousel-item>2</hx-carousel-item>
+          <hx-carousel-item>3</hx-carousel-item>
+        </hx-carousel>
+      `);
+      await el.updateComplete;
+
+      expect(el['_effectiveSlidesPerPage']).toBe(1);
+      // A negative page count must not inflate _maxIndex past the last slide
+      // (n - (-2) = n + 2 would strand goTo in an out-of-range/empty state).
+      expect(el['_maxIndex']).toBe(2);
+      const widthExpr = el['_computedSlideWidthExpr']();
+      expect(widthExpr).toBe('calc((100% - 0 * var(--hx-carousel-gap, 0px)) / 1)');
+
+      el.goTo(2);
+      await el.updateComplete;
+      expect(el['_currentIndex']).toBe(2);
+    });
+
+    it('fractional slides-per-page floors to whole slides per page', async () => {
+      const el = await fixture<HelixCarousel>(`
+        <hx-carousel style="display: block; width: 400px;">
+          <hx-carousel-item>1</hx-carousel-item>
+          <hx-carousel-item>2</hx-carousel-item>
+          <hx-carousel-item>3</hx-carousel-item>
+          <hx-carousel-item>4</hx-carousel-item>
+        </hx-carousel>
+      `);
+      el.slidesPerPage = 2.7;
+      await el.updateComplete;
+      expect(el['_effectiveSlidesPerPage']).toBe(2);
+      // Legacy non-loop page bound = n - floor(2.7) = 4 - 2 = 2.
+      expect(el['_maxIndex']).toBe(2);
+    });
   });
 
   // ─── Accessibility (axe-core) (3) ───

--- a/packages/hx-library/src/components/hx-carousel/hx-carousel.test.ts
+++ b/packages/hx-library/src/components/hx-carousel/hx-carousel.test.ts
@@ -860,6 +860,39 @@ describe('hx-carousel', () => {
       // Legacy non-loop page bound = n - floor(2.7) = 4 - 2 = 2.
       expect(el['_maxIndex']).toBe(2);
     });
+
+    it('positive fraction < 1 (0.5, 0.99) degrades to 1-up: floor(<1) never yields 0', async () => {
+      // A positive fraction below 1 passes `> 0` but `Math.floor` is 0 — the
+      // clamp to >= 1 keeps it a valid 1-up carousel (no divide-by-zero).
+      for (const value of [0.5, 0.99]) {
+        const el = await fixture<HelixCarousel>(`
+          <hx-carousel style="display: block; width: 400px;">
+            <hx-carousel-item>1</hx-carousel-item>
+            <hx-carousel-item>2</hx-carousel-item>
+            <hx-carousel-item>3</hx-carousel-item>
+          </hx-carousel>
+        `);
+        el.slidesPerPage = value;
+        await el.updateComplete;
+
+        expect(el['_effectiveSlidesPerPage']).toBe(1);
+        // Width math resolves to a single 100% page — no `/ 0`.
+        const widthExpr = el['_computedSlideWidthExpr']();
+        expect(widthExpr).toBe('calc((100% - 0 * var(--hx-carousel-gap, 0px)) / 1)');
+        expect(widthExpr).not.toContain('/ 0');
+
+        // Selection bound is the last real slide; transform is finite.
+        expect(el['_maxIndex']).toBe(2);
+        const transform = el['_trackTransform'];
+        expect(transform).not.toContain('NaN');
+        expect(transform).not.toContain('Infinity');
+
+        // goTo(last) works and stays clamped.
+        el.goTo(el['_slides'].length - 1);
+        await el.updateComplete;
+        expect(el['_currentIndex']).toBe(2);
+      }
+    });
   });
 
   // ─── Accessibility (axe-core) (3) ───

--- a/packages/hx-library/src/components/hx-carousel/hx-carousel.ts
+++ b/packages/hx-library/src/components/hx-carousel/hx-carousel.ts
@@ -77,7 +77,7 @@ const _svgPause = html`<hx-icon
  * @csspart play-pause-btn - The autoplay play/pause toggle button.
  *
  * @cssprop [--hx-carousel-gap=0px] - Gap between slides on the track. Defaults to 0 (flush slides).
- * @cssprop [--hx-carousel-slide-width] - Width override for each slide. Defaults to the per-page width computed from slides-per-page (100% / slides-per-page).
+ * @cssprop [--hx-carousel-slide-width] - Width override for each slide. Defaults to the gap-aware per-page width computed from slides-per-page.
  * @cssprop [--hx-carousel-nav-btn-size=2.5rem] - Size of previous/next navigation buttons.
  * @cssprop [--hx-carousel-pagination-dot-size=0.5rem] - Size of pagination dots.
  * @cssprop [--hx-space-3] - Spacing token.
@@ -677,6 +677,25 @@ export class HelixCarousel extends HelixElement {
   // ─── Navigation ───
 
   /**
+   * The effective slides-per-page used by ALL internal layout / bounds /
+   * navigation math — the public `slidesPerPage` normalized to an integer `>= 1`.
+   *
+   * A consumer can set `slides-per-page="0"` or a negative / fractional value; the
+   * public `@property` keeps that raw value (consumers read it back), but every
+   * MATH site reads this getter instead so a non-positive or fractional page count
+   * can never divide by zero in `_computedSlideWidthExpr` nor push `_maxIndex`
+   * past the last real slide (which would report an empty state while slides
+   * exist). Non-finite / `<= 0` degrades to a 1-up carousel; a fractional value
+   * floors to whole slides per page.
+   * @internal
+   */
+  private get _effectiveSlidesPerPage(): number {
+    return Number.isFinite(this.slidesPerPage) && this.slidesPerPage > 0
+      ? Math.floor(this.slidesPerPage)
+      : 1;
+  }
+
+  /**
    * Maximum SELECTABLE slide index (the selection bound, not the translate bound).
    *
    * Single static page (measured path, no overflow) → `0`. Whenever every slide is
@@ -710,9 +729,11 @@ export class HelixCarousel extends HelixElement {
       // emit `hx-slide-change` while the translate stays clamped at the page bound
       // 0 — phantom navigation of slides that never move. Collapse to 0 in that
       // case, exactly as the old `n - slidesPerPage` bound did.
-      return this._slides.length > this.slidesPerPage ? Math.max(0, this._slides.length - 1) : 0;
+      return this._slides.length > this._effectiveSlidesPerPage
+        ? Math.max(0, this._slides.length - 1)
+        : 0;
     }
-    return Math.max(0, this._slides.length - this.slidesPerPage);
+    return Math.max(0, this._slides.length - this._effectiveSlidesPerPage);
   }
 
   /**
@@ -725,7 +746,7 @@ export class HelixCarousel extends HelixElement {
    * @internal
    */
   private get _legacyPageBound(): number {
-    return Math.max(0, this._slides.length - this.slidesPerPage);
+    return Math.max(0, this._slides.length - this._effectiveSlidesPerPage);
   }
 
   /**
@@ -1162,7 +1183,7 @@ export class HelixCarousel extends HelixElement {
    * @internal
    */
   private _computedSlideWidthExpr(): string {
-    const n = this.slidesPerPage;
+    const n = this._effectiveSlidesPerPage;
     return `calc((100% - ${n - 1} * var(--hx-carousel-gap, 0px)) / ${n})`;
   }
 

--- a/packages/hx-library/src/components/hx-carousel/hx-carousel.ts
+++ b/packages/hx-library/src/components/hx-carousel/hx-carousel.ts
@@ -685,13 +685,14 @@ export class HelixCarousel extends HelixElement {
    * MATH site reads this getter instead so a non-positive or fractional page count
    * can never divide by zero in `_computedSlideWidthExpr` nor push `_maxIndex`
    * past the last real slide (which would report an empty state while slides
-   * exist). Non-finite / `<= 0` degrades to a 1-up carousel; a fractional value
-   * floors to whole slides per page.
+   * exist). Non-finite / `<= 0` degrades to a 1-up carousel; a positive fraction
+   * floors to whole slides per page but never below 1 — `Math.floor(0.5)` is `0`,
+   * which would re-introduce the divide-by-zero, so the result is clamped up to 1.
    * @internal
    */
   private get _effectiveSlidesPerPage(): number {
     return Number.isFinite(this.slidesPerPage) && this.slidesPerPage > 0
-      ? Math.floor(this.slidesPerPage)
+      ? Math.max(1, Math.floor(this.slidesPerPage))
       : 1;
   }
 

--- a/packages/hx-library/src/components/hx-form/hx-form.test.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.test.ts
@@ -79,9 +79,43 @@ class CustomFormControl extends HTMLElement {
 }
 customElements.define('custom-form-control', CustomFormControl);
 
+/**
+ * A form-associated custom element with only a PARTIAL validity surface — it
+ * exposes `checkValidity()` but NOT `reportValidity`/`validity`/
+ * `validationMessage`. It proves the P2 fix: such a control must NOT be pulled
+ * into the validatable set (where its `checkValidity()` could block a submit that
+ * `reportValidity()`/`_collectValidationErrors`/`_applyAriaInvalidFromValidity`
+ * can't surface), yet it is STILL serialized by `getFormData()` (a value-only
+ * control is effectively always-valid).
+ */
+class PartialValidityControl extends HTMLElement {
+  static formAssociated = true;
+
+  constructor() {
+    super();
+    // Attach internals so it is a genuine form-associated element, but expose no
+    // `validity` / `validationMessage` / `reportValidity` on the element itself.
+    this.attachInternals();
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  value = '';
+
+  // Always "invalid" if it were ever consulted — the whole point is that it is
+  // NOT consulted, so this must never block a submit.
+  checkValidity(): boolean {
+    return false;
+  }
+}
+customElements.define('partial-validity-control', PartialValidityControl);
+
 declare global {
   interface HTMLElementTagNameMap {
     'custom-form-control': CustomFormControl;
+    'partial-validity-control': PartialValidityControl;
   }
 }
 
@@ -669,6 +703,36 @@ describe('hx-form', () => {
       const validatable = el['_getAllValidatableElements']();
       const div = queryOrThrow<HTMLElement>(el, 'div[name="notAControl"]');
       expect(validatable).not.toContain(div);
+    });
+
+    it('a form-associated control with only a partial validity surface is serialized but not validated', async () => {
+      // partial-validity-control has checkValidity() but NOT reportValidity/
+      // validity/validationMessage. It must be EXCLUDED from the validatable set
+      // (so its always-false checkValidity can't block a submit that the
+      // report/collect/aria paths can't surface) while STILL being serialized.
+      const el = await fixture<HelixForm>(`
+        <hx-form>
+          <input type="text" name="native" value="n" />
+          <partial-validity-control name="partial"></partial-validity-control>
+        </hx-form>
+      `);
+      await el.updateComplete;
+
+      const control = queryOrThrow<PartialValidityControl>(el, 'partial-validity-control');
+      control.value = 'kept';
+
+      // Serialized: a value-only control still contributes to getFormData().
+      expect(el.getFormData().get('partial')).toBe('kept');
+
+      // NOT validatable: excluded from the set despite exposing checkValidity().
+      const validatable = el['_getAllValidatableElements']();
+      expect(validatable).not.toContain(control);
+
+      // And it does NOT block the form — checkValidity() ignores it entirely (the
+      // native field is valid, so the form is valid), instead of the partial
+      // control's always-false verdict blocking a submit with no feedback.
+      expect(el.checkValidity()).toBe(true);
+      expect(el.reportValidity()).toBe(true);
     });
   });
 

--- a/packages/hx-library/src/components/hx-form/hx-form.test.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.test.ts
@@ -26,6 +26,66 @@ declare global {
 }
 
 /**
+ * A minimal form-associated custom element that is NOT in `getFormElements()`'s
+ * hardcoded tag allowlist. It exists to prove the validation/serialization
+ * lockstep fix: `_getAllValidatableElements()` discovers it via the generic
+ * `static formAssociated = true` path (the same path `getFormData()` serializes
+ * over), so a control that is serialized is also validated — no divergence.
+ *
+ * `checkValidity()` reports the current `_valid` flag; `validity`/
+ * `validationMessage` mirror it so the constraint-collection path (used by
+ * `_handleSubmit`/`hx-invalid`) sees the same verdict.
+ */
+class CustomFormControl extends HTMLElement {
+  static formAssociated = true;
+  private _internals: ElementInternals;
+  private _valid = true;
+
+  constructor() {
+    super();
+    this._internals = this.attachInternals();
+  }
+
+  get name(): string {
+    return this.getAttribute('name') ?? '';
+  }
+
+  value = '';
+
+  /** Test hook: force this control valid or invalid. */
+  setValid(valid: boolean): void {
+    this._valid = valid;
+    this._internals.setValidity(
+      valid ? {} : { customError: true },
+      valid ? '' : 'Custom control is invalid.',
+    );
+  }
+
+  get validity(): ValidityState {
+    return this._internals.validity;
+  }
+
+  get validationMessage(): string {
+    return this._internals.validationMessage;
+  }
+
+  checkValidity(): boolean {
+    return this._valid;
+  }
+
+  reportValidity(): boolean {
+    return this._valid;
+  }
+}
+customElements.define('custom-form-control', CustomFormControl);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'custom-form-control': CustomFormControl;
+  }
+}
+
+/**
  * Query a single element from a fixture root, throwing a clear error (rather
  * than relying on a non-null assertion) when the selector matches nothing.
  * Narrows the return type so callers get a non-nullable element.
@@ -532,6 +592,83 @@ describe('hx-form', () => {
       await invalidPromise;
 
       expect(input.getAttribute('aria-invalid')).toBe('true');
+    });
+  });
+
+  // ─── Validation / serialization lockstep (3) ───
+
+  describe('Validation and serialization operate on the same control set', () => {
+    it('a form-associated custom element that getFormData serializes is also validated', async () => {
+      // custom-form-control is NOT in getFormElements()'s hardcoded allowlist,
+      // but it declares `static formAssociated = true`, so getFormData()'s generic
+      // discovery serializes it. The lockstep fix routes _getAllValidatableElements
+      // through the SAME discovery, so checkValidity() now also validates it.
+      const el = await fixture<HelixForm>(`
+        <hx-form>
+          <custom-form-control name="custom"></custom-form-control>
+        </hx-form>
+      `);
+      await el.updateComplete;
+
+      const control = queryOrThrow<CustomFormControl>(el, 'custom-form-control');
+      control.value = 'serialized';
+
+      // Serialized set includes it.
+      expect(el.getFormData().get('custom')).toBe('serialized');
+
+      // Validated set includes it too: forcing it invalid makes the form invalid.
+      control.setValid(false);
+      expect(el.checkValidity()).toBe(false);
+      expect(el.reportValidity()).toBe(false);
+
+      // And it is validatable via the same discovery path getFormData uses.
+      const validatable = el['_getAllValidatableElements']();
+      expect(validatable).toContain(control);
+    });
+
+    it('the validatable set equals the serialized form-associated set', async () => {
+      const el = await fixture<HelixForm>(`
+        <hx-form>
+          <input type="text" name="native" value="n" />
+          <hx-text-input name="hxField" value="v" label="Field"></hx-text-input>
+          <custom-form-control name="custom"></custom-form-control>
+        </hx-form>
+      `);
+      await el.updateComplete;
+
+      // Serialized set: the names getFormData() produces from form-associated controls.
+      const serializedNames = new Set([...el.getFormData().keys()]);
+
+      // Validated set: the names _getAllValidatableElements() discovers.
+      const validatableNames = new Set(
+        el['_getAllValidatableElements']().map((control) => {
+          const named = control as HTMLElement & { name?: string };
+          return named.name || control.tagName.toLowerCase();
+        }),
+      );
+
+      // Every serialized form-associated control is also validated — no divergence.
+      for (const name of serializedNames) {
+        expect(validatableNames.has(name)).toBe(true);
+      }
+      expect(validatableNames.has('custom')).toBe(true);
+    });
+
+    it('a control excluded from serialization is excluded from validation', async () => {
+      // A custom element WITHOUT `static formAssociated = true` is neither
+      // serialized nor validated — the two sets stay in lockstep on exclusion.
+      const el = await fixture<HelixForm>(`
+        <hx-form>
+          <input type="text" name="native" value="n" />
+          <div name="notAControl"></div>
+        </hx-form>
+      `);
+      await el.updateComplete;
+
+      expect(el.getFormData().has('notAControl')).toBe(false);
+      const validatable = el['_getAllValidatableElements']();
+      const div = queryOrThrow<HTMLElement>(el, 'div[name="notAControl"]');
+      expect(validatable).not.toContain(div);
     });
   });
 

--- a/packages/hx-library/src/components/hx-form/hx-form.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.ts
@@ -531,7 +531,18 @@ export class HelixForm extends HelixElement {
 
   /**
    * Returns elements that support constraint validation, including both native
-   * form elements and hx-* components with `checkValidity`.
+   * form elements and form-associated custom elements exposing `checkValidity`.
+   *
+   * Custom elements are discovered via the SAME path `getFormData()` uses —
+   * `_hostFormControls()` / `_isFormControl()` (the generic `static
+   * formAssociated = true` check), not the hardcoded `getFormElements()` tag
+   * allowlist. This keeps the VALIDATED set identical to the SERIALIZED set: a
+   * form-associated hx-* control that `getFormData()` serializes is also validated
+   * by `checkValidity`/`reportValidity`/`_handleSubmit`/`hx-invalid`, and a control
+   * excluded from one is excluded from the other — no divergence where a value is
+   * submitted while its validity is silently skipped. Custom elements without a
+   * `checkValidity` function are omitted (they contribute no constraint state);
+   * natives always expose it.
    *
    * When `scopeForm` is provided (the controlled-submit bridge passes the form
    * that fired the submit), the result is scoped to controls that belong to that
@@ -544,13 +555,19 @@ export class HelixForm extends HelixElement {
    * @internal
    */
   private _getAllValidatableElements(scopeForm: HTMLFormElement | null = null): HTMLElement[] {
-    const native = Array.from(this.querySelectorAll<HTMLElement>('input, select, textarea'));
-    const wcElements = this.getFormElements().filter(
+    // `_hostFormControls()` returns every form-associated control (natives —
+    // input/select/textarea — AND custom elements declaring `static
+    // formAssociated = true`), the SAME discovery `getFormData()` serializes over.
+    // Keep only elements exposing a `checkValidity` function: natives always do,
+    // and a form-associated custom element that does becomes validatable. This
+    // makes the validated set === the serialized set (minus controls with no
+    // constraint API), instead of pulling custom elements from the hardcoded
+    // `getFormElements()` tag allowlist which could diverge from serialization.
+    const all = this._hostFormControls().filter(
       (el): el is HTMLElement & { checkValidity: () => boolean } =>
         'checkValidity' in el &&
         typeof (el as { checkValidity: unknown }).checkValidity === 'function',
     );
-    const all = [...native, ...wcElements];
     if (scopeForm === null) {
       return all;
     }

--- a/packages/hx-library/src/components/hx-form/hx-form.ts
+++ b/packages/hx-library/src/components/hx-form/hx-form.ts
@@ -558,20 +558,57 @@ export class HelixForm extends HelixElement {
     // `_hostFormControls()` returns every form-associated control (natives —
     // input/select/textarea — AND custom elements declaring `static
     // formAssociated = true`), the SAME discovery `getFormData()` serializes over.
-    // Keep only elements exposing a `checkValidity` function: natives always do,
-    // and a form-associated custom element that does becomes validatable. This
-    // makes the validated set === the serialized set (minus controls with no
-    // constraint API), instead of pulling custom elements from the hardcoded
-    // `getFormElements()` tag allowlist which could diverge from serialization.
-    const all = this._hostFormControls().filter(
-      (el): el is HTMLElement & { checkValidity: () => boolean } =>
-        'checkValidity' in el &&
-        typeof (el as { checkValidity: unknown }).checkValidity === 'function',
+    // Keep only elements exposing the FULL constraint-validation surface this
+    // form's paths actually use: `checkValidity` (checkValidity/submit gate),
+    // `reportValidity` (reportValidity), and `validity` + `validationMessage`
+    // (`_collectValidationErrors` / `_applyAriaInvalidFromValidity`). Natives
+    // always expose all four; a form-associated custom control must too. A control
+    // with only a partial surface (e.g. `checkValidity` but no `validity`/
+    // `validationMessage`) is NOT validatable — otherwise its `checkValidity()`
+    // could BLOCK a submit while the error-collection / aria-invalid / reportValidity
+    // paths silently skip it, blocking the form with no visible feedback. It still
+    // SERIALIZES via `getFormData()` (a value-only control is effectively
+    // always-valid); it is only excluded from validation/blocking. This keeps the
+    // validated set aligned with serialization without pulling custom elements from
+    // the hardcoded `getFormElements()` tag allowlist (which could diverge).
+    const all = this._hostFormControls().filter((el): el is HTMLElement =>
+      this._isValidatableControl(el),
     );
     if (scopeForm === null) {
       return all;
     }
     return all.filter((el) => this._formOf(el) === scopeForm);
+  }
+
+  /**
+   * Whether a control exposes the FULL constraint-validation surface this form's
+   * validation paths rely on: `checkValidity()` AND `reportValidity()` (both
+   * functions), a `validity` object (a `ValidityState`-like with a boolean
+   * `valid`), and a string `validationMessage`. Requiring all four keeps
+   * `checkValidity`/submit-gating in lockstep with `reportValidity`,
+   * `_collectValidationErrors`, and `_applyAriaInvalidFromValidity` — a control
+   * with only a partial surface can't silently block a submit while producing no
+   * error summary, aria-invalid marker, or native bubble. Native input/select/
+   * textarea satisfy this; a form-associated custom control must implement the
+   * whole surface to be validated (else it's treated as always-valid and only
+   * serialized).
+   * @internal
+   */
+  private _isValidatableControl(el: Element): boolean {
+    const candidate = el as {
+      checkValidity?: unknown;
+      reportValidity?: unknown;
+      validity?: unknown;
+      validationMessage?: unknown;
+    };
+    return (
+      typeof candidate.checkValidity === 'function' &&
+      typeof candidate.reportValidity === 'function' &&
+      typeof candidate.validationMessage === 'string' &&
+      typeof candidate.validity === 'object' &&
+      candidate.validity !== null &&
+      typeof (candidate.validity as { valid?: unknown }).valid === 'boolean'
+    );
   }
 
   /**

--- a/packages/hx-library/src/components/hx-icon/hx-icon.ts
+++ b/packages/hx-library/src/components/hx-icon/hx-icon.ts
@@ -158,7 +158,7 @@ export class HelixIcon extends HelixElement {
    * @attr paint-mode
    */
   @property({ type: String, reflect: true, attribute: 'paint-mode' })
-  paintMode: IconPaintMode | undefined = undefined;
+  paintMode: 'fill' | 'stroke' | 'mixed' | undefined = undefined;
 
   /**
    * Stores the sanitized inner markup of an externally fetched SVG.

--- a/packages/hx-library/src/components/hx-text-input/hx-text-input.stories.ts
+++ b/packages/hx-library/src/components/hx-text-input/hx-text-input.stories.ts
@@ -967,7 +967,7 @@ export const FocusRingOffset: Story = {
 
       <div>
         <h4
-          style="margin: 0 0 var(--hx-space-2, 0.5rem); font-size: var(--hx-font-size-sm, 0.875rem); color: #6c757d;"
+          style="margin: 0 0 var(--hx-space-2, 0.5rem); font-size: var(--hx-font-size-sm, 0.875rem); color: var(--hx-color-neutral-500, #66787B);"
         >
           Default offset (0px)
         </h4>
@@ -976,7 +976,7 @@ export const FocusRingOffset: Story = {
 
       <div>
         <h4
-          style="margin: 0 0 var(--hx-space-2, 0.5rem); font-size: var(--hx-font-size-sm, 0.875rem); color: #6c757d;"
+          style="margin: 0 0 var(--hx-space-2, 0.5rem); font-size: var(--hx-font-size-sm, 0.875rem); color: var(--hx-color-neutral-500, #66787B);"
         >
           --hx-text-input-focus-ring-offset: 3px
         </h4>
@@ -989,7 +989,7 @@ export const FocusRingOffset: Story = {
 
       <div>
         <h4
-          style="margin: 0 0 var(--hx-space-2, 0.5rem); font-size: var(--hx-font-size-sm, 0.875rem); color: #6c757d;"
+          style="margin: 0 0 var(--hx-space-2, 0.5rem); font-size: var(--hx-font-size-sm, 0.875rem); color: var(--hx-color-neutral-500, #66787B);"
         >
           Error-state ring honors the offset too
         </h4>

--- a/packages/hx-react/src/components/HxIcon/types.ts
+++ b/packages/hx-react/src/components/HxIcon/types.ts
@@ -66,5 +66,5 @@ is applied automatically — set this ONLY for the explicit `sprite-url` /
 `name="#…"` escape hatches when pinning a STROKE sprite sheet (e.g. the
 bundled `feather.svg` / `lucide.svg`), where no registry library is
 consulted. An explicit value overrides the library-derived mode. */
-  paintMode?: string | undefined;
+  paintMode?: 'fill' | 'stroke' | 'mixed' | undefined;
 }

--- a/scripts/ci/shelf-guard.mjs
+++ b/scripts/ci/shelf-guard.mjs
@@ -244,7 +244,10 @@ function objectFieldNames(text) {
     const name = field.slice(0, idx).trim().replace(/\?$/, '').trim();
     if (name) names.add(name);
   }
-  return names.size ? names : null;
+  // Always return the Set (even when empty) so an object literal that loses all
+  // its fields — `{ foo }` → `{}` — stays comparable. Returning null here would
+  // skip the removal-check branch below and miss every removed detail field.
+  return names;
 }
 
 /** Split on top-level occurrences of any char in `seps`, respecting nesting. */

--- a/scripts/ci/shelf-guard.mjs
+++ b/scripts/ci/shelf-guard.mjs
@@ -228,8 +228,17 @@ function splitUnion(text) {
 }
 
 /**
- * Field names of the outermost object literal in a type string, or null if there
- * is none. Used for event-detail payloads (e.g. `CustomEvent<{value, date}>`).
+ * Named field names of the outermost object literal in a type string. Returns:
+ *   - the Set of plain property names when the object has named fields;
+ *   - an EMPTY Set for a genuinely-empty object `{}` (no members at all), so a
+ *     `{ foo }` → `{}` narrowing stays comparable and every removed field is
+ *     detected; and
+ *   - `null` when there is no object literal, OR when the object has ONLY
+ *     non-enumerable members (index / call / construct signatures) and no named
+ *     fields — such a shape isn't a named-field map, so we can't assert any
+ *     named field was removed and must skip the removal check rather than
+ *     mis-report a removal (e.g. `{ foo }` → `{ [key: string]: unknown }`).
+ * Used for event-detail payloads (e.g. `CustomEvent<{value, date}>`).
  * Optionality and field types are intentionally ignored — see the events check.
  */
 function objectFieldNames(text) {
@@ -238,15 +247,26 @@ function objectFieldNames(text) {
   const end = t.lastIndexOf('}');
   if (start === -1 || end <= start) return null;
   const names = new Set();
+  let sawSignature = false;
   for (const field of splitTopLevelChars(t.slice(start + 1, end), [';', ','])) {
     const idx = topLevelColon(field);
-    if (idx === -1) continue; // index/call signature — skip
+    if (idx === -1) {
+      // No top-level `:` — a bare call/construct signature (e.g. `() => void`).
+      sawSignature = true;
+      continue;
+    }
     const name = field.slice(0, idx).trim().replace(/\?$/, '').trim();
-    if (name) names.add(name);
+    // Index (`[key: string]`), call (`(x): T`), and construct (`new (): T`)
+    // signatures are not enumerable property names — never treat them as fields.
+    if (!name || name.startsWith('[') || name.startsWith('(') || /^new\s*\(/.test(name)) {
+      sawSignature = true;
+      continue;
+    }
+    names.add(name);
   }
-  // Always return the Set (even when empty) so an object literal that loses all
-  // its fields — `{ foo }` → `{}` — stays comparable. Returning null here would
-  // skip the removal-check branch below and miss every removed detail field.
+  // Empty names with a signature present → not a named-field map; skip the
+  // removal check. A truly-empty `{}` (no members at all) returns the empty Set.
+  if (names.size === 0 && sawSignature) return null;
   return names;
 }
 


### PR DESCRIPTION
## Resolve the 3.11.0 release-review (CodeRabbit) Major/Minor findings

Addresses the CodeRabbit findings raised on the release PR #1781 (full 3.11.0 delta). Fixes every Major finding + the actionable Minors across components, icons, protected CI workflows, and docs. Flows to `dev` → `staging` so #1781's threads clear. Codex-reviewed to a **clean pass (0 findings)**; protected-path `/codex-review` audit written.

### Components
- **hx-carousel** — clamp `slidesPerPage` to an integer ≥ 1 (`_effectiveSlidesPerPage`, `Math.max(1, Math.floor(...))`) so `0`/negative/`(0,1)` fractions can't divide-by-zero or corrupt `_maxIndex`; `@cssprop` doc corrected to the gap-aware default.
- **hx-form** — `getFormData()` serialization and validation now use the same control-discovery path; a control is treated as *validatable* only when it exposes the full validity surface (`checkValidity`/`reportValidity`/`validity`/`validationMessage`) — minimal FACE controls serialize but don't block submit with no feedback.

### Icons
- Escape third-party SVG attribute values before serializing into the published sprite (`generate-sprite` + `generate-tree-shake`) — closes an attribute-injection vector.
- Case-insensitive preserved-paint matching (`currentcolor`, `CONTEXT-STROKE`, …) so valid paints survive sanitization.
- `hx-icon` `paintMode` now surfaces its literal union `'fill' | 'stroke' | 'mixed'` in the generated React wrapper (was `string`).

### CI (protected workflows + script)
- Kill shell-template-injection from `github.base_ref` (passed via `env`) in `ci.yml` + `audit-batch-ci.yml`.
- The API breaking-change gate now requires `success` (no longer passes on `cancelled`/`skipped`).
- `shelf-guard.mjs` — preserve empty event-detail objects as comparable so removed detail fields are detected.

### Docs
- Tokenize the text-input focus-ring-offset story colors; refresh the 3.x audit register (E4) — `mixinDelegatesAria` is now publicly re-exported in 3.11.0.

### Dispositioned (resolved with justification on #1781, no code change)
- "hx-form changeset should be major" — owner-decided **minor** (removed action-mode was already non-functional).
- "minlength/maxlength-message should reflect" — consistent with the established `required-message` pattern (attribute→property; reflection not required for set-once config).

Tests: carousel + form 281 pass; icons 76 + 76 pass. type-check/eslint/prettier clean; CEM + react wrappers regenerated with no unexpected drift.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved `paintMode` typing for icons in UI integrations.
* **Bug Fixes**
  * Carousel now handles zero, negative, and fractional `slides-per-page` values without layout/math issues.
  * Form validation and form-data collection stay in sync for form-associated custom controls.
  * SVG icon generation is safer against malformed/unsafe attributes, and paint keywords are preserved case-insensitively.
* **CI / Reliability**
  * Hardened API-breaking change gate logic and base reference handling.
* **Documentation**
  * Updated audit documentation to reflect the now-public API export.
* **Tests**
  * Added regression and security-focused test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->