### PR TITLE
fix(drift-gate): keep the floating-form skip at bare major, annotate the anti-pattern

### DIFF
--- a/apps/docs/src/content/docs/components/distribution/cdn.md
+++ b/apps/docs/src/content/docs/components/distribution/cdn.md
@@ -416,11 +416,8 @@ This URL is permanently cached. When `3.10.0` ships, a new URL is served. Old UR
 <!-- ❌ BAD — a new release changes what this URL serves -->
 <script type="module" src="https://cdn.jsdelivr.net/npm/@helixui/library@3/dist/index.js"></script>
 
-<!-- ❌ BAD — minor/patch updates silently change the file -->
-<script
-  type="module"
-  src="https://cdn.jsdelivr.net/npm/@helixui/library@3.11/dist/index.js"
-></script>
+<!-- ❌ BAD — minor/patch updates silently change the file (illustrative; do not copy) -->
+<script type="module" src="https://unpkg.com/@helixui/library@3.11/dist/index.js"></script>
 ```
 
 Floating ranges work in `package.json` (with a lockfile) because `npm ci` resolves and pins the version. On CDN URLs there is no lockfile, so a minor update can silently break a Drupal site.

--- a/scripts/check-version-drift.mjs
+++ b/scripts/check-version-drift.mjs
@@ -270,14 +270,19 @@ async function scanFile(absPath, relPath, versions) {
       continue;
     }
 
-    // Skip floating forms (`@1`, `@3`, `@^4`, `@3.11`) when they appear in a
-    // CDN / import-map context — those track a branch rather than pinning a
-    // release, so they never go stale. A major.minor form like `@3.11` is a
-    // valid jsDelivr/unpkg range and is exactly what the "do not use floating
-    // ranges" anti-pattern examples need to show. The context detector strips
-    // the matched span itself so a literal `@helixui/<pkg>@<ver>` on the line
+    // Skip bare floating-major forms (`@1`, `@3`, `@^4`) when they appear in
+    // a CDN / import-map context — those are intentional "track the major
+    // branch" pins, not stale exact pins. The context detector strips the
+    // matched span itself so a literal `@helixui/<pkg>@<ver>` on the line
     // doesn't accidentally count as evidence of import-map shape.
-    if (/^\^?\d+(\.\d+)?$/.test(versionString)) {
+    //
+    // Deliberately NOT widened to `major.minor`. A `@3.10` in a production
+    // install snippet is a real stale pin once the library moves on, and
+    // exempting the whole shape would blind the gate to that class. Snippets
+    // that need a floating minor — the "do not use floating ranges"
+    // anti-pattern examples — annotate themselves with `illustrative`, which
+    // the context skip above already honours.
+    if (/^\^?\d+$/.test(versionString)) {
       const cleanedContext = surroundingLines
         .slice(0, surroundingLines.indexOf(match[0]))
         .concat(surroundingLines.slice(surroundingLines.indexOf(match[0]) + match[0].length));


### PR DESCRIPTION
Found by the codex deep review of the `dev` → `staging` promotion (#1806). **A regression I introduced in #1804.**

## The bug

To let the "do not use floating ranges" anti-pattern example in `cdn.md` show `@helixui/library@3.11`, I widened `check-version-drift.mjs`'s floating-form skip from bare-major (`@3`, `@^3`) to `major.minor`.

That exempts **every** `@<major>.<minor>` CDN reference. A genuinely stale pin such as `@helixui/library@3.10` sitting in a production install snippet would silently stop failing the gate once the library moved past it — blinding `check-version-drift.mjs` to an entire class of docs regression, in order to make one example render.

That is a worse outcome than the problem it solved, and it would have surfaced two releases later as "why are the install docs pinning an old version?"

## The fix

- Regex reverted to bare-major (`/^\^?\d+$/`), with a comment recording why it must **not** be widened.
- The one snippet that legitimately needs a floating minor annotates itself with `illustrative` — a marker the script's context skip already honours (alongside `deprecated`, `hypothetical`, `placeholder`, …).
- That context window is only the immediately adjacent line, so the tag has to stay on one line. The jsDelivr URL is 102 chars against prettier's `printWidth: 100`, so the example uses the unpkg mirror — a host this page already documents.

## Proven, not assumed

| Case | Expected | Result |
|---|---|---|
| Real docs | pass | `exit 0` |
| Planted `@helixui/library@3.10` in a normal install snippet | **caught** | `exit 1` |
| Planted `@helixui/library@3.9.0` | **caught** | `exit 1` |
| Clean again after reverting probes | pass | `exit 0` |

Gate 12 (docs claims) unchanged: 0 blocking. Codex adversarial review: **pass, 0 findings**.

Docs-only + build-script change. No component source, no version bump, no changeset.