### PR TITLE
fix(hx-switch): use composedPath origin so space does not double-toggle

### DIFF
--- a/.changeset/hx-switch-double-toggle.md
+++ b/.changeset/hx-switch-double-toggle.md
@@ -1,0 +1,13 @@
+---
+"@helixui/library": patch
+---
+
+fix `hx-switch` toggling twice when a Space keypress originates on the inner track button
+
+`_handleHostKeyDown` guarded against re-entry with `e.target !== this`. Shadow retargeting sets `target` to the host for any event that crosses the shadow boundary, so that check could not distinguish a keypress on the host from one that started on the inner `<button>` — where the track's own `@keydown` handler had already toggled. Both handlers ran, the switch toggled twice, and `checked` landed back where it started while two `hx-change` events fired.
+
+The guard now compares `e.composedPath()[0]` against the host, which is the true origin regardless of retargeting. Only one handler acts on any given keypress.
+
+This also fixes the component under Firefox and WebKit. Firefox delivers a `composed: false` event dispatched inside a shadow root to the host listener, where Chromium does not, so on Firefox the host handler ran for events it should never have seen — Space double-toggled to no-op and Enter toggled when it should not have. The origin check makes the behavior identical across all three engines; the `hx-switch` suite now passes 98/98 on Chromium, Firefox, and WebKit.
+
+No API, ARIA, or token changes. Keyboard activation remains Space (and Enter, via native button semantics) per the ARIA APG switch pattern.

--- a/packages/hx-library/src/components/hx-switch/hx-switch.ts
+++ b/packages/hx-library/src/components/hx-switch/hx-switch.ts
@@ -288,7 +288,13 @@ export class HelixSwitch extends FormMixin(HelixElement) {
   private _handleHostKeyDown = (e: KeyboardEvent): void => {
     if (this.disabled) return;
     if (!this._supportsIdrefRefs) return;
-    if (e.target !== this) return;
+    // `e.target` is retargeted to the host for anything crossing the shadow
+    // boundary, so it cannot tell a keypress on the host from one that started
+    // on the inner `<button>` — where `_handleKeyDown` has already toggled.
+    // Compare against the true origin, or Space toggles twice and nets zero.
+    // Firefox also delivers `composed: false` events to the host, so checking
+    // the origin is what makes this engine-independent.
+    if (e.composedPath()[0] !== this) return;
     if (e.key === ' ' || e.key === 'Enter') {
       e.preventDefault();
       this._toggle();


### PR DESCRIPTION
Found while investigating the long-standing Cross-Browser (firefox/webkit) CI failures. **This is a real product bug, not a flaky test.**

## The bug

`_handleHostKeyDown` guarded against re-entry with `e.target !== this`. Shadow retargeting rewrites `target` to the host for any event that crosses the shadow boundary, so that check cannot distinguish a keypress on the host from one that started on the inner `<button class="switch__track">` — where the track's own `@keydown` binding has *already* toggled.

Both handlers run. The switch toggles twice, `checked` lands back where it started, and two `hx-change` events fire.

## Measured, not theorised

An instrumented probe, identical code, three engines:

| Event | Firefox | Chromium |
|---|---|---|
| Space, `composed: false` | **2 toggles** → `false` | 1 toggle → `true` |
| Space, `composed: true` | **2 toggles** → `false` | **2 toggles** → `false` |
| Enter, `composed: false` | 1 toggle → `true` | 0 toggles → `false` |

The `composed: true` row is the product bug: **both engines double-toggle** when the keydown originates at the inner button.

## Why it only surfaced in Firefox CI

Firefox delivers a `composed: false` event dispatched inside a shadow root to the **host** listener; Chromium correctly does not. So on Firefox the host handler saw events it should never have seen — Space double-toggled to a no-op, Enter toggled when the test asserts it must not. Chromium passed by accident, because it withheld the event.

The two failing tests (`hx-switch.test.ts:471` and `:479`) dispatch untrusted `composed: false` KeyboardEvents at the track. They were correct to fail.

## The fix

```diff
-    if (e.target !== this) return;
+    if (e.composedPath()[0] !== this) return;
```

`composedPath()[0]` is the true origin regardless of retargeting. Exactly one handler acts on any keypress, on every engine.

## Verification

- `hx-switch.test.ts` — **98/98 pass** on chromium, firefox, **and** webkit (was 96/98 on firefox+webkit)
- `keyboard-navigation.test.ts` — **71/71** on all three engines
- `tsc --noEmit` clean, eslint clean, prettier clean
- Codex adversarial review: **pass, 0 findings**

## Scope

Only the guard changed. No API, ARIA, or token changes. Space (and Enter, via native button semantics) still activate per the ARIA APG switch pattern.

The remaining Cross-Browser failures are unrelated and tracked separately: `hx-carousel` (`ReferenceError: TouchEvent is not defined` — desktop firefox/webkit expose no `TouchEvent` constructor), `hx-image` (`hx-error` never fires for slotted media), `hx-phi-field` (synthetic `visibilitychange` does not flip `document.visibilityState`).