### PR TITLE
promote: dev → staging (cdn anti-pattern example fixes)

### DIFF
--- a/apps/docs/src/content/docs/drupal/installation/cdn.md
+++ b/apps/docs/src/content/docs/drupal/installation/cdn.md
@@ -273,17 +273,17 @@ When a new HELiX version is available:
 4. Hard-reload the browser (Cmd+Shift+R) to bypass browser cache
 
 ```yaml
-# Before
+# Before — both the URL pin and the Drupal version key name the old release
 helix-components:
-  version: 3.11.2
+  version: PREVIOUS_VERSION
   js:
-    https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/index.js:
+    https://cdn.jsdelivr.net/npm/@helixui/library@PREVIOUS_VERSION/dist/index.js:
       type: external
       attributes:
         type: module
       preprocess: false
 
-# After upgrade
+# After upgrade — change both, or Drupal keeps serving the cached asset
 helix-components:
   version: 3.11.2
   js:
@@ -299,7 +299,7 @@ helix-components:
 ```yaml
 # DO NOT do this in production
 js:
-  https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/index.js:
+  https://cdn.jsdelivr.net/npm/@helixui/library@latest/dist/index.js:
     type: external
     attributes:
       type: module


### PR DESCRIPTION
Follow-up promotion. Carries #1809 — two docs fixes from the codex deep review of the `staging` → `main` release PR (#1808).

- The Drupal "Before / After upgrade" example showed the same URL and the same `version` key on both sides, demonstrating no upgrade. `Before` now names `PREVIOUS_VERSION` in both places.
- The "Never Use `@latest` in Production" block showed an exact pin — after the version bump, byte-identical to the recommended safe example. It now shows `@latest`.

Both were pre-existing defects on `main`, worsened by the bulk pin bump in #1804. Neither replacement carries a version number, so neither can go stale.

Codex: pass, 0 findings. CodeRabbit: clean, 0 threads. Gates 11 and 12 green.

Merging this updates #1808 (its head is `staging`), which then re-runs CI before the release.