### PR TITLE
docs: complete the 3.11.2 version sweep (drupal + extending guides, import maps)

### DIFF
--- a/apps/docs/src/content/docs/drupal/best-practices.mdx
+++ b/apps/docs/src/content/docs/drupal/best-practices.mdx
@@ -917,7 +917,7 @@ For optimal performance, define one library per component and attach conditional
 
 # Full library bundle (loaded on every page if you don't tree-shake)
 helix-core:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/index.js:
       preprocess: false
@@ -926,7 +926,7 @@ helix-core:
 
 # Individual components (loaded on-demand)
 helix-button:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/components/hx-button/index.js:
       preprocess: false
@@ -936,7 +936,7 @@ helix-button:
     - mytheme/helix-core
 
 helix-card:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/components/hx-card/index.js:
       preprocess: false
@@ -946,7 +946,7 @@ helix-card:
     - mytheme/helix-core
 
 helix-data-table:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/components/hx-data-table/index.js:
       preprocess: false
@@ -1285,7 +1285,7 @@ Pin component library versions in production, use ranges in development.
 ```json
 {
   "dependencies": {
-    "@helixui/library": "^3.9.0"
+    "@helixui/library": "^3.11.2"
   }
 }
 ```
@@ -1296,7 +1296,7 @@ Pin component library versions in production, use ranges in development.
 # mytheme.libraries.yml
 
 helix-components:
-  version: 3.9.0 # Explicit version for cache-busting
+  version: 3.11.2 # Explicit version for cache-busting
   js:
     dist/index.js:
       preprocess: false
