### PR TITLE
docs(cdn): make the upgrade and @latest examples demonstrate what they claim

### DIFF
--- a/apps/docs/src/content/docs/drupal/installation/cdn.md
+++ b/apps/docs/src/content/docs/drupal/installation/cdn.md
@@ -273,17 +273,17 @@ When a new HELiX version is available:
 4. Hard-reload the browser (Cmd+Shift+R) to bypass browser cache
 
 ```yaml
-# Before
+# Before — both the URL pin and the Drupal version key name the old release
 helix-components:
-  version: 3.11.2
+  version: PREVIOUS_VERSION
   js:
-    https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/index.js:
+    https://cdn.jsdelivr.net/npm/@helixui/library@PREVIOUS_VERSION/dist/index.js:
       type: external
       attributes:
         type: module
       preprocess: false
 
-# After upgrade
+# After upgrade — change both, or Drupal keeps serving the cached asset
 helix-components:
   version: 3.11.2
   js:
@@ -299,7 +299,7 @@ helix-components:
 ```yaml
 # DO NOT do this in production
 js:
-  https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/index.js:
+  https://cdn.jsdelivr.net/npm/@helixui/library@latest/dist/index.js:
     type: external
     attributes:
       type: module


### PR DESCRIPTION
Two P3 findings from the codex deep review of the `staging` → `main` promotion (#1808). Both were **already broken on `main`** and the bulk pin bump in #1804 made them worse.

## 1. The upgrade example showed no upgrade

```yaml
# Before
  version: 3.11.2
    …@helixui/library@3.11.2/dist/index.js

# After upgrade
  version: 3.11.2
    …@helixui/library@3.11.2/dist/index.js
```

On `main` both entries already used the same library URL (`@3.9.0`), differing only in the Drupal `version` key (`1.1.2` → `1.2.0`). Aligning that key with the CDN pin — correct in every other block — flattened the one remaining difference here, so the section stopped showing a Drupal user what they actually need to change.

The `Before` entry now names `PREVIOUS_VERSION` in **both** the URL pin and the `version` key, and the comments say to change both or Drupal keeps serving the cached asset.

## 2. The `@latest` anti-pattern never showed `@latest`

The block titled **"Never Use `@latest` in Production"** showed an exact pin on `main`. After the bump that pin became `@3.11.2` — byte-identical to the recommended safe example three sections up. The "DO NOT do this" snippet and the "do this" snippet were the same YAML.

It now shows `@helixui/library@latest`, which is what the surrounding prose spends a paragraph warning about.

## Why these can't rot

`PREVIOUS_VERSION` and `@latest` carry no version number, so no future release can make either stale — the same reasoning applied to the `npm pack` tarball name and the SRI digest placeholder earlier in this series.

## Verification

- `check-version-drift.mjs` → pass (neither placeholder matches the pin pattern)
- `check-docs-claims.mjs` → 0 blocking
- Prettier clean
- Codex adversarial review: **pass, 0 findings**

Docs-only. No component source, no version bump, no changeset.