### PR TITLE
fix(release): widen icons peer range to stop spurious 3.11.0 → 4.0.0 major

### DIFF
--- a/.changeset/fix-icons-peer-range-linked-major.md
+++ b/.changeset/fix-icons-peer-range-linked-major.md
@@ -1,0 +1,9 @@
+---
+"@helixui/library": patch
+---
+
+fix(release): widen the `@helixui/icons` peer range so a same-cycle icons bump no longer forces a spurious major
+
+`@helixui/library` declared `"@helixui/icons": "workspace:*"` as a peer dependency. Because `workspace:*` resolves to the icons package's exact current version at publish time (an exact pin such as `1.0.4`), any release cycle that bumped `@helixui/icons` (even a minor) caused Changesets' `shouldBumpMajor` peer-dependent rule to fire: the incremented icons version left library's exact-pinned peer range, so library was force-bumped to a **major**. Through the `[@helixui/library, @helixui/tokens, @helixui/react]` linked group and library's downstream dependents, that spurious major cascaded (library/react → 4.0.0, drupal packages → 5.0.0) even though every changeset in the cycle was minor/patch.
+
+Changing the peer specifier to `workspace:^` publishes a caret range (`^1.1.0`) that a compatible icons minor satisfies, so a same-cycle icons bump no longer leaves the range and library versions on its own changeset severity. The change is specifier-only — the resolved workspace link is unchanged and the lockfile is unaffected. The published peer range moves from an exact `icons` pin to a caret range, which is the intended, less-brittle contract.

--- a/packages/hx-library/package.json
+++ b/packages/hx-library/package.json
@@ -102,7 +102,7 @@
   },
   "peerDependencies": {
     "@floating-ui/dom": "^1.7.6",
-    "@helixui/icons": "workspace:*"
+    "@helixui/icons": "workspace:^"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem

The pending 3.11.0 release computes a **spurious MAJOR**. The Changesets version PR (#1789) bumps `@helixui/library` 3.10.0 → **4.0.0** and `@helixui/react` → **4.0.0**, cascading `@helixui/drupal-behaviors`/`drupal-starter` to **5.0.0** — even though every one of the 14 release changesets is `minor`/`patch` (none `major`). #1789's own CHANGELOG lists the 4.0.0 bump under "### Minor Changes," which is self-contradictory.

## Root cause

`@helixui/library` declared its icons peer dependency as:

```json
"peerDependencies": { "@helixui/icons": "workspace:*" }
```

`workspace:*` resolves to the dependency's **exact current version** at compute/publish time (an exact pin, e.g. `1.0.4`). This release cycle bumps `@helixui/icons` 1.0.4 → 1.1.0 (via the feather/lucide changeset). Changesets' `determineDependents` → `shouldBumpMajor` rule fires **only for peerDependencies**:

- `depType === "peerDependencies"` ✓
- icons bump type is `minor` (not none/patch) ✓
- with `onlyUpdatePeerDependentsWhenOutOfRange: true`, it checks whether the incremented icons version (`1.1.0`) satisfies library's peer range (`1.0.4`) → it does **not** → **library is force-bumped to `major`**

That major then propagates through the `[library, tokens, react]` `linked` group (react → 4.0.0) and through library's own dependents: `drupal-behaviors`/`drupal-starter` peer-depend on library via `workspace:^` (= `^3.10.0`), which `4.0.0` leaves → they too get force-majored to 5.0.0.

The stale `## 4.0.0 [DEPRECATED]` heading in `hx-tokens/CHANGELOG.md` and the `hx-tokens` version drift (3.9.4 vs library 3.10.0) are **not** the cause — Changesets computes versions from `package.json`, never from CHANGELOG files. Verified empirically: removing the CHANGELOG heading alone still produced 4.0.0.

## Fix

Change the icons **peerDependency** specifier from `workspace:*` to `workspace:^`:

```diff
   "peerDependencies": {
     "@floating-ui/dom": "^1.7.6",
-    "@helixui/icons": "workspace:*"
+    "@helixui/icons": "workspace:^"
   },
```

`workspace:^` publishes a caret range (`^1.1.0`) that a compatible icons minor satisfies, so the peer no longer leaves its range and library versions on its own changeset severity (minor → 3.11.0). The `devDependency` on icons is intentionally left as `workspace:*` (devDependencies do not participate in `shouldBumpMajor`).

This is specifier-only: the resolved workspace link is unchanged and the lockfile is unaffected (`pnpm install --frozen-lockfile` passes with zero diff).

## Verified post-fix computation

`pnpm exec changeset version` against this branch yields:

| Package | Before (broken) | After (this fix) |
|---|---|---|
| `@helixui/library` | 4.0.0 | **3.11.0** |
| `@helixui/react` | 4.0.0 | **3.11.0** |
| `@helixui/tokens` | 3.9.4 | 3.9.4 (no changeset; unchanged) |
| `@helixui/icons` | 1.1.0 | 1.1.0 |
| `@helixui/drupal-behaviors` | 5.0.0 | 4.0.1 (no forced major) |
| `@helixui/drupal-starter` | 5.0.0 | 4.0.1 (no forced major) |
| `@helixui/react-starter` | — | 0.0.22 (patch dependent) |

No 4.x / no 5.x anywhere. The generated CHANGELOGs contain no "### Major Changes" heading.

## Release flow

Once this merges to `main`, the Changesets Action re-runs `changeset version` on the updated `main` and regenerates #1789 (`changeset-release/main`) — which will then read **3.11.0**. Merging that regenerated version PR publishes 3.11.0.

## Scope / safety

- One-line functional change + one documenting changeset (`@helixui/library` patch).
- No source, test, type, or lockfile impact. `--frozen-lockfile` clean.
- Codex local review: pass (0 findings). Push-gate codex round: pass (0 findings).