@@ -1637,7 +1637,7 @@ function mytheme_preprocess_node(&$variables) {
 
   // Add cache tags for component library
   $variables['#cache']['tags'][] = 'helix:components';
-  $variables['#cache']['tags'][] = 'helix:card:v3.9.0';
+  $variables['#cache']['tags'][] = 'helix:card:v3.11.2';
 
   // Add cache contexts
   $variables['#cache']['contexts'][] = 'user.permissions';

--- a/apps/docs/src/content/docs/drupal/installation/module.md
+++ b/apps/docs/src/content/docs/drupal/installation/module.md
@@ -110,7 +110,7 @@ use Drupal\Core\Routing\RouteMatchInterface;
 function hx_library_help($route_name, RouteMatchInterface $route_match) {
   if ($route_name === 'help.page.hx_library') {
     $output = '<h3>' . t('About') . '</h3>';
-    $output .= '<p>' . t('Provides HELiX web components (@helixui/library v3.9.0) as Drupal library assets.') . '</p>';
+    $output .= '<p>' . t('Provides HELiX web components (@helixui/library v3.11.2) as Drupal library assets.') . '</p>';
     $output .= '<h3>' . t('Usage') . '</h3>';
     $output .= '<pre><code>';
     $output .= "# In mytheme.info.yml\nlibraries:\n  - hx_library/components\n\n";
@@ -133,7 +133,7 @@ function hx_library_help($route_name, RouteMatchInterface $route_match) {
 ```yaml
 # Full library bundle — loads all HELiX components
 components:
-  version: 3.9.0
+  version: 3.11.2
   js:
     libraries/helix/dist/index.js:
       attributes:
@@ -176,7 +176,7 @@ For large sites where different page types use different components:
 
 # Full bundle
 components:
-  version: 3.9.0
+  version: 3.11.2
   js:
     libraries/helix/dist/index.js:
       attributes:
@@ -186,7 +186,7 @@ components:
 
 # Individual component libraries
 button:
-  version: 3.9.0
+  version: 3.11.2
   js:
     libraries/helix/dist/components/hx-button/index.js:
       attributes:
@@ -195,7 +195,7 @@ button:
       minified: true
 
 card:
-  version: 3.9.0
+  version: 3.11.2
   js:
     libraries/helix/dist/components/hx-card/index.js:
       attributes:
@@ -204,7 +204,7 @@ card:
       minified: true
 
 text-input:
-  version: 3.9.0
+  version: 3.11.2
   js:
     libraries/helix/dist/components/hx-text-input/index.js:
       attributes:
@@ -273,7 +273,7 @@ Use Composer to manage the JavaScript dependency alongside your PHP packages.
 **Require the package:**
 
 ```bash
-composer require npm-asset/helixui--library:^3.9.0
+composer require npm-asset/helixui--library:^3.11.2
 ```
 
 **Configure installer path in `composer.json`:**
@@ -282,9 +282,7 @@ composer require npm-asset/helixui--library:^3.9.0
 {
   "extra": {
     "installer-paths": {
-      "web/modules/custom/hx_library/libraries/helix": [
-        "npm-asset/helixui--library"
-      ]
+      "web/modules/custom/hx_library/libraries/helix": ["npm-asset/helixui--library"]
     }
   }
 }
@@ -295,7 +293,7 @@ After `composer install`, the HELiX dist files land at `web/modules/custom/hx_li
 **Updating:**
 
 ```bash
-composer require npm-asset/helixui--library:^3.9.0
+composer require npm-asset/helixui--library:^3.11.2
 drush cr
 ```
 
@@ -433,6 +431,7 @@ function mytheme_page_attachments(array &$attachments) {
 ```
 
 Key attribute notes:
+
 - Use `hx-size` (not `size`) for component sizing
 - Use the `href` attribute on `hx-card` for link card behavior; the card fires `hx-click` on activation
 
@@ -504,12 +503,12 @@ function hx_library_requirements($phase) {
 }
 
 /**
- * Update HELiX library version to 3.9.0.
+ * Update HELiX library version to 3.11.2.
  */
 function hx_library_update_10001() {
   // Clear all caches to reload updated library definitions.
   drupal_flush_all_caches();
-  return t('HELiX Library updated to version 3.9.0. Cache cleared.');
+  return t('HELiX Library updated to version 3.11.2. Cache cleared.');
 }
 ```
 
@@ -524,7 +523,7 @@ The `hook_requirements()` implementation makes the status report at `/admin/repo
 **`config/install/hx_library.settings.yml`:**
 
 ```yaml
-version: '3.9.0'
+version: '3.11.2'
 use_cdn_fallback: false
 cdn_url: 'https://cdn.jsdelivr.net/npm/@helixui/library'
 ```
@@ -608,7 +607,7 @@ function hx_library_library_info_alter(&$libraries, $extension) {
 
   // Allow per-site CDN fallback via settings.
   if ($config->get('use_cdn_fallback')) {
-    $version = $config->get('version') ?? '3.9.0';
+    $version = $config->get('version') ?? '3.11.2';
     $cdn_url = $config->get('cdn_url') ?? 'https://cdn.jsdelivr.net/npm/@helixui/library';
 
     // Rewrite BOTH the JS entry AND the CSS entries — if you only
@@ -639,7 +638,7 @@ Override in a site-specific `settings.php`:
 ```php
 // sites/site-a.example.com/settings.php
 $config['hx_library.settings']['use_cdn_fallback'] = TRUE;
-$config['hx_library.settings']['version'] = '3.9.0';
+$config['hx_library.settings']['version'] = '3.11.2';
 ```
 
 ---
@@ -648,15 +647,15 @@ $config['hx_library.settings']['version'] = '3.9.0';
 
 HELiX itself has no Drupal PHP version dependencies — it is entirely a JavaScript/CSS library. Drupal-side compatibility comes from the module scaffolding:
 
-| Feature | Drupal 10 | Drupal 11 |
-|---|---|---|
-| `core_version_requirement: ^10 \|\| ^11` | Yes | Yes |
-| Libraries API (`*.libraries.yml`) | Yes | Yes |
-| `attributes: { type: module }` in libraries | Yes (since D9.3) | Yes |
-| `hook_page_attachments()` | Yes | Yes |
-| `hook_library_info_alter()` | Yes | Yes |
-| Configuration management | Yes | Yes |
-| Composer dependency management | Yes | Yes |
+| Feature                                     | Drupal 10        | Drupal 11 |
+| ------------------------------------------- | ---------------- | --------- |
+| `core_version_requirement: ^10 \|\| ^11`    | Yes              | Yes       |
+| Libraries API (`*.libraries.yml`)           | Yes              | Yes       |
+| `attributes: { type: module }` in libraries | Yes (since D9.3) | Yes       |
+| `hook_page_attachments()`                   | Yes              | Yes       |
+| `hook_library_info_alter()`                 | Yes              | Yes       |
+| Configuration management                    | Yes              | Yes       |
+| Composer dependency management              | Yes              | Yes       |
 
 No conditional code or version detection is needed in the module. The same `.info.yml`, `.libraries.yml`, and hook implementations work identically on Drupal 10 and 11.
 
@@ -712,11 +711,11 @@ libraries/helix/dist/index.js:
 
 ```yaml
 components:
-  version: 3.9.0
+  version: 3.11.2
   js:
     libraries/helix/dist/index.js:
       attributes:
-        type: module    # This line is required
+        type: module # This line is required
       preprocess: false
 ```
 
@@ -742,11 +741,11 @@ When a new HELiX version is available:
 
 ```php
 /**
- * Update HELiX library files to version 3.9.0.
+ * Update HELiX library files to version 3.11.2.
  */
 function hx_library_update_10002() {
   drupal_flush_all_caches();
-  return t('HELiX Library updated to version 3.9.0.');
+  return t('HELiX Library updated to version 3.11.2.');
 }
 ```
 

--- a/apps/docs/src/content/docs/drupal/installation/npm.md
+++ b/apps/docs/src/content/docs/drupal/installation/npm.md
@@ -176,6 +176,7 @@ export default defineConfig({
 ```
 
 With `manualChunks`, Vite produces two output files:
+
 - `dist/js/helix.js` — The HELiX library chunk
 - `dist/js/theme.js` — Your theme code that imports the HELiX chunk
 
@@ -193,7 +194,7 @@ This separation allows browsers to cache HELiX independently of your theme code.
     "build:prod": "NODE_ENV=production vite build"
   },
   "dependencies": {
-    "@helixui/library": "3.9.0"
+    "@helixui/library": "3.11.2"
   },
   "devDependencies": {
     "vite": "^6.0.0"
@@ -201,7 +202,7 @@ This separation allows browsers to cache HELiX independently of your theme code.
 }
 ```
 
-Use exact versions (`"3.9.0"` not `"^3.9.0"`) for `@helixui/library` in production themes. This ensures identical bundles across environments.
+Use exact versions (`"3.11.2"` not `"^3.11.2"`) for `@helixui/library` in production themes. This ensures identical bundles across environments.
 
 ### Option B: Webpack
 
@@ -484,6 +485,7 @@ jobs:
 ```
 
 **Key points:**
+
 - Use `npm ci` (not `npm install`) in CI. It installs exactly what's in `package-lock.json` and fails if the lockfile is out of date.
 - Cache the `node_modules` directory using the lockfile hash for faster CI runs.
 - Never deploy `node_modules` to the server — only deploy compiled `dist/` assets.
@@ -507,7 +509,7 @@ npm run build:prod
 
 # Commit the updated package-lock.json and built assets
 git add package.json package-lock.json dist/
-git commit -m "chore(theme): update @helixui/library to 3.9.0"
+git commit -m "chore(theme): update @helixui/library to 3.11.2"
 ```
 
 Always review the HELiX changelog before updating. Check for attribute name changes, removed components, or slot renames that would require template updates.
@@ -626,7 +628,7 @@ In local development with `npm run dev` (watch mode), clear caches once after se
 - [ ] `node_modules/` is never deployed (only used at build time)
 - [ ] `attributes: { type: module }` present in `.libraries.yml` for all JS entries
 - [ ] `package-lock.json` is committed to source control
-- [ ] Exact version pinned in `package.json` (`"3.9.0"` not `"^3.9.0"`)
+- [ ] Exact version pinned in `package.json` (`"3.11.2"` not `"^3.11.2"`)
 - [ ] Source maps generated for production debugging
 - [ ] `drush cr` runs post-deployment
 - [ ] Components tested in target browsers after deployment

--- a/apps/docs/src/content/docs/drupal/library-system.md
+++ b/apps/docs/src/content/docs/drupal/library-system.md
@@ -236,7 +236,7 @@ helix-behaviors:
 
 ```yaml
 helix-button:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-button.js:
       attributes:
@@ -245,7 +245,7 @@ helix-button:
 
 **Version affects:**
 
-- Cache-busting query strings (`hx-button.js?v=3.9.0`)
+- Cache-busting query strings (`hx-button.js?v=3.11.2`)
 - Cache and dependency-graph metadata (the version contributes to cache hashes and library replacement keys; Drupal's libraries API does not perform semver dependency-compatibility checks)
 - Library replacement (modules can replace libraries with specific versions)
 
@@ -265,7 +265,7 @@ helix-button:
         type: module
 
 helix-button-theme-versioned:
-  version: '3.9.0' # Literal — track this library's version explicitly
+  version: '3.11.2' # Literal — track this library's version explicitly
   js:
     dist/components/hx-button/index.js:
       attributes:
@@ -410,7 +410,7 @@ helix-all:
 # mytheme.libraries.yml
 
 helix-button:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-button.js:
       preprocess: false
@@ -418,7 +418,7 @@ helix-button:
         type: module
 
 helix-card:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-card.js:
       preprocess: false
@@ -426,7 +426,7 @@ helix-card:
         type: module
 
 helix-text-input:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-text-input.js:
       preprocess: false
@@ -456,7 +456,7 @@ helix-text-input:
 
 # Core utilities and shared dependencies
 helix-core:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/helix-core.js:
       preprocess: false
@@ -465,7 +465,7 @@ helix-core:
 
 # Common component bundle (buttons, badges, alerts)
 helix-common:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/helix-common.js:
       preprocess: false
@@ -476,7 +476,7 @@ helix-common:
 
 # Heavy components loaded on-demand
 helix-data-table:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-data-table.js:
       preprocess: false
@@ -486,7 +486,7 @@ helix-data-table:
     - mytheme/helix-core
 
 helix-data-table:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/components/hx-data-table/index.js:
       preprocess: false
@@ -746,7 +746,7 @@ helix-button:
     "dev": "vite build --watch"
   },
   "dependencies": {
-    "@helixui/library": "^3.9.0"
+    "@helixui/library": "^3.11.2"
   }
 }
 ```
@@ -789,7 +789,7 @@ import '@helixui/library/components/hx-button';
 # mytheme.libraries.yml
 
 helix-card:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-card.js:
       minified: true
@@ -808,7 +808,7 @@ helix-card:
 # mytheme.libraries.yml
 
 helix-card:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-card.js:
       minified: true
@@ -877,7 +877,7 @@ helix-card:
 
 # Core design tokens and utilities
 helix-core:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/helix-core.js:
       minified: true
@@ -887,7 +887,7 @@ helix-core:
 
 # Common UI components (bundled for performance)
 helix-common:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/helix-common.js:
       minified: true
@@ -900,7 +900,7 @@ helix-common:
 
 # Individual form components
 helix-text-input:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-text-input.js:
       minified: true
@@ -911,7 +911,7 @@ helix-text-input:
     - mytheme/helix-core
 
 helix-select:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-select.js:
       minified: true
@@ -922,7 +922,7 @@ helix-select:
     - mytheme/helix-core
 
 helix-checkbox:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-checkbox.js:
       minified: true
@@ -944,7 +944,7 @@ helix-forms:
 
 # Heavy components (load on-demand)
 helix-data-table:
-  version: 3.9.0
+  version: 3.11.2
   js:
     dist/js/hx-data-table.js:
       minified: true

--- a/apps/docs/src/content/docs/drupal/per-component-loading.md
+++ b/apps/docs/src/content/docs/drupal/per-component-loading.md
@@ -184,7 +184,7 @@ Every HELiX integration starts with the runtime library. This is the shared foun
 # alongside the components is the design-token CSS.
 
 hx.runtime:
-  version: 3.9.0
+  version: 3.11.2
   css:
     theme:
       # Design tokens: CSS custom properties for theming
@@ -230,7 +230,7 @@ Each component gets its own library entry with explicit dependencies.
 # ─── Atoms ───
 
 hx.button:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-button/index.js:
       type: module
@@ -240,7 +240,7 @@ hx.button:
     - mytheme/hx.runtime
 
 hx.icon:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-icon/index.js:
       type: module
@@ -250,7 +250,7 @@ hx.icon:
     - mytheme/hx.runtime
 
 hx.badge:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-badge/index.js:
       type: module
@@ -260,7 +260,7 @@ hx.badge:
     - mytheme/hx.runtime
 
 hx.spinner:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-spinner/index.js:
       type: module
@@ -273,7 +273,7 @@ hx.spinner:
 # Form elements depend on the runtime only
 
 hx.text_input:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-text-input/index.js:
       type: module
@@ -283,7 +283,7 @@ hx.text_input:
     - mytheme/hx.runtime
 
 hx.textarea:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-textarea/index.js:
       type: module
@@ -293,7 +293,7 @@ hx.textarea:
     - mytheme/hx.runtime
 
 hx.select:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-select/index.js:
       type: module
@@ -303,7 +303,7 @@ hx.select:
     - mytheme/hx.runtime
 
 hx.checkbox:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-checkbox/index.js:
       type: module
@@ -313,7 +313,7 @@ hx.checkbox:
     - mytheme/hx.runtime
 
 hx.radio_group:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-radio-group/index.js:
       type: module
@@ -323,7 +323,7 @@ hx.radio_group:
     - mytheme/hx.runtime
 
 hx.switch:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-switch/index.js:
       type: module
@@ -336,7 +336,7 @@ hx.switch:
 # Molecules may depend on atoms they use internally
 
 hx.card:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-card/index.js:
       type: module
@@ -351,7 +351,7 @@ hx.card:
   # in templates that put an <hx-button> inside hx-card's actions slot.
 
 hx.alert:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-alert/index.js:
       type: module
@@ -362,7 +362,7 @@ hx.alert:
     - mytheme/hx.icon # Alerts show icons for variant (info, warning, etc.)
 
 hx.breadcrumb:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-breadcrumb/index.js:
       type: module
@@ -375,7 +375,7 @@ hx.breadcrumb:
 # Organisms compose multiple components
 
 hx.dialog:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-dialog/index.js:
       type: module
@@ -386,7 +386,7 @@ hx.dialog:
     - mytheme/hx.button # Modal footer actions use buttons
 
 hx.accordion:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-accordion/index.js:
       type: module
@@ -397,7 +397,7 @@ hx.accordion:
     - mytheme/hx.icon # Accordion uses chevron icons
 
 hx.form:
-  version: 3.9.0
+  version: 3.11.2
   js:
     vendor/helix/components/hx-form/index.js:
       type: module
@@ -434,7 +434,7 @@ Groups are pure dependency aggregators with NO JavaScript of their own.
 # Use these in preprocess functions for cleaner code.
 
 hx.group_core:
-  version: 3.9.0
+  version: 3.11.2
   # No js: or css: — pure dependency aggregator
   dependencies:
     - mytheme/hx.button
@@ -443,7 +443,7 @@ hx.group_core:
     - mytheme/hx.spinner
 
 hx.group_forms:
-  version: 3.9.0
+  version: 3.11.2
   dependencies:
     - mytheme/hx.text_input
     - mytheme/hx.textarea
@@ -454,7 +454,7 @@ hx.group_forms:
     - mytheme/hx.group_core # Forms use buttons for submit
 
 hx.group_content:
-  version: 3.9.0
+  version: 3.11.2
   dependencies:
     - mytheme/hx.card
     - mytheme/hx.alert
@@ -462,7 +462,7 @@ hx.group_content:
     - mytheme/hx.group_core # Content uses buttons, badges
 
 hx.group_interactive:
-  version: 3.9.0
+  version: 3.11.2
   dependencies:
     - mytheme/hx.dialog
     - mytheme/hx.accordion
@@ -471,7 +471,7 @@ hx.group_interactive:
 # ─── Development Bundle (NEVER in production) ───
 
 hx.all:
-  version: 3.9.0
+  version: 3.11.2
   dependencies:
     - mytheme/hx.group_core
     - mytheme/hx.group_forms
@@ -847,7 +847,7 @@ Inter-component dependencies must be kept accurate. When a component template ch
 
 ```diff
  hx.card:
-   version: 3.9.0
+   version: 3.11.2
    js:
      vendor/helix/components/hx-card/index.js:
        type: module

--- a/apps/docs/src/content/docs/drupal/performance/overview.md
+++ b/apps/docs/src/content/docs/drupal/performance/overview.md
@@ -13,12 +13,12 @@ HELiX components are ES modules built on Lit. Loading them efficiently in Drupal
 
 These sizes are gzipped. Raw sizes are approximately 2.5–3× larger.
 
-| Load strategy                        | Approximate gzipped size | When to use                             |
-| ------------------------------------ | ------------------------ | --------------------------------------- |
-| Full bundle (`dist/index.js`)        | ~38 KB                   | Prototypes, sites using 8+ components   |
-| Per-component (e.g., `hx-button`)    | 3–6 KB per component     | Production sites, page-specific loading |
-| Lit runtime alone                    | ~12 KB                   | Shared dependency baseline              |
-| Tokens CSS (`@helixui/tokens@3.9.4`) | ~4 KB                    | Always load separately                  |
+| Load strategy                        | Approximate gzipped size | When to use                                        |
+| ------------------------------------ | ------------------------ | -------------------------------------------------- |
+| Full bundle (`dist/index.js`)        | ~38 KB                   | Prototypes, sites using 8+ components              |
+| Per-component (e.g., `hx-button`)    | 3–6 KB per component     | Production sites, page-specific loading            |
+| Lit runtime alone                    | ~12 KB                   | Shared dependency baseline                         |
+| Tokens CSS (`@helixui/tokens@3.9.4`) | ~4 KB                    | Only if theme CSS uses `--hx-*` outside components |
 
 The full bundle CDN URL is:
 

--- a/apps/docs/src/content/docs/drupal/security-xss.md
+++ b/apps/docs/src/content/docs/drupal/security-xss.md
@@ -257,14 +257,17 @@ helix-button:
 
 Get the hash from [https://www.srihash.org](https://www.srihash.org) or jsDelivr's SRI tool.
 
-The per-component module above imports a shared chunk that pulls `lit` from a bare specifier. Ship an import map (or use the bundled aggregate entry, `dist/index.js`) so the browser can resolve `lit` — otherwise the module fails to load even with a valid `integrity` hash:
+The per-component module above imports a shared chunk that pulls `lit`, `@helixui/tokens`, and `@helixui/icons` from bare specifiers. Ship an import map (or use the bundled aggregate entry, `dist/index.js`) so the browser can resolve them — otherwise the module fails to load even with a valid `integrity` hash:
 
 ```html
 <script type="importmap">
   {
     "imports": {
       "lit": "https://cdn.jsdelivr.net/npm/lit@3/index.js",
-      "lit/": "https://cdn.jsdelivr.net/npm/lit@3/"
+      "lit/": "https://cdn.jsdelivr.net/npm/lit@3/",
+      "@helixui/tokens": "https://cdn.jsdelivr.net/npm/@helixui/tokens@3.9.4/dist/index.js",
+      "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist/index.js",
+      "@floating-ui/dom": "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm"
     }
   }
 </script>

--- a/apps/docs/src/content/docs/extending/multi-brand-theming.md
+++ b/apps/docs/src/content/docs/extending/multi-brand-theming.md
@@ -807,13 +807,15 @@ function harbor_health_preprocess_html(array &$variables): void {
     <title>{{ head_title }}</title>
     {{ head }}
     {# HELiX library — loaded from CDN. The published distribution imports
-       `lit` and `@helixui/icons` from bare specifiers, so a CDN load needs
-       an import map; see /drupal/theming/ for the canonical snippet. #}
+       `lit`, `@helixui/tokens`, and `@helixui/icons` from bare specifiers, so
+       a CDN load needs an import map; see /drupal/theming/ for the canonical
+       snippet. #}
     <script type="importmap">
       {
         "imports": {
           "lit": "https://cdn.jsdelivr.net/npm/lit@3/index.js",
           "lit/": "https://cdn.jsdelivr.net/npm/lit@3/",
+          "@helixui/tokens": "https://cdn.jsdelivr.net/npm/@helixui/tokens@3.9.4/dist/index.js",
           "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist/index.js",
           "@floating-ui/dom": "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm"
         }

--- a/apps/docs/src/content/docs/extending/register-bundle-publish.md
+++ b/apps/docs/src/content/docs/extending/register-bundle-publish.md
@@ -328,7 +328,7 @@ An import map pins bare module specifiers to resolved URLs, preventing duplicate
       "@lit/reactive-element": "https://cdn.jsdelivr.net/npm/@lit/reactive-element@2/reactive-element.js",
       "lit-html": "https://cdn.jsdelivr.net/npm/lit-html@3/lit-html.js",
       "@helixui/tokens": "https://cdn.jsdelivr.net/npm/@helixui/tokens@3.9.4/dist/index.js",
-      "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1/dist/index.js",
+      "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist/index.js",
       "@floating-ui/dom": "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm",
       "@helixui/library": "https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/index.js",
       "@helixui/library/components/hx-card": "https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/components/hx-card/index.js"
@@ -362,7 +362,7 @@ For incremental adoption — loading only the components a specific page needs:
       "lit/": "https://cdn.jsdelivr.net/npm/lit@3/",
       "lit/directives/class-map.js": "https://cdn.jsdelivr.net/npm/lit@3/directives/class-map.js",
       "@helixui/tokens": "https://cdn.jsdelivr.net/npm/@helixui/tokens@3.9.4/dist/index.js",
-      "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1/dist/index.js",
+      "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist/index.js",
       "@floating-ui/dom": "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1/+esm",
       "@helixui/library/components/hx-card": "https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/components/hx-card/index.js"
     }

--- a/apps/docs/src/content/docs/framework-integration/html.md
+++ b/apps/docs/src/content/docs/framework-integration/html.md
@@ -11,7 +11,7 @@ HELIX components work in any HTML page with a single `<script>` tag. No build to
 
 ## CDN via Script Tag (import map)
 
-A bare specifier like `import '@helixui/library'` only resolves in the browser if an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) is in scope — otherwise the browser throws a module-resolution error. Use a pinned, version-locked CDN URL plus an import map for the library's bare dependencies (`lit`, `lit/*`, `@helixui/tokens`, `@helixui/icons`):
+A bare specifier like `import '@helixui/library'` only resolves in the browser if an [import map](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) is in scope — otherwise the browser throws a module-resolution error. Use a pinned, version-locked CDN URL plus an import map for the library's bare dependencies (`lit`, `lit/*`, `@helixui/tokens`, `@helixui/icons`, `@floating-ui/dom`):
 
 ```html
 <!DOCTYPE html>
@@ -26,6 +26,7 @@ A bare specifier like `import '@helixui/library'` only resolves in the browser i
           "@helixui/library": "https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/index.js",
           "@helixui/tokens": "https://cdn.jsdelivr.net/npm/@helixui/tokens@3.9.4/dist/index.js",
           "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist/index.js",
+          "@floating-ui/dom": "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.6/+esm",
           "lit": "https://cdn.jsdelivr.net/npm/lit@3/+esm",
           "lit/": "https://cdn.jsdelivr.net/npm/lit@3/"
         }
@@ -56,6 +57,7 @@ For performance, load only the components you use. Per-component entry points re
       "@helixui/library/components/hx-text-input": "https://cdn.jsdelivr.net/npm/@helixui/library@3.11.2/dist/components/hx-text-input/index.js",
       "@helixui/tokens": "https://cdn.jsdelivr.net/npm/@helixui/tokens@3.9.4/dist/index.js",
       "@helixui/icons": "https://cdn.jsdelivr.net/npm/@helixui/icons@1.1.0/dist/index.js",
+      "@floating-ui/dom": "https://cdn.jsdelivr.net/npm/@floating-ui/dom@1.7.6/+esm",
       "lit": "https://cdn.jsdelivr.net/npm/lit@3/+esm",
       "lit/": "https://cdn.jsdelivr.net/npm/lit@3/"
     }

--- a/apps/docs/src/content/docs/getting-started/installation.md
+++ b/apps/docs/src/content/docs/getting-started/installation.md
@@ -41,8 +41,8 @@ Current versions:
 | `@helixui/library` | ^3.11.2 | Lit 3.x components (core)                                                                                                          |
 | `@helixui/icons`   | ^1.1.0  | Required peer — icon registry                                                                                                      |
 | `@floating-ui/dom` | ^1.7.6  | Required peer — positioning engine for popover-style parts                                                                         |
-| `@helixui/tokens`  | ^3.9.0  | Direct dependency of `@helixui/library`; installs automatically. Pin explicitly only if your build needs deterministic resolution. |
-| `@helixui/react`   | ^3.9.0  | Optional — React 18/19 wrappers                                                                                                    |
+| `@helixui/tokens`  | ^3.9.4  | Direct dependency of `@helixui/library`; installs automatically. Pin explicitly only if your build needs deterministic resolution. |
+| `@helixui/react`   | ^3.11.2 | Optional — React 18/19 wrappers                                                                                                    |
 
 If you are upgrading an existing project from `@helixui/library@3.8.x` or earlier, see the [3.8.0 → 3.9.0 migration guide](/migration/3-8-0-to-3-9-0/) — `@helixui/icons` is a new required peer dependency.
 

--- a/apps/docs/src/content/docs/getting-started/release-policy.md
+++ b/apps/docs/src/content/docs/getting-started/release-policy.md
@@ -15,7 +15,7 @@ HELiX follows [Semantic Versioning 2.0.0](https://semver.org/) for canonical rel
 
 > **Note:** Versions in the `0.y.z` range are considered initial development. The public API is not yet stable and breaking changes may occur in any release during this phase.
 
-> **`@helixui/library@4.0.0` is a deprecated accidental release** that shipped as a major during the 2026-05 icons epic without intentional breaking changes. `3.9.0` is the supported current line; do not upgrade past it. A planned 4.x reset will follow once the affected packages republish from a known-clean state.
+> **`@helixui/library@4.0.0` is a deprecated accidental release** that shipped as a major during the 2026-05 icons epic without intentional breaking changes. The `3.x` line — currently `3.11.x` — is the supported current release; adopt the latest `3.x` and do **not** install `4.0.0`. A planned 4.x reset will follow once the affected packages republish from a known-clean state.
 
 ### What Counts as Public API
 
@@ -35,11 +35,11 @@ Internal implementation details (private methods, internal DOM structure, undocu
 
 Releases are driven by accumulated changesets rather than a fixed calendar — `.github/workflows/publish.yml` opens a Release PR whenever unreleased changesets exist on `main`, and the team merges that PR when the changes are ready to ship. There is no enforced monthly/quarterly mechanism in CI today.
 
-| Release Type | Trigger                                  | Content                      |
-| ------------ | ---------------------------------------- | ---------------------------- |
-| Patch        | As needed (bug fixes accumulated)        | Bug fixes, security patches  |
-| Minor        | When new-feature changesets accumulate   | New features, new components |
-| Major        | When breaking-change changesets land     | Breaking changes, batched    |
+| Release Type | Trigger                                | Content                      |
+| ------------ | -------------------------------------- | ---------------------------- |
+| Patch        | As needed (bug fixes accumulated)      | Bug fixes, security patches  |
+| Minor        | When new-feature changesets accumulate | New features, new components |
+| Major        | When breaking-change changesets land   | Breaking changes, batched    |
 
 ### Pre-release Versions
 
@@ -69,11 +69,11 @@ HELiX uses a **three-branch promotion pipeline** to ensure changes are validated
 feature/* → dev → staging → main
 ```
 
-| Stage             | Branch    | Purpose                                               |
-| ----------------- | --------- | ----------------------------------------------------- |
-| Development       | `dev`     | Active integration; all feature PRs target this branch |
-| Staging           | `staging` | Pre-release validation; promotion from `dev`          |
-| Production        | `main`    | Published releases; promotion from `staging`          |
+| Stage       | Branch    | Purpose                                                |
+| ----------- | --------- | ------------------------------------------------------ |
+| Development | `dev`     | Active integration; all feature PRs target this branch |
+| Staging     | `staging` | Pre-release validation; promotion from `dev`           |
+| Production  | `main`    | Published releases; promotion from `staging`           |
 
 ### How Releases Ship
 
@@ -103,11 +103,11 @@ Verify the gate's exact monitored-path list in `.github/workflows/ci.yml` before
 
 ## Support Policy
 
-| Version        | Support Level                                                                                       |
-| -------------- | --------------------------------------------------------------------------------------------------- |
-| Current major (3.x for `@helixui/library`) | Full support — bug fixes, security patches, new features                |
-| Previous major | Maintenance — critical bug fixes and security patches for a published support window (see migration guide for the active line) |
-| Older majors   | Unsupported — no fixes, no patches                                                                  |
+| Version                                    | Support Level                                                                                                                  |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Current major (3.x for `@helixui/library`) | Full support — bug fixes, security patches, new features                                                                       |
+| Previous major                             | Maintenance — critical bug fixes and security patches for a published support window (see migration guide for the active line) |
+| Older majors                               | Unsupported — no fixes, no patches                                                                                             |
 
 > See [Upgrading to 3](/migration/upgrading-to-3/) for the canonical support-window statement of the 2.x → 3.x line. Other package lines (`@helixui/drupal-starter`, `@helixui/drupal-behaviors` on 4.x; `@helixui/icons` on 1.x; `@helixui/mcp` on 0.x) version independently and their support windows follow the same pattern relative to each line's current major.
 

--- a/apps/storybook/stories/patterns/Patterns.mdx
+++ b/apps/storybook/stories/patterns/Patterns.mdx
@@ -17,7 +17,7 @@ import '@helixui/library/components/hx-avatar';
 <div className="hx-docs">
 
 <EyebrowHeading
-  eyebrow="Patterns · v3.9.0"
+  eyebrow="Patterns · v3.11.2"
   title="The shapes our same components keep forming."
   lede={
     <>


### PR DESCRIPTION
Finishes the version sync that #1804 started. CodeRabbit's review of the release PR (#1808) correctly flagged that the sync was only partial — several guides showed 3.11.2 CDN URLs while still carrying 3.9.0 in Composer commands, update hooks, config, and cache keys, and several import-map examples were runtime-broken. This clears the **whole class** so no follow-up round is needed. Also completes the deferred task-#13 scope.

## Version refresh (72 refs)

- **module.md** (the MAJOR one CodeRabbit flagged) — `composer require` pins, `hook_update_N` bodies, `hook_help` text, default config, CDN-fallback default → 3.11.2. Users could previously install an outdated version by following the guide.
- **npm.md** — package.json pin, commit-message example, exact-vs-caret pedagogy (both sides bumped, the teaching preserved).
- **library-system.md**, **per-component-loading.md**, **best-practices.mdx** — `version:` cache-bust keys, `?v=` query strings, cache tags.
- **installation.md** — dependency table (tokens → 3.9.4, library → 3.11.2).

## Import-map completeness (runtime correctness)

A CDN example that loads `@helixui/library` needs every bare specifier it imports, or the browser throws `Failed to resolve module specifier`:

- **security-xss.md** — was `lit`-only; the documented per-component `hx-button` module also pulls `@helixui/tokens` (auto-adoption) and `@helixui/icons`, so the example was broken. Completed to the full 5-entry map + fixed prose.
- **multi-brand-theming.md** — added missing `@helixui/tokens`.
- **html.md** — added missing `@floating-ui/dom` (both maps).
- **register-bundle-publish.md** — pinned `@helixui/icons@1` → `1.1.0`.

## Content fixes

- **performance/overview.md** — "Always load tokens CSS separately" → only when the theme's own CSS consumes `--hx-*` outside components (Shadow DOM components carry their own tokens).
- **release-policy.md** — the 4.0.0-avoidance note said "`3.9.0` is the supported current line; do not upgrade past it," written when 3.9.0 was the top of the 3.x line. Shipping 3.11.3 while that stands tells consumers not to adopt the release. Now points at the current 3.x (3.11.x) while keeping the do-not-install-4.0.0 guidance intact.

## Deliberately left alone

"As of / Prior to v3.9.0" historical prose; deliberate broad-range peerDep pedagogy in register-bundle-publish; migration archives; and the **VPAT / AAA cert documents** (formal conformance attestations to the 3.9.0 surface — a hand-edit would falsify a compliance claim; tracked separately). A false "library+tokens always publish in lockstep" claim in release-policy.md is logged as a follow-up — it needs a careful rewrite of the changeset linked-semantics, out of scope here.

## Verification

- `check-version-drift.mjs` → 0 stale refs across 176 files
- `check-docs-claims.mjs` → 0 blocking
- Prettier clean; codex adversarial review: **pass, 0 findings**

Docs-only. No component source, no version bump, no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated HELiX examples and installation guidance to version 3.11.2.
  - Updated token and React dependency references to current versions.
  - Expanded import map and CDN guidance for required dependencies.
  - Refined token CSS loading recommendations and security examples.
  - Corrected release policy guidance for supported 3.x releases.
  - Updated Patterns documentation to display version 3.11.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->